### PR TITLE
feat(sandbox): add Nix-based container image for sandbox agent pods

### DIFF
--- a/charts/galoy-agents/templates/sandbox-template.yaml
+++ b/charts/galoy-agents/templates/sandbox-template.yaml
@@ -24,7 +24,11 @@ spec:
       {{- end }}
       containers:
       - name: sandbox
+        {{- if .Values.sandbox.image.digest }}
+        image: {{ .Values.sandbox.image.repository }}@{{ .Values.sandbox.image.digest }}
+        {{- else }}
         image: {{ .Values.sandbox.image.repository }}:{{ .Values.sandbox.image.tag }}
+        {{- end }}
         command: ["sleep", "infinity"]
         resources:
           {{- toYaml .Values.sandbox.resources | nindent 10 }}

--- a/charts/galoy-agents/values.yaml
+++ b/charts/galoy-agents/values.yaml
@@ -61,8 +61,9 @@ sandbox:
   automountServiceAccountToken: false
   networkPolicyManagement: Managed
   image:
-    repository: ubuntu
-    tag: "24.04"
+    repository: us.gcr.io/galoyorg/sandbox-base
+    digest: ""
+    tag: edge
   resources:
     requests:
       cpu: 500m

--- a/ci/deploy/galoy-agents/prod-values.yml.tmpl
+++ b/ci/deploy/galoy-agents/prod-values.yml.tmpl
@@ -42,6 +42,9 @@ sandbox:
   installController: false
   templateName: agent-sandbox
   runtimeClassName: gvisor
+  image:
+    repository: us.gcr.io/galoyorg/sandbox-base
+    tag: edge
   warmPool:
     enabled: true
     minReady: 2

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -12,6 +12,9 @@ groups:
   - deploy-to-prod
   - train-classifier
   - build-style-index
+- name: sandbox-base
+  jobs:
+  - build-sandbox-base-image
 
 jobs:
 - name: check-code
@@ -282,6 +285,39 @@ jobs:
       repository: repo-updated
       rebase: true
 
+- name: build-sandbox-base-image
+  serial: true
+  plan:
+  - get: repo-sandbox-image
+    trigger: true
+  - task: build-image
+    config:
+      platform: linux
+      image_resource: #@ nix_flake_cachix_image_config()
+      inputs:
+      - name: repo-sandbox-image
+        path: repo
+      outputs:
+      - name: image
+      params:
+        CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
+        CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
+      run:
+        path: sh
+        args:
+          - -exc
+          - |
+            set -euo pipefail
+            cd repo
+            cachix use $CACHIX_CACHE_NAME
+            cachix watch-exec $CACHIX_CACHE_NAME -- nix build .#sandbox-base-image
+            gunzip -c result > ../image/image.tar
+  - put: sandbox-base-edge-image
+    params:
+      image: image/image.tar
+    get_params:
+      skip_download: true
+
 resource_types:
 - name: terraform
   type: registry-image
@@ -317,6 +353,15 @@ resources:
     - charts/galoy-agents/values.yaml
     - style-agent/labels/*
   webhook_token: ((webhook.secret))
+
+- name: repo-sandbox-image
+  type: git
+  source:
+    uri: #@ data.values.git_uri
+    branch: #@ data.values.git_branch
+    private_key: #@ data.values.github_private_key
+    paths:
+    - images/sandbox-base/
 
 - name: repo-labels
   type: git
@@ -379,6 +424,14 @@ resources:
     username: #@ data.values.gar_registry_user
     password: #@ data.values.gar_registry_password
     repository: #@ data.values.gar_registry + "/" + data.values.folder_registry_image
+
+- name: sandbox-base-edge-image
+  type: registry-image
+  source:
+    tag: edge
+    username: #@ data.values.gar_registry_user
+    password: #@ data.values.gar_registry_password
+    repository: #@ data.values.gar_registry + "/sandbox-base"
 
 - name: tf-galoy-agents-prod
   type: terraform

--- a/flake.nix
+++ b/flake.nix
@@ -234,6 +234,8 @@
           };
         };
 
+        packages.sandbox-base-image = import ./images/sandbox-base/default.nix { inherit pkgs; };
+
         devShells.training = pkgs.mkShell {
           buildInputs = [ pythonEnv ];
           shellHook = ''

--- a/images/sandbox-base/default.nix
+++ b/images/sandbox-base/default.nix
@@ -1,0 +1,70 @@
+{ pkgs }:
+let
+  passwd = pkgs.writeTextDir "etc/passwd" ''
+    root:x:0:0:root:/root:/bin/bash
+    agent:x:1000:1000:Agent:/home/agent:/bin/bash
+    nobody:x:65534:65534:Nobody:/:/sbin/nologin
+  '';
+  group = pkgs.writeTextDir "etc/group" ''
+    root:x:0:
+    agent:x:1000:
+    nogroup:x:65534:
+  '';
+  shadow = pkgs.writeTextDir "etc/shadow" ''
+    root:!:1::::::
+    agent:!:1::::::
+    nobody:!:1::::::
+  '';
+  nsswitch = pkgs.writeTextDir "etc/nsswitch.conf" ''
+    hosts: files dns
+  '';
+  nixConf = pkgs.writeTextDir "etc/nix/nix.conf" ''
+    experimental-features = nix-command flakes
+    sandbox = false
+    filter-syscalls = false
+  '';
+in
+pkgs.dockerTools.buildLayeredImage {
+  name = "sandbox-base";
+  tag = "latest";
+  contents = [
+    passwd
+    group
+    shadow
+    nsswitch
+    nixConf
+    pkgs.bashInteractive
+    pkgs.coreutils
+    pkgs.git
+    pkgs.curl
+    pkgs.cacert
+    pkgs.nix
+    pkgs.gnutar
+    pkgs.gzip
+    pkgs.xz
+    pkgs.findutils
+    pkgs.gnused
+    pkgs.gnugrep
+    pkgs.openssh
+  ];
+  fakeRootCommands = ''
+    mkdir -p ./home/agent
+    chown 1000:1000 ./home/agent
+    mkdir -p ./nix/var/nix/{db,daemon-socket,gc,profiles,temproots,userpool}
+    chmod -R 777 ./nix/var
+    chmod 1777 ./nix/store
+    mkdir -p ./tmp
+    chmod 1777 ./tmp
+  '';
+  config = {
+    Cmd = [ "/bin/bash" ];
+    User = "1000:1000";
+    WorkingDir = "/home/agent";
+    Env = [
+      "HOME=/home/agent"
+      "USER=agent"
+      "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+      "NIX_SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+    ];
+  };
+}


### PR DESCRIPTION
## Summary
- Add a minimal Nix-built container image (`images/sandbox-base/default.nix`) for GKE sandbox agent pods, replacing the generic `ubuntu:24.04` image
- Image includes bash, git, curl, coreutils, nix (with flakes enabled), openssh, and a non-root `agent` user (uid 1000)
- Add Concourse CI job (`build-sandbox-base-image`) that builds and pushes the image on changes to `images/sandbox-base/`
- Update Helm chart to reference the new image with optional digest-based pinning

## Test plan
- [ ] Verify `nix build .#sandbox-base-image` produces a valid container image
- [ ] Confirm the Concourse pipeline renders correctly with `ytt`
- [ ] Deploy to staging and verify sandbox pods start with the new image
- [ ] Test `nix develop` works inside a sandbox pod

🤖 Generated with [Claude Code](https://claude.com/claude-code)