### PR TITLE
feat(memory): add memory crate with hybrid search via MCP gateway

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1227,10 +1227,13 @@ dependencies = [
  "clap",
  "galoy-agents-domain",
  "galoy-agents-mcp-gateway",
+ "galoy-agents-memory",
  "galoy-agents-web",
  "serde",
  "serde_yaml",
  "sqlx",
+ "style-agent-core",
+ "style-agent-server",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -1264,13 +1267,35 @@ dependencies = [
  "anyhow",
  "axum",
  "galoy-agents-domain",
+ "galoy-agents-memory",
  "http",
  "rmcp",
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "style-agent-core",
  "style-agent-server",
  "tracing",
+]
+
+[[package]]
+name = "galoy-agents-memory"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "rmcp",
+ "rusqlite",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "sqlite-vec",
+ "style-agent-core",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "uuid",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ members = [
   "cli",
   "domain",
   "mcp-gateway",
+  "memory",
   "web",
   "style-agent/crates/core",
   "style-agent/crates/server",
@@ -18,9 +19,10 @@ version = "0.1.0"
 name = "galoy-agents"
 
 [workspace.dependencies]
-# Internal style-agent crates
+# Internal crates
 style-agent-core = { path = "style-agent/crates/core" }
 style-agent-server = { path = "style-agent/crates/server" }
+galoy-agents-memory = { path = "memory" }
 
 # MCP
 rmcp = { version = "1.2", features = ["server", "transport-streamable-http-server", "macros"] }
@@ -51,6 +53,9 @@ tokio = { version = "1", features = ["full"] }
 
 # HTTP client
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "charset", "http2", "macos-system-configuration"] }
+
+# Time
+chrono = { version = "0.4", features = ["serde"] }
 
 # IDs
 uuid = { version = "1", features = ["v4"] }

--- a/bats/helpers.bash
+++ b/bats/helpers.bash
@@ -26,6 +26,7 @@ start_server() {
   export GITHUB_CLIENT_SECRET="test-client-secret"
   export GALOY_AGENTS_CONFIG="$REPO_ROOT/galoy-agents.yml"
   export STYLE_AGENT_DB_PATH=""  # disable style-agent in tests
+  export MEMORY_DB_PATH=""        # disable memory in tests
 
   $GALOY_AGENTS_BIN > "$BATS_FILE_TMPDIR/server.log" 2>&1 &
   echo "$!" > "$SERVER_PID_FILE"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -9,8 +9,11 @@ path = "src/main.rs"
 
 [dependencies]
 galoy-agents-domain = { path = "../domain" }
+galoy-agents-memory = { workspace = true }
 galoy-agents-mcp-gateway = { path = "../mcp-gateway" }
 galoy-agents-web = { path = "../web" }
+style-agent-core = { workspace = true }
+style-agent-server = { workspace = true }
 anyhow = "1"
 axum = { workspace = true }
 clap = { version = "4", features = ["derive", "env"] }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
-use galoy_agents_mcp_gateway::StyleAgentConfig;
+use galoy_agents_mcp_gateway::{MemoryConfig, StyleAgentConfig};
 use galoy_agents_web::auth::config::AuthConfig;
 
 #[derive(Clone, Deserialize)]
@@ -16,6 +16,8 @@ pub struct Config {
     pub db: DbConfig,
     #[serde(default)]
     pub style_agent: StyleAgentConfig,
+    #[serde(default)]
+    pub memory: MemoryConfig,
 }
 
 #[derive(Clone, Deserialize)]
@@ -106,6 +108,11 @@ impl Config {
         // Style-agent env overrides
         if let Ok(val) = std::env::var("STYLE_AGENT_DB_PATH") {
             config.style_agent.db_path = val;
+        }
+
+        // Memory env overrides
+        if let Ok(val) = std::env::var("MEMORY_DB_PATH") {
+            config.memory.db_path = val;
         }
 
         Ok(config)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,7 @@
 mod config;
 
+use std::sync::Arc;
+
 use clap::Parser;
 
 use config::{Config, EnvSecrets};
@@ -65,8 +67,32 @@ async fn main() -> anyhow::Result<()> {
         secure_cookies: config.server.secure_cookies,
     };
 
-    let (mcp_service, style_agent_endpoints) =
-        galoy_agents_mcp_gateway::McpGateway::service(app.clone(), &config.style_agent)?;
+    // Create shared embedder only if at least one service needs it.
+    let needs_embedder =
+        !config.style_agent.db_path.is_empty() || !config.memory.db_path.is_empty();
+    let embedder = if needs_embedder {
+        Some(style_agent_core::embedder::Embedder::new()?)
+    } else {
+        None
+    };
+
+    // Init memory service with shared embedder (disabled when db_path is empty).
+    let memory_endpoints = if config.memory.db_path.is_empty() {
+        tracing::info!("Memory service disabled (db_path is empty)");
+        galoy_agents_memory::MemoryEndpoints::disabled()
+    } else {
+        let emb = embedder.clone().expect("embedder needed for memory");
+        let svc = galoy_agents_memory::MemoryService::new(&config.memory, Arc::new(emb))?;
+        galoy_agents_memory::MemoryEndpoints::new(svc)
+    };
+
+    // Build MCP service; style-agent uses app.style_agent_logs() logger.
+    let (mcp_service, style_agent_endpoints) = galoy_agents_mcp_gateway::McpGateway::service(
+        app.clone(),
+        &config.style_agent,
+        embedder,
+        memory_endpoints,
+    )?;
 
     let app_state = galoy_agents_web::AppState::new(
         app,

--- a/galoy-agents.yml
+++ b/galoy-agents.yml
@@ -9,3 +9,6 @@ oauth:
   github_allowed_teams: []
 style_agent:
   db_path: "./data/style-agent.db"
+memory:
+  db_path: "./data/memory.db"
+  decay_half_life_days: 14.0

--- a/mcp-gateway/Cargo.toml
+++ b/mcp-gateway/Cargo.toml
@@ -7,6 +7,8 @@ edition.workspace = true
 
 [dependencies]
 galoy-agents-domain = { path = "../domain" }
+galoy-agents-memory = { workspace = true }
+style-agent-core = { workspace = true }
 style-agent-server = { workspace = true }
 anyhow = { workspace = true }
 axum = { workspace = true }

--- a/mcp-gateway/src/lib.rs
+++ b/mcp-gateway/src/lib.rs
@@ -9,8 +9,12 @@ use rmcp::{schemars, tool, tool_handler, tool_router, ServerHandler};
 
 use galoy_agents_domain::auth::AuthContext;
 use galoy_agents_domain::App;
+use galoy_agents_memory::{
+    ListMemoriesParams, MemoryEndpoints, SearchMemoryParams, StoreMemoryParams,
+};
 use style_agent_server::{SearchCodeParams, StyleAgentEndpoints};
 
+pub use galoy_agents_memory::MemoryConfig;
 pub use style_agent_server::StyleAgentConfig;
 
 #[derive(Clone)]
@@ -18,36 +22,49 @@ pub struct McpGateway {
     #[allow(dead_code)]
     app: App,
     style_agent: Option<StyleAgentEndpoints>,
+    memory: MemoryEndpoints,
     tool_router: ToolRouter<Self>,
 }
 
 impl McpGateway {
-    fn new(app: App, style_agent: Option<StyleAgentEndpoints>) -> Self {
+    fn new(app: App, style_agent: Option<StyleAgentEndpoints>, memory: MemoryEndpoints) -> Self {
         Self {
             app,
             style_agent,
+            memory,
             tool_router: Self::tool_router(),
         }
     }
 
     /// Build the MCP service, using `app.style_agent_logs()` as the request logger.
+    ///
+    /// Accepts an optional shared [`Embedder`] so the caller can reuse it for
+    /// other services (e.g. the memory crate).  When `None`, falls back to
+    /// `init_endpoints_with_logger` which creates its own embedder only if
+    /// style-agent is actually enabled.
     pub fn service(
         app: App,
         style_agent_config: &StyleAgentConfig,
+        embedder: Option<style_agent_core::embedder::Embedder>,
+        memory: MemoryEndpoints,
     ) -> anyhow::Result<(
         StreamableHttpService<Self, LocalSessionManager>,
         Option<StyleAgentEndpoints>,
     )> {
         let logger = app.style_agent_logs().clone();
-        let style_agent =
-            style_agent_server::init_endpoints_with_logger(style_agent_config, logger)?;
-        let svc = Self::build_service(app, style_agent.clone());
+        let style_agent = if let Some(embedder) = embedder {
+            style_agent_server::init_endpoints_with_embedder(style_agent_config, embedder, logger)?
+        } else {
+            style_agent_server::init_endpoints_with_logger(style_agent_config, logger)?
+        };
+        let svc = Self::build_service(app, style_agent.clone(), memory);
         Ok((svc, style_agent))
     }
 
     fn build_service(
         app: App,
         style_agent: Option<StyleAgentEndpoints>,
+        memory: MemoryEndpoints,
     ) -> StreamableHttpService<Self, LocalSessionManager> {
         let config = StreamableHttpServerConfig {
             stateful_mode: false,
@@ -55,7 +72,13 @@ impl McpGateway {
             ..Default::default()
         };
         StreamableHttpService::new(
-            move || Ok(McpGateway::new(app.clone(), style_agent.clone())),
+            move || {
+                Ok(McpGateway::new(
+                    app.clone(),
+                    style_agent.clone(),
+                    memory.clone(),
+                ))
+            },
             LocalSessionManager::default().into(),
             config,
         )
@@ -108,6 +131,45 @@ impl McpGateway {
                 None::<serde_json::Value>,
             )),
         }
+    }
+
+    /// Store a research finding, decision, or piece of knowledge for future agents.
+    #[tool(
+        description = "Store a research finding, decision, or piece of knowledge for future agents. Always store important findings before completing a task."
+    )]
+    async fn store_memory(
+        &self,
+        Extension(parts): Extension<http::request::Parts>,
+        Parameters(params): Parameters<StoreMemoryParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Self::require_auth(&parts)?;
+        self.memory.store_memory(params).await
+    }
+
+    /// Search stored memories and research reports.
+    #[tool(
+        description = "Search stored memories and research reports. Always search before starting research — someone may have already investigated your topic."
+    )]
+    async fn search_memory(
+        &self,
+        Extension(parts): Extension<http::request::Parts>,
+        Parameters(params): Parameters<SearchMemoryParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Self::require_auth(&parts)?;
+        self.memory.search_memory(params).await
+    }
+
+    /// List stored memories and research reports.
+    #[tool(
+        description = "List stored memories and research reports, optionally filtered by project or type."
+    )]
+    async fn list_memories(
+        &self,
+        Extension(parts): Extension<http::request::Parts>,
+        Parameters(params): Parameters<ListMemoriesParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Self::require_auth(&parts)?;
+        self.memory.list_memories(params).await
     }
 }
 

--- a/memory/Cargo.toml
+++ b/memory/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "galoy-agents-memory"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+style-agent-core = { workspace = true }
+rusqlite = { workspace = true }
+sqlite-vec = { workspace = true }
+zerocopy = { workspace = true }
+chrono = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+uuid = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+tracing = { workspace = true }
+tokio = { workspace = true }
+rmcp = { workspace = true }
+schemars = { workspace = true }

--- a/memory/src/config.rs
+++ b/memory/src/config.rs
@@ -1,0 +1,26 @@
+/// Configuration for the memory service.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct MemoryConfig {
+    #[serde(default = "default_db_path")]
+    pub db_path: String,
+    #[serde(default = "default_decay_half_life_days")]
+    pub decay_half_life_days: f64,
+}
+
+impl Default for MemoryConfig {
+    fn default() -> Self {
+        Self {
+            db_path: default_db_path(),
+            decay_half_life_days: default_decay_half_life_days(),
+        }
+    }
+}
+
+fn default_db_path() -> String {
+    "/data/memory/memory.db".to_string()
+}
+
+fn default_decay_half_life_days() -> f64 {
+    14.0
+}

--- a/memory/src/endpoints.rs
+++ b/memory/src/endpoints.rs
@@ -1,0 +1,253 @@
+use rmcp::model::{CallToolResult, Content};
+use rmcp::schemars;
+
+use crate::memory::NewMemory;
+use crate::service::MemoryService;
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct StoreMemoryParams {
+    /// Descriptive title for the memory
+    #[schemars(description = "Descriptive title for the memory")]
+    title: String,
+
+    /// Full content (findings, decisions, patterns, etc.)
+    #[schemars(description = "Full content (findings, decisions, patterns, etc.)")]
+    content: String,
+
+    /// Lowercase tags for categorization
+    #[schemars(description = "Lowercase tags for categorization")]
+    tags: Option<Vec<String>>,
+
+    /// Project scope for this memory
+    #[schemars(description = "Project scope for this memory")]
+    project: Option<String>,
+
+    /// 'memory' (default) or 'report'
+    #[schemars(description = "'memory' (default) or 'report'")]
+    memory_type: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SearchMemoryParams {
+    /// Search query (keywords or natural language)
+    #[schemars(description = "Search query (keywords or natural language)")]
+    query: String,
+
+    /// Filter results by project
+    #[schemars(description = "Filter results by project")]
+    project: Option<String>,
+
+    /// Maximum number of results to return (default: 10)
+    #[schemars(description = "Maximum number of results to return (default: 10)")]
+    limit: Option<u64>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ListMemoriesParams {
+    /// Filter by project
+    #[schemars(description = "Filter by project")]
+    project: Option<String>,
+
+    /// Filter by type: 'memory' or 'report'
+    #[schemars(description = "Filter by type: 'memory' or 'report'")]
+    memory_type: Option<String>,
+
+    /// Maximum number of results to return (default: 20)
+    #[schemars(description = "Maximum number of results to return (default: 20)")]
+    limit: Option<u64>,
+}
+
+/// Facade for memory MCP endpoints, to be held by the MCP gateway.
+#[derive(Debug, Clone)]
+pub struct MemoryEndpoints {
+    service: Option<MemoryService>,
+}
+
+impl MemoryEndpoints {
+    pub fn new(service: MemoryService) -> Self {
+        Self {
+            service: Some(service),
+        }
+    }
+
+    /// Create a disabled instance (when `db_path` is empty).
+    pub fn disabled() -> Self {
+        Self { service: None }
+    }
+
+    fn require_service(&self) -> Result<&MemoryService, rmcp::ErrorData> {
+        self.service.as_ref().ok_or_else(|| {
+            rmcp::ErrorData::new(
+                rmcp::model::ErrorCode::INTERNAL_ERROR,
+                "Memory service is disabled (no db_path configured)",
+                None::<serde_json::Value>,
+            )
+        })
+    }
+
+    /// Execute a `store_memory` call.
+    pub async fn store_memory(
+        &self,
+        params: StoreMemoryParams,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let service = self.require_service()?;
+        let tags = params
+            .tags
+            .unwrap_or_default()
+            .into_iter()
+            .map(|t| t.to_lowercase())
+            .collect::<Vec<_>>();
+
+        // Treat memory_type=report as persistent.
+        let persistent = params.memory_type.as_deref() == Some("report");
+
+        let new = NewMemory {
+            title: params.title.clone(),
+            content: params.content,
+            tags: tags.clone(),
+            project: params.project,
+            source_task: None,
+            source_type: "agent".to_string(),
+            persistent,
+        };
+
+        match service.store(new).await {
+            Ok(memory) => {
+                let short_id = &memory.id[..8.min(memory.id.len())];
+                let tags_display = if tags.is_empty() {
+                    String::from("(none)")
+                } else {
+                    tags.join(", ")
+                };
+                let label = if memory.persistent {
+                    "persistent memory"
+                } else {
+                    "memory"
+                };
+                let text = format!(
+                    "Stored {label}: \"{}\" (id: {short_id})\nTags: {tags_display}",
+                    params.title
+                );
+                Ok(CallToolResult::success(vec![Content::text(text)]))
+            }
+            Err(e) => Err(rmcp::ErrorData::internal_error(
+                format!("Failed to store memory: {e}"),
+                None,
+            )),
+        }
+    }
+
+    /// Execute a `search_memory` query.
+    pub async fn search_memory(
+        &self,
+        params: SearchMemoryParams,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let service = self.require_service()?;
+        let limit = params.limit.unwrap_or(10) as usize;
+        let project = params.project.as_deref();
+
+        match service.search(&params.query, project, limit).await {
+            Ok(results) => {
+                if results.is_empty() {
+                    return Ok(CallToolResult::success(vec![Content::text(
+                        "No results found.",
+                    )]));
+                }
+
+                let mut text = format!("## Results ({} found)\n", results.len());
+
+                for (i, r) in results.iter().enumerate() {
+                    text.push_str(&format!(
+                        "\n### {}. {} (score: {:.2}, decay: {:.0}%",
+                        i + 1,
+                        r.title,
+                        r.score,
+                        r.decay_factor * 100.0,
+                    ));
+                    if r.persistent {
+                        text.push_str(", persistent");
+                    }
+                    if r.pinned {
+                        text.push_str(", pinned");
+                    }
+                    text.push(')');
+
+                    if !r.tags.is_empty() {
+                        text.push_str(&format!("\nTags: {}", r.tags.join(", ")));
+                    }
+                    if let Some(ref proj) = r.project {
+                        text.push_str(&format!("\nProject: {proj}"));
+                    }
+
+                    // Content snippet (first 300 chars).
+                    let snippet: String = r.content.chars().take(300).collect();
+                    text.push_str(&format!("\n\n{snippet}"));
+                    if r.content.len() > 300 {
+                        text.push_str("...");
+                    }
+                    text.push_str("\n\n---");
+                }
+
+                Ok(CallToolResult::success(vec![Content::text(text)]))
+            }
+            Err(e) => Err(rmcp::ErrorData::internal_error(
+                format!("Search failed: {e}"),
+                None,
+            )),
+        }
+    }
+
+    /// Execute a `list_memories` query.
+    pub async fn list_memories(
+        &self,
+        params: ListMemoriesParams,
+    ) -> Result<CallToolResult, rmcp::ErrorData> {
+        let service = self.require_service()?;
+        let limit = params.limit.unwrap_or(20) as usize;
+        let project = params.project.as_deref();
+
+        // Treat memory_type=report as persistent filter.
+        let persistent_filter = match params.memory_type.as_deref() {
+            Some("report") => Some(true),
+            Some("memory") => Some(false),
+            _ => None,
+        };
+
+        match service.list(project, persistent_filter, limit) {
+            Ok(memories) => {
+                if memories.is_empty() {
+                    return Ok(CallToolResult::success(vec![Content::text(
+                        "No memories found.",
+                    )]));
+                }
+
+                let mut text = String::new();
+                for m in &memories {
+                    let short_id = &m.id[..8.min(m.id.len())];
+                    let tags_display = if m.tags.is_empty() {
+                        String::new()
+                    } else {
+                        format!("\n  Tags: {}", m.tags.join(", "))
+                    };
+                    let project_display = m
+                        .project
+                        .as_deref()
+                        .map(|p| format!("\n  Project: {p}"))
+                        .unwrap_or_default();
+                    let flags = if m.persistent { " [persistent]" } else { "" };
+
+                    text.push_str(&format!(
+                        "- {}{flags} (id: {short_id}){tags_display}{project_display}\n",
+                        m.title
+                    ));
+                }
+
+                Ok(CallToolResult::success(vec![Content::text(text)]))
+            }
+            Err(e) => Err(rmcp::ErrorData::internal_error(
+                format!("Failed to list memories: {e}"),
+                None,
+            )),
+        }
+    }
+}

--- a/memory/src/error.rs
+++ b/memory/src/error.rs
@@ -1,0 +1,21 @@
+/// Errors for the memory crate.
+#[derive(Debug, thiserror::Error)]
+pub enum MemoryError {
+    #[error("sqlite error: {0}")]
+    Sqlite(#[from] rusqlite::Error),
+
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("json error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("embedding error: {0}")]
+    Embedding(#[from] anyhow::Error),
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("{0}")]
+    Other(String),
+}

--- a/memory/src/lib.rs
+++ b/memory/src/lib.rs
@@ -1,0 +1,10 @@
+pub mod config;
+pub mod endpoints;
+pub mod error;
+pub mod memory;
+pub mod service;
+mod store;
+
+pub use config::MemoryConfig;
+pub use endpoints::{ListMemoriesParams, MemoryEndpoints, SearchMemoryParams, StoreMemoryParams};
+pub use service::MemoryService;

--- a/memory/src/memory.rs
+++ b/memory/src/memory.rs
@@ -1,0 +1,53 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// A stored memory — observation, decision, research finding, or knowledge.
+///
+/// Memories decay over time unless pinned or persistent.
+/// Persistent memories are exempt from decay.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Memory {
+    pub id: String,
+    pub title: String,
+    pub content: String,
+    pub tags: Vec<String>,
+    pub project: Option<String>,
+    pub source_task: Option<String>,
+    pub source_type: String,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub last_accessed: Option<DateTime<Utc>>,
+    pub access_count: i64,
+    pub pinned: bool,
+    /// Persistent memories are exempt from decay.
+    pub persistent: bool,
+}
+
+/// Input for creating a new memory.
+#[derive(Debug, Clone)]
+pub struct NewMemory {
+    pub title: String,
+    pub content: String,
+    pub tags: Vec<String>,
+    pub project: Option<String>,
+    pub source_task: Option<String>,
+    pub source_type: String,
+    /// When true, the memory is exempt from decay.
+    pub persistent: bool,
+}
+
+/// A search result with relevance scoring and decay information.
+#[derive(Debug, Clone, Serialize)]
+pub struct SearchResult {
+    pub id: String,
+    pub title: String,
+    pub content: String,
+    pub tags: Vec<String>,
+    pub project: Option<String>,
+    pub score: f64,
+    /// Decay factor (1.0 = fully fresh, 0.0 = fully decayed).
+    /// Persistent or pinned memories always have 1.0.
+    pub decay_factor: f64,
+    pub pinned: bool,
+    pub persistent: bool,
+}

--- a/memory/src/service.rs
+++ b/memory/src/service.rs
@@ -1,0 +1,226 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use chrono::{DateTime, Utc};
+
+use style_agent_core::embedder::Embedder;
+
+use crate::config::MemoryConfig;
+use crate::error::MemoryError;
+use crate::memory::{Memory, NewMemory, SearchResult};
+use crate::store::MemoryStore;
+
+/// Minimum strength before a memory is filtered from search results.
+const DECAY_MIN_STRENGTH: f64 = 0.05;
+
+/// Compute exponential decay factor based on time since last access.
+fn decay_factor(last_accessed: DateTime<Utc>, half_life_days: f64) -> f64 {
+    let lambda = (2.0_f64).ln() / half_life_days;
+    let days_elapsed = Utc::now()
+        .signed_duration_since(last_accessed)
+        .num_seconds() as f64
+        / 86400.0;
+    (-lambda * days_elapsed).exp()
+}
+
+/// High-level orchestrator for memory operations.
+///
+/// Coordinates the SQLite store and shared embedder for hybrid search.
+#[derive(Clone)]
+pub struct MemoryService {
+    store: Arc<MemoryStore>,
+    embedder: Arc<Embedder>,
+    decay_half_life_days: f64,
+}
+
+impl std::fmt::Debug for MemoryService {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryService").finish_non_exhaustive()
+    }
+}
+
+impl MemoryService {
+    /// Create a new MemoryService from config and a shared embedder.
+    #[tracing::instrument(name = "memory.service.new", skip_all)]
+    pub fn new(config: &MemoryConfig, embedder: Arc<Embedder>) -> Result<Self, MemoryError> {
+        let store = MemoryStore::new(std::path::Path::new(&config.db_path))?;
+
+        tracing::info!(db_path = %config.db_path, "Memory service ready");
+        Ok(Self {
+            store: Arc::new(store),
+            embedder,
+            decay_half_life_days: config.decay_half_life_days,
+        })
+    }
+
+    // ── Store ───────────────────────────────────────────────────────
+
+    /// Store a new memory.
+    #[tracing::instrument(name = "memory.service.store", skip_all, fields(title = %new.title))]
+    pub async fn store(&self, new: NewMemory) -> Result<Memory, MemoryError> {
+        let now = Utc::now();
+        let id = uuid::Uuid::new_v4().to_string();
+
+        let memory = Memory {
+            id: id.clone(),
+            title: new.title,
+            content: new.content,
+            tags: new.tags,
+            project: new.project,
+            source_task: new.source_task,
+            source_type: new.source_type,
+            created_at: now,
+            updated_at: now,
+            last_accessed: None,
+            access_count: 0,
+            pinned: false,
+            persistent: new.persistent,
+        };
+
+        // Insert into SQLite.
+        self.store.insert(&memory)?;
+
+        // Update FTS index.
+        let tags_str = memory.tags.join(", ");
+        self.store
+            .upsert_fts(&id, &memory.title, &memory.content, &tags_str)?;
+
+        // Generate embedding and store vector.
+        let text = format!("{}\n\n{}", memory.title, memory.content);
+        let embedder = self.embedder.clone();
+        let store = self.store.clone();
+        let embed_id = id.clone();
+        tokio::task::spawn(async move {
+            match embedder.embed_document(&text).await {
+                Ok(embedding) => {
+                    if let Err(e) = store.upsert_embedding(&embed_id, &embedding) {
+                        tracing::warn!(error = %e, "Failed to store embedding");
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "Failed to generate embedding");
+                }
+            }
+        });
+
+        tracing::info!(id = %memory.id, persistent = memory.persistent, "Memory stored");
+        Ok(memory)
+    }
+
+    // ── List ────────────────────────────────────────────────────────
+
+    /// List memories with optional filters.
+    #[tracing::instrument(name = "memory.service.list", skip_all)]
+    pub fn list(
+        &self,
+        project: Option<&str>,
+        persistent: Option<bool>,
+        limit: usize,
+    ) -> Result<Vec<Memory>, MemoryError> {
+        self.store.list(project, persistent, limit)
+    }
+
+    // ── Search ──────────────────────────────────────────────────────
+
+    /// Hybrid search: FTS + vector with Reciprocal Rank Fusion.
+    #[tracing::instrument(name = "memory.service.search", skip_all, fields(query = %query))]
+    pub async fn search(
+        &self,
+        query: &str,
+        project: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<SearchResult>, MemoryError> {
+        let fetch_limit = limit * 3;
+
+        // 1. FTS keyword search.
+        let fts_results = self.store.search_fts(query, fetch_limit)?;
+
+        // 2. Vector search (if embeddings exist).
+        let vec_results = if self.store.has_embeddings()? {
+            match self.embedder.embed_query(query).await {
+                Ok(query_embedding) => self.store.search_vector(&query_embedding, fetch_limit)?,
+                Err(e) => {
+                    tracing::warn!(error = %e, "Vector search failed, using FTS only");
+                    Vec::new()
+                }
+            }
+        } else {
+            Vec::new()
+        };
+
+        // 3. Reciprocal Rank Fusion.
+        let k = 60.0_f64;
+        let mut scores: HashMap<String, f64> = HashMap::new();
+
+        for (rank, result) in fts_results.iter().enumerate() {
+            *scores.entry(result.id.clone()).or_default() += 1.0 / (k + rank as f64 + 1.0);
+        }
+        for (rank, result) in vec_results.iter().enumerate() {
+            *scores.entry(result.id.clone()).or_default() += 1.0 / (k + rank as f64 + 1.0);
+        }
+
+        // Sort by RRF score descending.
+        let mut ranked: Vec<(String, f64)> = scores.into_iter().collect();
+        ranked.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+
+        // Fetch full memories and build results with decay scoring.
+        let mut results = Vec::new();
+        let half_life = self.decay_half_life_days;
+
+        for (id, rrf_score) in &ranked {
+            let m = match self.store.find_by_id(id) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+
+            // Project filter.
+            if let Some(proj) = project {
+                if m.project.as_deref() != Some(proj) {
+                    continue;
+                }
+            }
+
+            let exempt = m.pinned || m.persistent;
+            let df = if exempt {
+                1.0
+            } else {
+                let accessed = m.last_accessed.unwrap_or(m.created_at);
+                decay_factor(accessed, half_life)
+            };
+
+            // Filter below minimum strength.
+            if !exempt && df < DECAY_MIN_STRENGTH {
+                continue;
+            }
+
+            let adjusted_score = rrf_score * df;
+            results.push(SearchResult {
+                id: m.id.clone(),
+                title: m.title.clone(),
+                content: m.content.clone(),
+                tags: m.tags.clone(),
+                project: m.project.clone(),
+                score: adjusted_score,
+                decay_factor: df,
+                pinned: m.pinned,
+                persistent: m.persistent,
+            });
+        }
+
+        // Re-sort by adjusted score descending.
+        results.sort_by(|a, b| {
+            b.score
+                .partial_cmp(&a.score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        results.truncate(limit);
+
+        // Record access for returned memories.
+        let returned_ids: Vec<String> = results.iter().map(|r| r.id.clone()).collect();
+        if let Err(e) = self.store.record_access(&returned_ids) {
+            tracing::warn!(error = %e, "Failed to record access for search results");
+        }
+
+        Ok(results)
+    }
+}

--- a/memory/src/store.rs
+++ b/memory/src/store.rs
@@ -1,0 +1,444 @@
+use std::path::Path;
+use std::sync::Mutex;
+
+use chrono::{DateTime, Utc};
+use rusqlite::Connection;
+use sqlite_vec::sqlite3_vec_init;
+
+use crate::error::MemoryError;
+use crate::memory::Memory;
+
+/// Embedding dimensions for nomic-embed-text-v1.5.
+const VECTOR_DIM: usize = 768;
+
+/// FTS keyword search result before merging.
+#[derive(Debug)]
+pub(crate) struct FtsResult {
+    pub(crate) id: String,
+    // Rank is returned by FTS5 but we use positional RRF scoring instead.
+    #[allow(dead_code)]
+    pub(crate) rank: f64,
+}
+
+/// Vector similarity search result before merging.
+#[derive(Debug)]
+pub(crate) struct VecResult {
+    pub(crate) id: String,
+    // Distance is returned by sqlite-vec but we use positional RRF scoring instead.
+    #[allow(dead_code)]
+    pub(crate) distance: f64,
+}
+
+/// SQLite-backed memory store with FTS5 and sqlite-vec for hybrid search.
+pub(crate) struct MemoryStore {
+    conn: Mutex<Connection>,
+}
+
+impl std::fmt::Debug for MemoryStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("MemoryStore").finish_non_exhaustive()
+    }
+}
+
+impl MemoryStore {
+    /// Open (or create) the SQLite database at the given path with sqlite-vec loaded.
+    pub(crate) fn new(db_path: &Path) -> Result<Self, MemoryError> {
+        if let Some(parent) = db_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+
+        unsafe {
+            rusqlite::ffi::sqlite3_auto_extension(Some(std::mem::transmute::<
+                *const (),
+                unsafe extern "C" fn(
+                    *mut rusqlite::ffi::sqlite3,
+                    *mut *mut i8,
+                    *const rusqlite::ffi::sqlite3_api_routines,
+                ) -> i32,
+            >(
+                sqlite3_vec_init as *const ()
+            )));
+        }
+
+        let conn = Connection::open(db_path)?;
+        conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
+
+        let store = Self {
+            conn: Mutex::new(conn),
+        };
+        store.ensure_tables()?;
+
+        Ok(store)
+    }
+
+    /// Create tables if they don't already exist.
+    fn ensure_tables(&self) -> Result<(), MemoryError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| MemoryError::Other(e.to_string()))?;
+
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS memories (
+                id TEXT PRIMARY KEY,
+                title TEXT NOT NULL,
+                content TEXT NOT NULL,
+                tags TEXT NOT NULL DEFAULT '[]',
+                project TEXT,
+                source_task TEXT,
+                source_type TEXT NOT NULL DEFAULT 'agent',
+                created_at TEXT NOT NULL,
+                updated_at TEXT NOT NULL,
+                last_accessed TEXT,
+                access_count INTEGER NOT NULL DEFAULT 0,
+                pinned INTEGER NOT NULL DEFAULT 0,
+                persistent INTEGER NOT NULL DEFAULT 0
+            );",
+        )?;
+
+        // FTS5 content table for keyword search.
+        conn.execute_batch(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS memory_fts USING fts5(
+                memory_id UNINDEXED,
+                title,
+                content,
+                tags_text,
+                tokenize='porter unicode61'
+            );",
+        )?;
+
+        // sqlite-vec virtual table for vector similarity.
+        conn.execute_batch(&format!(
+            "CREATE VIRTUAL TABLE IF NOT EXISTS memory_vectors USING vec0(
+                memory_id TEXT PRIMARY KEY,
+                embedding float[{VECTOR_DIM}] distance_metric=cosine
+            );"
+        ))?;
+
+        Ok(())
+    }
+
+    // ── Insert ───────────────────────────────────────────────────────
+
+    /// Insert a new memory into the store.
+    pub(crate) fn insert(&self, memory: &Memory) -> Result<(), MemoryError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| MemoryError::Other(e.to_string()))?;
+        let tags_json = serde_json::to_string(&memory.tags)?;
+
+        conn.execute(
+            "INSERT OR REPLACE INTO memories
+                (id, title, content, tags, project, source_task, source_type,
+                 created_at, updated_at, last_accessed, access_count, pinned, persistent)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13)",
+            rusqlite::params![
+                memory.id,
+                memory.title,
+                memory.content,
+                tags_json,
+                memory.project,
+                memory.source_task,
+                memory.source_type,
+                memory.created_at.to_rfc3339(),
+                memory.updated_at.to_rfc3339(),
+                memory.last_accessed.map(|dt| dt.to_rfc3339()),
+                memory.access_count,
+                memory.pinned as i32,
+                memory.persistent as i32,
+            ],
+        )?;
+
+        Ok(())
+    }
+
+    /// Insert or update an FTS5 entry for a memory.
+    pub(crate) fn upsert_fts(
+        &self,
+        memory_id: &str,
+        title: &str,
+        content: &str,
+        tags_text: &str,
+    ) -> Result<(), MemoryError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| MemoryError::Other(e.to_string()))?;
+
+        // FTS5 doesn't support UPDATE; delete then re-insert.
+        conn.execute(
+            "DELETE FROM memory_fts WHERE memory_id = ?1",
+            rusqlite::params![memory_id],
+        )?;
+        conn.execute(
+            "INSERT INTO memory_fts(memory_id, title, content, tags_text) VALUES (?1, ?2, ?3, ?4)",
+            rusqlite::params![memory_id, title, content, tags_text],
+        )?;
+
+        Ok(())
+    }
+
+    /// Store a vector embedding for a memory.
+    pub(crate) fn upsert_embedding(
+        &self,
+        memory_id: &str,
+        embedding: &[f32],
+    ) -> Result<(), MemoryError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| MemoryError::Other(e.to_string()))?;
+
+        // vec0 doesn't support UPDATE; delete then re-insert.
+        conn.execute(
+            "DELETE FROM memory_vectors WHERE memory_id = ?1",
+            rusqlite::params![memory_id],
+        )?;
+        conn.execute(
+            "INSERT INTO memory_vectors(memory_id, embedding) VALUES (?1, ?2)",
+            rusqlite::params![memory_id, embedding_to_bytes(embedding)],
+        )?;
+
+        Ok(())
+    }
+
+    // ── Query ────────────────────────────────────────────────────────
+
+    /// Find a memory by exact ID.
+    pub(crate) fn find_by_id(&self, id: &str) -> Result<Memory, MemoryError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| MemoryError::Other(e.to_string()))?;
+        let mut stmt = conn.prepare(
+            "SELECT id, title, content, tags, project, source_task, source_type,
+                    created_at, updated_at, last_accessed, access_count, pinned, persistent
+             FROM memories WHERE id = ?1",
+        )?;
+
+        let memory = stmt
+            .query_row(rusqlite::params![id], |row| Ok(row_to_memory(row)))
+            .map_err(|_| MemoryError::NotFound(format!("memory '{id}'")))?;
+
+        Ok(memory)
+    }
+
+    /// List memories with optional filters, ordered by created_at DESC.
+    pub(crate) fn list(
+        &self,
+        project: Option<&str>,
+        persistent: Option<bool>,
+        limit: usize,
+    ) -> Result<Vec<Memory>, MemoryError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| MemoryError::Other(e.to_string()))?;
+
+        let mut sql = String::from(
+            "SELECT id, title, content, tags, project, source_task, source_type,
+                    created_at, updated_at, last_accessed, access_count, pinned, persistent
+             FROM memories WHERE 1=1",
+        );
+        let mut params: Vec<Box<dyn rusqlite::types::ToSql>> = Vec::new();
+
+        if let Some(proj) = project {
+            sql.push_str(&format!(" AND project = ?{}", params.len() + 1));
+            params.push(Box::new(proj.to_string()));
+        }
+        if let Some(p) = persistent {
+            sql.push_str(&format!(" AND persistent = ?{}", params.len() + 1));
+            params.push(Box::new(p as i32));
+        }
+        sql.push_str(&format!(
+            " ORDER BY created_at DESC LIMIT ?{}",
+            params.len() + 1
+        ));
+        params.push(Box::new(limit as i64));
+
+        let mut stmt = conn.prepare(&sql)?;
+        let param_refs: Vec<&dyn rusqlite::types::ToSql> =
+            params.iter().map(|p| p.as_ref()).collect();
+        let rows = stmt
+            .query_map(param_refs.as_slice(), |row| Ok(row_to_memory(row)))?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(rows)
+    }
+
+    /// Record access for a batch of memory IDs.
+    pub(crate) fn record_access(&self, ids: &[String]) -> Result<(), MemoryError> {
+        if ids.is_empty() {
+            return Ok(());
+        }
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| MemoryError::Other(e.to_string()))?;
+        let now = Utc::now().to_rfc3339();
+
+        for id in ids {
+            conn.execute(
+                "UPDATE memories SET last_accessed = ?1, access_count = access_count + 1 WHERE id = ?2",
+                rusqlite::params![now, id],
+            )?;
+        }
+
+        Ok(())
+    }
+
+    // ── Search ───────────────────────────────────────────────────────
+
+    /// Full-text keyword search, returning ranked results.
+    pub(crate) fn search_fts(
+        &self,
+        query: &str,
+        limit: usize,
+    ) -> Result<Vec<FtsResult>, MemoryError> {
+        let escaped = escape_fts5_query(query);
+        if escaped.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| MemoryError::Other(e.to_string()))?;
+        let mut stmt = conn.prepare(
+            "SELECT memory_id, rank
+             FROM memory_fts
+             WHERE memory_fts MATCH ?1
+             ORDER BY rank
+             LIMIT ?2",
+        )?;
+
+        let rows = stmt
+            .query_map(rusqlite::params![escaped, limit as i64], |row| {
+                Ok(FtsResult {
+                    id: row.get(0)?,
+                    rank: row.get(1)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(rows)
+    }
+
+    /// Vector similarity search (KNN), returning ranked results.
+    pub(crate) fn search_vector(
+        &self,
+        query_embedding: &[f32],
+        limit: usize,
+    ) -> Result<Vec<VecResult>, MemoryError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| MemoryError::Other(e.to_string()))?;
+        let mut stmt = conn.prepare(
+            "SELECT memory_id, distance
+             FROM memory_vectors
+             WHERE embedding MATCH ?1 AND k = ?2",
+        )?;
+
+        let rows = stmt
+            .query_map(
+                rusqlite::params![embedding_to_bytes(query_embedding), limit as i64],
+                |row| {
+                    Ok(VecResult {
+                        id: row.get(0)?,
+                        distance: row.get(1)?,
+                    })
+                },
+            )?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(rows)
+    }
+
+    /// Check whether any embeddings exist.
+    pub(crate) fn has_embeddings(&self) -> Result<bool, MemoryError> {
+        let conn = self
+            .conn
+            .lock()
+            .map_err(|e| MemoryError::Other(e.to_string()))?;
+        let count: i64 =
+            conn.query_row("SELECT COUNT(*) FROM memory_vectors", [], |row| row.get(0))?;
+        Ok(count > 0)
+    }
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/// Convert f32 embedding slice to bytes for sqlite-vec.
+fn embedding_to_bytes(embedding: &[f32]) -> Vec<u8> {
+    embedding.iter().flat_map(|f| f.to_le_bytes()).collect()
+}
+
+/// Escape a user query for safe use in FTS5 MATCH expressions.
+///
+/// Wraps each token in double quotes to prevent FTS5 column-filter
+/// interpretation (e.g. `word:term`).
+fn escape_fts5_query(query: &str) -> String {
+    query
+        .split_whitespace()
+        .map(|term| format!("\"{}\"", term.replace('"', "")))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn row_to_memory(row: &rusqlite::Row<'_>) -> Memory {
+    let tags_json: String = row.get_unwrap(3);
+    let tags: Vec<String> = serde_json::from_str(&tags_json).unwrap_or_default();
+    let created_str: String = row.get_unwrap(7);
+    let updated_str: String = row.get_unwrap(8);
+    let last_accessed_str: Option<String> = row.get_unwrap(9);
+    let pinned_int: i32 = row.get_unwrap(11);
+    let persistent_int: i32 = row.get_unwrap(12);
+
+    Memory {
+        id: row.get_unwrap(0),
+        title: row.get_unwrap(1),
+        content: row.get_unwrap(2),
+        tags,
+        project: row.get_unwrap(4),
+        source_task: row.get_unwrap(5),
+        source_type: row.get_unwrap(6),
+        created_at: parse_dt(&created_str),
+        updated_at: parse_dt(&updated_str),
+        last_accessed: last_accessed_str.as_deref().map(parse_dt),
+        access_count: row.get_unwrap(10),
+        pinned: pinned_int != 0,
+        persistent: persistent_int != 0,
+    }
+}
+
+fn parse_dt(s: &str) -> DateTime<Utc> {
+    DateTime::parse_from_rfc3339(s)
+        .map(|dt| dt.with_timezone(&Utc))
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn escape_fts5_plain_terms() {
+        assert_eq!(escape_fts5_query("hello world"), "\"hello\" \"world\"");
+    }
+
+    #[test]
+    fn escape_fts5_column_like_term() {
+        assert_eq!(
+            escape_fts5_query("style-agent:value"),
+            "\"style-agent:value\""
+        );
+    }
+
+    #[test]
+    fn escape_fts5_empty_query() {
+        assert_eq!(escape_fts5_query(""), "");
+        assert_eq!(escape_fts5_query("   "), "");
+    }
+}

--- a/style-agent/crates/core/src/embedder.rs
+++ b/style-agent/crates/core/src/embedder.rs
@@ -20,6 +20,7 @@ fn truncate(text: &str, limit: usize) -> String {
 }
 
 /// In-process embedding via fastembed ONNX (nomic-embed-text-v1.5 quantized).
+#[derive(Clone)]
 pub struct Embedder {
     model: Arc<Mutex<TextEmbedding>>,
 }

--- a/style-agent/crates/server/src/endpoints.rs
+++ b/style-agent/crates/server/src/endpoints.rs
@@ -185,6 +185,26 @@ fn init_endpoints_inner(
     logger: Arc<dyn RequestLogger>,
 ) -> anyhow::Result<Option<StyleAgentEndpoints>> {
     use style_agent_core::embedder::Embedder;
+
+    // Check before loading the model — avoids loading when disabled.
+    if config.db_path.is_empty() {
+        tracing::info!("Style-agent disabled (db_path is empty)");
+        return Ok(None);
+    }
+
+    let embedder = Embedder::new()?;
+    init_endpoints_with_embedder(config, embedder, logger)
+}
+
+/// Initialise the style-agent endpoints with a shared embedder and external logger.
+///
+/// Returns `Ok(None)` when `db_path` is empty — style-agent is disabled.
+/// Returns `Ok(Some(...))` on success.
+pub fn init_endpoints_with_embedder(
+    config: &StyleAgentConfig,
+    embedder: style_agent_core::embedder::Embedder,
+    logger: Arc<dyn RequestLogger>,
+) -> anyhow::Result<Option<StyleAgentEndpoints>> {
     use style_agent_core::store::VectorStore;
 
     if config.db_path.is_empty() {
@@ -207,7 +227,6 @@ fn init_endpoints_inner(
     store.ensure_collection()?;
     store.ensure_anti_pattern_tables()?;
 
-    let embedder = Embedder::new()?;
     let search_engine = Arc::new(SearchEngine::new(embedder, store));
 
     tracing::info!("Style-agent search engine ready");

--- a/style-agent/crates/server/src/lib.rs
+++ b/style-agent/crates/server/src/lib.rs
@@ -5,6 +5,7 @@ mod standalone_server;
 
 pub use config::StyleAgentConfig;
 pub use endpoints::init_endpoints;
+pub use endpoints::init_endpoints_with_embedder;
 pub use endpoints::init_endpoints_with_logger;
 pub use endpoints::{SearchCodeParams, StyleAgentEndpoints};
 pub use request_logger::{LoggerError, NoopRequestLogger, RequestLogger};


### PR DESCRIPTION
## Summary

- **New `galoy-agents-memory` workspace crate** with SQLite-backed memory store using FTS5 keyword search + sqlite-vec vector similarity, combined via Reciprocal Rank Fusion (RRF)
- **Shared Embedder**: Added `Clone` to the fastembed `Embedder` and `init_endpoints_with_embedder()` to style-agent-server so both style-agent and memory share one nomic-embed-text-v1.5 model instance
- **3 MCP tools** wired into McpGateway: `store_memory`, `search_memory`, `list_memories`
- **Decay scoring**: Exponential decay with 14-day half-life; persistent memories (reports) are exempt
- **Configuration**: `memory.db_path` and `memory.decay_half_life_days` in galoy-agents.yml, with `MEMORY_DB_PATH` env override

### Crate structure
```
memory/
├── src/
│   ├── lib.rs         — public API re-exports
│   ├── config.rs      — MemoryConfig (db_path, decay_half_life_days)
│   ├── error.rs       — MemoryError (thiserror)
│   ├── memory.rs      — Memory, NewMemory, SearchResult types
│   ├── store.rs       — MemoryStore (rusqlite + FTS5 + sqlite-vec)
│   ├── service.rs     — MemoryService (hybrid search, decay, embeddings)
│   └── endpoints.rs   — MemoryEndpoints facade (MCP tool handlers)
└── Cargo.toml
```

## Test plan
- [ ] `nix flake check` passes (fmt, clippy --deny warnings, nextest)
- [ ] Verify store/search/list MCP tools work end-to-end via gateway
- [ ] Confirm shared embedder doesn't cause contention under load

🤖 Generated with [Claude Code](https://claude.com/claude-code)