### PR TITLE
feat(cli): add web frontend with Askama templates and htmx

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,6 +95,82 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
 
 [[package]]
+name = "askama"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08e1676b346cadfec169374f949d7490fd80a24193d37d2afce0c047cf695e57"
+dependencies = [
+ "askama_macros",
+ "itoa",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7661ff56517787343f376f75db037426facd7c8d3049cef8911f1e75016f3a37"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "memchr",
+ "proc-macro2",
+ "quote",
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "syn",
+]
+
+[[package]]
+name = "askama_macros"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "713ee4dbfd1eb719c2dab859465b01fa1d21cb566684614a713a6b7a99a4e47b"
+dependencies = [
+ "askama_derive",
+]
+
+[[package]]
+name = "askama_parser"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d62d674238a526418b30c0def480d5beadb9d8964e7f38d635b03bf639c704c"
+dependencies = [
+ "rustc-hash",
+ "serde",
+ "serde_derive",
+ "unicode-ident",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "askama_web"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eb6d818ce4fb74822f2676eb0047daf25a8b2cb88f0c9fe8ca690170a6cb6cd"
+dependencies = [
+ "askama",
+ "askama_web_derive",
+ "axum-core",
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "askama_web_derive"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9767c17d33a63daf6da5872ffaf2ab0c289cd73ce7ed4f41d5ddf9149c004873"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "async-graphql"
 version = "7.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,6 +388,15 @@ name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "basic-toml"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba62675e8242a4c4e806d12f11d136e626e6c8361d6b829310732241652a178a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitflags"
@@ -902,13 +987,18 @@ name = "galoy-agents-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "askama",
+ "askama_web",
  "axum",
  "clap",
  "mcp-gateway",
+ "serde",
+ "sha2",
  "sqlx",
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -1949,6 +2039,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2628,7 +2724,7 @@ dependencies = [
  "indexmap",
  "toml_datetime",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -2637,7 +2733,7 @@ version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -3221,6 +3317,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winnow"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,10 +9,15 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+askama = "0.15"
+askama_web = { version = "0.15", features = ["axum-0.8"] }
 axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
 mcp-gateway = { path = "../mcp-gateway" }
+serde = { version = "1.0", features = ["derive"] }
+sha2 = "0.10"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+uuid = { version = "1", features = ["v4"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,3 +1,5 @@
+mod web;
+
 use clap::Parser;
 
 #[derive(Parser)]
@@ -28,9 +30,11 @@ async fn main() -> anyhow::Result<()> {
     let users = mcp_gateway::user::Users::new(&pool);
     let agents = mcp_gateway::agent::Agents::new(&pool);
 
-    let schema = mcp_gateway::graphql::schema(users, agents);
+    let schema = mcp_gateway::graphql::schema(users.clone(), agents.clone());
 
-    let app = axum::Router::new()
+    let web_state = web::AppState { users, agents };
+
+    let app = web::router(web_state)
         .route(
             "/graphql",
             axum::routing::get(mcp_gateway::graphql::graphql_playground)

--- a/cli/src/web/mod.rs
+++ b/cli/src/web/mod.rs
@@ -1,0 +1,168 @@
+mod templates;
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    response::{IntoResponse, Redirect, Response},
+    routing::{get, post},
+    Form, Router,
+};
+use sha2::{Digest, Sha256};
+use tracing::instrument;
+
+use mcp_gateway::{
+    agent::{Agent, Agents},
+    primitives::{AgentId, UserId},
+    user::Users,
+};
+
+use templates::*;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub users: Users,
+    pub agents: Agents,
+}
+
+pub fn router(state: AppState) -> Router {
+    Router::new()
+        .route("/", get(index))
+        .route("/dashboard", get(dashboard))
+        .route("/dashboard/agents", get(agent_list))
+        .route("/agents/create", post(create_agent))
+        .route("/agents/{id}/revoke", post(revoke_agent))
+        .with_state(Arc::new(state))
+}
+
+fn extract_user_id(_headers: &axum::http::HeaderMap) -> Option<UserId> {
+    // TODO: Extract user_id from session cookie once OAuth is implemented.
+    // For now, this is a placeholder that returns None (not authenticated).
+    None
+}
+
+fn agent_to_view(agent: &Agent) -> AgentView {
+    AgentView {
+        id: agent.id.to_string(),
+        name: agent.name.clone(),
+        scopes: agent.scopes.join(", "),
+        created_at: agent.created_at().format("%Y-%m-%d %H:%M UTC").to_string(),
+        is_revoked: agent.is_revoked(),
+    }
+}
+
+fn hash_token(token: &str) -> String {
+    let hash = Sha256::digest(token.as_bytes());
+    format!("{hash:x}")
+}
+
+#[instrument(name = "web.index", skip_all)]
+async fn index(State(state): State<Arc<AppState>>) -> Response {
+    let _state = state;
+
+    // TODO: Check session for logged-in user, redirect to dashboard if found.
+    // For now, always show login page.
+    LoginTemplate.into_response()
+}
+
+#[instrument(name = "web.dashboard", skip_all)]
+async fn dashboard(State(state): State<Arc<AppState>>) -> Response {
+    let user_id = match extract_user_id(&axum::http::HeaderMap::new()) {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+
+    let user = match state.users.find_by_id(user_id).await {
+        Ok(user) => user,
+        Err(_) => return Redirect::to("/").into_response(),
+    };
+
+    let agents = state
+        .agents
+        .list_all_for_user(user.id)
+        .await
+        .unwrap_or_default();
+
+    let user_name = user.name.clone().unwrap_or_else(|| user.github_id.clone());
+
+    DashboardTemplate {
+        user_name,
+        agents: agents.iter().map(agent_to_view).collect(),
+    }
+    .into_response()
+}
+
+#[derive(serde::Deserialize)]
+pub struct CreateAgentForm {
+    name: String,
+    scopes: String,
+}
+
+#[instrument(name = "web.create_agent", skip_all)]
+async fn create_agent(
+    State(state): State<Arc<AppState>>,
+    Form(form): Form<CreateAgentForm>,
+) -> Response {
+    let user_id = match extract_user_id(&axum::http::HeaderMap::new()) {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+
+    let raw_token = uuid::Uuid::new_v4().to_string();
+    let token_hash = hash_token(&raw_token);
+    let scopes: Vec<String> = form
+        .scopes
+        .split(',')
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    match state
+        .agents
+        .create_for_user(user_id, &form.name, token_hash, scopes)
+        .await
+    {
+        Ok(_agent) => AgentCreatedTemplate {
+            token: raw_token,
+            agent_name: form.name,
+        }
+        .into_response(),
+        Err(_) => axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+#[instrument(name = "web.revoke_agent", skip_all)]
+async fn revoke_agent(State(state): State<Arc<AppState>>, Path(id): Path<uuid::Uuid>) -> Response {
+    let _user_id = match extract_user_id(&axum::http::HeaderMap::new()) {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+
+    let agent_id = AgentId::from(id);
+    match state.agents.revoke(agent_id).await {
+        Ok(agent) => AgentRowTemplate {
+            agent: agent_to_view(&agent),
+        }
+        .into_response(),
+        Err(_) => axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+#[instrument(name = "web.agent_list", skip_all)]
+async fn agent_list(State(state): State<Arc<AppState>>) -> Response {
+    let user_id = match extract_user_id(&axum::http::HeaderMap::new()) {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+
+    let agents = state
+        .agents
+        .list_all_for_user(user_id)
+        .await
+        .unwrap_or_default();
+
+    AgentListTemplate {
+        agents: agents.iter().map(agent_to_view).collect(),
+    }
+    .into_response()
+}

--- a/cli/src/web/templates.rs
+++ b/cli/src/web/templates.rs
@@ -1,0 +1,40 @@
+use askama::Template;
+use askama_web::WebTemplate;
+
+pub struct AgentView {
+    pub id: String,
+    pub name: String,
+    pub scopes: String,
+    pub created_at: String,
+    pub is_revoked: bool,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "login.html")]
+pub struct LoginTemplate;
+
+#[derive(Template, WebTemplate)]
+#[template(path = "dashboard.html")]
+pub struct DashboardTemplate {
+    pub user_name: String,
+    pub agents: Vec<AgentView>,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "agent_created.html")]
+pub struct AgentCreatedTemplate {
+    pub token: String,
+    pub agent_name: String,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "agent_row.html")]
+pub struct AgentRowTemplate {
+    pub agent: AgentView,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "agent_list.html")]
+pub struct AgentListTemplate {
+    pub agents: Vec<AgentView>,
+}

--- a/cli/templates/agent_created.html
+++ b/cli/templates/agent_created.html
@@ -1,0 +1,21 @@
+<article aria-label="Agent token created">
+  <header>
+    <h3>Agent Created Successfully</h3>
+  </header>
+  <p class="token-warning">This token will not be shown again. Copy it now.</p>
+  <div class="token-box">
+    <code id="token-value">{{ token }}</code>
+    <button
+      onclick="navigator.clipboard.writeText(document.getElementById('token-value').textContent).then(function(){this.textContent='Copied!'}.bind(this))"
+      class="outline"
+    >
+      Copy
+    </button>
+  </div>
+  <p>Agent name: <strong>{{ agent_name }}</strong></p>
+</article>
+
+<script>
+  document.querySelector('#agent-list')
+    && htmx.ajax('GET', '/dashboard/agents', {target: '#agent-list', swap: 'innerHTML'});
+</script>

--- a/cli/templates/agent_list.html
+++ b/cli/templates/agent_list.html
@@ -1,0 +1,3 @@
+{% for agent in agents %}
+{% include "agent_row.html" %}
+{% endfor %}

--- a/cli/templates/agent_row.html
+++ b/cli/templates/agent_row.html
@@ -1,0 +1,26 @@
+<tr id="agent-{{ agent.id }}">
+  <td>{{ agent.name }}</td>
+  <td>{{ agent.scopes }}</td>
+  <td>{{ agent.created_at }}</td>
+  <td>
+    {% if agent.is_revoked %}
+    <span class="badge-revoked">Revoked</span>
+    {% else %}
+    <span class="badge-active">Active</span>
+    {% endif %}
+  </td>
+  <td>
+    {% if !agent.is_revoked %}
+    <button
+      hx-post="/agents/{{ agent.id }}/revoke"
+      hx-target="#agent-{{ agent.id }}"
+      hx-swap="outerHTML"
+      hx-confirm="Are you sure you want to revoke this agent?"
+      class="secondary outline"
+      style="padding: 0.25rem 0.5rem; margin: 0;"
+    >
+      Revoke
+    </button>
+    {% endif %}
+  </td>
+</tr>

--- a/cli/templates/base.html
+++ b/cli/templates/base.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{% block title %}Galoy Agents{% endblock %}</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+  <script src="https://unpkg.com/htmx.org@2.0.4"></script>
+  <style>
+    .token-box {
+      position: relative;
+      background: var(--pico-code-background-color);
+      border: 2px solid var(--pico-primary-background);
+      border-radius: var(--pico-border-radius);
+      padding: 1rem;
+      margin: 1rem 0;
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .token-box code {
+      flex: 1;
+      word-break: break-all;
+      background: none;
+      padding: 0;
+    }
+    .token-box button {
+      width: auto;
+      margin: 0;
+      padding: 0.25rem 0.75rem;
+      white-space: nowrap;
+    }
+    .token-warning {
+      color: var(--pico-del-color);
+      font-weight: bold;
+    }
+    .badge-active {
+      color: var(--pico-ins-color);
+    }
+    .badge-revoked {
+      color: var(--pico-del-color);
+    }
+  </style>
+  {% block head %}{% endblock %}
+</head>
+<body>
+  <main class="container">
+    {% block content %}{% endblock %}
+  </main>
+</body>
+</html>

--- a/cli/templates/dashboard.html
+++ b/cli/templates/dashboard.html
@@ -1,0 +1,53 @@
+{% extends "base.html" %}
+
+{% block title %}Dashboard — Galoy Agents{% endblock %}
+
+{% block content %}
+<nav>
+  <ul><li><strong>Galoy Agents</strong></li></ul>
+  <ul>
+    <li>{{ user_name }}</li>
+    <li><a href="/auth/logout">Logout</a></li>
+  </ul>
+</nav>
+
+<section>
+  <h2>Create Agent</h2>
+  <form hx-post="/agents/create" hx-target="#agent-result" hx-swap="innerHTML">
+    <div class="grid">
+      <label>
+        Name
+        <input type="text" name="name" required placeholder="my-agent">
+      </label>
+      <label>
+        Scopes (comma-separated)
+        <input type="text" name="scopes" value="read" placeholder="read,write">
+      </label>
+    </div>
+    <button type="submit">Create Agent</button>
+  </form>
+  <div id="agent-result"></div>
+</section>
+
+<section>
+  <h2>Your Agents</h2>
+  <figure>
+    <table>
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Scopes</th>
+          <th>Created</th>
+          <th>Status</th>
+          <th></th>
+        </tr>
+      </thead>
+      <tbody id="agent-list">
+        {% for agent in agents %}
+        {% include "agent_row.html" %}
+        {% endfor %}
+      </tbody>
+    </table>
+  </figure>
+</section>
+{% endblock %}

--- a/cli/templates/login.html
+++ b/cli/templates/login.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+
+{% block title %}Login — Galoy Agents{% endblock %}
+
+{% block content %}
+<article style="margin-top: 4rem; max-width: 480px; margin-left: auto; margin-right: auto;">
+  <header>
+    <h1>Galoy Agents</h1>
+    <p>Manage your MCP gateway agents</p>
+  </header>
+  <a href="/auth/github" role="button" style="display: block; text-align: center;">
+    Sign in with GitHub
+  </a>
+</article>
+{% endblock %}

--- a/flake.nix
+++ b/flake.nix
@@ -28,6 +28,7 @@
           filter = path: type:
             (builtins.match ".*\.sqlx/.*" path != null) ||
             (builtins.match ".*\.sql$" path != null) ||
+            (builtins.match ".*\.html$" path != null) ||
             craneLib.filterCargoSources path type;
         };
 

--- a/mcp-gateway/src/agent/mod.rs
+++ b/mcp-gateway/src/agent/mod.rs
@@ -96,6 +96,19 @@ impl Agents {
             .await?)
     }
 
+    #[instrument(name = "mcp_gateway.agent.list_all_for_user", skip(self))]
+    pub async fn list_all_for_user(&self, user_id: UserId) -> Result<Vec<Agent>, AgentError> {
+        let query = es_entity::PaginatedQueryArgs {
+            first: 100,
+            after: None,
+        };
+        let result = self
+            .repo
+            .list_for_user_id_by_created_at(user_id, query, es_entity::ListDirection::Descending)
+            .await?;
+        Ok(result.entities)
+    }
+
     #[instrument(name = "mcp_gateway.agent.find_by_id", skip(self))]
     pub async fn find_by_id(
         &self,


### PR DESCRIPTION
## Summary

- Add web interface for managing MCP gateway agents using Askama server-side templates + htmx for dynamic interactions
- Templates: login page, dashboard with agent list/create form, one-time token display with copy button, agent row fragments for htmx swaps
- Axum routes: `GET /`, `GET /dashboard`, `GET /dashboard/agents`, `POST /agents/create`, `POST /agents/{id}/revoke`
- Pico CSS + htmx loaded from CDN (no JS build pipeline)
- SHA-256 token hashing, `Agents::list_all_for_user()` convenience method, flake.nix updated for .html files

## Test plan

- [x] `cargo check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo nextest run` — 4 tests pass
- [x] `nix flake check` passes
- [ ] Manual: run server, verify login page renders at `/`
- [ ] Manual: once OAuth is wired, verify dashboard/create/revoke flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)