### PR TITLE
feat(infra): add GCP infrastructure boilerplate

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -68,6 +68,7 @@
             pkgs.cargo-nextest
             pkgs.pkg-config
             pkgs.docker-compose
+            pkgs.opentofu
           ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
             pkgs.libiconv
           ];

--- a/infra/Makefile
+++ b/infra/Makefile
@@ -1,0 +1,15 @@
+TF := tofu
+
+bootstrap:
+	cd bootstrap && $(TF) init && $(TF) apply
+
+inception:
+	cd inception && $(TF) init && $(TF) apply
+
+platform:
+	cd platform && $(TF) init && $(TF) apply
+
+fmt:
+	$(TF) fmt -recursive
+
+.PHONY: bootstrap inception platform fmt

--- a/infra/README.md
+++ b/infra/README.md
@@ -1,0 +1,65 @@
+# Infrastructure
+
+GCP infrastructure for galoy-agents, using [galoy-infra](https://github.com/GaloyMoney/galoy-infra) modules.
+
+## Phases
+
+Infrastructure is rolled out in order. Each phase depends on outputs from the previous one.
+
+### 1. Bootstrap
+
+Sets up foundational GCP resources:
+- Enables required GCP APIs
+- Creates the Terraform state GCS bucket
+- Creates the inception service account
+
+```bash
+cd bootstrap
+tofu init    # First run: use -backend=false, then configure backend after bucket exists
+tofu apply
+```
+
+> **Note**: On first run the state bucket doesn't exist yet. Run with
+> `-backend-config="prefix=galoy-agents/bootstrap"` using a local backend first,
+> then migrate state to GCS after the bucket is created.
+
+### 2. Inception
+
+Sets up networking and compute:
+- VPC and subnets
+- Bastion host
+- GKE node service account
+- Backup buckets
+
+```bash
+cd inception
+tofu init
+tofu apply -var="inception_sa=<email from bootstrap output>"
+```
+
+### 3. Platform
+
+Sets up the GKE cluster and platform resources:
+
+```bash
+cd platform
+tofu init
+tofu apply -var="node_service_account=<email from inception output>"
+```
+
+## Makefile
+
+From the `infra/` directory:
+
+```bash
+make bootstrap   # Phase 1
+make inception   # Phase 2
+make platform    # Phase 3
+make fmt         # Format all .tf files
+```
+
+## Module Source
+
+All modules reference [galoy-infra](https://github.com/GaloyMoney/galoy-infra) at
+commit `29a90ad` via git source URLs. To upgrade, update the `?ref=` parameter in
+each `main.tf`.

--- a/infra/bootstrap/main.tf
+++ b/infra/bootstrap/main.tf
@@ -1,0 +1,9 @@
+module "bootstrap" {
+  source = "git::https://github.com/GaloyMoney/galoy-infra.git//modules/bootstrap/gcp?ref=29a90ad"
+
+  name_prefix                   = var.name_prefix
+  gcp_project                   = var.gcp_project
+  enable_services               = var.enable_services
+  tf_state_bucket_force_destroy = var.tf_state_bucket_force_destroy
+  tf_state_bucket_location      = var.tf_state_bucket_location
+}

--- a/infra/bootstrap/outputs.tf
+++ b/infra/bootstrap/outputs.tf
@@ -1,0 +1,14 @@
+output "inception_sa" {
+  description = "Service account email for the inception phase"
+  value       = module.bootstrap.inception_sa
+}
+
+output "tf_state_bucket_name" {
+  description = "Name of the GCS bucket storing Terraform state"
+  value       = module.bootstrap.tf_state_bucket_name
+}
+
+output "tf_state_bucket_location" {
+  description = "Location of the Terraform state bucket"
+  value       = module.bootstrap.tf_state_bucket_location
+}

--- a/infra/bootstrap/terraform.tf
+++ b/infra/bootstrap/terraform.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "galoy-agents-tf-state"
+    prefix = "galoy-agents/bootstrap"
+  }
+}

--- a/infra/bootstrap/variables.tf
+++ b/infra/bootstrap/variables.tf
@@ -1,0 +1,24 @@
+variable "gcp_project" {
+  description = "GCP project ID"
+  default     = "galoy-agents"
+}
+
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  default     = "galoy-agents"
+}
+
+variable "tf_state_bucket_location" {
+  description = "Location for the Terraform state bucket"
+  default     = "US-EAST1"
+}
+
+variable "tf_state_bucket_force_destroy" {
+  description = "Allow force-destroying the state bucket"
+  default     = false
+}
+
+variable "enable_services" {
+  description = "Enable required GCP APIs"
+  default     = true
+}

--- a/infra/inception/main.tf
+++ b/infra/inception/main.tf
@@ -1,0 +1,12 @@
+module "inception" {
+  source = "git::https://github.com/GaloyMoney/galoy-infra.git//modules/inception/gcp?ref=29a90ad"
+
+  name_prefix             = var.name_prefix
+  gcp_project             = var.gcp_project
+  inception_sa            = var.inception_sa
+  tf_state_bucket_name    = var.tf_state_bucket_name
+  buckets_location        = var.buckets_location
+  backups_bucket_location = var.backups_bucket_location
+  cluster_zone            = var.cluster_zone
+  users                   = var.users
+}

--- a/infra/inception/outputs.tf
+++ b/infra/inception/outputs.tf
@@ -1,0 +1,24 @@
+output "bastion_name" {
+  description = "Name of the bastion host instance"
+  value       = module.inception.bastion_name
+}
+
+output "bastion_zone" {
+  description = "Zone of the bastion host instance"
+  value       = module.inception.bastion_zone
+}
+
+output "cluster_sa" {
+  description = "Service account for GKE cluster nodes"
+  value       = module.inception.cluster_sa
+}
+
+output "backups_bucket_name" {
+  description = "Name of the backups GCS bucket"
+  value       = module.inception.backups_bucket_name
+}
+
+output "backups_sa" {
+  description = "Service account for backups bucket access"
+  value       = module.inception.backups_sa
+}

--- a/infra/inception/terraform.tf
+++ b/infra/inception/terraform.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "galoy-agents-tf-state"
+    prefix = "galoy-agents/inception"
+  }
+}

--- a/infra/inception/variables.tf
+++ b/infra/inception/variables.tf
@@ -1,0 +1,46 @@
+variable "gcp_project" {
+  description = "GCP project ID"
+  default     = "galoy-agents"
+}
+
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  default     = "galoy-agents"
+}
+
+variable "inception_sa" {
+  description = "Service account email from bootstrap phase"
+  type        = string
+}
+
+variable "tf_state_bucket_name" {
+  description = "Name of the GCS bucket storing Terraform state"
+  default     = "galoy-agents-tf-state"
+}
+
+variable "buckets_location" {
+  description = "Location for GCS buckets"
+  default     = "US-EAST1"
+}
+
+variable "backups_bucket_location" {
+  description = "Location for the backups bucket"
+  default     = "US-EAST1"
+}
+
+variable "cluster_zone" {
+  description = "GKE cluster zone suffix (e.g. 'b' for us-east1-b)"
+  default     = "b"
+}
+
+variable "users" {
+  description = "List of users with role-based access flags"
+  type = list(object({
+    id        = string
+    bastion   = bool
+    inception = bool
+    platform  = bool
+    logs      = bool
+  }))
+  default = []
+}

--- a/infra/platform/main.tf
+++ b/infra/platform/main.tf
@@ -1,0 +1,11 @@
+module "platform" {
+  source = "git::https://github.com/GaloyMoney/galoy-infra.git//modules/platform/gcp?ref=29a90ad"
+
+  name_prefix               = var.name_prefix
+  gcp_project               = var.gcp_project
+  node_service_account      = var.node_service_account
+  node_default_machine_type = var.node_default_machine_type
+  min_default_node_count    = var.min_default_node_count
+  max_default_node_count    = var.max_default_node_count
+  cluster_zone              = var.cluster_zone
+}

--- a/infra/platform/outputs.tf
+++ b/infra/platform/outputs.tf
@@ -1,0 +1,20 @@
+output "cluster_ca_cert" {
+  description = "GKE cluster CA certificate"
+  value       = module.platform.cluster_ca_cert
+  sensitive   = true
+}
+
+output "master_endpoint" {
+  description = "GKE cluster master endpoint URL"
+  value       = module.platform.master_endpoint
+}
+
+output "cluster_name" {
+  description = "GKE cluster name"
+  value       = module.platform.cluster_name
+}
+
+output "cluster_location" {
+  description = "GKE cluster location"
+  value       = module.platform.cluster_location
+}

--- a/infra/platform/terraform.tf
+++ b/infra/platform/terraform.tf
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "galoy-agents-tf-state"
+    prefix = "galoy-agents/platform"
+  }
+}

--- a/infra/platform/variables.tf
+++ b/infra/platform/variables.tf
@@ -1,0 +1,34 @@
+variable "gcp_project" {
+  description = "GCP project ID"
+  default     = "galoy-agents"
+}
+
+variable "name_prefix" {
+  description = "Prefix for all resource names"
+  default     = "galoy-agents"
+}
+
+variable "node_service_account" {
+  description = "Service account email for GKE cluster nodes (from inception output)"
+  type        = string
+}
+
+variable "cluster_zone" {
+  description = "GKE cluster zone suffix (e.g. 'b' for us-east1-b)"
+  default     = "b"
+}
+
+variable "node_default_machine_type" {
+  description = "Machine type for default GKE node pool"
+  default     = "e2-standard-2"
+}
+
+variable "min_default_node_count" {
+  description = "Minimum number of nodes in the default pool"
+  default     = 1
+}
+
+variable "max_default_node_count" {
+  description = "Maximum number of nodes in the default pool"
+  default     = 3
+}


### PR DESCRIPTION
## Summary
- Adds three-phase GCP infrastructure wrapping [galoy-infra](https://github.com/GaloyMoney/galoy-infra) modules (bootstrap → inception → platform)
- Each phase has `main.tf`, `variables.tf`, `outputs.tf`, `terraform.tf` with sensible defaults for a `galoy-agents` GCP project
- Adds OpenTofu (`tofu`) to the nix dev shell
- Includes Makefile and README documenting rollout order

## Test plan
- [ ] Verify `nix develop -c tofu --version` works
- [ ] Review terraform files reference correct galoy-infra modules
- [ ] Validate variable defaults match project naming conventions
- [ ] Dry-run `tofu init` + `tofu plan` in each phase (requires GCP credentials)

🤖 Generated with [Claude Code](https://claude.com/claude-code)