### PR TITLE
fix: wire up OAuth, sessions, and auth middleware for POC e2e flow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,6 +1037,7 @@ dependencies = [
  "galoy-agents-web",
  "sqlx",
  "tokio",
+ "tower-sessions",
  "tracing",
  "tracing-subscriber",
 ]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,7 +14,8 @@ galoy-agents-web = { path = "../web" }
 anyhow = "1"
 axum = "0.8"
 clap = { version = "4", features = ["derive", "env"] }
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres"] }
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "migrate"] }
 tokio = { version = "1", features = ["full"] }
+tower-sessions = "0.15"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,4 +1,7 @@
 use clap::Parser;
+use tower_sessions::SessionManagerLayer;
+
+use galoy_agents_web::auth::{config::AuthConfig, session_store::PgSessionStore};
 
 #[derive(Parser)]
 #[command(name = "galoy-agents", about = "Galoy Agents CLI")]
@@ -24,19 +27,34 @@ async fn main() -> anyhow::Result<()> {
     let cli = Cli::parse();
 
     let pool = sqlx::PgPool::connect(&cli.database_url).await?;
+    sqlx::migrate!("../domain/migrations").run(&pool).await?;
 
     let users = galoy_agents_domain::user::Users::new(&pool);
     let agents = galoy_agents_domain::agent::Agents::new(&pool);
 
-    let schema = galoy_agents_graphql::schema(users.clone(), agents.clone());
+    let auth_config = AuthConfig::from_env();
+    let oauth_client = auth_config.oauth_client();
 
-    let app = galoy_agents_web::router(users, agents)
+    let app_state = galoy_agents_web::AppState::new(users.clone(), agents.clone(), oauth_client);
+
+    let schema = galoy_agents_graphql::schema(users, agents);
+
+    let session_store = PgSessionStore::new(&pool);
+    let session_layer = SessionManagerLayer::new(session_store);
+
+    let app = galoy_agents_web::router()
         .route(
             "/graphql",
             axum::routing::get(galoy_agents_graphql::graphql_playground)
                 .post(galoy_agents_graphql::graphql_handler),
         )
-        .layer(axum::Extension(schema));
+        .layer(axum::Extension(schema))
+        .layer(axum::middleware::from_fn(
+            galoy_agents_web::auth::auth_middleware,
+        ))
+        .layer(axum::Extension(app_state.clone()))
+        .layer(session_layer)
+        .with_state(app_state);
 
     let addr = std::net::SocketAddr::from(([0, 0, 0, 0], cli.port));
     tracing::info!("Starting server on {addr}");

--- a/domain/src/agent/error.rs
+++ b/domain/src/agent/error.rs
@@ -16,4 +16,6 @@ pub enum AgentError {
     Query(#[from] AgentQueryError),
     #[error("AgentError - AgentAlreadyRevoked")]
     AgentAlreadyRevoked,
+    #[error("AgentError - AuthorizationError")]
+    AuthorizationError,
 }

--- a/domain/src/agent/mod.rs
+++ b/domain/src/agent/mod.rs
@@ -68,10 +68,15 @@ impl Agents {
     #[instrument(name = "domain.agent.revoke", skip(self))]
     pub async fn revoke(
         &self,
+        user_id: UserId,
         id: impl Into<AgentId> + std::fmt::Debug,
     ) -> Result<Agent, AgentError> {
         let id = id.into();
         let mut agent = self.repo.find_by_id(id).await?;
+
+        if agent.user_id != user_id {
+            return Err(AgentError::AuthorizationError);
+        }
 
         if agent.revoke().did_execute() {
             self.repo.update(&mut agent).await?;

--- a/graphql/src/lib.rs
+++ b/graphql/src/lib.rs
@@ -88,13 +88,7 @@ impl Mutation {
             .into();
 
         let agents = ctx.data::<Agents>()?;
-        let agent = agents.find_by_id(id).await?;
-
-        if agent.user_id != user_id {
-            return Err(async_graphql::Error::new("Agent not found"));
-        }
-
-        let agent = agents.revoke(id).await?;
+        let agent = agents.revoke(user_id, id).await?;
 
         Ok(RevokeAgentPayload {
             agent: AgentType::from(&agent),
@@ -119,10 +113,12 @@ pub fn schema(users: Users, agents: Agents) -> McpGatewaySchema {
 
 pub async fn graphql_handler(
     schema: axum::Extension<McpGatewaySchema>,
+    extensions: axum::extract::Extension<AuthContext>,
     req: async_graphql_axum::GraphQLRequest,
 ) -> async_graphql_axum::GraphQLResponse {
+    let auth_context = extensions.0;
     let mut req = req.into_inner();
-    req = req.data(AuthContext::Anonymous);
+    req = req.data(auth_context);
     schema.execute(req).await.into()
 }
 

--- a/web/src/auth/mod.rs
+++ b/web/src/auth/mod.rs
@@ -3,13 +3,7 @@ pub mod error;
 mod oauth;
 pub mod session_store;
 
-use axum::{
-    extract::{Request, State},
-    middleware::Next,
-    response::Response,
-    routing::get,
-    Router,
-};
+use axum::{extract::Request, middleware::Next, response::Response, routing::get, Router};
 use tower_sessions::Session;
 use tracing::instrument;
 
@@ -18,87 +12,77 @@ pub use error::AuthError;
 
 use galoy_agents_domain as domain;
 
-use domain::agent::Agents;
 use domain::auth::token::hash_token;
 use domain::auth::AuthContext;
-use domain::primitives::*;
-use domain::user::Users;
+use domain::primitives::UserId;
 
-use self::config::OAuthClient;
-
-/// Shared application state for auth routes and middleware.
-#[derive(Clone)]
-pub struct AuthAppState {
-    pub(crate) users: Users,
-    pub(crate) agents: Agents,
-    pub(crate) oauth_client: OAuthClient,
-}
-
-impl AuthAppState {
-    pub fn new(users: Users, agents: Agents, oauth_client: OAuthClient) -> Self {
-        Self {
-            users,
-            agents,
-            oauth_client,
-        }
-    }
-}
+use crate::AppState;
 
 /// Build the router for GitHub OAuth endpoints.
-pub fn auth_router() -> Router<AuthAppState> {
+pub fn auth_router() -> Router<AppState> {
     Router::new()
         .route("/auth/github", get(oauth::github_redirect))
         .route("/auth/github/callback", get(oauth::github_callback))
+        .route("/auth/logout", get(logout))
 }
 
 /// Axum middleware that resolves [`AuthContext`] and inserts it into request extensions.
+///
+/// Extracts headers and session synchronously from the request, then performs
+/// async lookups, to avoid holding `&Request` across `.await` boundaries.
 #[instrument(name = "web.auth.middleware", skip_all)]
-pub async fn auth_middleware(
-    State(state): State<AuthAppState>,
-    session: Session,
-    mut request: Request,
-    next: Next,
-) -> Response {
-    let auth_context = resolve_auth_context(&state, &session, &request).await;
+pub async fn auth_middleware(mut request: Request, next: Next) -> Response {
+    let state = request.extensions().get::<AppState>().cloned();
+    let session = request.extensions().get::<Session>().cloned();
+    let bearer_token = extract_bearer_token(&request);
+
+    let auth_context = resolve_auth_context(state.as_ref(), session.as_ref(), bearer_token).await;
     request.extensions_mut().insert(auth_context);
     next.run(request).await
 }
 
-async fn resolve_auth_context(
-    state: &AuthAppState,
-    session: &Session,
-    request: &Request,
-) -> AuthContext {
-    // 1. Check Authorization: Bearer header
-    if let Some(auth_context) = resolve_bearer_token(state, request).await {
-        return auth_context;
-    }
-
-    // 2. Check session cookie
-    if let Some(auth_context) = resolve_session(session).await {
-        return auth_context;
-    }
-
-    AuthContext::Anonymous
-}
-
-async fn resolve_bearer_token(state: &AuthAppState, request: &Request) -> Option<AuthContext> {
+fn extract_bearer_token(request: &Request) -> Option<String> {
     let header_value = request
         .headers()
         .get(axum::http::header::AUTHORIZATION)?
         .to_str()
         .ok()?;
-
     let raw_token = header_value.strip_prefix("Bearer ")?;
-    let token_hash = hash_token(raw_token);
-
-    match state.agents.find_by_token_hash(&token_hash).await {
-        Ok(Some(agent)) if !agent.is_revoked() => Some(AuthContext::Agent(agent.id, agent.user_id)),
-        _ => None,
-    }
+    Some(raw_token.to_string())
 }
 
-async fn resolve_session(session: &Session) -> Option<AuthContext> {
-    let user_id: UserId = session.get("user_id").await.ok()??;
-    Some(AuthContext::User(user_id))
+async fn resolve_auth_context(
+    state: Option<&AppState>,
+    session: Option<&Session>,
+    bearer_token: Option<String>,
+) -> AuthContext {
+    let state = match state {
+        Some(s) => s,
+        None => return AuthContext::Anonymous,
+    };
+
+    // 1. Check Authorization: Bearer header
+    if let Some(raw_token) = bearer_token {
+        let token_hash = hash_token(&raw_token);
+        if let Ok(Some(agent)) = state.agents.find_by_token_hash(&token_hash).await {
+            if !agent.is_revoked() {
+                return AuthContext::Agent(agent.id, agent.user_id);
+            }
+        }
+    }
+
+    // 2. Check session cookie
+    if let Some(session) = session {
+        if let Ok(Some(user_id)) = session.get::<UserId>("user_id").await {
+            return AuthContext::User(user_id);
+        }
+    }
+
+    AuthContext::Anonymous
+}
+
+#[instrument(name = "web.auth.logout", skip_all)]
+async fn logout(session: Session) -> axum::response::Redirect {
+    let _ = session.flush().await;
+    axum::response::Redirect::to("/")
 }

--- a/web/src/auth/oauth.rs
+++ b/web/src/auth/oauth.rs
@@ -7,7 +7,8 @@ use serde::Deserialize;
 use tower_sessions::Session;
 use tracing::instrument;
 
-use super::{error::AuthError, AuthAppState};
+use super::error::AuthError;
+use crate::AppState;
 
 const CSRF_SESSION_KEY: &str = "oauth_csrf_token";
 
@@ -26,7 +27,7 @@ struct GitHubUser {
 
 #[instrument(name = "web.auth.github_redirect", skip_all)]
 pub async fn github_redirect(
-    State(state): State<AuthAppState>,
+    State(state): State<AppState>,
     session: Session,
 ) -> Result<impl IntoResponse, AuthError> {
     let (auth_url, csrf_token) = state
@@ -45,7 +46,7 @@ pub async fn github_redirect(
 
 #[instrument(name = "web.auth.github_callback", skip_all)]
 pub async fn github_callback(
-    State(state): State<AuthAppState>,
+    State(state): State<AppState>,
     session: Session,
     Query(params): Query<CallbackParams>,
 ) -> Result<impl IntoResponse, AuthError> {

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -2,8 +2,6 @@ pub mod auth;
 mod routes;
 mod templates;
 
-use std::sync::Arc;
-
 use axum::Router;
 
 use galoy_agents_domain as domain;
@@ -11,13 +9,30 @@ use galoy_agents_domain as domain;
 use domain::agent::Agents;
 use domain::user::Users;
 
-pub use routes::AppState;
+use auth::config::OAuthClient;
 
-/// Build the web router with page routes.
+/// Unified application state shared by all routes and middleware.
+#[derive(Clone)]
+pub struct AppState {
+    pub users: Users,
+    pub agents: Agents,
+    pub oauth_client: OAuthClient,
+}
+
+impl AppState {
+    pub fn new(users: Users, agents: Agents, oauth_client: OAuthClient) -> Self {
+        Self {
+            users,
+            agents,
+            oauth_client,
+        }
+    }
+}
+
+/// Build the web router with page routes and auth routes.
 ///
-/// The returned router is not yet merged with auth or graphql routes —
-/// the caller (cli) is responsible for composing routers.
-pub fn router(users: Users, agents: Agents) -> Router {
-    let state = Arc::new(AppState { users, agents });
-    routes::router(state)
+/// The returned router is not yet layered with session or auth middleware —
+/// the caller (cli) is responsible for adding those layers and calling `.with_state()`.
+pub fn router() -> Router<AppState> {
+    routes::router().merge(auth::auth_router())
 }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -1,42 +1,32 @@
-use std::sync::Arc;
-
 use axum::{
     extract::{Path, State},
     response::{IntoResponse, Redirect, Response},
     routing::{get, post},
     Form, Router,
 };
+use tower_sessions::Session;
 use tracing::instrument;
 
 use galoy_agents_domain as domain;
 
-use domain::agent::{Agent, Agents};
+use domain::agent::Agent;
 use domain::auth::token::generate_token;
 use domain::primitives::{AgentId, UserId};
-use domain::user::Users;
 
 use crate::templates::*;
+use crate::AppState;
 
-#[derive(Clone)]
-pub struct AppState {
-    pub users: Users,
-    pub agents: Agents,
-}
-
-pub fn router(state: Arc<AppState>) -> Router {
+pub fn router() -> Router<AppState> {
     Router::new()
         .route("/", get(index))
         .route("/dashboard", get(dashboard))
         .route("/dashboard/agents", get(agent_list))
         .route("/agents/create", post(create_agent))
         .route("/agents/{id}/revoke", post(revoke_agent))
-        .with_state(state)
 }
 
-fn extract_user_id(_headers: &axum::http::HeaderMap) -> Option<UserId> {
-    // TODO: Extract user_id from session cookie once OAuth is implemented.
-    // For now, this is a placeholder that returns None (not authenticated).
-    None
+async fn extract_user_id(session: &Session) -> Option<UserId> {
+    session.get("user_id").await.ok()?
 }
 
 fn agent_to_view(agent: &Agent) -> AgentView {
@@ -50,17 +40,16 @@ fn agent_to_view(agent: &Agent) -> AgentView {
 }
 
 #[instrument(name = "web.index", skip_all)]
-async fn index(State(state): State<Arc<AppState>>) -> Response {
-    let _state = state;
-
-    // TODO: Check session for logged-in user, redirect to dashboard if found.
-    // For now, always show login page.
+async fn index(session: Session) -> Response {
+    if extract_user_id(&session).await.is_some() {
+        return Redirect::to("/dashboard").into_response();
+    }
     LoginTemplate.into_response()
 }
 
 #[instrument(name = "web.dashboard", skip_all)]
-async fn dashboard(State(state): State<Arc<AppState>>) -> Response {
-    let user_id = match extract_user_id(&axum::http::HeaderMap::new()) {
+async fn dashboard(State(state): State<AppState>, session: Session) -> Response {
+    let user_id = match extract_user_id(&session).await {
         Some(id) => id,
         None => return Redirect::to("/").into_response(),
     };
@@ -93,10 +82,11 @@ pub struct CreateAgentForm {
 
 #[instrument(name = "web.create_agent", skip_all)]
 async fn create_agent(
-    State(state): State<Arc<AppState>>,
+    State(state): State<AppState>,
+    session: Session,
     Form(form): Form<CreateAgentForm>,
 ) -> Response {
-    let user_id = match extract_user_id(&axum::http::HeaderMap::new()) {
+    let user_id = match extract_user_id(&session).await {
         Some(id) => id,
         None => return Redirect::to("/").into_response(),
     };
@@ -124,14 +114,18 @@ async fn create_agent(
 }
 
 #[instrument(name = "web.revoke_agent", skip_all)]
-async fn revoke_agent(State(state): State<Arc<AppState>>, Path(id): Path<uuid::Uuid>) -> Response {
-    let _user_id = match extract_user_id(&axum::http::HeaderMap::new()) {
+async fn revoke_agent(
+    State(state): State<AppState>,
+    session: Session,
+    Path(id): Path<uuid::Uuid>,
+) -> Response {
+    let user_id = match extract_user_id(&session).await {
         Some(id) => id,
         None => return Redirect::to("/").into_response(),
     };
 
     let agent_id = AgentId::from(id);
-    match state.agents.revoke(agent_id).await {
+    match state.agents.revoke(user_id, agent_id).await {
         Ok(agent) => AgentRowTemplate {
             agent: agent_to_view(&agent),
         }
@@ -141,8 +135,8 @@ async fn revoke_agent(State(state): State<Arc<AppState>>, Path(id): Path<uuid::U
 }
 
 #[instrument(name = "web.agent_list", skip_all)]
-async fn agent_list(State(state): State<Arc<AppState>>) -> Response {
-    let user_id = match extract_user_id(&axum::http::HeaderMap::new()) {
+async fn agent_list(State(state): State<AppState>, session: Session) -> Response {
+    let user_id = match extract_user_id(&session).await {
         Some(id) => id,
         None => return Redirect::to("/").into_response(),
     };


### PR DESCRIPTION
## Summary
- Fixes 7 blocking integration gaps to make the POC end-to-end flow work: GitHub OAuth login → create agent → get bearer token
- Unifies `AppState` and `AuthAppState` into a single shared state type
- Wires up `PgSessionStore`, `SessionManagerLayer`, and auth middleware in the composition root (`cli/main.rs`)
- Fixes `extract_user_id()` to actually read from the session instead of always returning `None`
- Fixes GraphQL handler to inject real `AuthContext` from request extensions
- Adds `/auth/logout` route and ownership check to `revoke_agent`
- Runs database migrations at startup

## Test plan
- [x] All 8 existing unit tests pass (`cargo nextest run`)
- [x] `nix flake check` passes (fmt + clippy + nextest)
- [ ] Manual: start server with `DATABASE_URL` and GitHub OAuth env vars, verify OAuth login flow
- [ ] Manual: create agent via dashboard, verify token is returned
- [ ] Manual: use bearer token against `/graphql` endpoint, verify authenticated queries work
- [ ] Manual: revoke agent owned by another user returns authorization error

🤖 Generated with [Claude Code](https://claude.com/claude-code)