### PR TITLE
feat(mcp-gateway): integrate Concourse CI tools

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -533,6 +533,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "concourse-client"
+version = "0.1.0"
+dependencies = [
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,6 +1276,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "axum",
+ "concourse-client",
  "galoy-agents-domain",
  "http",
  "rmcp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
   "cli",
+  "concourse-client",
   "domain",
   "mcp-gateway",
   "web",
@@ -18,7 +19,8 @@ version = "0.1.0"
 name = "galoy-agents"
 
 [workspace.dependencies]
-# Internal style-agent crates
+# Internal crates
+concourse-client = { path = "concourse-client" }
 style-agent-core = { path = "style-agent/crates/core" }
 style-agent-server = { path = "style-agent/crates/server" }
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use serde::Deserialize;
 
-use galoy_agents_mcp_gateway::StyleAgentConfig;
+use galoy_agents_mcp_gateway::{ConcourseConfig, StyleAgentConfig};
 use galoy_agents_web::auth::config::AuthConfig;
 
 #[derive(Clone, Deserialize)]
@@ -16,6 +16,8 @@ pub struct Config {
     pub db: DbConfig,
     #[serde(default)]
     pub style_agent: StyleAgentConfig,
+    #[serde(default)]
+    pub concourse: ConcourseConfig,
 }
 
 #[derive(Clone, Deserialize)]
@@ -106,6 +108,14 @@ impl Config {
         // Style-agent env overrides
         if let Ok(val) = std::env::var("STYLE_AGENT_DB_PATH") {
             config.style_agent.db_path = val;
+        }
+
+        // Concourse env overrides (credentials are never in the config file)
+        if let Ok(val) = std::env::var("CONCOURSE_USERNAME") {
+            config.concourse.username = val;
+        }
+        if let Ok(val) = std::env::var("CONCOURSE_PASSWORD") {
+            config.concourse.password = val;
         }
 
         Ok(config)

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -65,8 +65,11 @@ async fn main() -> anyhow::Result<()> {
         secure_cookies: config.server.secure_cookies,
     };
 
-    let (mcp_service, style_agent_endpoints) =
-        galoy_agents_mcp_gateway::McpGateway::service(app.clone(), &config.style_agent)?;
+    let (mcp_service, style_agent_endpoints) = galoy_agents_mcp_gateway::McpGateway::service(
+        app.clone(),
+        &config.style_agent,
+        &config.concourse,
+    )?;
 
     let app_state = galoy_agents_web::AppState::new(
         app,

--- a/concourse-client/Cargo.toml
+++ b/concourse-client/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "concourse-client"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+reqwest = { workspace = true, features = ["stream"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+url = "2"

--- a/concourse-client/src/auth.rs
+++ b/concourse-client/src/auth.rs
@@ -1,0 +1,89 @@
+use reqwest::header::{HeaderMap, HeaderValue, AUTHORIZATION};
+use tokio::sync::RwLock;
+use url::Url;
+
+use crate::error::ConcourseError;
+use crate::types::TokenResponse;
+
+/// Manages authentication state with interior mutability via RwLock,
+/// allowing `&self` access from the client.
+pub(crate) struct AuthManager {
+    username: String,
+    password: String,
+    token: RwLock<Option<String>>,
+}
+
+impl AuthManager {
+    pub fn new(username: String, password: String) -> Self {
+        Self {
+            username,
+            password,
+            token: RwLock::new(None),
+        }
+    }
+
+    /// Ensure we have a bearer token, fetching one if needed.
+    pub async fn ensure_token(
+        &self,
+        http: &reqwest::Client,
+        base_url: &Url,
+    ) -> Result<(), ConcourseError> {
+        {
+            let token = self.token.read().await;
+            if token.is_some() {
+                return Ok(());
+            }
+        }
+
+        let mut token = self.token.write().await;
+        // Double-check after acquiring write lock
+        if token.is_some() {
+            return Ok(());
+        }
+
+        let token_url = base_url.join("/sky/issuer/token")?;
+
+        // Concourse uses Dex with client_id="fly", client_secret="Zmx5".
+        let resp = http
+            .post(token_url)
+            .basic_auth("fly", Some("Zmx5"))
+            .form(&[
+                ("grant_type", "password"),
+                ("username", self.username.as_str()),
+                ("password", self.password.as_str()),
+                ("scope", "openid profile email federated:id groups"),
+            ])
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ConcourseError::Auth(format!(
+                "token request failed (HTTP {status}): {body}"
+            )));
+        }
+
+        let token_resp: TokenResponse = resp.json().await?;
+        *token = Some(token_resp.access_token);
+        Ok(())
+    }
+
+    /// Clear cached token (used on 401 to trigger re-auth).
+    pub async fn clear_token(&self) {
+        let mut token = self.token.write().await;
+        *token = None;
+    }
+
+    /// Return headers with the `Authorization: Bearer …` header set.
+    pub async fn auth_headers(&self) -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        let token = self.token.read().await;
+        if let Some(token) = token.as_ref() {
+            if let Ok(val) = HeaderValue::from_str(&format!("Bearer {token}")) {
+                headers.insert(AUTHORIZATION, val);
+            }
+        }
+        headers
+    }
+}

--- a/concourse-client/src/client.rs
+++ b/concourse-client/src/client.rs
@@ -1,0 +1,231 @@
+use url::Url;
+
+use crate::auth::AuthManager;
+use crate::error::ConcourseError;
+use crate::types::*;
+
+/// Async client for the Concourse CI REST API.
+///
+/// All methods take `&self` — interior mutability for the token cache
+/// is handled by `AuthManager` using `tokio::sync::RwLock`.
+pub struct ConcourseClient {
+    http: reqwest::Client,
+    base_url: Url,
+    team: String,
+    auth: AuthManager,
+}
+
+impl ConcourseClient {
+    /// Create a new client.
+    ///
+    /// * `base_url` — root URL of the Concourse instance (e.g. `https://ci.example.com`)
+    /// * `team` — default team name for API calls
+    /// * `username` / `password` — credentials for sky token exchange
+    pub fn new(
+        base_url: &str,
+        team: String,
+        username: String,
+        password: String,
+    ) -> Result<Self, ConcourseError> {
+        let base_url = Url::parse(base_url)?;
+        let http = reqwest::Client::builder()
+            .user_agent("concourse-client-rs/0.1")
+            .build()?;
+        Ok(Self {
+            http,
+            base_url,
+            team,
+            auth: AuthManager::new(username, password),
+        })
+    }
+
+    // ----- helpers ----------------------------------------------------------
+
+    fn api_url(&self, path: &str) -> Result<Url, ConcourseError> {
+        let url = self.base_url.join(&format!("/api/v1{path}"))?;
+        Ok(url)
+    }
+
+    /// GET with auth, automatic 401 retry.
+    async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T, ConcourseError> {
+        self.auth.ensure_token(&self.http, &self.base_url).await?;
+        let url = self.api_url(path)?;
+
+        let resp = self
+            .http
+            .get(url.clone())
+            .headers(self.auth.auth_headers().await)
+            .send()
+            .await?;
+
+        if resp.status().as_u16() == 401 {
+            self.auth.clear_token().await;
+            self.auth.ensure_token(&self.http, &self.base_url).await?;
+            let resp = self
+                .http
+                .get(url)
+                .headers(self.auth.auth_headers().await)
+                .send()
+                .await?;
+            return Self::handle_response(resp).await;
+        }
+
+        Self::handle_response(resp).await
+    }
+
+    /// POST (empty body) with auth, automatic 401 retry.
+    async fn post_empty<T: serde::de::DeserializeOwned>(
+        &self,
+        path: &str,
+    ) -> Result<T, ConcourseError> {
+        self.auth.ensure_token(&self.http, &self.base_url).await?;
+        let url = self.api_url(path)?;
+
+        let resp = self
+            .http
+            .post(url.clone())
+            .headers(self.auth.auth_headers().await)
+            .send()
+            .await?;
+
+        if resp.status().as_u16() == 401 {
+            self.auth.clear_token().await;
+            self.auth.ensure_token(&self.http, &self.base_url).await?;
+            let resp = self
+                .http
+                .post(url)
+                .headers(self.auth.auth_headers().await)
+                .send()
+                .await?;
+            return Self::handle_response(resp).await;
+        }
+
+        Self::handle_response(resp).await
+    }
+
+    async fn handle_response<T: serde::de::DeserializeOwned>(
+        resp: reqwest::Response,
+    ) -> Result<T, ConcourseError> {
+        let status = resp.status();
+        if !status.is_success() {
+            let code = status.as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ConcourseError::Api {
+                status: code,
+                message: body,
+            });
+        }
+        let body = resp.json::<T>().await?;
+        Ok(body)
+    }
+
+    // ----- public API -------------------------------------------------------
+
+    /// Return the configured team name.
+    pub fn team(&self) -> &str {
+        &self.team
+    }
+
+    /// `GET /api/v1/teams/{team}/pipelines` — list pipelines for the configured team.
+    #[tracing::instrument(name = "concourse_client.list_pipelines", skip_all)]
+    pub async fn list_pipelines(&self) -> Result<Vec<Pipeline>, ConcourseError> {
+        let team = &self.team;
+        self.get(&format!("/teams/{team}/pipelines")).await
+    }
+
+    /// `GET /api/v1/teams/{team}/pipelines/{pipeline}/jobs` — list jobs in a pipeline.
+    #[tracing::instrument(name = "concourse_client.list_jobs", skip_all)]
+    pub async fn list_jobs(&self, pipeline: &str) -> Result<Vec<Job>, ConcourseError> {
+        let team = &self.team;
+        self.get(&format!("/teams/{team}/pipelines/{pipeline}/jobs"))
+            .await
+    }
+
+    /// `GET /api/v1/teams/{team}/pipelines/{pipeline}/jobs/{job}/builds` —
+    /// list builds for a job (most recent first).
+    #[tracing::instrument(name = "concourse_client.list_job_builds", skip_all)]
+    pub async fn list_job_builds(
+        &self,
+        pipeline: &str,
+        job: &str,
+    ) -> Result<Vec<Build>, ConcourseError> {
+        let team = &self.team;
+        self.get(&format!(
+            "/teams/{team}/pipelines/{pipeline}/jobs/{job}/builds"
+        ))
+        .await
+    }
+
+    /// `GET /api/v1/builds/{id}` — get build details.
+    #[tracing::instrument(name = "concourse_client.get_build", skip_all)]
+    pub async fn get_build(&self, build_id: i64) -> Result<Build, ConcourseError> {
+        self.get(&format!("/builds/{build_id}")).await
+    }
+
+    /// `GET /api/v1/builds/{id}/events` — fetch build log output.
+    ///
+    /// Reads the SSE event stream and extracts log lines from `"log"` events,
+    /// returning them as a single string.
+    #[tracing::instrument(name = "concourse_client.get_build_logs", skip_all)]
+    pub async fn get_build_logs(&self, build_id: i64) -> Result<String, ConcourseError> {
+        self.auth.ensure_token(&self.http, &self.base_url).await?;
+        let url = self.api_url(&format!("/builds/{build_id}/events"))?;
+
+        let resp = self
+            .http
+            .get(url)
+            .headers(self.auth.auth_headers().await)
+            .header("Accept", "text/event-stream")
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ConcourseError::Api {
+                status,
+                message: body,
+            });
+        }
+
+        let body = resp.text().await?;
+        let mut logs = String::new();
+        extract_logs_from_sse(&body, &mut logs);
+        Ok(logs)
+    }
+
+    /// `POST /api/v1/teams/{team}/pipelines/{pipeline}/jobs/{job}/builds` —
+    /// trigger a new build.
+    #[tracing::instrument(name = "concourse_client.trigger_build", skip_all)]
+    pub async fn trigger_build(&self, pipeline: &str, job: &str) -> Result<Build, ConcourseError> {
+        let team = &self.team;
+        self.post_empty(&format!(
+            "/teams/{team}/pipelines/{pipeline}/jobs/{job}/builds"
+        ))
+        .await
+    }
+}
+
+/// Parse SSE text and extract log lines from event envelopes.
+fn extract_logs_from_sse(body: &str, out: &mut String) {
+    for line in body.lines() {
+        let Some(data) = line.strip_prefix("data:") else {
+            continue;
+        };
+        let data = data.trim();
+        if data.is_empty() {
+            continue;
+        }
+        let Ok(envelope) = serde_json::from_str::<BuildEventEnvelope>(data) else {
+            continue;
+        };
+        if envelope.event != "log" {
+            continue;
+        }
+        if let Some(payload) = envelope.data.get("payload") {
+            if let Some(text) = payload.as_str() {
+                out.push_str(text);
+            }
+        }
+    }
+}

--- a/concourse-client/src/client.rs
+++ b/concourse-client/src/client.rs
@@ -165,9 +165,23 @@ impl ConcourseClient {
     /// `GET /api/v1/builds/{id}/events` — fetch build log output.
     ///
     /// Reads the SSE event stream and extracts log lines from `"log"` events,
-    /// returning them as a single string.
+    /// returning them as a single string. Best for finished builds.
     #[tracing::instrument(name = "concourse_client.get_build_logs", skip_all)]
     pub async fn get_build_logs(&self, build_id: i64) -> Result<String, ConcourseError> {
+        let resp = self.open_build_events(build_id).await?;
+        let body = resp.text().await?;
+        let mut logs = String::new();
+        extract_logs_from_sse(&body, &mut logs);
+        Ok(logs)
+    }
+
+    /// Open an authenticated SSE connection to build events.
+    ///
+    /// Returns the raw response for streaming consumption by [`BuildLogStore`].
+    pub(crate) async fn open_build_events(
+        &self,
+        build_id: i64,
+    ) -> Result<reqwest::Response, ConcourseError> {
         self.auth.ensure_token(&self.http, &self.base_url).await?;
         let url = self.api_url(&format!("/builds/{build_id}/events"))?;
 
@@ -188,10 +202,7 @@ impl ConcourseClient {
             });
         }
 
-        let body = resp.text().await?;
-        let mut logs = String::new();
-        extract_logs_from_sse(&body, &mut logs);
-        Ok(logs)
+        Ok(resp)
     }
 
     /// `POST /api/v1/teams/{team}/pipelines/{pipeline}/jobs/{job}/builds` —

--- a/concourse-client/src/error.rs
+++ b/concourse-client/src/error.rs
@@ -1,0 +1,20 @@
+use thiserror::Error;
+
+/// Errors returned by the Concourse client.
+#[derive(Debug, Error)]
+pub enum ConcourseError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("failed to parse URL: {0}")]
+    Url(#[from] url::ParseError),
+
+    #[error("JSON serialization/deserialization error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("authentication failed: {0}")]
+    Auth(String),
+
+    #[error("API error (HTTP {status}): {message}")]
+    Api { status: u16, message: String },
+}

--- a/concourse-client/src/lib.rs
+++ b/concourse-client/src/lib.rs
@@ -1,0 +1,8 @@
+mod auth;
+mod client;
+mod error;
+mod types;
+
+pub use client::ConcourseClient;
+pub use error::ConcourseError;
+pub use types::*;

--- a/concourse-client/src/lib.rs
+++ b/concourse-client/src/lib.rs
@@ -1,8 +1,10 @@
 mod auth;
 mod client;
 mod error;
+mod log_buffer;
 mod types;
 
 pub use client::ConcourseClient;
 pub use error::ConcourseError;
+pub use log_buffer::{BuildLogResponse, BuildLogStore};
 pub use types::*;

--- a/concourse-client/src/log_buffer.rs
+++ b/concourse-client/src/log_buffer.rs
@@ -1,0 +1,301 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use serde::Serialize;
+use tokio::sync::RwLock;
+
+use crate::client::ConcourseClient;
+use crate::error::ConcourseError;
+use crate::types::BuildEventEnvelope;
+
+/// How long a buffer can remain unaccessed before being eligible for cleanup.
+const STALE_TTL: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+
+/// Response from an offset-based log read.
+#[derive(Debug, Clone, Serialize)]
+pub struct BuildLogResponse {
+    /// Log lines for the requested range.
+    pub lines: Vec<String>,
+    /// The offset to use for the next poll.
+    pub next_offset: usize,
+    /// Whether the SSE stream has ended (build finished).
+    pub is_complete: bool,
+    /// Current build status string (e.g. "started", "succeeded", "failed").
+    pub build_status: String,
+}
+
+/// Internal buffer for a single build's log output.
+struct BuildLogBuffer {
+    lines: Vec<String>,
+    is_complete: bool,
+    build_status: String,
+    last_accessed: std::time::Instant,
+}
+
+impl BuildLogBuffer {
+    fn new() -> Self {
+        Self {
+            lines: Vec::new(),
+            is_complete: false,
+            build_status: "pending".to_string(),
+            last_accessed: std::time::Instant::now(),
+        }
+    }
+}
+
+/// Manages in-memory log buffers for live build tailing.
+///
+/// On first request for a build_id, opens an SSE connection via a background
+/// tokio task that continuously appends log lines. Subsequent calls return
+/// slices from the buffer using offset/limit pagination.
+pub struct BuildLogStore {
+    buffers: RwLock<HashMap<i64, Arc<RwLock<BuildLogBuffer>>>>,
+}
+
+impl Default for BuildLogStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl BuildLogStore {
+    pub fn new() -> Self {
+        Self {
+            buffers: RwLock::new(HashMap::new()),
+        }
+    }
+
+    /// Read log lines for a build with offset-based pagination.
+    ///
+    /// On the first call for a given `build_id`, spawns a background task to
+    /// stream SSE events from Concourse and buffer log lines. Returns
+    /// immediately with whatever lines are available.
+    #[tracing::instrument(name = "build_log_store.read_logs", skip_all, fields(%build_id))]
+    pub async fn read_logs(
+        &self,
+        build_id: i64,
+        client: &Arc<ConcourseClient>,
+        offset: usize,
+        limit: usize,
+    ) -> Result<BuildLogResponse, ConcourseError> {
+        self.cleanup_stale().await;
+
+        let buf = self.get_or_start(build_id, client).await?;
+        let mut guard = buf.write().await;
+        guard.last_accessed = std::time::Instant::now();
+
+        let total = guard.lines.len();
+        let start = offset.min(total);
+        let end = (start + limit).min(total);
+        let lines = guard.lines[start..end].to_vec();
+        let next_offset = end;
+
+        Ok(BuildLogResponse {
+            lines,
+            next_offset,
+            is_complete: guard.is_complete,
+            build_status: guard.build_status.clone(),
+        })
+    }
+
+    /// Get an existing buffer or start streaming for this build.
+    async fn get_or_start(
+        &self,
+        build_id: i64,
+        client: &Arc<ConcourseClient>,
+    ) -> Result<Arc<RwLock<BuildLogBuffer>>, ConcourseError> {
+        // Fast path: buffer already exists
+        {
+            let buffers = self.buffers.read().await;
+            if let Some(buf) = buffers.get(&build_id) {
+                return Ok(Arc::clone(buf));
+            }
+        }
+
+        // Slow path: create buffer and start streaming
+        let mut buffers = self.buffers.write().await;
+
+        // Double-check after acquiring write lock
+        if let Some(buf) = buffers.get(&build_id) {
+            return Ok(Arc::clone(buf));
+        }
+
+        let buf = Arc::new(RwLock::new(BuildLogBuffer::new()));
+        buffers.insert(build_id, Arc::clone(&buf));
+
+        // Spawn background SSE consumer
+        let client = Arc::clone(client);
+        let buf_clone = Arc::clone(&buf);
+        tokio::spawn(async move {
+            stream_build_events(client, build_id, buf_clone).await;
+        });
+
+        Ok(buf)
+    }
+
+    /// Remove buffers that haven't been accessed within the TTL.
+    async fn cleanup_stale(&self) {
+        let mut buffers = self.buffers.write().await;
+        let now = std::time::Instant::now();
+        buffers.retain(|_build_id, buf| {
+            // Try to read-lock without blocking; if locked, keep the entry
+            match buf.try_read() {
+                Ok(guard) => now.duration_since(guard.last_accessed) < STALE_TTL,
+                Err(_) => true, // Buffer is actively in use
+            }
+        });
+    }
+}
+
+/// Background task: opens SSE stream and appends log lines to the buffer.
+async fn stream_build_events(
+    client: Arc<ConcourseClient>,
+    build_id: i64,
+    buffer: Arc<RwLock<BuildLogBuffer>>,
+) {
+    let mut resp = match client.open_build_events(build_id).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!(%build_id, error = %e, "Failed to open build events stream");
+            let mut buf = buffer.write().await;
+            buf.is_complete = true;
+            buf.build_status = format!("error: {e}");
+            return;
+        }
+    };
+
+    let mut parser = SseParser::new();
+
+    loop {
+        match resp.chunk().await {
+            Ok(Some(bytes)) => {
+                let text = String::from_utf8_lossy(&bytes);
+                let events = parser.feed(&text);
+                let mut buf = buffer.write().await;
+                for envelope in events {
+                    process_envelope(&envelope, &mut buf);
+                }
+            }
+            Ok(None) => {
+                // Stream ended
+                let mut buf = buffer.write().await;
+                // Process any remaining buffered data
+                let events = parser.flush();
+                for envelope in events {
+                    process_envelope(&envelope, &mut buf);
+                }
+                buf.is_complete = true;
+                break;
+            }
+            Err(e) => {
+                tracing::warn!(%build_id, error = %e, "Error reading build events stream");
+                let mut buf = buffer.write().await;
+                buf.is_complete = true;
+                break;
+            }
+        }
+    }
+}
+
+/// Process a single SSE event envelope into the buffer.
+fn process_envelope(envelope: &BuildEventEnvelope, buf: &mut BuildLogBuffer) {
+    match envelope.event.as_str() {
+        "log" => {
+            if let Some(payload) = envelope.data.get("payload") {
+                if let Some(text) = payload.as_str() {
+                    // Split multi-line payloads into individual lines
+                    for line in text.split('\n') {
+                        if !line.is_empty() {
+                            buf.lines.push(line.to_string());
+                        }
+                    }
+                }
+            }
+        }
+        "status" => {
+            if let Some(status) = envelope.data.get("status") {
+                if let Some(s) = status.as_str() {
+                    buf.build_status = s.to_string();
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Incremental SSE parser that processes chunks of text into complete events.
+struct SseParser {
+    buffer: String,
+    current_data: String,
+    saw_end_event: bool,
+}
+
+impl SseParser {
+    fn new() -> Self {
+        Self {
+            buffer: String::new(),
+            current_data: String::new(),
+            saw_end_event: false,
+        }
+    }
+
+    /// Feed a chunk of text and return any complete events.
+    fn feed(&mut self, text: &str) -> Vec<BuildEventEnvelope> {
+        if self.saw_end_event {
+            return Vec::new();
+        }
+
+        self.buffer.push_str(text);
+        self.extract_events()
+    }
+
+    /// Flush any remaining buffered data as events.
+    fn flush(&mut self) -> Vec<BuildEventEnvelope> {
+        if self.current_data.is_empty() {
+            return Vec::new();
+        }
+        let data = std::mem::take(&mut self.current_data);
+        match serde_json::from_str::<BuildEventEnvelope>(&data) {
+            Ok(env) => vec![env],
+            Err(_) => Vec::new(),
+        }
+    }
+
+    fn extract_events(&mut self) -> Vec<BuildEventEnvelope> {
+        let mut events = Vec::new();
+
+        while let Some(newline_pos) = self.buffer.find('\n') {
+            let line = self.buffer[..newline_pos]
+                .trim_end_matches('\r')
+                .to_string();
+            self.buffer.drain(..=newline_pos);
+
+            if line.is_empty() {
+                // Empty line = end of SSE frame, dispatch event
+                if !self.current_data.is_empty() {
+                    let data = std::mem::take(&mut self.current_data);
+                    if let Ok(env) = serde_json::from_str::<BuildEventEnvelope>(&data) {
+                        events.push(env);
+                    }
+                }
+                continue;
+            }
+
+            if let Some(value) = line.strip_prefix("event:") {
+                let event_type = value.trim();
+                if event_type == "end" {
+                    self.saw_end_event = true;
+                    return events;
+                }
+            } else if let Some(value) = line.strip_prefix("data:") {
+                if !self.current_data.is_empty() {
+                    self.current_data.push('\n');
+                }
+                self.current_data.push_str(value.trim());
+            }
+            // Ignore id:, comment lines, and unknown fields
+        }
+
+        events
+    }
+}

--- a/concourse-client/src/types.rs
+++ b/concourse-client/src/types.rs
@@ -1,0 +1,118 @@
+use std::collections::HashMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Pipeline instance variables (opaque).
+pub type InstanceVars = HashMap<String, serde_json::Value>;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Pipeline {
+    pub id: u64,
+    pub name: String,
+    #[serde(default)]
+    pub instance_vars: Option<InstanceVars>,
+    #[serde(default)]
+    pub paused: bool,
+    #[serde(default)]
+    pub public: bool,
+    #[serde(default)]
+    pub archived: bool,
+    #[serde(default)]
+    pub team_name: String,
+    #[serde(default)]
+    pub last_updated: Option<i64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Job {
+    pub id: u64,
+    pub name: String,
+    #[serde(default)]
+    pub team_name: String,
+    #[serde(default)]
+    pub pipeline_id: u64,
+    #[serde(default)]
+    pub pipeline_name: String,
+    #[serde(default)]
+    pub paused: bool,
+    #[serde(default)]
+    pub has_new_inputs: bool,
+    #[serde(default)]
+    pub groups: Vec<String>,
+    #[serde(default)]
+    pub disable_manual_trigger: bool,
+    #[serde(default)]
+    pub next_build: Option<Build>,
+    #[serde(default)]
+    pub finished_build: Option<Build>,
+    #[serde(default)]
+    pub transition_build: Option<Build>,
+    #[serde(default)]
+    pub inputs: Vec<JobInput>,
+    #[serde(default)]
+    pub outputs: Vec<JobOutput>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobInput {
+    pub name: String,
+    #[serde(default)]
+    pub resource: String,
+    #[serde(default)]
+    pub trigger: bool,
+    #[serde(default)]
+    pub passed: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobOutput {
+    pub name: String,
+    #[serde(default)]
+    pub resource: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Build {
+    pub id: u64,
+    #[serde(default)]
+    pub team_name: String,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub api_url: String,
+    #[serde(default)]
+    pub job_name: Option<String>,
+    #[serde(default)]
+    pub pipeline_id: Option<u64>,
+    #[serde(default)]
+    pub pipeline_name: Option<String>,
+    #[serde(default)]
+    pub pipeline_instance_vars: Option<InstanceVars>,
+    #[serde(default)]
+    pub start_time: Option<i64>,
+    #[serde(default)]
+    pub end_time: Option<i64>,
+    #[serde(default)]
+    pub created_by: Option<String>,
+}
+
+/// SSE build event envelope.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BuildEventEnvelope {
+    pub data: serde_json::Value,
+    pub event: String,
+    #[serde(default)]
+    pub version: String,
+}
+
+/// OAuth2 token response from Concourse sky/issuer.
+#[derive(Debug, Clone, Deserialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+    #[serde(default)]
+    pub token_type: String,
+    #[serde(default)]
+    pub expires_in: Option<u64>,
+}

--- a/mcp-gateway/Cargo.toml
+++ b/mcp-gateway/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 [lib]
 
 [dependencies]
+concourse-client = { workspace = true }
 galoy-agents-domain = { path = "../domain" }
 style-agent-server = { workspace = true }
 anyhow = { workspace = true }

--- a/mcp-gateway/src/concourse/config.rs
+++ b/mcp-gateway/src/concourse/config.rs
@@ -1,0 +1,23 @@
+use serde::Deserialize;
+
+#[derive(Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct ConcourseConfig {
+    /// Enable Concourse CI integration.
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Base URL of the Concourse instance (e.g. `https://ci.galoy.io`).
+    #[serde(default)]
+    pub url: String,
+
+    /// Default Concourse team name.
+    #[serde(default)]
+    pub team: String,
+
+    /// Credentials — populated from environment variables, not the config file.
+    #[serde(skip)]
+    pub username: String,
+    #[serde(skip)]
+    pub password: String,
+}

--- a/mcp-gateway/src/concourse/mod.rs
+++ b/mcp-gateway/src/concourse/mod.rs
@@ -1,0 +1,194 @@
+mod config;
+
+use std::sync::Arc;
+
+use rmcp::model::{CallToolResult, Content, ErrorCode, ErrorData};
+
+use concourse_client::ConcourseClient;
+
+pub use config::ConcourseConfig;
+
+/// Holds an initialized Concourse client for use by MCP tool handlers.
+#[derive(Clone)]
+pub struct ConcourseEndpoints {
+    client: Arc<ConcourseClient>,
+}
+
+impl ConcourseEndpoints {
+    /// Initialize from config. Returns `Ok(None)` if Concourse is disabled.
+    pub fn try_new(config: &ConcourseConfig) -> Result<Option<Self>, anyhow::Error> {
+        if !config.enabled {
+            tracing::info!("Concourse integration disabled");
+            return Ok(None);
+        }
+
+        if config.url.is_empty() {
+            tracing::warn!("Concourse enabled but no URL configured — skipping");
+            return Ok(None);
+        }
+
+        if config.username.is_empty() || config.password.is_empty() {
+            tracing::warn!(
+                "Concourse enabled but CONCOURSE_USERNAME/CONCOURSE_PASSWORD not set — skipping"
+            );
+            return Ok(None);
+        }
+
+        let client = ConcourseClient::new(
+            &config.url,
+            config.team.clone(),
+            config.username.clone(),
+            config.password.clone(),
+        )?;
+
+        tracing::info!(
+            url = %config.url,
+            team = %config.team,
+            "Concourse integration initialized"
+        );
+
+        Ok(Some(Self {
+            client: Arc::new(client),
+        }))
+    }
+
+    /// List all pipelines for the configured team.
+    pub async fn list_pipelines(&self) -> Result<CallToolResult, ErrorData> {
+        let pipelines = self.client.list_pipelines().await.map_err(concourse_err)?;
+
+        let summary: Vec<serde_json::Value> = pipelines
+            .iter()
+            .map(|p| {
+                serde_json::json!({
+                    "name": p.name,
+                    "paused": p.paused,
+                    "public": p.public,
+                    "archived": p.archived,
+                    "team": p.team_name,
+                })
+            })
+            .collect();
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&summary).unwrap_or_default(),
+        )]))
+    }
+
+    /// List jobs in a pipeline.
+    pub async fn list_jobs(&self, pipeline: &str) -> Result<CallToolResult, ErrorData> {
+        let jobs = self
+            .client
+            .list_jobs(pipeline)
+            .await
+            .map_err(concourse_err)?;
+
+        let summary: Vec<serde_json::Value> = jobs
+            .iter()
+            .map(|j| {
+                let mut obj = serde_json::json!({
+                    "name": j.name,
+                    "paused": j.paused,
+                    "pipeline": j.pipeline_name,
+                });
+                if let Some(b) = &j.finished_build {
+                    obj["last_status"] = serde_json::json!(b.status);
+                }
+                if let Some(b) = &j.next_build {
+                    obj["current_build"] = serde_json::json!({
+                        "id": b.id,
+                        "status": b.status,
+                    });
+                }
+                obj
+            })
+            .collect();
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&summary).unwrap_or_default(),
+        )]))
+    }
+
+    /// Get the latest build status for a job.
+    pub async fn get_build_status(
+        &self,
+        pipeline: &str,
+        job: &str,
+    ) -> Result<CallToolResult, ErrorData> {
+        let builds = self
+            .client
+            .list_job_builds(pipeline, job)
+            .await
+            .map_err(concourse_err)?;
+
+        let Some(latest) = builds.first() else {
+            return Ok(CallToolResult::success(vec![Content::text(
+                "No builds found for this job.",
+            )]));
+        };
+
+        let result = serde_json::json!({
+            "build_id": latest.id,
+            "name": latest.name,
+            "status": latest.status,
+            "pipeline": latest.pipeline_name,
+            "job": latest.job_name,
+            "start_time": latest.start_time,
+            "end_time": latest.end_time,
+        });
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap_or_default(),
+        )]))
+    }
+
+    /// Get build output/logs.
+    pub async fn get_build_logs(&self, build_id: i64) -> Result<CallToolResult, ErrorData> {
+        let logs = self
+            .client
+            .get_build_logs(build_id)
+            .await
+            .map_err(concourse_err)?;
+
+        if logs.is_empty() {
+            return Ok(CallToolResult::success(vec![Content::text(
+                "No log output available for this build.",
+            )]));
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(logs)]))
+    }
+
+    /// Trigger a new build for a job.
+    pub async fn trigger_build(
+        &self,
+        pipeline: &str,
+        job: &str,
+    ) -> Result<CallToolResult, ErrorData> {
+        let build = self
+            .client
+            .trigger_build(pipeline, job)
+            .await
+            .map_err(concourse_err)?;
+
+        let result = serde_json::json!({
+            "build_id": build.id,
+            "name": build.name,
+            "status": build.status,
+            "pipeline": build.pipeline_name,
+            "job": build.job_name,
+            "api_url": build.api_url,
+        });
+
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap_or_default(),
+        )]))
+    }
+}
+
+fn concourse_err(e: concourse_client::ConcourseError) -> ErrorData {
+    ErrorData::new(
+        ErrorCode::INTERNAL_ERROR,
+        format!("Concourse API error: {e}"),
+        None::<serde_json::Value>,
+    )
+}

--- a/mcp-gateway/src/concourse/mod.rs
+++ b/mcp-gateway/src/concourse/mod.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 
 use rmcp::model::{CallToolResult, Content, ErrorCode, ErrorData};
 
-use concourse_client::ConcourseClient;
+use concourse_client::{BuildLogStore, ConcourseClient};
 
 pub use config::ConcourseConfig;
 
@@ -12,6 +12,7 @@ pub use config::ConcourseConfig;
 #[derive(Clone)]
 pub struct ConcourseEndpoints {
     client: Arc<ConcourseClient>,
+    log_store: Arc<BuildLogStore>,
 }
 
 impl ConcourseEndpoints {
@@ -49,6 +50,7 @@ impl ConcourseEndpoints {
 
         Ok(Some(Self {
             client: Arc::new(client),
+            log_store: Arc::new(BuildLogStore::new()),
         }))
     }
 
@@ -141,21 +143,47 @@ impl ConcourseEndpoints {
         )]))
     }
 
-    /// Get build output/logs.
-    pub async fn get_build_logs(&self, build_id: i64) -> Result<CallToolResult, ErrorData> {
-        let logs = self
-            .client
-            .get_build_logs(build_id)
-            .await
-            .map_err(concourse_err)?;
+    /// Get build output/logs with optional offset-based pagination.
+    ///
+    /// - **No offset**: returns all logs at once (backward-compatible, best for finished builds)
+    /// - **With offset**: uses buffered SSE streaming for live build tailing
+    pub async fn get_build_logs(
+        &self,
+        build_id: i64,
+        offset: Option<usize>,
+        limit: Option<usize>,
+    ) -> Result<CallToolResult, ErrorData> {
+        match offset {
+            None => {
+                // Backward-compatible: fetch all logs at once
+                let logs = self
+                    .client
+                    .get_build_logs(build_id)
+                    .await
+                    .map_err(concourse_err)?;
 
-        if logs.is_empty() {
-            return Ok(CallToolResult::success(vec![Content::text(
-                "No log output available for this build.",
-            )]));
+                if logs.is_empty() {
+                    return Ok(CallToolResult::success(vec![Content::text(
+                        "No log output available for this build.",
+                    )]));
+                }
+
+                Ok(CallToolResult::success(vec![Content::text(logs)]))
+            }
+            Some(offset) => {
+                // Buffered streaming approach
+                let limit = limit.unwrap_or(200);
+                let resp = self
+                    .log_store
+                    .read_logs(build_id, &self.client, offset, limit)
+                    .await
+                    .map_err(concourse_err)?;
+
+                Ok(CallToolResult::success(vec![Content::text(
+                    serde_json::to_string_pretty(&resp).unwrap_or_default(),
+                )]))
+            }
         }
-
-        Ok(CallToolResult::success(vec![Content::text(logs)]))
     }
 
     /// Trigger a new build for a job.

--- a/mcp-gateway/src/lib.rs
+++ b/mcp-gateway/src/lib.rs
@@ -125,6 +125,13 @@ struct GetBuildStatusParams {
 struct GetBuildLogsParams {
     /// The numeric build ID
     build_id: i64,
+    /// Starting line offset for paginated reads (enables live tailing mode).
+    /// When omitted, returns all logs at once (best for finished builds).
+    /// Use 0 for the first poll, then use `next_offset` from the response.
+    offset: Option<usize>,
+    /// Maximum number of lines to return per request (default: 200).
+    /// Only used when `offset` is provided.
+    limit: Option<usize>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -209,7 +216,7 @@ impl McpGateway {
 
     /// Get build output/logs from Concourse.
     #[tool(
-        description = "Get the build output/logs for a Concourse build by its numeric build ID."
+        description = "Get build output/logs for a Concourse build by its numeric build ID.\n\nTwo modes:\n- **All-at-once** (offset omitted): returns complete log output as plain text. Best for finished builds.\n- **Live tailing** (offset provided): returns paginated lines with next_offset for polling. Use offset=0 for the first call, then pass next_offset from the response. Response includes is_complete and build_status fields.\n\nExample polling loop: call with offset=0, then keep calling with next_offset until is_complete is true."
     )]
     async fn get_build_logs(
         &self,
@@ -218,7 +225,7 @@ impl McpGateway {
     ) -> Result<CallToolResult, ErrorData> {
         Self::require_auth(&parts)?;
         self.require_concourse()?
-            .get_build_logs(params.build_id)
+            .get_build_logs(params.build_id, params.offset, params.limit)
             .await
     }
 

--- a/mcp-gateway/src/lib.rs
+++ b/mcp-gateway/src/lib.rs
@@ -1,3 +1,5 @@
+mod concourse;
+
 use rmcp::handler::server::router::tool::ToolRouter;
 use rmcp::handler::server::tool::Extension;
 use rmcp::handler::server::wrapper::Parameters;
@@ -11,6 +13,8 @@ use galoy_agents_domain::auth::AuthContext;
 use galoy_agents_domain::App;
 use style_agent_server::{SearchCodeParams, StyleAgentEndpoints};
 
+pub use concourse::ConcourseConfig;
+use concourse::ConcourseEndpoints;
 pub use style_agent_server::StyleAgentConfig;
 
 #[derive(Clone)]
@@ -18,14 +22,20 @@ pub struct McpGateway {
     #[allow(dead_code)]
     app: App,
     style_agent: Option<StyleAgentEndpoints>,
+    concourse: Option<ConcourseEndpoints>,
     tool_router: ToolRouter<Self>,
 }
 
 impl McpGateway {
-    fn new(app: App, style_agent: Option<StyleAgentEndpoints>) -> Self {
+    fn new(
+        app: App,
+        style_agent: Option<StyleAgentEndpoints>,
+        concourse: Option<ConcourseEndpoints>,
+    ) -> Self {
         Self {
             app,
             style_agent,
+            concourse,
             tool_router: Self::tool_router(),
         }
     }
@@ -34,6 +44,7 @@ impl McpGateway {
     pub fn service(
         app: App,
         style_agent_config: &StyleAgentConfig,
+        concourse_config: &ConcourseConfig,
     ) -> anyhow::Result<(
         StreamableHttpService<Self, LocalSessionManager>,
         Option<StyleAgentEndpoints>,
@@ -41,13 +52,15 @@ impl McpGateway {
         let logger = app.style_agent_logs().clone();
         let style_agent =
             style_agent_server::init_endpoints_with_logger(style_agent_config, logger)?;
-        let svc = Self::build_service(app, style_agent.clone());
+        let concourse = ConcourseEndpoints::try_new(concourse_config)?;
+        let svc = Self::build_service(app, style_agent.clone(), concourse);
         Ok((svc, style_agent))
     }
 
     fn build_service(
         app: App,
         style_agent: Option<StyleAgentEndpoints>,
+        concourse: Option<ConcourseEndpoints>,
     ) -> StreamableHttpService<Self, LocalSessionManager> {
         let config = StreamableHttpServerConfig {
             stateful_mode: false,
@@ -55,7 +68,13 @@ impl McpGateway {
             ..Default::default()
         };
         StreamableHttpService::new(
-            move || Ok(McpGateway::new(app.clone(), style_agent.clone())),
+            move || {
+                Ok(McpGateway::new(
+                    app.clone(),
+                    style_agent.clone(),
+                    concourse.clone(),
+                ))
+            },
             LocalSessionManager::default().into(),
             config,
         )
@@ -71,11 +90,49 @@ impl McpGateway {
             )),
         }
     }
+
+    fn require_concourse(&self) -> Result<&ConcourseEndpoints, ErrorData> {
+        self.concourse.as_ref().ok_or_else(|| {
+            ErrorData::new(
+                ErrorCode::INTERNAL_ERROR,
+                "Concourse integration is disabled",
+                None::<serde_json::Value>,
+            )
+        })
+    }
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 struct HelloParams {
     name: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct ListJobsParams {
+    /// The pipeline name to list jobs for
+    pipeline: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct GetBuildStatusParams {
+    /// The pipeline name
+    pipeline: String,
+    /// The job name
+    job: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct GetBuildLogsParams {
+    /// The numeric build ID
+    build_id: i64,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+struct TriggerBuildParams {
+    /// The pipeline name
+    pipeline: String,
+    /// The job name to trigger
+    job: String,
 }
 
 #[tool_router]
@@ -108,6 +165,76 @@ impl McpGateway {
                 None::<serde_json::Value>,
             )),
         }
+    }
+
+    /// List all pipelines for the configured Concourse team.
+    #[tool(
+        description = "List all pipelines for the configured Concourse CI team. Returns pipeline names, paused/archived status."
+    )]
+    async fn list_pipelines(
+        &self,
+        Extension(parts): Extension<http::request::Parts>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Self::require_auth(&parts)?;
+        self.require_concourse()?.list_pipelines().await
+    }
+
+    /// List jobs in a Concourse pipeline.
+    #[tool(
+        description = "List jobs in a Concourse pipeline. Returns job names, paused state, and last build status."
+    )]
+    async fn list_jobs(
+        &self,
+        Extension(parts): Extension<http::request::Parts>,
+        Parameters(params): Parameters<ListJobsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Self::require_auth(&parts)?;
+        self.require_concourse()?.list_jobs(&params.pipeline).await
+    }
+
+    /// Get the latest build status for a Concourse job.
+    #[tool(
+        description = "Get the latest build status for a specific job in a Concourse pipeline. Returns build ID, status, and timestamps."
+    )]
+    async fn get_build_status(
+        &self,
+        Extension(parts): Extension<http::request::Parts>,
+        Parameters(params): Parameters<GetBuildStatusParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Self::require_auth(&parts)?;
+        self.require_concourse()?
+            .get_build_status(&params.pipeline, &params.job)
+            .await
+    }
+
+    /// Get build output/logs from Concourse.
+    #[tool(
+        description = "Get the build output/logs for a Concourse build by its numeric build ID."
+    )]
+    async fn get_build_logs(
+        &self,
+        Extension(parts): Extension<http::request::Parts>,
+        Parameters(params): Parameters<GetBuildLogsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Self::require_auth(&parts)?;
+        self.require_concourse()?
+            .get_build_logs(params.build_id)
+            .await
+    }
+
+    /// Trigger a new build for a Concourse job.
+    #[tool(
+        description = "Trigger a new build for a job in a Concourse pipeline. Returns the new build ID and status."
+    )]
+    async fn trigger_build(
+        &self,
+        Extension(parts): Extension<http::request::Parts>,
+        Parameters(params): Parameters<TriggerBuildParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        Self::require_auth(&parts)?;
+        self.require_concourse()?
+            .trigger_build(&params.pipeline, &params.job)
+            .await
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `concourse-client` crate — async HTTP client for Concourse CI REST API with RwLock-based token cache, automatic 401 retry, and sky/issuer token exchange
- Wire 5 MCP tools into the gateway following the existing optional provider pattern (same as style-agent):
  - `list_pipelines` — list all pipelines for the configured team
  - `list_jobs` — list jobs in a pipeline with last build status
  - `get_build_status` — get latest build status for a specific job
  - `get_build_logs` — fetch build output/logs by numeric build ID
  - `trigger_build` — trigger a new build for a job
- Configuration via `concourse.enabled`, `concourse.url`, `concourse.team` in galoy-agents.yml
- Credentials via `CONCOURSE_USERNAME` / `CONCOURSE_PASSWORD` env vars (never in config file)

## Test plan
- [ ] Verify `nix flake check` passes (fmt, clippy, nextest)
- [ ] Deploy with Concourse credentials and test each tool via MCP client
- [ ] Verify graceful degradation when `concourse.enabled = false` (default)
- [ ] Verify tools return proper error when Concourse is enabled but credentials missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)