### PR TITLE
feat(cli): wire style-agent MCP server into galoy-agents binary

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1223,12 +1223,15 @@ name = "galoy-agents-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "axum",
  "clap",
  "galoy-agents-domain",
  "galoy-agents-web",
  "serde",
  "serde_yaml",
  "sqlx",
+ "style-agent-core",
+ "style-agent-server",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/charts/galoy-agents/templates/deployment.yaml
+++ b/charts/galoy-agents/templates/deployment.yaml
@@ -106,6 +106,12 @@ spec:
         - name: GITHUB_ALLOWED_TEAMS
           value: {{ .Values.galoyAgents.githubAllowedTeams | join "," | quote }}
         {{- end }}
+        {{- if .Values.galoyAgents.styleAgent.indexHash }}
+        - name: STYLE_AGENT_ENABLED
+          value: "true"
+        - name: STYLE_AGENT_DB_PATH
+          value: "/data/style-agent/style-agent.db"
+        {{- end }}
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -10,7 +10,10 @@ path = "src/main.rs"
 [dependencies]
 galoy-agents-domain = { path = "../domain" }
 galoy-agents-web = { path = "../web" }
+style-agent-core = { workspace = true }
+style-agent-server = { workspace = true }
 anyhow = "1"
+axum = { workspace = true }
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -13,6 +13,8 @@ pub struct Config {
     pub oauth: OAuthConfig,
     #[serde(default)]
     pub db: DbConfig,
+    #[serde(default)]
+    pub style_agent: StyleAgentConfig,
 }
 
 #[derive(Clone, Deserialize)]
@@ -75,6 +77,19 @@ pub struct DbConfig {
     pub pg_con: String,
 }
 
+#[derive(Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct StyleAgentConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    #[serde(default = "default_style_agent_db_path")]
+    pub db_path: String,
+}
+
+fn default_style_agent_db_path() -> String {
+    "/data/style-agent/style-agent.db".to_string()
+}
+
 pub struct EnvSecrets {
     pub pg_con: String,
     pub github_client_id: String,
@@ -100,6 +115,14 @@ impl Config {
         config.oauth.github_client_secret = secrets.github_client_secret;
         if !secrets.github_allowed_teams.is_empty() {
             config.oauth.github_allowed_teams = secrets.github_allowed_teams;
+        }
+
+        // Style-agent env overrides
+        if let Ok(val) = std::env::var("STYLE_AGENT_ENABLED") {
+            config.style_agent.enabled = val == "true" || val == "1";
+        }
+        if let Ok(val) = std::env::var("STYLE_AGENT_DB_PATH") {
+            config.style_agent.db_path = val;
         }
 
         Ok(config)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,7 @@
 mod config;
 
+use std::sync::Arc;
+
 use clap::Parser;
 
 use config::{Config, EnvSecrets};
@@ -67,18 +69,51 @@ async fn main() -> anyhow::Result<()> {
     let app_state = galoy_agents_web::AppState::new(
         app,
         oauth_client,
-        config.server.mcp_endpoint,
+        config.server.mcp_endpoint.clone(),
         auth_config.github_allowed_teams,
     );
 
-    galoy_agents_web::server::run(
-        galoy_agents_web::server::ServerConfig {
-            host: config.server.host,
-            port: config.server.port,
-            secure_cookies: config.server.secure_cookies,
-        },
-        &pool,
-        app_state,
-    )
-    .await
+    let server_config = galoy_agents_web::server::ServerConfig {
+        host: config.server.host.clone(),
+        port: config.server.port,
+        secure_cookies: config.server.secure_cookies,
+    };
+
+    let mut router = galoy_agents_web::server::build_app(&server_config, &pool, app_state);
+
+    if config.style_agent.enabled {
+        let style_agent_router = init_style_agent(&config.style_agent)?;
+        router = router.nest("/style-agent", style_agent_router);
+    }
+
+    let addr: std::net::SocketAddr =
+        format!("{}:{}", config.server.host, config.server.port).parse()?;
+    tracing::info!("Starting server on {addr}");
+
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, router).await?;
+
+    Ok(())
+}
+
+/// Initialise the style-agent search engine and return its axum router.
+fn init_style_agent(config: &config::StyleAgentConfig) -> anyhow::Result<axum::Router> {
+    use std::path::Path;
+    use style_agent_core::embedder::Embedder;
+    use style_agent_core::search::SearchEngine;
+    use style_agent_core::store::VectorStore;
+
+    tracing::info!(db_path = %config.db_path, "Initialising style-agent");
+
+    let store = VectorStore::new(Path::new(&config.db_path))?;
+    store.ensure_collection()?;
+    store.ensure_anti_pattern_tables()?;
+
+    let embedder = Embedder::new()?;
+    let search_engine = Arc::new(SearchEngine::new(embedder, store));
+
+    let router = style_agent_server::router(search_engine);
+
+    tracing::info!("Style-agent mounted at /style-agent/mcp");
+    Ok(router)
 }

--- a/galoy-agents.yml
+++ b/galoy-agents.yml
@@ -6,3 +6,6 @@ server:
 oauth:
   github_redirect_uri: "http://localhost:4200/auth/github/callback"
   github_allowed_teams: []
+style_agent:
+  enabled: false
+  db_path: "/data/style-agent/style-agent.db"

--- a/style-agent/crates/server/src/lib.rs
+++ b/style-agent/crates/server/src/lib.rs
@@ -560,6 +560,41 @@ async fn stats_handler(
     }
 }
 
+/// Handler for `GET /health` — simple liveness check.
+async fn health_handler() -> &'static str {
+    "ok"
+}
+
+/// Build the style-agent axum [`Router`] with `/mcp`, `/stats`, and `/health` routes.
+///
+/// Use this to embed style-agent routes in an existing axum server via
+/// [`axum::Router::nest`]. For a standalone server, use [`run_server`].
+pub fn router(search_engine: Arc<SearchEngine>) -> axum::Router {
+    use rmcp::transport::streamable_http_server::{
+        session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
+    };
+
+    let config = StreamableHttpServerConfig {
+        stateful_mode: false,
+        json_response: true,
+        ..Default::default()
+    };
+
+    let stats_engine = Arc::clone(&search_engine);
+
+    let service = StreamableHttpService::new(
+        move || Ok(StyleAgentServer::new(Arc::clone(&search_engine))),
+        LocalSessionManager::default().into(),
+        config,
+    );
+
+    axum::Router::new()
+        .route("/health", axum::routing::get(health_handler))
+        .route("/stats", axum::routing::get(stats_handler))
+        .with_state(stats_engine)
+        .nest_service("/mcp", service)
+}
+
 /// Start the HTTP MCP server from a `CoreConfig` and block until shutdown.
 pub async fn run_server_with_config(
     config: &style_agent_core::CoreConfig,
@@ -579,34 +614,13 @@ pub async fn run_server_with_config(
 
 /// Start the HTTP MCP server and block until shutdown.
 pub async fn run_server(search_engine: Arc<SearchEngine>, bind_addr: &str) -> anyhow::Result<()> {
-    use rmcp::transport::streamable_http_server::{
-        session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
-    };
-
-    let config = StreamableHttpServerConfig {
-        stateful_mode: false,
-        json_response: true,
-        ..Default::default()
-    };
-
-    let stats_engine = Arc::clone(&search_engine);
-
-    let service = StreamableHttpService::new(
-        move || Ok(StyleAgentServer::new(Arc::clone(&search_engine))),
-        LocalSessionManager::default().into(),
-        config,
-    );
-
-    let router = axum::Router::new()
-        .route("/stats", axum::routing::get(stats_handler))
-        .with_state(stats_engine)
-        .nest_service("/mcp", service);
+    let app = router(search_engine);
     let listener = tokio::net::TcpListener::bind(bind_addr).await?;
     let url = format!("http://{bind_addr}/mcp");
 
     tracing::info!(%url, "Style Agent MCP server listening");
     println!("Style Agent MCP server listening at {url}");
 
-    axum::serve(listener, router).await?;
+    axum::serve(listener, app).await?;
     Ok(())
 }

--- a/web/src/server.rs
+++ b/web/src/server.rs
@@ -12,12 +12,12 @@ pub struct ServerConfig {
     pub secure_cookies: bool,
 }
 
-#[instrument(name = "web.server.run", skip_all, fields(addr))]
-pub async fn run(
-    config: ServerConfig,
-    pool: &sqlx::PgPool,
-    app_state: AppState,
-) -> anyhow::Result<()> {
+/// Build the axum [`Router`] with all web routes, MCP gateway, auth, and
+/// session middleware applied.
+///
+/// Returns a `Router<()>` that can be extended (e.g. with
+/// [`axum::Router::nest`]) before binding to a listener.
+pub fn build_app(config: &ServerConfig, pool: &sqlx::PgPool, app_state: AppState) -> axum::Router {
     let session_store = PgSessionStore::new(pool);
     let session_layer = SessionManagerLayer::new(session_store)
         .with_same_site(SameSite::Lax)
@@ -25,12 +25,21 @@ pub async fn run(
 
     let mcp_service = McpGateway::service(app_state.app.clone());
 
-    let app = crate::router()
+    crate::router()
         .nest_service("/mcp", mcp_service)
         .layer(axum::middleware::from_fn(crate::auth::auth_middleware))
         .layer(axum::Extension(app_state.clone()))
         .layer(session_layer)
-        .with_state(app_state);
+        .with_state(app_state)
+}
+
+#[instrument(name = "web.server.run", skip_all, fields(addr))]
+pub async fn run(
+    config: ServerConfig,
+    pool: &sqlx::PgPool,
+    app_state: AppState,
+) -> anyhow::Result<()> {
+    let app = build_app(&config, pool, app_state);
 
     let addr: std::net::SocketAddr = format!("{}:{}", config.host, config.port)
         .parse()


### PR DESCRIPTION
## Summary
- Mounts the style-agent `search_code` and `review_code` MCP tools on the main galoy-agents HTTP server at `/style-agent/mcp`, gated behind `style_agent.enabled` config flag
- Extracts a public `style_agent_server::router()` function so the MCP service can be embedded in an existing axum server (also adds `/style-agent/health` and `/style-agent/stats` endpoints)
- Adds `StyleAgentConfig` (`enabled`, `db_path`) to cli config with env var overrides (`STYLE_AGENT_ENABLED`, `STYLE_AGENT_DB_PATH`)
- Refactors `web::server` into `build_app()` + `run()` so `main.rs` can nest additional routes before starting the listener
- Updates Helm deployment template to set style-agent env vars when `indexHash` is configured

## Test plan
- [x] `nix flake check` passes (fmt, clippy, nextest)
- [ ] Start server with `style_agent.enabled: true` and a valid `style-agent.db` — verify `/style-agent/health` returns `ok`
- [ ] Verify `/style-agent/mcp` responds to MCP protocol requests (requires Ollama or fastembed model cache)
- [ ] Verify existing routes (`/mcp`, `/dashboard`, OAuth) still work unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)