### PR TITLE
feat(sandbox): add network policy for pod isolation

### DIFF
--- a/charts/galoy-agents/templates/sandbox-network-policy.yaml
+++ b/charts/galoy-agents/templates/sandbox-network-policy.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.sandbox.enabled }}
+# Default-deny all ingress and egress for sandbox pods, then allow specific traffic.
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ template "galoyAgents.fullname" . }}-sandbox-isolation
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: sandbox
+  policyTypes:
+  - Ingress
+  - Egress
+  # Ingress: only allow from galoy-agents server (exec proxy)
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          app: {{ template "galoyAgents.fullname" . }}
+          release: {{ .Release.Name }}
+  egress:
+  # 1. DNS — allow kube-dns for internal service resolution
+  - ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+  # 2. Dashboard callback — galoy-agents server ClusterIP
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.galoyAgents.server.service.port }}
+    to:
+    - podSelector:
+        matchLabels:
+          app: {{ template "galoyAgents.fullname" . }}
+          release: {{ .Release.Name }}
+  # 3. Internet — all non-RFC1918 destinations (via NAT gateway)
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+        except:
+        - 10.0.0.0/8
+        - 172.16.0.0/12
+        - 192.168.0.0/16
+{{- end }}

--- a/charts/galoy-agents/templates/sandbox-template.yaml
+++ b/charts/galoy-agents/templates/sandbox-template.yaml
@@ -10,6 +10,9 @@ metadata:
     release: "{{ .Release.Name }}"
 spec:
   podTemplate:
+    metadata:
+      labels:
+        app.kubernetes.io/component: sandbox
     spec:
       runtimeClassName: {{ .Values.sandbox.runtimeClassName }}
       tolerations:


### PR DESCRIPTION
## Summary
- Adds a Kubernetes `NetworkPolicy` to enforce sandbox pod isolation in GKE
- Default-deny all ingress/egress, then allow only:
  - **Ingress**: from galoy-agents server pods (for exec proxy)
  - **Egress DNS**: to kube-dns in kube-system (port 53 UDP/TCP) for internal service resolution
  - **Egress dashboard**: to galoy-agents server on its service port (for sandbox callback)
  - **Egress internet**: to 0.0.0.0/0 excluding RFC1918 ranges (10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16) — traffic exits via NAT gateway
- Adds `app.kubernetes.io/component: sandbox` label to the SandboxTemplate podTemplate for NetworkPolicy pod selection
- Gated on `sandbox.enabled` (same pattern as other sandbox templates)

## Test plan
- [ ] Deploy to sandbox cluster and verify sandbox pods receive the NetworkPolicy
- [ ] Verify sandbox pod can reach external internet (e.g. `curl https://httpbin.org/get`)
- [ ] Verify sandbox pod can reach galoy-agents dashboard server
- [ ] Verify sandbox pod **cannot** reach other pods in the namespace
- [ ] Verify sandbox pod **cannot** reach kube-api or other cluster services
- [ ] Verify sandbox pod DNS resolution works (kube-dns for service names, 8.8.8.8/1.1.1.1 for external)

🤖 Generated with [Claude Code](https://claude.com/claude-code)