### PR TITLE
feat(web): dashboard UI with search, stats, and request logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ style-agent/labels/audit-suspects.jsonl
 data/
 .fastembed_cache/
 style-agent/models/
+.playwright-mcp/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1290,6 +1290,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sqlx",
+ "style-agent-server",
  "thiserror 2.0.18",
  "time",
  "tokio",

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -59,21 +59,22 @@ async fn main() -> anyhow::Result<()> {
     let app = galoy_agents_domain::App::new(&pool);
     let auth_config = config.auth_config();
     let oauth_client = auth_config.oauth_client();
-    let app_state = galoy_agents_web::AppState::new(
-        app,
-        oauth_client,
-        config.server.mcp_endpoint.clone(),
-        auth_config.github_allowed_teams,
-    );
-
     let server_config = galoy_agents_web::server::ServerConfig {
         host: config.server.host.clone(),
         port: config.server.port,
         secure_cookies: config.server.secure_cookies,
     };
 
-    let mcp_service =
-        galoy_agents_mcp_gateway::McpGateway::service(app_state.app.clone(), &config.style_agent)?;
+    let (mcp_service, style_agent_endpoints) =
+        galoy_agents_mcp_gateway::McpGateway::service(app.clone(), &config.style_agent)?;
+
+    let app_state = galoy_agents_web::AppState::new(
+        app,
+        oauth_client,
+        config.server.mcp_endpoint.clone(),
+        auth_config.github_allowed_teams,
+        style_agent_endpoints,
+    );
 
     let router = galoy_agents_web::server::build_app(&server_config, &pool, app_state, mcp_service);
 

--- a/domain/src/style_agent_logs/mod.rs
+++ b/domain/src/style_agent_logs/mod.rs
@@ -116,6 +116,54 @@ impl StyleAgentLogs {
             .collect())
     }
 
+    /// Return least useful requests: low scores, errors, empty results.
+    #[instrument(name = "domain.style_agent_logs.least_useful", skip_all)]
+    pub async fn least_useful(
+        &self,
+        limit: i64,
+    ) -> Result<Vec<StyleAgentRequestRow>, StyleAgentLogsError> {
+        let rows: Vec<RawRequestRow> = sqlx::query_as(
+            r#"SELECT
+                id, tool_name, query, num_results, top_score, latency_ms,
+                label_filter, language_filter, repo_filter, error,
+                created_at
+            FROM style_agent_request_log
+            WHERE error IS NOT NULL
+               OR num_results = 0
+               OR (top_score IS NOT NULL AND top_score < 0.3)
+            ORDER BY created_at DESC
+            LIMIT $1"#,
+        )
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| {
+                let top_score_fmt =
+                    r.4.map(|s| format!("{s:.3}"))
+                        .unwrap_or_else(|| "—".to_string());
+                let has_error = r.9.is_some();
+                StyleAgentRequestRow {
+                    id: r.0,
+                    tool_name: r.1,
+                    query: r.2,
+                    num_results: r.3,
+                    top_score: r.4,
+                    top_score_fmt,
+                    latency_ms: r.5,
+                    label_filter: r.6,
+                    language_filter: r.7,
+                    repo_filter: r.8,
+                    error: r.9,
+                    has_error,
+                    created_at: r.10.format("%Y-%m-%d %H:%M:%S").to_string(),
+                }
+            })
+            .collect())
+    }
+
     /// Return aggregated dashboard stats for the web UI.
     #[instrument(name = "domain.style_agent_logs.dashboard_stats", skip_all)]
     pub async fn dashboard_stats(&self) -> Result<DashboardStats, StyleAgentLogsError> {

--- a/domain/src/style_agent_logs/mod.rs
+++ b/domain/src/style_agent_logs/mod.rs
@@ -15,6 +15,7 @@ pub struct StyleAgentRequestRow {
     pub num_results: i32,
     pub top_score: Option<f64>,
     pub top_score_fmt: String,
+    pub score_class: String,
     pub latency_ms: i32,
     pub label_filter: Option<String>,
     pub language_filter: Option<String>,
@@ -22,6 +23,7 @@ pub struct StyleAgentRequestRow {
     pub error: Option<String>,
     pub has_error: bool,
     pub created_at: String,
+    pub results_json: String,
 }
 
 /// A query string and how often it was used (for the dashboard).
@@ -54,6 +56,7 @@ type RawRequestRow = (
     Option<String>,
     Option<String>,
     Option<String>,
+    Option<serde_json::Value>,
     chrono::DateTime<chrono::Utc>,
 );
 
@@ -66,6 +69,50 @@ pub struct StyleAgentLogs {
     pool: sqlx::PgPool,
 }
 
+fn score_class(score: Option<f64>) -> String {
+    match score {
+        Some(s) if s >= 0.5 => "score-green",
+        Some(s) if s >= 0.3 => "score-orange",
+        Some(_) => "score-red",
+        None => "score-none",
+    }
+    .to_string()
+}
+
+fn row_to_view(r: RawRequestRow) -> StyleAgentRequestRow {
+    let top_score_fmt =
+        r.4.map(|s| format!("{s:.3}"))
+            .unwrap_or_else(|| "—".to_string());
+    let has_error = r.9.is_some();
+    let sc = score_class(r.4);
+    let results_json =
+        r.10.map(|v| serde_json::to_string_pretty(&v).unwrap_or_default())
+            .unwrap_or_default();
+    StyleAgentRequestRow {
+        id: r.0,
+        tool_name: r.1,
+        query: r.2,
+        num_results: r.3,
+        top_score: r.4,
+        top_score_fmt,
+        score_class: sc,
+        latency_ms: r.5,
+        label_filter: r.6,
+        language_filter: r.7,
+        repo_filter: r.8,
+        error: r.9,
+        has_error,
+        created_at: r.11.format("%Y-%m-%d %H:%M:%S").to_string(),
+        results_json,
+    }
+}
+
+const SELECT_COLS: &str = r#"SELECT
+    id, tool_name, query, num_results, top_score, latency_ms,
+    label_filter, language_filter, repo_filter, error, results,
+    created_at
+FROM style_agent_request_log"#;
+
 impl StyleAgentLogs {
     pub fn new(pool: &sqlx::PgPool) -> Self {
         Self { pool: pool.clone() }
@@ -77,91 +124,21 @@ impl StyleAgentLogs {
         &self,
         limit: i64,
     ) -> Result<Vec<StyleAgentRequestRow>, StyleAgentLogsError> {
-        let rows: Vec<RawRequestRow> = sqlx::query_as(
-            r#"SELECT
-                id, tool_name, query, num_results, top_score, latency_ms,
-                label_filter, language_filter, repo_filter, error,
-                created_at
-            FROM style_agent_request_log
-            ORDER BY created_at DESC
-            LIMIT $1"#,
-        )
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
-
-        Ok(rows
-            .into_iter()
-            .map(|r| {
-                let top_score_fmt =
-                    r.4.map(|s| format!("{s:.3}"))
-                        .unwrap_or_else(|| "—".to_string());
-                let has_error = r.9.is_some();
-                StyleAgentRequestRow {
-                    id: r.0,
-                    tool_name: r.1,
-                    query: r.2,
-                    num_results: r.3,
-                    top_score: r.4,
-                    top_score_fmt,
-                    latency_ms: r.5,
-                    label_filter: r.6,
-                    language_filter: r.7,
-                    repo_filter: r.8,
-                    error: r.9,
-                    has_error,
-                    created_at: r.10.format("%Y-%m-%d %H:%M:%S").to_string(),
-                }
-            })
-            .collect())
+        let q = format!("{SELECT_COLS} ORDER BY created_at DESC LIMIT $1");
+        let rows: Vec<RawRequestRow> = sqlx::query_as(&q).bind(limit).fetch_all(&self.pool).await?;
+        Ok(rows.into_iter().map(row_to_view).collect())
     }
 
-    /// Return least useful requests: low scores, errors, empty results.
+    /// Return requests ordered by score ascending (least useful first).
     #[instrument(name = "domain.style_agent_logs.least_useful", skip_all)]
     pub async fn least_useful(
         &self,
         limit: i64,
     ) -> Result<Vec<StyleAgentRequestRow>, StyleAgentLogsError> {
-        let rows: Vec<RawRequestRow> = sqlx::query_as(
-            r#"SELECT
-                id, tool_name, query, num_results, top_score, latency_ms,
-                label_filter, language_filter, repo_filter, error,
-                created_at
-            FROM style_agent_request_log
-            WHERE error IS NOT NULL
-               OR num_results = 0
-               OR (top_score IS NOT NULL AND top_score < 0.3)
-            ORDER BY created_at DESC
-            LIMIT $1"#,
-        )
-        .bind(limit)
-        .fetch_all(&self.pool)
-        .await?;
-
-        Ok(rows
-            .into_iter()
-            .map(|r| {
-                let top_score_fmt =
-                    r.4.map(|s| format!("{s:.3}"))
-                        .unwrap_or_else(|| "—".to_string());
-                let has_error = r.9.is_some();
-                StyleAgentRequestRow {
-                    id: r.0,
-                    tool_name: r.1,
-                    query: r.2,
-                    num_results: r.3,
-                    top_score: r.4,
-                    top_score_fmt,
-                    latency_ms: r.5,
-                    label_filter: r.6,
-                    language_filter: r.7,
-                    repo_filter: r.8,
-                    error: r.9,
-                    has_error,
-                    created_at: r.10.format("%Y-%m-%d %H:%M:%S").to_string(),
-                }
-            })
-            .collect())
+        let q =
+            format!("{SELECT_COLS} ORDER BY COALESCE(top_score, 0) ASC, created_at DESC LIMIT $1");
+        let rows: Vec<RawRequestRow> = sqlx::query_as(&q).bind(limit).fetch_all(&self.pool).await?;
+        Ok(rows.into_iter().map(row_to_view).collect())
     }
 
     /// Return aggregated dashboard stats for the web UI.

--- a/domain/src/style_agent_logs/mod.rs
+++ b/domain/src/style_agent_logs/mod.rs
@@ -86,8 +86,23 @@ fn row_to_view(r: RawRequestRow) -> StyleAgentRequestRow {
     let has_error = r.9.is_some();
     let sc = score_class(r.4);
     let results_json =
-        r.10.map(|v| serde_json::to_string_pretty(&v).unwrap_or_default())
-            .unwrap_or_default();
+        r.10.and_then(|v| {
+            let arr = v.as_array()?;
+            let code_blocks: Vec<String> = arr
+                .iter()
+                .filter_map(|item| {
+                    let file = item.get("file")?.as_str()?;
+                    let content = item.get("content")?.as_str()?;
+                    Some(format!("// {file}\n{content}"))
+                })
+                .collect();
+            if code_blocks.is_empty() {
+                None
+            } else {
+                Some(code_blocks.join("\n\n"))
+            }
+        })
+        .unwrap_or_default();
     StyleAgentRequestRow {
         id: r.0,
         tool_name: r.1,

--- a/galoy-agents.yml
+++ b/galoy-agents.yml
@@ -4,7 +4,7 @@ server:
   secure_cookies: false
   mcp_endpoint: "http://localhost:4200/mcp"
 oauth:
-  github_client_id: ""
+  github_client_id: "Ov23li9ZTNnKjiTRwDcb"
   github_redirect_uri: "http://localhost:4200/auth/github/callback"
   github_allowed_teams: []
 style_agent:

--- a/mcp-gateway/src/lib.rs
+++ b/mcp-gateway/src/lib.rs
@@ -34,11 +34,15 @@ impl McpGateway {
     pub fn service(
         app: App,
         style_agent_config: &StyleAgentConfig,
-    ) -> anyhow::Result<StreamableHttpService<Self, LocalSessionManager>> {
+    ) -> anyhow::Result<(
+        StreamableHttpService<Self, LocalSessionManager>,
+        Option<StyleAgentEndpoints>,
+    )> {
         let logger = app.style_agent_logs().clone();
         let style_agent =
             style_agent_server::init_endpoints_with_logger(style_agent_config, logger)?;
-        Ok(Self::build_service(app, style_agent))
+        let svc = Self::build_service(app, style_agent.clone());
+        Ok((svc, style_agent))
     }
 
     fn build_service(

--- a/style-agent/crates/server/src/endpoints.rs
+++ b/style-agent/crates/server/src/endpoints.rs
@@ -64,6 +64,20 @@ impl StyleAgentEndpoints {
         }
     }
 
+    /// Run a search and return the raw results (for the web dashboard).
+    pub async fn search_raw(
+        &self,
+        query: &str,
+        limit: u64,
+        label: Option<&str>,
+    ) -> Result<Vec<SearchResult>, anyhow::Error> {
+        let results = self
+            .search_engine
+            .search(query, limit, None, None, label, None, None)
+            .await?;
+        Ok(results)
+    }
+
     /// Execute a `search_code` query.
     pub async fn search_code(
         &self,

--- a/style-agent/crates/server/src/endpoints.rs
+++ b/style-agent/crates/server/src/endpoints.rs
@@ -262,6 +262,7 @@ fn build_results_json(results: &[SearchResult]) -> String {
                 "score": format!("{:.3}", r.score),
                 "labels": r.labels,
                 "lines": format!("{}-{}", r.line_start, r.line_end),
+                "content": r.content,
             })
         })
         .collect();

--- a/style-agent/crates/server/src/lib.rs
+++ b/style-agent/crates/server/src/lib.rs
@@ -14,3 +14,4 @@ pub use standalone_server::{
 
 pub use style_agent_core::request_log;
 pub use style_agent_core::search::SearchEngine;
+pub use style_agent_core::store::SearchResult;

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 
 [dependencies]
 galoy-agents-domain = { path = "../domain" }
+style-agent-server = { workspace = true }
 anyhow = "1"
 askama = "0.15"
 askama_web = { version = "0.15", features = ["axum-0.8"] }

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -10,6 +10,7 @@ use galoy_agents_domain as domain;
 use domain::App;
 
 use auth::config::OAuthClient;
+use style_agent_server::StyleAgentEndpoints;
 
 /// Unified application state shared by all routes and middleware.
 #[derive(Clone)]
@@ -18,6 +19,7 @@ pub struct AppState {
     pub oauth_client: OAuthClient,
     pub mcp_endpoint: String,
     pub github_allowed_teams: Vec<String>,
+    pub style_agent: Option<StyleAgentEndpoints>,
 }
 
 impl AppState {
@@ -26,12 +28,14 @@ impl AppState {
         oauth_client: OAuthClient,
         mcp_endpoint: String,
         github_allowed_teams: Vec<String>,
+        style_agent: Option<StyleAgentEndpoints>,
     ) -> Self {
         Self {
             app,
             oauth_client,
             mcp_endpoint,
             github_allowed_teams,
+            style_agent,
         }
     }
 }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -32,6 +32,7 @@ pub fn router() -> Router<AppState> {
         .route("/style-agent", get(style_agent_dashboard))
         .route("/style-agent/recent", get(style_agent_recent))
         .route("/style-agent/least-useful", get(style_agent_least_useful))
+        .route("/style-agent/search", get(style_agent_search))
 }
 
 async fn extract_user_id(session: &Session) -> Option<UserId> {
@@ -225,4 +226,78 @@ async fn style_agent_least_useful(State(state): State<AppState>, session: Sessio
     };
 
     StyleAgentRecentTemplate { rows }.into_response()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SearchParams {
+    q: Option<String>,
+    label: Option<String>,
+}
+
+#[instrument(name = "web.style_agent_search", skip_all)]
+async fn style_agent_search(
+    State(state): State<AppState>,
+    session: Session,
+    Query(params): Query<SearchParams>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    let query = params.q.unwrap_or_default();
+    if query.is_empty() {
+        return StyleAgentSearchResultsTemplate {
+            query,
+            results: vec![],
+            error: None,
+        }
+        .into_response();
+    }
+
+    let endpoints = match state.style_agent.as_ref() {
+        Some(ep) => ep,
+        None => {
+            return StyleAgentSearchResultsTemplate {
+                query,
+                results: vec![],
+                error: Some("Style-agent is not configured".to_string()),
+            }
+            .into_response();
+        }
+    };
+
+    let label = params.label.as_deref().filter(|s| !s.is_empty());
+
+    match endpoints.search_raw(&query, 10, label).await {
+        Ok(raw_results) => {
+            let results = raw_results
+                .iter()
+                .map(|r| SearchResultView {
+                    file_path: r.file_path.clone(),
+                    repo: r.repo.clone(),
+                    score: format!("{:.3}", r.score),
+                    labels: r.labels.join(", "),
+                    lines: format!("{}-{}", r.line_start, r.line_end),
+                    content: r.content.clone(),
+                    language: if r.language.is_empty() {
+                        "rust".to_string()
+                    } else {
+                        r.language.clone()
+                    },
+                })
+                .collect();
+            StyleAgentSearchResultsTemplate {
+                query,
+                results,
+                error: None,
+            }
+            .into_response()
+        }
+        Err(e) => StyleAgentSearchResultsTemplate {
+            query,
+            results: vec![],
+            error: Some(e.to_string()),
+        }
+        .into_response(),
+    }
 }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -31,6 +31,7 @@ pub fn router() -> Router<AppState> {
         .route("/agents/{id}/revoke", post(revoke_agent))
         .route("/style-agent", get(style_agent_dashboard))
         .route("/style-agent/recent", get(style_agent_recent))
+        .route("/style-agent/least-useful", get(style_agent_least_useful))
 }
 
 async fn extract_user_id(session: &Session) -> Option<UserId> {
@@ -202,6 +203,23 @@ async fn style_agent_recent(State(state): State<AppState>, session: Session) -> 
         Ok(rows) => rows,
         Err(e) => {
             tracing::error!(error = %e, "Failed to load recent requests");
+            return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    StyleAgentRecentTemplate { rows }.into_response()
+}
+
+#[instrument(name = "web.style_agent_least_useful", skip_all)]
+async fn style_agent_least_useful(State(state): State<AppState>, session: Session) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    let rows = match state.app.style_agent_logs().least_useful(50).await {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to load least useful requests");
             return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
     };

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -53,3 +53,22 @@ pub struct StyleAgentTemplate {
 pub struct StyleAgentRecentTemplate {
     pub rows: Vec<StyleAgentRequestRow>,
 }
+
+/// A single search result for the web UI.
+pub struct SearchResultView {
+    pub file_path: String,
+    pub repo: String,
+    pub score: String,
+    pub labels: String,
+    pub lines: String,
+    pub content: String,
+    pub language: String,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "style_agent_search_results.html")]
+pub struct StyleAgentSearchResultsTemplate {
+    pub query: String,
+    pub results: Vec<SearchResultView>,
+    pub error: Option<String>,
+}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -7,6 +7,39 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
   <script src="https://unpkg.com/htmx.org@2.0.4"></script>
   <style>
+    body { display: flex; min-height: 100vh; margin: 0; }
+    .sidebar {
+      width: 220px;
+      background: var(--pico-card-background-color);
+      border-right: 1px solid var(--pico-muted-border-color);
+      padding: 1.5rem 1rem;
+      flex-shrink: 0;
+    }
+    .sidebar h4 { margin-bottom: 1.5rem; }
+    .sidebar nav ul { list-style: none; padding: 0; margin: 0; }
+    .sidebar nav ul li { margin-bottom: 0.25rem; }
+    .sidebar nav ul li a {
+      display: block;
+      padding: 0.5rem 0.75rem;
+      border-radius: var(--pico-border-radius);
+      text-decoration: none;
+      color: var(--pico-color);
+    }
+    .sidebar nav ul li a:hover,
+    .sidebar nav ul li a.active {
+      background: var(--pico-primary-background);
+      color: var(--pico-primary-inverse);
+    }
+    .sidebar .sidebar-bottom {
+      margin-top: auto;
+      padding-top: 1rem;
+      border-top: 1px solid var(--pico-muted-border-color);
+    }
+    .content-area {
+      flex: 1;
+      padding: 2rem;
+      overflow-y: auto;
+    }
     .token-box {
       position: relative;
       background: var(--pico-code-background-color);
@@ -44,8 +77,20 @@
   {% block head %}{% endblock %}
 </head>
 <body>
-  <main class="container">
+  <aside class="sidebar">
+    <h4>Galoy Agents</h4>
+    <nav>
+      <ul>
+        <li><a href="/dashboard" {% block nav_dashboard %}{% endblock %}>Agents</a></li>
+        <li><a href="/style-agent" {% block nav_style_agent %}{% endblock %}>Style Agent</a></li>
+      </ul>
+    </nav>
+    <div class="sidebar-bottom">
+      <a href="/auth/logout">Logout</a>
+    </div>
+  </aside>
+  <div class="content-area">
     {% block content %}{% endblock %}
-  </main>
+  </div>
 </body>
 </html>

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -2,14 +2,10 @@
 
 {% block title %}Dashboard — Galoy Agents{% endblock %}
 
+{% block nav_dashboard %}class="active"{% endblock %}
+
 {% block content %}
-<nav>
-  <ul><li><strong>Galoy Agents</strong></li></ul>
-  <ul>
-    <li>{{ user_name }}</li>
-    <li><a href="/auth/logout">Logout</a></li>
-  </ul>
-</nav>
+<p>Welcome, {{ user_name }}</p>
 
 <section>
   <h2>Create Agent</h2>

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -1,20 +1,27 @@
-{% extends "base.html" %}
-
-{% block title %}Login — Galoy Agents{% endblock %}
-
-{% block content %}
-<article style="margin-top: 4rem; max-width: 480px; margin-left: auto; margin-right: auto;">
-  <header>
-    <h1>Galoy Agents</h1>
-    <p>Manage your MCP gateway agents</p>
-  </header>
-  {% if let Some(msg) = error %}
-  <div role="alert" style="padding: 1rem; margin-bottom: 1rem; background: var(--pico-del-color, #c62828); color: white; border-radius: 4px;">
-    {{ msg }}
-  </div>
-  {% endif %}
-  <a href="/auth/github" role="button" style="display: block; text-align: center;">
-    Sign in with GitHub
-  </a>
-</article>
-{% endblock %}
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Login — Galoy Agents</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
+</head>
+<body>
+  <main class="container">
+    <article style="margin-top: 4rem; max-width: 480px; margin-left: auto; margin-right: auto;">
+      <header>
+        <h1>Galoy Agents</h1>
+        <p>Manage your MCP gateway agents</p>
+      </header>
+      {% if let Some(msg) = error %}
+      <div role="alert" style="padding: 1rem; margin-bottom: 1rem; background: var(--pico-del-color, #c62828); color: white; border-radius: 4px;">
+        {{ msg }}
+      </div>
+      {% endif %}
+      <a href="/auth/github" role="button" style="display: block; text-align: center;">
+        Sign in with GitHub
+      </a>
+    </article>
+  </main>
+</body>
+</html>

--- a/web/templates/style_agent.html
+++ b/web/templates/style_agent.html
@@ -2,11 +2,13 @@
 
 {% block title %}Style Agent — Galoy Agents{% endblock %}
 
+{% block nav_style_agent %}class="active"{% endblock %}
+
 {% block head %}
 <style>
   .stats-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
     gap: 1rem;
     margin-bottom: 2rem;
   }
@@ -32,29 +34,42 @@
     text-overflow: ellipsis;
     white-space: nowrap;
   }
-  .error-text {
-    color: var(--pico-del-color);
-    font-size: 0.85rem;
+  .error-text { color: var(--pico-del-color); font-size: 0.85rem; }
+  .score-low { color: var(--pico-del-color); }
+  .score-ok { color: var(--pico-ins-color); }
+  .tab-bar {
+    display: flex;
+    gap: 0;
+    border-bottom: 2px solid var(--pico-muted-border-color);
+    margin-bottom: 1rem;
   }
-  .score-low {
-    color: var(--pico-del-color);
+  .tab-bar button {
+    background: none;
+    border: none;
+    border-bottom: 2px solid transparent;
+    margin-bottom: -2px;
+    padding: 0.5rem 1.25rem;
+    cursor: pointer;
+    color: var(--pico-muted-color);
+    font-weight: 500;
   }
-  .score-ok {
-    color: var(--pico-ins-color);
+  .tab-bar button.active {
+    border-bottom-color: var(--pico-primary);
+    color: var(--pico-primary);
+  }
+  .two-col {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 2rem;
+  }
+  @media (max-width: 900px) {
+    .two-col { grid-template-columns: 1fr; }
   }
 </style>
 {% endblock %}
 
 {% block content %}
-<nav>
-  <ul><li><strong>Galoy Agents</strong></li></ul>
-  <ul>
-    <li><a href="/dashboard">Dashboard</a></li>
-    <li><a href="/auth/logout">Logout</a></li>
-  </ul>
-</nav>
-
-<h2>Style Agent Metrics</h2>
+<h2>Style Agent</h2>
 
 <div class="stats-grid">
   <div class="stat-card">
@@ -80,15 +95,12 @@
 </div>
 
 {% if !stats.top_queries.is_empty() %}
-<section>
-  <h3>Top Queries (7d)</h3>
+<details open>
+  <summary><strong>Top Queries (7d)</strong></summary>
   <figure>
     <table>
       <thead>
-        <tr>
-          <th>Query</th>
-          <th>Count</th>
-        </tr>
+        <tr><th>Query</th><th>Count</th></tr>
       </thead>
       <tbody>
         {% for q in stats.top_queries %}
@@ -100,18 +112,31 @@
       </tbody>
     </table>
   </figure>
-</section>
+</details>
 {% endif %}
 
-<section>
-  <h3>Recent Requests</h3>
-  <div
-    hx-get="/style-agent/recent"
-    hx-trigger="load"
-    hx-swap="innerHTML"
-    id="recent-requests"
-  >
-    <p aria-busy="true">Loading recent requests…</p>
-  </div>
-</section>
+<div class="tab-bar">
+  <button class="active"
+          onclick="switchTab(this, 'recent-tab')"
+          hx-get="/style-agent/recent" hx-target="#recent-tab" hx-swap="innerHTML"
+          hx-trigger="click, load">Recent Requests</button>
+  <button
+          onclick="switchTab(this, 'least-useful-tab')"
+          hx-get="/style-agent/least-useful" hx-target="#least-useful-tab" hx-swap="innerHTML"
+          hx-trigger="click">Least Useful</button>
+</div>
+
+<div id="recent-tab">
+  <p aria-busy="true">Loading...</p>
+</div>
+<div id="least-useful-tab" style="display: none;"></div>
+
+<script>
+function switchTab(btn, tabId) {
+  document.querySelectorAll('.tab-bar button').forEach(b => b.classList.remove('active'));
+  btn.classList.add('active');
+  document.getElementById('recent-tab').style.display = tabId === 'recent-tab' ? '' : 'none';
+  document.getElementById('least-useful-tab').style.display = tabId === 'least-useful-tab' ? '' : 'none';
+}
+</script>
 {% endblock %}

--- a/web/templates/style_agent.html
+++ b/web/templates/style_agent.html
@@ -35,8 +35,10 @@
     white-space: nowrap;
   }
   .error-text { color: var(--pico-del-color); font-size: 0.85rem; }
-  .score-low { color: var(--pico-del-color); }
-  .score-ok { color: var(--pico-ins-color); }
+  .score-red { color: #d32f2f; font-weight: bold; }
+  .score-orange { color: #f57c00; font-weight: bold; }
+  .score-green { color: #388e3c; font-weight: bold; }
+  .score-none { color: var(--pico-muted-color); }
   .tab-bar {
     display: flex;
     gap: 0;

--- a/web/templates/style_agent.html
+++ b/web/templates/style_agent.html
@@ -71,6 +71,40 @@
 {% block content %}
 <h2>Style Agent</h2>
 
+<section>
+  <h3>Search Code</h3>
+  <form hx-get="/style-agent/search" hx-target="#search-results" hx-swap="innerHTML"
+        hx-indicator="#search-spinner">
+    <div style="display: flex; gap: 0.5rem; align-items: end;">
+      <label style="flex: 1;">
+        Query
+        <input type="text" name="q" placeholder="impl TryFromEvents for" required>
+      </label>
+      <label>
+        Label
+        <select name="label">
+          <option value="">All</option>
+          <option>entity</option>
+          <option>entity_event</option>
+          <option>entity_command</option>
+          <option>entity_hydration</option>
+          <option>service</option>
+          <option>service_method</option>
+          <option>repository</option>
+          <option>error</option>
+          <option>domain_primitives</option>
+          <option>api</option>
+          <option>test</option>
+          <option>config</option>
+        </select>
+      </label>
+      <button type="submit">Search</button>
+    </div>
+  </form>
+  <div id="search-results" style="margin-top: 1rem;"></div>
+  <span id="search-spinner" class="htmx-indicator" aria-busy="true"></span>
+</section>
+
 <div class="stats-grid">
   <div class="stat-card">
     <div class="stat-label">Requests (24h)</div>

--- a/web/templates/style_agent.html
+++ b/web/templates/style_agent.html
@@ -77,12 +77,12 @@
   <h3>Search Code</h3>
   <form hx-get="/style-agent/search" hx-target="#search-results" hx-swap="innerHTML"
         hx-indicator="#search-spinner">
-    <div style="display: flex; gap: 0.5rem; align-items: end;">
-      <label style="flex: 1;">
-        Query
-        <input type="text" name="q" placeholder="impl TryFromEvents for" required>
-      </label>
-      <label>
+    <label>
+      Query
+      <input type="text" name="q" placeholder="impl TryFromEvents for" required>
+    </label>
+    <div style="display: flex; gap: 1rem; align-items: end;">
+      <label style="width: 200px;">
         Label
         <select name="label">
           <option value="">All</option>
@@ -100,7 +100,7 @@
           <option>config</option>
         </select>
       </label>
-      <button type="submit">Search</button>
+      <button type="submit" style="width: auto; margin-bottom: 0;">Search</button>
     </div>
   </form>
   <div id="search-results" style="margin-top: 1rem;"></div>

--- a/web/templates/style_agent_recent.html
+++ b/web/templates/style_agent_recent.html
@@ -3,7 +3,6 @@
     <thead>
       <tr>
         <th>Time</th>
-        <th>Tool</th>
         <th>Query</th>
         <th>Results</th>
         <th>Score</th>
@@ -16,21 +15,30 @@
       {% for row in rows %}
       <tr>
         <td>{{ row.created_at }}</td>
-        <td>{{ row.tool_name }}</td>
         <td class="query-text"><code>{{ row.query }}</code></td>
         <td>{{ row.num_results }}</td>
-        <td>{{ row.top_score_fmt }}</td>
+        <td><span class="{{ row.score_class }}">{{ row.top_score_fmt }}</span></td>
         <td>{{ row.latency_ms }}ms</td>
         <td>{{ row.label_filter.as_deref().unwrap_or("—") }}</td>
         <td>
           {% if row.has_error %}
-          <span class="error-text" title="{{ row.error.as_deref().unwrap_or("") }}">✗</span>
+          <span class="error-text" title="{{ row.error.as_deref().unwrap_or("") }}">error</span>
           {% endif %}
         </td>
       </tr>
+      {% if !row.results_json.is_empty() %}
+      <tr>
+        <td colspan="7" style="padding: 0;">
+          <details>
+            <summary style="padding: 0.25rem 0.5rem; font-size: 0.8rem; cursor: pointer;">Show returned results</summary>
+            <pre style="font-size: 0.75rem; max-height: 300px; overflow: auto; margin: 0; padding: 0.5rem;">{{ row.results_json }}</pre>
+          </details>
+        </td>
+      </tr>
+      {% endif %}
       {% endfor %}
       {% if rows.is_empty() %}
-      <tr><td colspan="8">No requests logged yet.</td></tr>
+      <tr><td colspan="7">No requests logged yet.</td></tr>
       {% endif %}
     </tbody>
   </table>

--- a/web/templates/style_agent_recent.html
+++ b/web/templates/style_agent_recent.html
@@ -2,33 +2,25 @@
   <table>
     <thead>
       <tr>
-        <th>Time</th>
         <th>Query</th>
+        <th>Label</th>
         <th>Results</th>
         <th>Score</th>
-        <th>Latency</th>
-        <th>Label</th>
-        <th>Error</th>
+        <th>Time</th>
       </tr>
     </thead>
     <tbody>
       {% for row in rows %}
       <tr>
-        <td>{{ row.created_at }}</td>
         <td class="query-text"><code>{{ row.query }}</code></td>
+        <td>{{ row.label_filter.as_deref().unwrap_or("—") }}</td>
         <td>{{ row.num_results }}</td>
         <td><span class="{{ row.score_class }}">{{ row.top_score_fmt }}</span></td>
-        <td>{{ row.latency_ms }}ms</td>
-        <td>{{ row.label_filter.as_deref().unwrap_or("—") }}</td>
-        <td>
-          {% if row.has_error %}
-          <span class="error-text" title="{{ row.error.as_deref().unwrap_or("") }}">error</span>
-          {% endif %}
-        </td>
+        <td>{{ row.created_at }}</td>
       </tr>
       {% if !row.results_json.is_empty() %}
       <tr>
-        <td colspan="7" style="padding: 0;">
+        <td colspan="5" style="padding: 0;">
           <details>
             <summary style="padding: 0.25rem 0.5rem; font-size: 0.8rem; cursor: pointer;">Show returned results</summary>
             <pre style="font-size: 0.75rem; max-height: 300px; overflow: auto; margin: 0; padding: 0.5rem;">{{ row.results_json }}</pre>
@@ -38,7 +30,7 @@
       {% endif %}
       {% endfor %}
       {% if rows.is_empty() %}
-      <tr><td colspan="7">No requests logged yet.</td></tr>
+      <tr><td colspan="5">No requests logged yet.</td></tr>
       {% endif %}
     </tbody>
   </table>

--- a/web/templates/style_agent_search_results.html
+++ b/web/templates/style_agent_search_results.html
@@ -1,0 +1,17 @@
+{% if let Some(err) = error %}
+<p style="color: var(--pico-del-color);">{{ err }}</p>
+{% endif %}
+
+{% if results.is_empty() && error.is_none() && !query.is_empty() %}
+<p>No matching code patterns found.</p>
+{% endif %}
+
+{% for r in results %}
+<details open>
+  <summary>
+    <code>{{ r.file_path }}</code>
+    <small>({{ r.repo }}) — score: {{ r.score }} | lines: {{ r.lines }}{% if !r.labels.is_empty() %} | {{ r.labels }}{% endif %}</small>
+  </summary>
+  <pre><code class="language-{{ r.language }}">{{ r.content }}</code></pre>
+</details>
+{% endfor %}


### PR DESCRIPTION
## Summary
- Sidebar navigation with Agents and Style Agent links
- Live code search from dashboard (query + label filter, htmx results)
- Stats cards: requests (24h/7d), avg latency, error rate, low score rate
- Top queries (7d) breakdown
- Tabbed view: Recent Requests / Least Useful (ordered by score ascending)
- Color-coded scores (red < 0.3, orange 0.3–0.5, green >= 0.5)
- Expandable rows showing returned code snippets
- Logged results now include actual code content in JSONB
- All style-agent web endpoints require authenticated session

## Test plan
- [ ] Log in, navigate to Style Agent via sidebar
- [ ] Search for a code pattern — verify results render with code blocks
- [ ] Make MCP search_code calls — verify they appear in Recent Requests
- [ ] Click "Least Useful" tab — verify rows ordered by score ascending
- [ ] Expand a result row — verify code snippets are shown
- [ ] Log out — verify `/style-agent` redirects to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)