### PR TITLE
fix(style-agent): reduce EMBED_BATCH_SIZE to 8 for CI memory

### DIFF
--- a/style-agent/crates/cli/src/indexer.rs
+++ b/style-agent/crates/cli/src/indexer.rs
@@ -11,7 +11,12 @@ use uuid::Uuid;
 use crate::config::Config;
 use crate::walker;
 
-const EMBED_BATCH_SIZE: usize = 32;
+/// Number of chunks to accumulate before embedding + flushing to SQLite.
+/// Each batch becomes a single ONNX forward pass (dynamic-quantization
+/// model requires `batch_size = None`). Smaller values reduce peak memory
+/// at the cost of throughput; 8 keeps the attention activation footprint
+/// manageable in memory-constrained CI workers.
+const EMBED_BATCH_SIZE: usize = 8;
 
 /// Index a single repository from a local path.
 ///

--- a/style-agent/crates/core/src/embedder.rs
+++ b/style-agent/crates/core/src/embedder.rs
@@ -7,12 +7,6 @@ const SEARCH_DOCUMENT_PREFIX: &str = "search_document: ";
 /// nomic-embed-text task prefix for search queries.
 const SEARCH_QUERY_PREFIX: &str = "search_query: ";
 
-/// Maximum texts per ONNX forward pass. Smaller values reduce peak memory
-/// (attention activations scale with batch_size × seq_len²) at the cost of
-/// throughput. The default fastembed batch size (256) can OOM in CI workers
-/// when processing long code chunks.
-const ONNX_BATCH_SIZE: usize = 8;
-
 /// nomic-embed-text has 8192 token context. Code tokenizes at ~2-3 chars/token.
 /// 6000 chars ≈ 2000-3000 tokens — safe margin under the 8192 limit.
 const MAX_CHARS: usize = 6000;
@@ -79,8 +73,9 @@ impl Embedder {
 
     /// Embed a batch of documents for indexing (prepends `search_document:` prefix to each).
     ///
-    /// Uses a small ONNX batch size to bound peak memory from transformer
-    /// attention activations (`batch × seq_len²`).
+    /// NomicEmbedTextV15Q uses dynamic quantization which requires all items
+    /// in a single forward pass (`batch_size = None`).  The caller controls
+    /// peak memory by sending small batches.
     pub async fn embed_document_batch(&self, texts: Vec<String>) -> anyhow::Result<Vec<Vec<f32>>> {
         let prefixed: Vec<String> = texts
             .into_iter()
@@ -89,7 +84,7 @@ impl Embedder {
         let model = self.model.clone();
         tokio::task::spawn_blocking(move || {
             let mut model = model.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
-            model.embed(prefixed, Some(ONNX_BATCH_SIZE))
+            model.embed(prefixed, None)
         })
         .await?
     }


### PR DESCRIPTION
## Summary
- **Revert ONNX sub-batching** — dynamic quantization (NomicEmbedTextV15Q) requires `batch_size = None`; passing `Some(8)` caused incompatible embeddings across sub-batches
- **Reduce `EMBED_BATCH_SIZE` from 32 → 8** — controls how many chunks go into each ONNX forward pass, cutting peak inference memory ~4× while keeping dynamic-quantization compatibility

Follows up on the streaming pipeline fix (already merged in `96b770c`) which processes files one-at-a-time. Together, peak memory is now ~1 file + 8 chunks + 1 ONNX pass.

## Test plan
- [x] `nix flake check` passes (clippy, fmt, nextest)
- [ ] Verify `build-style-index` CI job completes without OOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)