### PR TITLE
feat(style-agent): add JavaScript/TypeScript indexing support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,7 +3023,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3687,7 +3687,6 @@ dependencies = [
  "cfg-if",
  "libc",
  "psm",
- "windows-sys 0.52.0",
  "windows-sys 0.59.0",
 ]
 
@@ -3785,7 +3784,9 @@ dependencies = [
  "tokio",
  "tracing",
  "tree-sitter",
+ "tree-sitter-javascript",
  "tree-sitter-rust",
+ "tree-sitter-typescript",
  "uuid",
  "zerocopy 0.7.35",
 ]
@@ -4378,6 +4379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tree-sitter-javascript"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
 name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4388,6 +4399,16 @@ name = "tree-sitter-rust"
 version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca8ccb3e3a3495c8a943f6c3fd24c3804c471fd7f4f16087623c7fa4c0068e8a"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-typescript"
+version = "0.23.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,8 @@ zerocopy = { version = "0.7", features = ["derive"] }
 # Parsing
 tree-sitter = "0.25"
 tree-sitter-rust = "0.23"
+tree-sitter-javascript = "0.25"
+tree-sitter-typescript = "0.23"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/style-agent/crates/cli/src/indexer.rs
+++ b/style-agent/crates/cli/src/indexer.rs
@@ -4,6 +4,7 @@ use style_agent_core::bats_chunker::chunk_bats_file;
 use style_agent_core::chunker::chunk_file;
 use style_agent_core::classifier::Classifier;
 use style_agent_core::embedder::Embedder;
+use style_agent_core::js_chunker::{chunk_js_file, JsDialect};
 use style_agent_core::labeler::{classify_chunk, ChunkClassification, ChunkData as LabelChunkData};
 use style_agent_core::store::{IndexedChunk, VectorStore};
 use uuid::Uuid;
@@ -50,7 +51,18 @@ pub async fn index_repo(
         let chunks = match file.language.as_str() {
             "rust" => chunk_file(&file.content),
             "bats" | "bash" => chunk_bats_file(&file.content),
+            "javascript" => chunk_js_file(&file.content, JsDialect::JavaScript),
+            "jsx" => chunk_js_file(&file.content, JsDialect::Jsx),
+            "typescript" => chunk_js_file(&file.content, JsDialect::TypeScript),
+            "tsx" => chunk_js_file(&file.content, JsDialect::Tsx),
             _ => continue,
+        };
+
+        // Normalize language for storage: jsx→javascript, tsx→typescript
+        let stored_language = match file.language.as_str() {
+            "jsx" => "javascript".to_string(),
+            "tsx" => "typescript".to_string(),
+            other => other.to_string(),
         };
 
         for chunk in chunks {
@@ -63,7 +75,7 @@ pub async fn index_repo(
                 file_path: file.path.clone(),
                 repo: repo_name.to_string(),
                 module_path: file.module_path.clone(),
-                language: file.language.clone(),
+                language: stored_language.clone(),
             });
         }
     }

--- a/style-agent/crates/cli/src/walker.rs
+++ b/style-agent/crates/cli/src/walker.rs
@@ -2,8 +2,25 @@ use std::fs;
 use std::path::Path;
 
 /// Supported file extensions and their language identifiers.
-const SUPPORTED_EXTENSIONS: &[(&str, &str)] =
-    &[(".rs", "rust"), (".bats", "bats"), (".bash", "bash")];
+const SUPPORTED_EXTENSIONS: &[(&str, &str)] = &[
+    (".rs", "rust"),
+    (".bats", "bats"),
+    (".bash", "bash"),
+    (".ts", "typescript"),
+    (".tsx", "tsx"),
+    (".js", "javascript"),
+    (".jsx", "jsx"),
+];
+
+/// Directories always excluded for JS/TS projects.
+const JS_EXCLUDED_DIRS: &[&str] = &[
+    "node_modules",
+    "dist",
+    "build",
+    ".next",
+    "coverage",
+    "__generated__",
+];
 
 /// A source file discovered in a repository.
 pub struct RepoFile {
@@ -84,6 +101,10 @@ fn walk_dir(
             }
             // Skip user-configured exclude dirs
             if exclude_dirs.iter().any(|d| d == name.as_ref()) {
+                continue;
+            }
+            // Skip well-known JS/TS artifact directories
+            if JS_EXCLUDED_DIRS.contains(&name.as_ref()) {
                 continue;
             }
             walk_dir(base, &path, exclude_dirs, files)?;

--- a/style-agent/crates/core/Cargo.toml
+++ b/style-agent/crates/core/Cargo.toml
@@ -12,6 +12,8 @@ sqlite-vec = { workspace = true }
 zerocopy = { workspace = true }
 tree-sitter = { workspace = true }
 tree-sitter-rust = { workspace = true }
+tree-sitter-javascript = { workspace = true }
+tree-sitter-typescript = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }
 tokio = { workspace = true }

--- a/style-agent/crates/core/src/js_chunker.rs
+++ b/style-agent/crates/core/src/js_chunker.rs
@@ -1,0 +1,995 @@
+use crate::chunker::Chunk;
+use tree_sitter::Parser;
+
+/// Supported JS/TS file variants.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum JsDialect {
+    /// Plain JavaScript (`.js`)
+    JavaScript,
+    /// JavaScript with JSX (`.jsx`)
+    Jsx,
+    /// TypeScript (`.ts`)
+    TypeScript,
+    /// TypeScript with JSX (`.tsx`)
+    Tsx,
+}
+
+impl JsDialect {
+    /// Detect dialect from a file extension (including the dot).
+    pub fn from_extension(ext: &str) -> Option<Self> {
+        match ext {
+            ".js" => Some(Self::JavaScript),
+            ".jsx" => Some(Self::Jsx),
+            ".ts" => Some(Self::TypeScript),
+            ".tsx" => Some(Self::Tsx),
+            _ => None,
+        }
+    }
+
+    /// Language identifier for metadata.
+    pub fn language_id(self) -> &'static str {
+        match self {
+            Self::JavaScript | Self::Jsx => "javascript",
+            Self::TypeScript | Self::Tsx => "typescript",
+        }
+    }
+
+    fn tree_sitter_language(self) -> tree_sitter::Language {
+        match self {
+            // tree-sitter-javascript handles both .js and .jsx
+            Self::JavaScript | Self::Jsx => tree_sitter_javascript::LANGUAGE.into(),
+            Self::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            Self::Tsx => tree_sitter_typescript::LANGUAGE_TSX.into(),
+        }
+    }
+}
+
+/// Top-level AST node kinds to extract as chunks.
+const CHUNK_NODE_KINDS: &[&str] = &[
+    "function_declaration",
+    "class_declaration",
+    "lexical_declaration", // `const x = () => {}` — arrow functions and constants
+    "variable_declaration", // `var x = ...` — legacy
+    "export_statement",
+    // TypeScript-specific
+    "interface_declaration",
+    "type_alias_declaration",
+    "enum_declaration",
+];
+
+/// Thresholds for splitting large classes into per-method chunks.
+const MAX_METHODS_SINGLE_CHUNK: usize = 5;
+const MAX_CHARS_SINGLE_CHUNK: usize = 3200;
+
+/// Parse a JavaScript/TypeScript source file and extract code chunks.
+///
+/// The `dialect` parameter selects the correct tree-sitter grammar.
+pub fn chunk_js_file(source: &str, dialect: JsDialect) -> Vec<Chunk> {
+    let mut parser = Parser::new();
+    let language = dialect.tree_sitter_language();
+    parser
+        .set_language(&language)
+        .expect("failed to set JS/TS language");
+
+    let tree = match parser.parse(source, None) {
+        Some(t) => t,
+        None => return Vec::new(),
+    };
+
+    let root = tree.root_node();
+    let source_bytes = source.as_bytes();
+    let mut chunks = Vec::new();
+    let mut cursor = root.walk();
+
+    for child in root.named_children(&mut cursor) {
+        collect_chunks(child, source_bytes, source, &mut chunks);
+    }
+
+    chunks
+}
+
+fn collect_chunks(
+    node: tree_sitter::Node<'_>,
+    source_bytes: &[u8],
+    source: &str,
+    chunks: &mut Vec<Chunk>,
+) {
+    let kind = node.kind();
+
+    if !CHUNK_NODE_KINDS.contains(&kind) {
+        return;
+    }
+
+    // Unwrap export_statement → extract the inner declaration
+    if kind == "export_statement" {
+        collect_export_chunks(node, source_bytes, source, chunks);
+        return;
+    }
+
+    // Arrow function or const binding inside lexical/variable declaration
+    if kind == "lexical_declaration" || kind == "variable_declaration" {
+        collect_declaration_chunks(node, source_bytes, source, chunks);
+        return;
+    }
+
+    // Class declarations get special splitting treatment
+    if kind == "class_declaration" {
+        collect_class_chunks(node, source_bytes, source, chunks);
+        return;
+    }
+
+    // Plain function_declaration, interface, type_alias, enum
+    let entity_name = extract_entity_name(&node, source_bytes);
+    let doc_comment = extract_jsdoc_comment(&node, source);
+    let line_start = node.start_position().row + 1;
+    let line_end = node.end_position().row + 1;
+    let content = node.utf8_text(source_bytes).unwrap_or_default().to_string();
+
+    chunks.push(Chunk {
+        content,
+        chunk_type: kind.to_string(),
+        entity_name,
+        impl_type: None,
+        impl_trait: None,
+        line_start,
+        line_end,
+        doc_comment,
+    });
+}
+
+/// Handle `export_statement` by unwrapping to the inner declaration.
+fn collect_export_chunks(
+    node: tree_sitter::Node<'_>,
+    source_bytes: &[u8],
+    source: &str,
+    chunks: &mut Vec<Chunk>,
+) {
+    // Look for an inner declaration node
+    let mut cursor = node.walk();
+    let mut found_inner = false;
+
+    for child in node.named_children(&mut cursor) {
+        let child_kind = child.kind();
+        match child_kind {
+            "function_declaration" => {
+                found_inner = true;
+                // Include the full export statement text but classify by inner type
+                let entity_name = extract_entity_name(&child, source_bytes);
+                let doc_comment = extract_jsdoc_comment(&node, source);
+                let content = node.utf8_text(source_bytes).unwrap_or_default().to_string();
+                chunks.push(Chunk {
+                    content,
+                    chunk_type: "function_declaration".to_string(),
+                    entity_name,
+                    impl_type: None,
+                    impl_trait: None,
+                    line_start: node.start_position().row + 1,
+                    line_end: node.end_position().row + 1,
+                    doc_comment,
+                });
+            }
+            "class_declaration" => {
+                found_inner = true;
+                // Delegate to class handler but wrap in export text
+                collect_class_chunks_with_export(node, child, source_bytes, source, chunks);
+            }
+            "lexical_declaration" | "variable_declaration" => {
+                found_inner = true;
+                // Arrow function or const export
+                collect_declaration_chunks_with_export(node, child, source_bytes, source, chunks);
+            }
+            "interface_declaration" | "type_alias_declaration" | "enum_declaration" => {
+                found_inner = true;
+                let entity_name = extract_entity_name(&child, source_bytes);
+                let doc_comment = extract_jsdoc_comment(&node, source);
+                let content = node.utf8_text(source_bytes).unwrap_or_default().to_string();
+                chunks.push(Chunk {
+                    content,
+                    chunk_type: child_kind.to_string(),
+                    entity_name,
+                    impl_type: None,
+                    impl_trait: None,
+                    line_start: node.start_position().row + 1,
+                    line_end: node.end_position().row + 1,
+                    doc_comment,
+                });
+            }
+            _ => {}
+        }
+    }
+
+    // Bare export (re-export, default export expression, etc.)
+    if !found_inner {
+        let content = node.utf8_text(source_bytes).unwrap_or_default().to_string();
+        // Try to extract a name from `export default <identifier>` patterns
+        let entity_name = extract_export_default_name(&node, source_bytes);
+        let doc_comment = extract_jsdoc_comment(&node, source);
+        chunks.push(Chunk {
+            content,
+            chunk_type: "export_statement".to_string(),
+            entity_name,
+            impl_type: None,
+            impl_trait: None,
+            line_start: node.start_position().row + 1,
+            line_end: node.end_position().row + 1,
+            doc_comment,
+        });
+    }
+}
+
+/// Handle `lexical_declaration` (const/let) and `variable_declaration` (var).
+///
+/// Extracts the variable name. If the initializer is an arrow function or
+/// function expression, tags the chunk_type as `arrow_function` or
+/// `function_declaration` respectively.
+fn collect_declaration_chunks(
+    node: tree_sitter::Node<'_>,
+    source_bytes: &[u8],
+    source: &str,
+    chunks: &mut Vec<Chunk>,
+) {
+    let content = node.utf8_text(source_bytes).unwrap_or_default().to_string();
+    let doc_comment = extract_jsdoc_comment(&node, source);
+    let line_start = node.start_position().row + 1;
+    let line_end = node.end_position().row + 1;
+
+    // Walk variable_declarators to find names and initializer types
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if child.kind() == "variable_declarator" {
+            let name = child
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(source_bytes).ok())
+                .map(|s| s.to_string());
+
+            let chunk_type = match child.child_by_field_name("value") {
+                Some(val) if val.kind() == "arrow_function" => "arrow_function",
+                Some(val) if val.kind() == "function_expression" => "function_declaration",
+                Some(val) if val.kind() == "call_expression" => {
+                    // e.g. `const MyContext = React.createContext(null)`
+                    // or `const styled = styled.div``
+                    "lexical_declaration"
+                }
+                _ => "lexical_declaration",
+            };
+
+            chunks.push(Chunk {
+                content: content.clone(),
+                chunk_type: chunk_type.to_string(),
+                entity_name: name,
+                impl_type: None,
+                impl_trait: None,
+                line_start,
+                line_end,
+                doc_comment: doc_comment.clone(),
+            });
+            return;
+        }
+    }
+
+    // Fallback if no variable_declarator found
+    chunks.push(Chunk {
+        content,
+        chunk_type: node.kind().to_string(),
+        entity_name: None,
+        impl_type: None,
+        impl_trait: None,
+        line_start,
+        line_end,
+        doc_comment,
+    });
+}
+
+/// Handle exported lexical/variable declarations.
+fn collect_declaration_chunks_with_export(
+    export_node: tree_sitter::Node<'_>,
+    decl_node: tree_sitter::Node<'_>,
+    source_bytes: &[u8],
+    source: &str,
+    chunks: &mut Vec<Chunk>,
+) {
+    let content = export_node
+        .utf8_text(source_bytes)
+        .unwrap_or_default()
+        .to_string();
+    let doc_comment = extract_jsdoc_comment(&export_node, source);
+    let line_start = export_node.start_position().row + 1;
+    let line_end = export_node.end_position().row + 1;
+
+    let mut cursor = decl_node.walk();
+    for child in decl_node.named_children(&mut cursor) {
+        if child.kind() == "variable_declarator" {
+            let name = child
+                .child_by_field_name("name")
+                .and_then(|n| n.utf8_text(source_bytes).ok())
+                .map(|s| s.to_string());
+
+            let chunk_type = match child.child_by_field_name("value") {
+                Some(val) if val.kind() == "arrow_function" => "arrow_function",
+                Some(val) if val.kind() == "function_expression" => "function_declaration",
+                _ => "lexical_declaration",
+            };
+
+            chunks.push(Chunk {
+                content: content.clone(),
+                chunk_type: chunk_type.to_string(),
+                entity_name: name,
+                impl_type: None,
+                impl_trait: None,
+                line_start,
+                line_end,
+                doc_comment: doc_comment.clone(),
+            });
+            return;
+        }
+    }
+
+    chunks.push(Chunk {
+        content,
+        chunk_type: "lexical_declaration".to_string(),
+        entity_name: None,
+        impl_type: None,
+        impl_trait: None,
+        line_start,
+        line_end,
+        doc_comment,
+    });
+}
+
+/// Handle class declarations, splitting large classes into per-method chunks.
+fn collect_class_chunks(
+    node: tree_sitter::Node<'_>,
+    source_bytes: &[u8],
+    source: &str,
+    chunks: &mut Vec<Chunk>,
+) {
+    let class_name = extract_entity_name(&node, source_bytes);
+    let doc_comment = extract_jsdoc_comment(&node, source);
+    let content = node.utf8_text(source_bytes).unwrap_or_default().to_string();
+    let methods = extract_class_methods(&node, source_bytes, source);
+
+    let is_large =
+        methods.len() > MAX_METHODS_SINGLE_CHUNK || content.len() > MAX_CHARS_SINGLE_CHUNK;
+
+    if !is_large || methods.is_empty() {
+        chunks.push(Chunk {
+            content,
+            chunk_type: "class_declaration".to_string(),
+            entity_name: class_name,
+            impl_type: None,
+            impl_trait: None,
+            line_start: node.start_position().row + 1,
+            line_end: node.end_position().row + 1,
+            doc_comment,
+        });
+        return;
+    }
+
+    // Large class — split into per-method chunks + summary
+    let context_header = format!("// class {}", class_name.as_deref().unwrap_or("Anonymous"));
+
+    for method in &methods {
+        let method_content = format!("{context_header}\n{}", method.source);
+        chunks.push(Chunk {
+            content: method_content,
+            chunk_type: "method_definition".to_string(),
+            entity_name: Some(method.name.clone()),
+            impl_type: class_name.clone(),
+            impl_trait: None,
+            line_start: method.line_start,
+            line_end: method.line_end,
+            doc_comment: method.doc_comment.clone(),
+        });
+    }
+
+    // Summary with method signatures
+    let summary = build_class_summary(class_name.as_deref(), &methods);
+    chunks.push(Chunk {
+        content: summary,
+        chunk_type: "class_summary".to_string(),
+        entity_name: class_name,
+        impl_type: None,
+        impl_trait: None,
+        line_start: node.start_position().row + 1,
+        line_end: node.end_position().row + 1,
+        doc_comment,
+    });
+}
+
+/// Handle exported class declarations.
+fn collect_class_chunks_with_export(
+    export_node: tree_sitter::Node<'_>,
+    class_node: tree_sitter::Node<'_>,
+    source_bytes: &[u8],
+    source: &str,
+    chunks: &mut Vec<Chunk>,
+) {
+    let class_name = extract_entity_name(&class_node, source_bytes);
+    let doc_comment = extract_jsdoc_comment(&export_node, source);
+    let content = export_node
+        .utf8_text(source_bytes)
+        .unwrap_or_default()
+        .to_string();
+    let methods = extract_class_methods(&class_node, source_bytes, source);
+
+    let is_large =
+        methods.len() > MAX_METHODS_SINGLE_CHUNK || content.len() > MAX_CHARS_SINGLE_CHUNK;
+
+    if !is_large || methods.is_empty() {
+        chunks.push(Chunk {
+            content,
+            chunk_type: "class_declaration".to_string(),
+            entity_name: class_name,
+            impl_type: None,
+            impl_trait: None,
+            line_start: export_node.start_position().row + 1,
+            line_end: export_node.end_position().row + 1,
+            doc_comment,
+        });
+        return;
+    }
+
+    let context_header = format!("// class {}", class_name.as_deref().unwrap_or("Anonymous"));
+
+    for method in &methods {
+        let method_content = format!("{context_header}\n{}", method.source);
+        chunks.push(Chunk {
+            content: method_content,
+            chunk_type: "method_definition".to_string(),
+            entity_name: Some(method.name.clone()),
+            impl_type: class_name.clone(),
+            impl_trait: None,
+            line_start: method.line_start,
+            line_end: method.line_end,
+            doc_comment: method.doc_comment.clone(),
+        });
+    }
+
+    let summary = build_class_summary(class_name.as_deref(), &methods);
+    chunks.push(Chunk {
+        content: summary,
+        chunk_type: "class_summary".to_string(),
+        entity_name: class_name,
+        impl_type: None,
+        impl_trait: None,
+        line_start: export_node.start_position().row + 1,
+        line_end: export_node.end_position().row + 1,
+        doc_comment,
+    });
+}
+
+/// Information about a class method.
+struct MethodInfo {
+    name: String,
+    source: String,
+    signature: String,
+    line_start: usize,
+    line_end: usize,
+    doc_comment: Option<String>,
+}
+
+/// Extract methods from a class body.
+fn extract_class_methods(
+    class_node: &tree_sitter::Node<'_>,
+    source_bytes: &[u8],
+    source: &str,
+) -> Vec<MethodInfo> {
+    let body = match class_node.child_by_field_name("body") {
+        Some(b) => b,
+        None => return Vec::new(),
+    };
+
+    let mut methods = Vec::new();
+    let mut cursor = body.walk();
+
+    for child in body.named_children(&mut cursor) {
+        let child_kind = child.kind();
+        if child_kind != "method_definition" && child_kind != "public_field_definition" {
+            continue;
+        }
+
+        // Skip property definitions that aren't method-like
+        if child_kind == "public_field_definition" {
+            // Only include if initializer is a function/arrow
+            let has_fn = child
+                .child_by_field_name("value")
+                .map(|v| v.kind() == "arrow_function" || v.kind() == "function_expression")
+                .unwrap_or(false);
+            if !has_fn {
+                continue;
+            }
+        }
+
+        let name = child
+            .child_by_field_name("name")
+            .and_then(|n| n.utf8_text(source_bytes).ok())
+            .unwrap_or("")
+            .to_string();
+
+        let node_text = child
+            .utf8_text(source_bytes)
+            .unwrap_or_default()
+            .to_string();
+        let signature = extract_method_signature(&child, source_bytes);
+        let doc_comment = extract_jsdoc_comment(&child, source);
+
+        methods.push(MethodInfo {
+            name,
+            source: node_text,
+            signature,
+            line_start: child.start_position().row + 1,
+            line_end: child.end_position().row + 1,
+            doc_comment,
+        });
+    }
+
+    methods
+}
+
+/// Extract a method signature (everything before the body block).
+fn extract_method_signature(node: &tree_sitter::Node<'_>, source_bytes: &[u8]) -> String {
+    if let Some(body) = node.child_by_field_name("body") {
+        let sig_start = node.start_byte();
+        let sig_end = body.start_byte();
+        let sig_bytes = &source_bytes[sig_start..sig_end];
+        let sig = std::str::from_utf8(sig_bytes).unwrap_or("").trim_end();
+        return sig.to_string();
+    }
+    node.utf8_text(source_bytes).unwrap_or_default().to_string()
+}
+
+/// Build a class summary chunk with all method signatures.
+fn build_class_summary(class_name: Option<&str>, methods: &[MethodInfo]) -> String {
+    let header = format!("class {}", class_name.unwrap_or("Anonymous"));
+    let mut out = format!("{header} {{\n");
+    for method in methods {
+        out.push_str("  ");
+        out.push_str(&method.signature);
+        out.push_str(" { ... }\n");
+    }
+    out.push('}');
+    out
+}
+
+/// Extract the primary name from a node.
+fn extract_entity_name(node: &tree_sitter::Node<'_>, source_bytes: &[u8]) -> Option<String> {
+    // Try "name" field first (works for function_declaration, class_declaration,
+    // interface_declaration, enum_declaration, type_alias_declaration)
+    if let Some(name_node) = node.child_by_field_name("name") {
+        return name_node
+            .utf8_text(source_bytes)
+            .ok()
+            .map(|s| s.to_string());
+    }
+
+    // Fallback: first identifier child
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if child.kind() == "identifier" || child.kind() == "type_identifier" {
+            return child.utf8_text(source_bytes).ok().map(|s| s.to_string());
+        }
+    }
+    None
+}
+
+/// For `export default <identifier>`, extract the identifier name.
+fn extract_export_default_name(
+    node: &tree_sitter::Node<'_>,
+    source_bytes: &[u8],
+) -> Option<String> {
+    let mut cursor = node.walk();
+    for child in node.named_children(&mut cursor) {
+        if child.kind() == "identifier" {
+            return child.utf8_text(source_bytes).ok().map(|s| s.to_string());
+        }
+    }
+    None
+}
+
+/// Collect preceding JSDoc/block comments (`/** ... */`) immediately above the node.
+fn extract_jsdoc_comment(node: &tree_sitter::Node<'_>, source: &str) -> Option<String> {
+    let start_row = node.start_position().row;
+    if start_row == 0 {
+        return None;
+    }
+
+    let lines: Vec<&str> = source.lines().collect();
+    let mut doc_lines: Vec<&str> = Vec::new();
+    let mut in_block_comment = false;
+
+    // Walk backwards from the line before the node
+    let mut row = start_row;
+    while row > 0 {
+        row -= 1;
+        let line = lines.get(row).map(|l| l.trim()).unwrap_or("");
+
+        if line.is_empty() {
+            if !doc_lines.is_empty() {
+                break; // Gap between comment and node means it's not attached
+            }
+            continue;
+        }
+
+        // Single-line JSDoc: `/** brief */`
+        if line.starts_with("/**") && line.ends_with("*/") && !in_block_comment {
+            doc_lines.push(line);
+            break;
+        }
+
+        // End of block comment (scanning upward)
+        if line.ends_with("*/") && !in_block_comment {
+            in_block_comment = true;
+            doc_lines.push(line);
+            continue;
+        }
+
+        // Inside block comment
+        if in_block_comment {
+            doc_lines.push(line);
+            if line.starts_with("/**") || line.starts_with("/*") {
+                break;
+            }
+            continue;
+        }
+
+        // Single-line `//` comments
+        if line.starts_with("//") {
+            doc_lines.push(line);
+            continue;
+        }
+
+        // Decorators (skip them to find comments above)
+        if line.starts_with('@') {
+            continue;
+        }
+
+        break;
+    }
+
+    if doc_lines.is_empty() {
+        return None;
+    }
+
+    doc_lines.reverse();
+    Some(doc_lines.join("\n"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- basic function extraction ----
+
+    #[test]
+    fn chunk_function_declaration() {
+        let src = "function add(a, b) {\n  return a + b;\n}\n";
+        let chunks = chunk_js_file(src, JsDialect::JavaScript);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "function_declaration");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("add"));
+    }
+
+    #[test]
+    fn chunk_exported_function() {
+        let src = "export function greet(name) {\n  return `Hello ${name}`;\n}\n";
+        let chunks = chunk_js_file(src, JsDialect::JavaScript);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "function_declaration");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("greet"));
+        assert!(chunks[0].content.starts_with("export"));
+    }
+
+    #[test]
+    fn chunk_arrow_function() {
+        let src = "const add = (a, b) => a + b;\n";
+        let chunks = chunk_js_file(src, JsDialect::JavaScript);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "arrow_function");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("add"));
+    }
+
+    #[test]
+    fn chunk_exported_arrow_function() {
+        let src = "export const useAuth = () => {\n  return null;\n};\n";
+        let chunks = chunk_js_file(src, JsDialect::JavaScript);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "arrow_function");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("useAuth"));
+        assert!(chunks[0].content.starts_with("export"));
+    }
+
+    // ---- class extraction ----
+
+    #[test]
+    fn chunk_small_class() {
+        let src = r#"class Greeter {
+  constructor(name) {
+    this.name = name;
+  }
+
+  greet() {
+    return `Hello ${this.name}`;
+  }
+}
+"#;
+        let chunks = chunk_js_file(src, JsDialect::JavaScript);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "class_declaration");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("Greeter"));
+    }
+
+    #[test]
+    fn large_class_splits_into_methods() {
+        let src = r#"class BigService {
+  method_a() { return 1; }
+  method_b() { return 2; }
+  method_c() { return 3; }
+  method_d() { return 4; }
+  method_e() { return 5; }
+  method_f() { return 6; }
+  method_g() { return 7; }
+  method_h() { return 8; }
+}
+"#;
+        let chunks = chunk_js_file(src, JsDialect::JavaScript);
+
+        // 8 methods + 1 summary = 9
+        assert_eq!(chunks.len(), 9);
+
+        for chunk in &chunks[..8] {
+            assert_eq!(chunk.chunk_type, "method_definition");
+            assert_eq!(chunk.impl_type.as_deref(), Some("BigService"));
+            assert!(
+                chunk.content.starts_with("// class BigService\n"),
+                "Expected context header, got: {}",
+                &chunk.content[..chunk.content.len().min(40)]
+            );
+        }
+
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("method_a"));
+        assert_eq!(chunks[7].entity_name.as_deref(), Some("method_h"));
+
+        let summary = &chunks[8];
+        assert_eq!(summary.chunk_type, "class_summary");
+        assert!(summary.content.contains("class BigService {"));
+        assert!(summary.content.contains("method_a"));
+        assert!(summary.content.contains("{ ... }"));
+    }
+
+    // ---- TypeScript-specific ----
+
+    #[test]
+    fn chunk_interface_declaration() {
+        let src = "export interface UserProps {\n  name: string;\n  age: number;\n}\n";
+        let chunks = chunk_js_file(src, JsDialect::TypeScript);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "interface_declaration");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("UserProps"));
+    }
+
+    #[test]
+    fn chunk_type_alias() {
+        let src = "export type UserId = string;\n";
+        let chunks = chunk_js_file(src, JsDialect::TypeScript);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "type_alias_declaration");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("UserId"));
+    }
+
+    #[test]
+    fn chunk_enum_declaration() {
+        let src = "export enum Status {\n  Active,\n  Inactive,\n}\n";
+        let chunks = chunk_js_file(src, JsDialect::TypeScript);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "enum_declaration");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("Status"));
+    }
+
+    // ---- JSX / TSX ----
+
+    #[test]
+    fn chunk_tsx_component() {
+        let src = r#"export function MyComponent({ name }: { name: string }) {
+  return <div>{name}</div>;
+}
+"#;
+        let chunks = chunk_js_file(src, JsDialect::Tsx);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "function_declaration");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("MyComponent"));
+    }
+
+    #[test]
+    fn chunk_tsx_arrow_component() {
+        let src = r#"export const Card = ({ title }: { title: string }) => {
+  return <div className="card">{title}</div>;
+};
+"#;
+        let chunks = chunk_js_file(src, JsDialect::Tsx);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "arrow_function");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("Card"));
+    }
+
+    // ---- JSDoc comment extraction ----
+
+    #[test]
+    fn extracts_jsdoc_comment() {
+        let src = r#"/**
+ * Add two numbers.
+ * @param a First number
+ * @param b Second number
+ */
+function add(a, b) {
+  return a + b;
+}
+"#;
+        let chunks = chunk_js_file(src, JsDialect::JavaScript);
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].doc_comment.is_some());
+        assert!(chunks[0]
+            .doc_comment
+            .as_ref()
+            .unwrap()
+            .contains("Add two numbers"));
+    }
+
+    #[test]
+    fn extracts_single_line_comment() {
+        let src = "// Helper function\nfunction helper() { return 1; }\n";
+        let chunks = chunk_js_file(src, JsDialect::JavaScript);
+        assert_eq!(chunks.len(), 1);
+        assert!(chunks[0].doc_comment.is_some());
+        assert!(chunks[0]
+            .doc_comment
+            .as_ref()
+            .unwrap()
+            .contains("Helper function"));
+    }
+
+    // ---- line numbers ----
+
+    #[test]
+    fn line_numbers_are_one_based() {
+        let src = "\nfunction first() { return 1; }\n\nfunction second() { return 2; }\n";
+        let chunks = chunk_js_file(src, JsDialect::JavaScript);
+        assert_eq!(chunks.len(), 2);
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("first"));
+        assert_eq!(chunks[0].line_start, 2);
+        assert_eq!(chunks[1].entity_name.as_deref(), Some("second"));
+        assert_eq!(chunks[1].line_start, 4);
+    }
+
+    // ---- empty / comment-only files ----
+
+    #[test]
+    fn empty_file_returns_no_chunks() {
+        assert!(chunk_js_file("", JsDialect::JavaScript).is_empty());
+        assert!(chunk_js_file("// just a comment\n", JsDialect::JavaScript).is_empty());
+    }
+
+    // ---- barrel export ----
+
+    #[test]
+    fn barrel_export_produces_chunk() {
+        let src = "export { default as Button } from './Button';\n";
+        let chunks = chunk_js_file(src, JsDialect::JavaScript);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "export_statement");
+    }
+
+    // ---- default export expression ----
+
+    #[test]
+    fn default_export_identifier() {
+        let src = "function MyComponent() { return null; }\nexport default MyComponent;\n";
+        let chunks = chunk_js_file(src, JsDialect::JavaScript);
+        assert_eq!(chunks.len(), 2);
+        // First: the function
+        assert_eq!(chunks[0].chunk_type, "function_declaration");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("MyComponent"));
+        // Second: the default export
+        assert_eq!(chunks[1].chunk_type, "export_statement");
+        assert_eq!(chunks[1].entity_name.as_deref(), Some("MyComponent"));
+    }
+
+    // ---- mixed file ----
+
+    #[test]
+    fn mixed_js_file() {
+        let src = r#"import React from 'react';
+
+const API_URL = 'http://localhost:3000';
+
+export function useUsers() {
+  const [users, setUsers] = React.useState([]);
+  return { users, setUsers };
+}
+
+export class UserService {
+  getUser(id) { return fetch(`${API_URL}/users/${id}`); }
+}
+
+export default UserService;
+"#;
+        let chunks = chunk_js_file(src, JsDialect::JavaScript);
+        // API_URL (lexical_declaration) + useUsers (function) + UserService (class) + default export
+        assert_eq!(chunks.len(), 4);
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("API_URL"));
+        assert_eq!(chunks[1].entity_name.as_deref(), Some("useUsers"));
+        assert_eq!(chunks[2].entity_name.as_deref(), Some("UserService"));
+        assert_eq!(chunks[3].chunk_type, "export_statement");
+    }
+
+    // ---- dialect detection ----
+
+    #[test]
+    fn dialect_from_extension() {
+        assert_eq!(
+            JsDialect::from_extension(".js"),
+            Some(JsDialect::JavaScript)
+        );
+        assert_eq!(JsDialect::from_extension(".jsx"), Some(JsDialect::Jsx));
+        assert_eq!(
+            JsDialect::from_extension(".ts"),
+            Some(JsDialect::TypeScript)
+        );
+        assert_eq!(JsDialect::from_extension(".tsx"), Some(JsDialect::Tsx));
+        assert_eq!(JsDialect::from_extension(".rs"), None);
+    }
+
+    #[test]
+    fn language_id_mapping() {
+        assert_eq!(JsDialect::JavaScript.language_id(), "javascript");
+        assert_eq!(JsDialect::Jsx.language_id(), "javascript");
+        assert_eq!(JsDialect::TypeScript.language_id(), "typescript");
+        assert_eq!(JsDialect::Tsx.language_id(), "typescript");
+    }
+
+    // ---- hook detection via arrow function ----
+
+    #[test]
+    fn hook_as_arrow_function() {
+        let src = r#"export const useCounter = () => {
+  const [count, setCount] = useState(0);
+  return { count, increment: () => setCount(c => c + 1) };
+};
+"#;
+        let chunks = chunk_js_file(src, JsDialect::TypeScript);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "arrow_function");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("useCounter"));
+    }
+
+    // ---- GraphQL tagged template ----
+
+    #[test]
+    fn graphql_query_const() {
+        let src = r#"export const GET_USER = gql`
+  query GetUser($id: ID!) {
+    user(id: $id) {
+      id
+      name
+    }
+  }
+`;
+"#;
+        let chunks = chunk_js_file(src, JsDialect::TypeScript);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("GET_USER"));
+    }
+
+    // ---- TypeScript with complex types ----
+
+    #[test]
+    fn typescript_generic_function() {
+        let src = r#"export function identity<T>(value: T): T {
+  return value;
+}
+"#;
+        let chunks = chunk_js_file(src, JsDialect::TypeScript);
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0].chunk_type, "function_declaration");
+        assert_eq!(chunks[0].entity_name.as_deref(), Some("identity"));
+    }
+}

--- a/style-agent/crates/core/src/labeler.rs
+++ b/style-agent/crates/core/src/labeler.rs
@@ -38,8 +38,9 @@ pub struct ChunkClassification {
     pub uses: Vec<String>,
 }
 
-/// All 20 primary labels in the taxonomy.
+/// All primary labels in the taxonomy.
 pub const KNOWN_PRIMARY_LABELS: &[&str] = &[
+    // Backend (Rust)
     "entity",
     "entity_command",
     "entity_query",
@@ -60,6 +61,17 @@ pub const KNOWN_PRIMARY_LABELS: &[&str] = &[
     "type_conversion",
     "test",
     "config",
+    // Frontend (JS/TS)
+    "component",
+    "page",
+    "layout",
+    "hook",
+    "graphql_query",
+    "graphql_mutation",
+    "ui_primitive",
+    "store",
+    "route_handler",
+    "style_variant",
 ];
 
 /// The 4 layer values.
@@ -77,6 +89,7 @@ pub const KNOWN_USES: &[&str] = &[
 /// Priority order: most specific first. When multiple checkers fire,
 /// the first match in this list wins.
 const PRIORITY_ORDER: &[&str] = &[
+    // Backend
     "entity_hydration",
     "entity_command",
     "entity_query",
@@ -88,6 +101,14 @@ const PRIORITY_ORDER: &[&str] = &[
     "job",
     "type_conversion",
     "authorization",
+    // Frontend labels that should beat generic "api"
+    "hook",
+    "graphql_mutation",
+    "graphql_query",
+    "page",
+    "layout",
+    "route_handler",
+    // Back to backend
     "api",
     "service_method",
     "service",
@@ -97,10 +118,16 @@ const PRIORITY_ORDER: &[&str] = &[
     "test",
     "domain_primitives",
     "value_object",
+    // Remaining frontend
+    "store",
+    "style_variant",
+    "ui_primitive",
+    "component",
 ];
 
 /// All primary-label checker functions.
 const PRIMARY_CHECKERS: &[fn(&ChunkData) -> Option<LabeledRole>] = &[
+    // Backend
     check_entity,
     check_entity_event,
     check_error,
@@ -121,6 +148,17 @@ const PRIMARY_CHECKERS: &[fn(&ChunkData) -> Option<LabeledRole>] = &[
     check_api_handler,
     check_config,
     check_type_conversion,
+    // Frontend
+    check_component,
+    check_page,
+    check_layout,
+    check_hook,
+    check_graphql_query,
+    check_graphql_mutation,
+    check_ui_primitive,
+    check_store,
+    check_route_handler,
+    check_style_variant,
 ];
 
 /// Standard trait impls that are always boilerplate — never labeled.
@@ -225,12 +263,19 @@ fn detect_layer(c: &ChunkData) -> Option<String> {
     {
         return None;
     }
+    // JS/TS test files
+    if is_js_ts_file(&c.file_path)
+        && (c.file_path.contains(".test.")
+            || c.file_path.contains(".spec.")
+            || c.file_path.contains("/__tests__/"))
+    {
+        return None;
+    }
 
     // Interface layer
     if c.file_path.contains("graphql/") || c.file_path.contains("server/") {
         return Some("interface".to_string());
     }
-
     // Infrastructure layer
     if c.file_path.ends_with("repo.rs")
         || c.file_path.contains("publisher.rs")
@@ -241,9 +286,31 @@ fn detect_layer(c: &ChunkData) -> Option<String> {
     {
         return Some("infrastructure".to_string());
     }
+    // JS/TS infrastructure: API routes, store/state management (check before interface)
+    if is_js_ts_file(&c.file_path)
+        && (c.file_path.contains("/api/")
+            || c.file_path.contains("/store/")
+            || c.file_path.contains("/stores/"))
+    {
+        return Some("infrastructure".to_string());
+    }
+
+    // JS/TS interface layer (pages, components, layouts)
+    if is_js_ts_file(&c.file_path)
+        && (c.file_path.contains("/pages/")
+            || c.file_path.contains("/app/")
+            || c.file_path.contains("/components/")
+            || c.file_path.contains("/layouts/"))
+    {
+        return Some("interface".to_string());
+    }
 
     // Application layer
     if c.file_path.ends_with("mod.rs") || c.file_path.ends_with("lib.rs") {
+        return Some("application".to_string());
+    }
+    // JS/TS application: hooks (business logic)
+    if is_js_ts_file(&c.file_path) && c.file_path.contains("/hooks/") {
         return Some("application".to_string());
     }
 
@@ -631,6 +698,22 @@ fn check_test(c: &ChunkData) -> Option<LabeledRole> {
     if c.content.contains("#[cfg(test)]") {
         signals.push("attr:cfg_test".to_string());
     }
+    // JS/TS test patterns
+    if is_js_ts_file(&c.file_path) {
+        if c.file_path.contains(".test.") || c.file_path.contains(".spec.") {
+            signals.push("file_path:test/spec".to_string());
+        }
+        if c.file_path.contains("/__tests__/") {
+            signals.push("file_path:__tests__/".to_string());
+        }
+        if (c.content.contains("describe(")
+            || c.content.contains("it(")
+            || c.content.contains("test("))
+            && (c.content.contains("expect(") || c.content.contains("assert"))
+        {
+            signals.push("content:jest/vitest_pattern".to_string());
+        }
+    }
 
     some_if("test", 0.95, signals)
 }
@@ -772,6 +855,343 @@ fn check_type_conversion(c: &ChunkData) -> Option<LabeledRole> {
     }
 
     some_if("type_conversion", 0.80, signals)
+}
+
+// ---------- frontend (JS/TS) checkers ----------
+
+/// React/Vue/Svelte component — function or arrow returning JSX, or in components/ dir.
+fn check_component(c: &ChunkData) -> Option<LabeledRole> {
+    if !is_js_ts_file(&c.file_path) {
+        return None;
+    }
+    let mut signals = Vec::new();
+
+    // File in a components/ directory
+    if c.file_path.contains("/components/") || c.file_path.contains("/Components/") {
+        signals.push("file_path:components/".to_string());
+    }
+
+    // PascalCase function/arrow that returns JSX
+    let is_pascal = c
+        .entity_name
+        .chars()
+        .next()
+        .is_some_and(|ch| ch.is_uppercase());
+    let is_fn = c.chunk_type == "function_declaration" || c.chunk_type == "arrow_function";
+    if is_fn && is_pascal && has_jsx_return(&c.content) {
+        signals.push("pascal_case_fn+jsx_return".to_string());
+    }
+
+    // forwardRef pattern
+    if c.content.contains("forwardRef") {
+        signals.push("call:forwardRef".to_string());
+    }
+
+    some_if("component", 0.85, signals)
+}
+
+/// Page component — in pages/ or app/ directory.
+fn check_page(c: &ChunkData) -> Option<LabeledRole> {
+    if !is_js_ts_file(&c.file_path) {
+        return None;
+    }
+    let mut signals = Vec::new();
+
+    if c.file_path.contains("/pages/") || c.file_path.contains("/Pages/") {
+        signals.push("file_path:pages/".to_string());
+    }
+    // Next.js app directory page files
+    if c.file_path.contains("/app/")
+        && path_ends_with_any(
+            &c.file_path,
+            &["page.tsx", "page.jsx", "page.ts", "page.js"],
+        )
+    {
+        signals.push("file_path:app/page".to_string());
+    }
+    // Default export in pages dir (common Next.js pattern)
+    if signals.is_empty()
+        && c.chunk_type == "export_statement"
+        && c.content.contains("default")
+        && c.file_path.contains("/pages/")
+    {
+        signals.push("file_path:pages/+default_export".to_string());
+    }
+
+    some_if("page", 0.90, signals)
+}
+
+/// Layout component — in layouts/ or named layout.
+fn check_layout(c: &ChunkData) -> Option<LabeledRole> {
+    if !is_js_ts_file(&c.file_path) {
+        return None;
+    }
+    let mut signals = Vec::new();
+
+    if c.file_path.contains("/layouts/") || c.file_path.contains("/Layouts/") {
+        signals.push("file_path:layouts/".to_string());
+    }
+    if path_ends_with_any(
+        &c.file_path,
+        &["layout.tsx", "layout.jsx", "layout.ts", "layout.js"],
+    ) {
+        signals.push("file_path:layout.*".to_string());
+    }
+    let name_lower = c.entity_name.to_lowercase();
+    if name_lower.ends_with("layout") || name_lower.starts_with("layout") {
+        signals.push("entity_name:*layout*".to_string());
+    }
+
+    some_if("layout", 0.85, signals)
+}
+
+/// React hook — function/arrow starting with `use`.
+fn check_hook(c: &ChunkData) -> Option<LabeledRole> {
+    if !is_js_ts_file(&c.file_path) {
+        return None;
+    }
+    let mut signals = Vec::new();
+
+    let is_fn = c.chunk_type == "function_declaration" || c.chunk_type == "arrow_function";
+    if is_fn && c.entity_name.starts_with("use") && c.entity_name.len() > 3 {
+        // Ensure the character after "use" is uppercase (useAuth, useQuery, etc.)
+        let after_use = &c.entity_name[3..];
+        if after_use.starts_with(|ch: char| ch.is_uppercase()) {
+            signals.push("entity_name:use*".to_string());
+        }
+    }
+
+    if c.file_path.contains("/hooks/") || c.file_path.contains("/Hooks/") {
+        signals.push("file_path:hooks/".to_string());
+    }
+
+    some_if("hook", 0.95, signals)
+}
+
+/// GraphQL query — gql tagged template or .graphql file with query.
+fn check_graphql_query(c: &ChunkData) -> Option<LabeledRole> {
+    if !is_js_ts_file(&c.file_path) {
+        return None;
+    }
+    let mut signals = Vec::new();
+
+    let has_gql_tag = c.content.contains("gql`") || c.content.contains("graphql`");
+    let is_query = c.content.contains("query ") || c.content.contains("query(");
+
+    if has_gql_tag && is_query && !c.content.contains("mutation ") {
+        signals.push("gql_tagged_template+query".to_string());
+    }
+    if c.content.contains("useQuery(")
+        || c.content.contains("useLazyQuery(")
+        || c.content.contains("useSuspenseQuery(")
+    {
+        signals.push("call:useQuery".to_string());
+    }
+    if has_gql_tag
+        && (c.entity_name.starts_with("GET_")
+            || c.entity_name.starts_with("FETCH_")
+            || c.entity_name.starts_with("LIST_")
+            || c.entity_name.ends_with("_QUERY")
+            || c.entity_name.ends_with("Query"))
+    {
+        signals.push("entity_name:query_pattern+gql".to_string());
+    }
+
+    some_if("graphql_query", 0.90, signals)
+}
+
+/// GraphQL mutation — gql tagged template with mutation keyword.
+fn check_graphql_mutation(c: &ChunkData) -> Option<LabeledRole> {
+    if !is_js_ts_file(&c.file_path) {
+        return None;
+    }
+    let mut signals = Vec::new();
+
+    let has_gql_tag = c.content.contains("gql`") || c.content.contains("graphql`");
+
+    if has_gql_tag && c.content.contains("mutation ") {
+        signals.push("gql_tagged_template+mutation".to_string());
+    }
+    if c.content.contains("useMutation(") {
+        signals.push("call:useMutation".to_string());
+    }
+    if (c.entity_name.starts_with("CREATE_")
+        || c.entity_name.starts_with("UPDATE_")
+        || c.entity_name.starts_with("DELETE_")
+        || c.entity_name.ends_with("_MUTATION")
+        || c.entity_name.ends_with("Mutation"))
+        && has_gql_tag
+    {
+        signals.push("entity_name:mutation_pattern+gql".to_string());
+    }
+
+    some_if("graphql_mutation", 0.90, signals)
+}
+
+/// UI primitive — small reusable component in a ui/ or primitives/ directory.
+fn check_ui_primitive(c: &ChunkData) -> Option<LabeledRole> {
+    if !is_js_ts_file(&c.file_path) {
+        return None;
+    }
+    // Require the file to be in a ui/ or primitives/ directory
+    if !c.file_path.contains("/ui/") && !c.file_path.contains("/primitives/") {
+        return None;
+    }
+    let mut signals = Vec::new();
+    signals.push("file_path:ui/|primitives/".to_string());
+
+    // Boost confidence if name matches common UI primitive names
+    let name_lower = c.entity_name.to_lowercase();
+    let ui_names = [
+        "button",
+        "input",
+        "select",
+        "checkbox",
+        "radio",
+        "toggle",
+        "switch",
+        "modal",
+        "dialog",
+        "tooltip",
+        "popover",
+        "dropdown",
+        "badge",
+        "avatar",
+        "spinner",
+        "skeleton",
+        "divider",
+        "separator",
+        "icon",
+        "label",
+        "textarea",
+    ];
+    if ui_names.iter().any(|n| name_lower == *n) {
+        signals.push("entity_name:ui_primitive".to_string());
+    }
+
+    some_if("ui_primitive", 0.80, signals)
+}
+
+/// State store — Redux, Zustand, MobX, or similar state management.
+fn check_store(c: &ChunkData) -> Option<LabeledRole> {
+    if !is_js_ts_file(&c.file_path) {
+        return None;
+    }
+    let mut signals = Vec::new();
+
+    if c.file_path.contains("/store/") || c.file_path.contains("/stores/") {
+        signals.push("file_path:store/".to_string());
+    }
+    if c.content.contains("createSlice(") || c.content.contains("createStore(") {
+        signals.push("call:createSlice/createStore".to_string());
+    }
+    if c.content.contains("zustand") || c.content.contains("create(") && c.content.contains("set(")
+    {
+        signals.push("pattern:zustand".to_string());
+    }
+    if c.content.contains("configureStore(") || c.content.contains("combineReducers(") {
+        signals.push("call:redux_configure".to_string());
+    }
+    if c.entity_name.ends_with("Store")
+        || c.entity_name.ends_with("Slice")
+        || c.entity_name.ends_with("Reducer")
+    {
+        signals.push("entity_name:*Store/*Slice/*Reducer".to_string());
+    }
+
+    some_if("store", 0.85, signals)
+}
+
+/// Route handler — Express/Next.js API route handler.
+fn check_route_handler(c: &ChunkData) -> Option<LabeledRole> {
+    if !is_js_ts_file(&c.file_path) {
+        return None;
+    }
+    let mut signals = Vec::new();
+
+    // Next.js API routes
+    if c.file_path.contains("/api/")
+        && path_ends_with_any(
+            &c.file_path,
+            &["route.ts", "route.js", "route.tsx", "route.jsx"],
+        )
+    {
+        signals.push("file_path:api/route".to_string());
+    }
+    // Express-style route handlers
+    if c.content.contains("app.get(")
+        || c.content.contains("app.post(")
+        || c.content.contains("app.put(")
+        || c.content.contains("app.delete(")
+        || c.content.contains("router.get(")
+        || c.content.contains("router.post(")
+        || c.content.contains("router.put(")
+        || c.content.contains("router.delete(")
+    {
+        signals.push("call:express_route".to_string());
+    }
+    // Next.js API route exports
+    if c.file_path.contains("/api/")
+        && (c.entity_name == "GET"
+            || c.entity_name == "POST"
+            || c.entity_name == "PUT"
+            || c.entity_name == "DELETE"
+            || c.entity_name == "PATCH")
+    {
+        signals.push("export:http_method_handler".to_string());
+    }
+
+    some_if("route_handler", 0.85, signals)
+}
+
+/// Style variant — styled-components, CSS-in-JS, or cva/class-variance-authority.
+fn check_style_variant(c: &ChunkData) -> Option<LabeledRole> {
+    if !is_js_ts_file(&c.file_path) {
+        return None;
+    }
+    let mut signals = Vec::new();
+
+    if c.content.contains("styled.") || c.content.contains("styled(") {
+        signals.push("call:styled".to_string());
+    }
+    if c.content.contains("cva(") || c.content.contains("class-variance-authority") {
+        signals.push("call:cva".to_string());
+    }
+    if c.content.contains("css`") || c.content.contains("css({") {
+        signals.push("css_in_js".to_string());
+    }
+    let name_lower = c.entity_name.to_lowercase();
+    if name_lower.ends_with("variants") || name_lower.ends_with("styles") {
+        signals.push("entity_name:*variants/*styles".to_string());
+    }
+
+    some_if("style_variant", 0.80, signals)
+}
+
+// ---------- frontend helpers ----------
+
+/// Check if the file path is a JS/TS file.
+fn is_js_ts_file(path: &str) -> bool {
+    path.ends_with(".js")
+        || path.ends_with(".jsx")
+        || path.ends_with(".ts")
+        || path.ends_with(".tsx")
+        || path.ends_with(".mjs")
+        || path.ends_with(".cjs")
+}
+
+/// Check if content contains JSX return patterns.
+fn has_jsx_return(content: &str) -> bool {
+    // JSX return: `return (<div`, `return <div`, or template with < in return
+    content.contains("return (") && content.contains('<')
+        || content.contains("return <")
+        || content.contains("=> (") && content.contains('<')
+        || content.contains("=> <")
+}
+
+/// Check if a file path ends with any of the given suffixes.
+fn path_ends_with_any(path: &str, suffixes: &[&str]) -> bool {
+    suffixes.iter().any(|s| path.ends_with(s))
 }
 
 // ---------- helpers ----------
@@ -1734,5 +2154,343 @@ mod tests {
         );
         let roles = label_chunk(&c);
         assert!(roles.is_empty());
+    }
+
+    // ---- frontend: component ----
+
+    #[test]
+    fn component_by_path() {
+        let c = chunk_with(
+            "export function Button() { return <button>Click</button>; }",
+            "src/components/Button.tsx",
+            "function_declaration",
+            "Button",
+        );
+        assert_eq!(primary(&c), Some("component".to_string()));
+    }
+
+    #[test]
+    fn component_by_jsx_return() {
+        let c = chunk_with(
+            "export function Card({ title }) { return <div>{title}</div>; }",
+            "src/shared/Card.tsx",
+            "function_declaration",
+            "Card",
+        );
+        assert_eq!(primary(&c), Some("component".to_string()));
+    }
+
+    #[test]
+    fn component_forward_ref() {
+        let c = chunk_with(
+            "export const Input = forwardRef((props, ref) => { return <input ref={ref} />; });",
+            "src/components/Input.tsx",
+            "arrow_function",
+            "Input",
+        );
+        assert_eq!(primary(&c), Some("component".to_string()));
+    }
+
+    // ---- frontend: page ----
+
+    #[test]
+    fn page_by_pages_dir() {
+        let c = chunk_with(
+            "export default function Home() { return <div>Home</div>; }",
+            "src/pages/index.tsx",
+            "function_declaration",
+            "Home",
+        );
+        assert_eq!(primary(&c), Some("page".to_string()));
+    }
+
+    #[test]
+    fn page_by_app_dir() {
+        let c = chunk_with(
+            "export default function Page() { return <main>Content</main>; }",
+            "src/app/dashboard/page.tsx",
+            "function_declaration",
+            "Page",
+        );
+        assert_eq!(primary(&c), Some("page".to_string()));
+    }
+
+    // ---- frontend: layout ----
+
+    #[test]
+    fn layout_by_dir() {
+        let c = chunk_with(
+            "export function MainLayout({ children }) { return <div>{children}</div>; }",
+            "src/layouts/MainLayout.tsx",
+            "function_declaration",
+            "MainLayout",
+        );
+        assert_eq!(primary(&c), Some("layout".to_string()));
+    }
+
+    #[test]
+    fn layout_by_filename() {
+        let c = chunk_with(
+            "export default function RootLayout({ children }) { return <html>{children}</html>; }",
+            "src/app/layout.tsx",
+            "function_declaration",
+            "RootLayout",
+        );
+        assert_eq!(primary(&c), Some("layout".to_string()));
+    }
+
+    // ---- frontend: hook ----
+
+    #[test]
+    fn hook_by_name() {
+        let c = chunk_with(
+            "export function useAuth() { const [user, setUser] = useState(null); return { user }; }",
+            "src/hooks/useAuth.ts",
+            "function_declaration",
+            "useAuth",
+        );
+        assert_eq!(primary(&c), Some("hook".to_string()));
+    }
+
+    #[test]
+    fn hook_arrow_function() {
+        let c = chunk_with(
+            "export const useCounter = () => { const [c, set] = useState(0); return c; };",
+            "src/hooks/useCounter.ts",
+            "arrow_function",
+            "useCounter",
+        );
+        assert_eq!(primary(&c), Some("hook".to_string()));
+    }
+
+    #[test]
+    fn hook_not_use_lowercase() {
+        // "user" starts with "use" but 4th char is lowercase — not a hook
+        let c = chunk_with(
+            "export function user() { return {}; }",
+            "src/lib/user.ts",
+            "function_declaration",
+            "user",
+        );
+        assert_ne!(primary(&c), Some("hook".to_string()));
+    }
+
+    // ---- frontend: graphql_query ----
+
+    #[test]
+    fn graphql_query_by_gql_tag() {
+        let c = chunk_with(
+            "export const GET_USER = gql`\n  query GetUser($id: ID!) {\n    user(id: $id) { id name }\n  }\n`;",
+            "src/graphql/queries.ts",
+            "lexical_declaration",
+            "GET_USER",
+        );
+        assert_eq!(primary(&c), Some("graphql_query".to_string()));
+    }
+
+    #[test]
+    fn graphql_query_by_usequery() {
+        let c = chunk_with(
+            "export function useUserData(id) { return useQuery(GET_USER, { variables: { id } }); }",
+            "src/hooks/useUserData.ts",
+            "function_declaration",
+            "useUserData",
+        );
+        // hook takes priority over graphql_query in priority order
+        assert_eq!(primary(&c), Some("hook".to_string()));
+    }
+
+    // ---- frontend: graphql_mutation ----
+
+    #[test]
+    fn graphql_mutation_by_gql_tag() {
+        let c = chunk_with(
+            "export const CREATE_USER = gql`\n  mutation CreateUser($input: CreateUserInput!) {\n    createUser(input: $input) { id }\n  }\n`;",
+            "src/graphql/mutations.ts",
+            "lexical_declaration",
+            "CREATE_USER",
+        );
+        assert_eq!(primary(&c), Some("graphql_mutation".to_string()));
+    }
+
+    #[test]
+    fn graphql_mutation_by_usemutation() {
+        let c = chunk_with(
+            "export const useCreateUser = () => { const [create] = useMutation(CREATE_USER); return create; };",
+            "src/hooks/useCreateUser.ts",
+            "arrow_function",
+            "useCreateUser",
+        );
+        // hook wins by priority
+        assert_eq!(primary(&c), Some("hook".to_string()));
+    }
+
+    // ---- frontend: ui_primitive ----
+
+    #[test]
+    fn ui_primitive_by_dir() {
+        let c = chunk_with(
+            "export function Badge({ text }) { return <span className='badge'>{text}</span>; }",
+            "src/ui/Badge.tsx",
+            "function_declaration",
+            "Badge",
+        );
+        assert_eq!(primary(&c), Some("ui_primitive".to_string()));
+    }
+
+    // ---- frontend: store ----
+
+    #[test]
+    fn store_by_create_slice() {
+        let c = chunk_with(
+            "export const userSlice = createSlice({ name: 'user', initialState: {} });",
+            "src/store/userSlice.ts",
+            "lexical_declaration",
+            "userSlice",
+        );
+        assert_eq!(primary(&c), Some("store".to_string()));
+    }
+
+    #[test]
+    fn store_by_entity_name() {
+        let c = chunk_with(
+            "export const authStore = create((set) => ({ user: null }));",
+            "src/stores/auth.ts",
+            "lexical_declaration",
+            "authStore",
+        );
+        assert_eq!(primary(&c), Some("store".to_string()));
+    }
+
+    // ---- frontend: route_handler ----
+
+    #[test]
+    fn route_handler_nextjs_api() {
+        let c = chunk_with(
+            "export async function GET(request) { return Response.json({ ok: true }); }",
+            "src/app/api/users/route.ts",
+            "function_declaration",
+            "GET",
+        );
+        assert_eq!(primary(&c), Some("route_handler".to_string()));
+    }
+
+    #[test]
+    fn route_handler_express() {
+        let c = chunk_with(
+            "router.get('/users', async (req, res) => { res.json([]); });",
+            "src/routes/users.ts",
+            "arrow_function",
+            "getUsers",
+        );
+        assert_eq!(primary(&c), Some("route_handler".to_string()));
+    }
+
+    // ---- frontend: style_variant ----
+
+    #[test]
+    fn style_variant_styled_components() {
+        let c = chunk_with(
+            "export const StyledButton = styled.button`\n  background: blue;\n  color: white;\n`;",
+            "src/components/Button.styles.ts",
+            "lexical_declaration",
+            "StyledButton",
+        );
+        assert_eq!(primary(&c), Some("style_variant".to_string()));
+    }
+
+    #[test]
+    fn style_variant_cva() {
+        let c = chunk_with(
+            "export const buttonVariants = cva('base-class', { variants: { size: { sm: 'px-2' } } });",
+            "src/components/button.variants.ts",
+            "lexical_declaration",
+            "buttonVariants",
+        );
+        assert_eq!(primary(&c), Some("style_variant".to_string()));
+    }
+
+    // ---- frontend: test detection ----
+
+    #[test]
+    fn js_test_by_spec_file() {
+        let c = chunk_with(
+            "describe('Button', () => { it('renders', () => { expect(true).toBe(true); }); });",
+            "src/components/Button.spec.tsx",
+            "arrow_function",
+            "ButtonSpec",
+        );
+        assert_eq!(primary(&c), Some("test".to_string()));
+    }
+
+    #[test]
+    fn js_test_by_test_file() {
+        let c = chunk_with(
+            "test('adds numbers', () => { expect(add(1, 2)).toBe(3); });",
+            "src/utils/math.test.ts",
+            "arrow_function",
+            "addsNumbers",
+        );
+        assert_eq!(primary(&c), Some("test".to_string()));
+    }
+
+    // ---- frontend: layer detection ----
+
+    #[test]
+    fn js_interface_layer_components() {
+        let c = chunk_with(
+            "export function Button() { return <button/>; }",
+            "src/components/Button.tsx",
+            "function_declaration",
+            "Button",
+        );
+        assert_eq!(layer(&c), Some("interface".to_string()));
+    }
+
+    #[test]
+    fn js_infrastructure_layer_api() {
+        let c = chunk_with(
+            "export async function GET() { return Response.json({}); }",
+            "src/app/api/users/route.ts",
+            "function_declaration",
+            "GET",
+        );
+        assert_eq!(layer(&c), Some("infrastructure".to_string()));
+    }
+
+    #[test]
+    fn js_application_layer_hooks() {
+        let c = chunk_with(
+            "export function useAuth() { return {}; }",
+            "src/hooks/useAuth.ts",
+            "function_declaration",
+            "useAuth",
+        );
+        assert_eq!(layer(&c), Some("application".to_string()));
+    }
+
+    #[test]
+    fn js_test_no_layer() {
+        let c = chunk_with(
+            "describe('test', () => { it('works', () => { expect(1).toBe(1); }); });",
+            "src/components/Button.test.tsx",
+            "arrow_function",
+            "test",
+        );
+        assert_eq!(layer(&c), None);
+    }
+
+    // ---- frontend: non-JS files don't match ----
+
+    #[test]
+    fn rust_file_not_component() {
+        let c = chunk_with(
+            "pub fn Button() -> Html { html! { <button/> } }",
+            "src/components/button.rs",
+            "function_item",
+            "Button",
+        );
+        // Rust file should not match component checker
+        assert_ne!(primary(&c), Some("component".to_string()));
     }
 }

--- a/style-agent/crates/core/src/lib.rs
+++ b/style-agent/crates/core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod classifier;
 pub mod config;
 pub mod embedder;
 pub mod error;
+pub mod js_chunker;
 pub mod label_store;
 pub mod labeler;
 pub mod request_log;


### PR DESCRIPTION
## Summary

- Add tree-sitter based JS/TS chunking (`js_chunker.rs`) supporting `.js/.jsx/.ts/.tsx` files with proper dialect detection and grammar selection
- Integrate JS/TS files into the walker/indexer pipeline with auto-exclusion of `node_modules/`, `dist/`, `build/`, `.next/`, `coverage/`, `__generated__/`
- Add 10 new frontend labeling heuristics: `component`, `page`, `layout`, `hook`, `graphql_query`, `graphql_mutation`, `ui_primitive`, `store`, `route_handler`, `style_variant`
- 51 new tests (163 total): 23 for js_chunker, 28 for frontend labels

## Implementation Details

### JS/TS Chunker
- Uses `tree-sitter-javascript` (0.25) for JS/JSX and `tree-sitter-typescript` (0.23) for TS/TSX
- Extracts: function declarations, arrow functions, class declarations, interfaces, type aliases, enums, export statements
- Handles arrow function entity extraction (unwraps `lexical_declaration` → `variable_declarator`)
- Handles export wrapping (unwraps `export_statement` to extract inner declaration type)
- Splits large classes (>5 methods or >3200 chars) into per-method chunks + summary, mirroring Rust impl block splitting
- Extracts JSDoc block comments and single-line comments

### Frontend Labels
| Label | Detection Strategy |
|---|---|
| `component` | PascalCase fn + JSX return, or in `components/` dir |
| `page` | Files in `pages/` or `app/*/page.tsx` |
| `layout` | Files in `layouts/` or named `*layout*` |
| `hook` | Functions named `use*` (e.g., `useAuth`) |
| `graphql_query` | `gql` tagged template + `query` keyword |
| `graphql_mutation` | `gql` tagged template + `mutation` keyword |
| `ui_primitive` | Components in `ui/` or `primitives/` dirs |
| `store` | Redux `createSlice`/`createStore`, Zustand patterns |
| `route_handler` | Express routes or Next.js API route files |
| `style_variant` | `styled.`/`styled()`, `cva()`, `css` tagged templates |

## Test plan
- [x] All 163 unit tests pass (`cargo test -p style-agent-core --lib`)
- [x] Clippy clean (`cargo clippy --all-targets -- -D warnings`)
- [x] `nix flake check` passes (fmt + clippy + nextest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)