### PR TITLE
feat(auth): add GitHub team whitelisting for OAuth login

### DIFF
--- a/charts/galoy-agents/templates/deployment.yaml
+++ b/charts/galoy-agents/templates/deployment.yaml
@@ -93,6 +93,10 @@ spec:
             secretKeyRef:
               name: {{ template "galoyAgents.fullname" . }}
               key: "github-redirect-uri"
+        {{- if .Values.galoyAgents.githubAllowedTeams }}
+        - name: GITHUB_ALLOWED_TEAMS
+          value: {{ .Values.galoyAgents.githubAllowedTeams | join "," | quote }}
+        {{- end }}
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:

--- a/charts/galoy-agents/values.yaml
+++ b/charts/galoy-agents/values.yaml
@@ -17,6 +17,7 @@ galoyAgents:
     tag: edge
   replicas: 1
   annotations:
+  githubAllowedTeams: []
   secrets:
     create: true
     pgCon: ""

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -64,6 +64,8 @@ pub struct OAuthConfig {
     pub github_client_id: String,
     #[serde(skip)]
     pub github_client_secret: String,
+    #[serde(default)]
+    pub github_allowed_teams: Vec<String>,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -77,6 +79,7 @@ pub struct EnvSecrets {
     pub pg_con: String,
     pub github_client_id: String,
     pub github_client_secret: String,
+    pub github_allowed_teams: Vec<String>,
 }
 
 impl Config {
@@ -95,6 +98,9 @@ impl Config {
         config.db.pg_con = secrets.pg_con;
         config.oauth.github_client_id = secrets.github_client_id;
         config.oauth.github_client_secret = secrets.github_client_secret;
+        if !secrets.github_allowed_teams.is_empty() {
+            config.oauth.github_allowed_teams = secrets.github_allowed_teams;
+        }
 
         Ok(config)
     }
@@ -104,6 +110,7 @@ impl Config {
             github_client_id: self.oauth.github_client_id.clone(),
             github_client_secret: self.oauth.github_client_secret.clone(),
             github_redirect_uri: self.oauth.github_redirect_uri.clone(),
+            github_allowed_teams: self.oauth.github_allowed_teams.clone(),
         }
     }
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -22,6 +22,11 @@ struct Cli {
     /// GitHub OAuth client secret
     #[arg(long, env = "GITHUB_CLIENT_SECRET")]
     github_client_secret: String,
+
+    /// Comma-separated list of allowed GitHub teams (org/team-slug format).
+    /// If empty, all GitHub users can log in.
+    #[arg(long, env = "GITHUB_ALLOWED_TEAMS", default_value = "")]
+    github_allowed_teams: String,
 }
 
 #[tokio::main]
@@ -35,12 +40,21 @@ async fn main() -> anyhow::Result<()> {
 
     let cli = Cli::parse();
 
+    let allowed_teams: Vec<String> = cli
+        .github_allowed_teams
+        .split(',')
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect();
+
     let config = Config::try_new(
         &cli.config,
         EnvSecrets {
             pg_con: cli.pg_con,
             github_client_id: cli.github_client_id,
             github_client_secret: cli.github_client_secret,
+            github_allowed_teams: allowed_teams,
         },
     )?;
 
@@ -48,8 +62,14 @@ async fn main() -> anyhow::Result<()> {
     sqlx::migrate!("../domain/migrations").run(&pool).await?;
 
     let app = galoy_agents_domain::App::new(&pool);
-    let oauth_client = config.auth_config().oauth_client();
-    let app_state = galoy_agents_web::AppState::new(app, oauth_client, config.server.mcp_endpoint);
+    let auth_config = config.auth_config();
+    let oauth_client = auth_config.oauth_client();
+    let app_state = galoy_agents_web::AppState::new(
+        app,
+        oauth_client,
+        config.server.mcp_endpoint,
+        auth_config.github_allowed_teams,
+    );
 
     galoy_agents_web::server::run(
         galoy_agents_web::server::ServerConfig {

--- a/galoy-agents.yml
+++ b/galoy-agents.yml
@@ -5,3 +5,4 @@ server:
   mcp_endpoint: "http://localhost:4200/mcp"
 oauth:
   github_redirect_uri: "http://localhost:4200/auth/github/callback"
+  github_allowed_teams: []

--- a/style-agent/crates/cli/src/commands/build_index.rs
+++ b/style-agent/crates/cli/src/commands/build_index.rs
@@ -23,9 +23,7 @@ pub async fn run(config: &Config, repos_dir_arg: &str) -> anyhow::Result<()> {
     // Discover repo subdirectories (follow symlinks, skip hidden dirs)
     let mut repo_dirs: Vec<_> = std::fs::read_dir(repos_dir)?
         .filter_map(|e| e.ok())
-        .filter(|e| {
-            e.path().is_dir() && !e.file_name().to_string_lossy().starts_with('.')
-        })
+        .filter(|e| e.path().is_dir() && !e.file_name().to_string_lossy().starts_with('.'))
         .collect();
     repo_dirs.sort_by_key(|e| e.file_name());
 
@@ -89,10 +87,7 @@ pub async fn run(config: &Config, repos_dir_arg: &str) -> anyhow::Result<()> {
     }
 
     println!("\n=== Build-index complete ===");
-    println!(
-        "Repos: {} | Total chunks: {total_chunks}",
-        repo_dirs.len()
-    );
+    println!("Repos: {} | Total chunks: {total_chunks}", repo_dirs.len());
     println!("Database: {}", db_path.display());
 
     Ok(())

--- a/style-agent/crates/cli/src/main.rs
+++ b/style-agent/crates/cli/src/main.rs
@@ -112,9 +112,7 @@ async fn main() -> anyhow::Result<()> {
     match cli.command {
         Command::Up => commands::up::run(&config).await,
         Command::Bootstrap => commands::bootstrap::run(&config).await,
-        Command::BuildIndex { repos_dir } => {
-            commands::build_index::run(&config, &repos_dir).await
-        }
+        Command::BuildIndex { repos_dir } => commands::build_index::run(&config, &repos_dir).await,
         Command::Reindex { repo_name } => {
             commands::reindex::run(&config, repo_name.as_deref()).await
         }

--- a/web/src/auth/config.rs
+++ b/web/src/auth/config.rs
@@ -29,6 +29,7 @@ pub struct AuthConfig {
     pub github_client_id: String,
     pub github_client_secret: String,
     pub github_redirect_uri: String,
+    pub github_allowed_teams: Vec<String>,
 }
 
 impl AuthConfig {

--- a/web/src/auth/error.rs
+++ b/web/src/auth/error.rs
@@ -15,6 +15,8 @@ pub enum AuthError {
     OAuth(String),
     #[error("AuthError - CsrfMismatch")]
     CsrfMismatch,
+    #[error("AuthError - TeamNotAuthorized")]
+    TeamNotAuthorized,
     #[error("AuthError - Session: {0}")]
     Session(#[from] tower_sessions::session::Error),
     #[error("AuthError - GitHubApi: {0}")]
@@ -24,10 +26,19 @@ pub enum AuthError {
 impl axum::response::IntoResponse for AuthError {
     fn into_response(self) -> axum::response::Response {
         tracing::error!(%self, "auth error");
-        let status = match &self {
-            AuthError::CsrfMismatch => axum::http::StatusCode::FORBIDDEN,
-            _ => axum::http::StatusCode::INTERNAL_SERVER_ERROR,
-        };
-        (status, self.to_string()).into_response()
+        match &self {
+            AuthError::TeamNotAuthorized => axum::response::Redirect::to(
+                "/?error=Your+GitHub+account+is+not+in+an+authorized+team",
+            )
+            .into_response(),
+            AuthError::CsrfMismatch => {
+                (axum::http::StatusCode::FORBIDDEN, self.to_string()).into_response()
+            }
+            _ => (
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+                self.to_string(),
+            )
+                .into_response(),
+        }
     }
 }

--- a/web/src/auth/oauth.rs
+++ b/web/src/auth/oauth.rs
@@ -26,6 +26,17 @@ struct GitHubUser {
     name: Option<String>,
 }
 
+#[derive(Debug, Deserialize)]
+struct GitHubTeam {
+    slug: String,
+    organization: GitHubOrganization,
+}
+
+#[derive(Debug, Deserialize)]
+struct GitHubOrganization {
+    login: String,
+}
+
 #[instrument(name = "web.auth.github_redirect", skip_all)]
 pub async fn github_redirect(
     State(state): State<AppState>,
@@ -36,6 +47,7 @@ pub async fn github_redirect(
         .authorize_url(CsrfToken::new_random)
         .add_scope(Scope::new("read:user".to_string()))
         .add_scope(Scope::new("user:email".to_string()))
+        .add_scope(Scope::new("read:org".to_string()))
         .url();
 
     let cookie = Cookie::build((CSRF_COOKIE_NAME, csrf_token.secret().clone()))
@@ -69,7 +81,26 @@ pub async fn github_callback(
         .await
         .map_err(|e| AuthError::OAuth(e.to_string()))?;
 
-    let github_user = fetch_github_user(token_result.access_token().secret()).await?;
+    let access_token = token_result.access_token().secret();
+    let github_user = fetch_github_user(access_token).await?;
+
+    if !state.github_allowed_teams.is_empty() {
+        let user_teams = fetch_github_teams(access_token).await?;
+        let is_member = user_teams.iter().any(|team| {
+            let full_slug = format!("{}/{}", team.organization.login, team.slug);
+            state
+                .github_allowed_teams
+                .iter()
+                .any(|allowed| allowed.eq_ignore_ascii_case(&full_slug))
+        });
+        if !is_member {
+            tracing::warn!(
+                github_id = github_user.id,
+                "user not in any allowed GitHub team"
+            );
+            return Err(AuthError::TeamNotAuthorized);
+        }
+    }
 
     let github_id_str = github_user.id.to_string();
     let user = match state.app.users().find_by_github_id(&github_id_str).await? {
@@ -103,5 +134,19 @@ async fn fetch_github_user(access_token: &str) -> Result<GitHubUser, reqwest::Er
         .await?
         .error_for_status()?
         .json::<GitHubUser>()
+        .await
+}
+
+async fn fetch_github_teams(access_token: &str) -> Result<Vec<GitHubTeam>, reqwest::Error> {
+    reqwest::Client::new()
+        .get("https://api.github.com/user/teams")
+        .header("Authorization", format!("Bearer {access_token}"))
+        .header("User-Agent", "galoy-agents")
+        .header("Accept", "application/vnd.github+json")
+        .query(&[("per_page", "100")])
+        .send()
+        .await?
+        .error_for_status()?
+        .json::<Vec<GitHubTeam>>()
         .await
 }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -17,14 +17,21 @@ pub struct AppState {
     pub app: App,
     pub oauth_client: OAuthClient,
     pub mcp_endpoint: String,
+    pub github_allowed_teams: Vec<String>,
 }
 
 impl AppState {
-    pub fn new(app: App, oauth_client: OAuthClient, mcp_endpoint: String) -> Self {
+    pub fn new(
+        app: App,
+        oauth_client: OAuthClient,
+        mcp_endpoint: String,
+        github_allowed_teams: Vec<String>,
+    ) -> Self {
         Self {
             app,
             oauth_client,
             mcp_endpoint,
+            github_allowed_teams,
         }
     }
 }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -1,9 +1,10 @@
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     response::{IntoResponse, Redirect, Response},
     routing::{get, post},
     Form, Router,
 };
+use serde::Deserialize;
 use tower_sessions::Session;
 use tracing::instrument;
 
@@ -15,6 +16,11 @@ use domain::primitives::{AgentId, UserId};
 
 use crate::templates::*;
 use crate::AppState;
+
+#[derive(Debug, Deserialize, Default)]
+pub struct IndexParams {
+    pub error: Option<String>,
+}
 
 pub fn router() -> Router<AppState> {
     Router::new()
@@ -39,11 +45,14 @@ fn agent_to_view(agent: &Agent) -> AgentView {
 }
 
 #[instrument(name = "web.index", skip_all)]
-async fn index(session: Session) -> Response {
+async fn index(session: Session, Query(params): Query<IndexParams>) -> Response {
     if extract_user_id(&session).await.is_some() {
         return Redirect::to("/dashboard").into_response();
     }
-    LoginTemplate.into_response()
+    LoginTemplate {
+        error: params.error,
+    }
+    .into_response()
 }
 
 #[instrument(name = "web.dashboard", skip_all)]

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -10,7 +10,9 @@ pub struct AgentView {
 
 #[derive(Template, WebTemplate)]
 #[template(path = "login.html")]
-pub struct LoginTemplate;
+pub struct LoginTemplate {
+    pub error: Option<String>,
+}
 
 #[derive(Template, WebTemplate)]
 #[template(path = "dashboard.html")]

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -8,6 +8,11 @@
     <h1>Galoy Agents</h1>
     <p>Manage your MCP gateway agents</p>
   </header>
+  {% if let Some(msg) = error %}
+  <div role="alert" style="padding: 1rem; margin-bottom: 1rem; background: var(--pico-del-color, #c62828); color: white; border-radius: 4px;">
+    {{ msg }}
+  </div>
+  {% endif %}
   <a href="/auth/github" role="button" style="display: block; text-align: center;">
     Sign in with GitHub
   </a>


### PR DESCRIPTION
## Summary
- Adds GitHub team membership check during OAuth login callback — only users in configured teams can log in
- New `github_allowed_teams` config (YAML list or `GITHUB_ALLOWED_TEAMS` comma-separated env var); empty = allow all (backwards compatible)
- Requests `read:org` OAuth scope so the token can call GitHub's `/user/teams` API
- Rejected users see a clear error message on the login page instead of a generic 401

## Changes
- **cli/src/config.rs** — `github_allowed_teams: Vec<String>` on `OAuthConfig`/`EnvSecrets`, propagated to `AuthConfig`
- **cli/src/main.rs** — New `--github-allowed-teams` / `GITHUB_ALLOWED_TEAMS` CLI arg, parsed as comma-separated list
- **web/src/auth/config.rs** — `github_allowed_teams` field on `AuthConfig`
- **web/src/auth/oauth.rs** — `read:org` scope added; `fetch_github_teams()` + membership check before user creation
- **web/src/auth/error.rs** — `TeamNotAuthorized` variant that redirects to `/?error=...`
- **web/src/lib.rs** — `github_allowed_teams` in `AppState`
- **web/src/routes.rs** — `IndexParams` query struct to display error messages on login page
- **web/src/templates.rs** + **web/templates/login.html** — Error banner on login page
- **charts/** — `githubAllowedTeams` Helm value + deployment env var
- **galoy-agents.yml** — Example config with empty default

## Test plan
- [ ] Deploy with `GITHUB_ALLOWED_TEAMS=""` — all users can log in (no regression)
- [ ] Deploy with `GITHUB_ALLOWED_TEAMS="MyOrg/my-team"` — only team members can log in
- [ ] Non-member sees "Your GitHub account is not in an authorized team" on login page
- [ ] Non-member does NOT get a User entity created or a session set
- [ ] Verify `read:org` scope appears in the GitHub OAuth consent screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)