### PR TITLE
feat(web): add browser-based terminal with xterm.js

### DIFF
--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -43,6 +43,7 @@ pub fn router() -> Router<AppState> {
         .route("/sandboxes/create", post(sandbox_create))
         .route("/sandboxes/{name}/delete", post(sandbox_delete))
         .route("/sandboxes/{name}/status", get(sandbox_status))
+        .route("/sandboxes/{name}/terminal", get(sandbox_terminal))
 }
 
 async fn extract_user_id(session: &Session) -> Option<UserId> {
@@ -435,6 +436,21 @@ async fn sandbox_status(
             axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
     }
+}
+
+#[instrument(name = "web.sandbox_terminal", skip_all)]
+async fn sandbox_terminal(
+    State(state): State<AppState>,
+    session: Session,
+    Path(name): Path<String>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return Redirect::to("/").into_response();
+    }
+    if state.sandbox.is_none() {
+        return Redirect::to("/sandboxes").into_response();
+    }
+    SandboxTerminalTemplate { name }.into_response()
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -103,3 +103,9 @@ pub struct SandboxRowTemplate {
 pub struct SandboxCreatedTemplate {
     pub name: String,
 }
+
+#[derive(Template, WebTemplate)]
+#[template(path = "sandbox_terminal.html")]
+pub struct SandboxTerminalTemplate {
+    pub name: String,
+}

--- a/web/templates/sandbox_row.html
+++ b/web/templates/sandbox_row.html
@@ -7,6 +7,12 @@
     </span>
   </td>
   <td class="sandbox-actions">
+    {% if sb.phase == "Ready" %}
+    <a role="button" class="outline"
+      href="/sandboxes/{{ sb.name }}/terminal">
+      Terminal
+    </a>
+    {% endif %}
     <button class="secondary outline"
       hx-get="/sandboxes/{{ sb.name }}/status"
       hx-target="#sandbox-{{ sb.name }}"

--- a/web/templates/sandbox_terminal.html
+++ b/web/templates/sandbox_terminal.html
@@ -1,0 +1,174 @@
+{% extends "base.html" %}
+
+{% block title %}Terminal — {{ name }} — Galoy Agents{% endblock %}
+
+{% block nav_sandboxes %}class="active"{% endblock %}
+
+{% block head %}
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+<style>
+  .terminal-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 4rem);
+  }
+  .terminal-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+    flex-shrink: 0;
+  }
+  .terminal-header h2 { margin: 0; }
+  .terminal-status {
+    font-size: 0.85em;
+    padding: 0.25rem 0.75rem;
+    border-radius: var(--pico-border-radius);
+  }
+  .status-connecting { color: #e89f0c; }
+  .status-connected { color: var(--pico-ins-color); }
+  .status-disconnected { color: var(--pico-del-color); }
+  #terminal-container {
+    flex: 1;
+    background: #000;
+    border-radius: var(--pico-border-radius);
+    padding: 4px;
+    min-height: 0;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="terminal-wrapper">
+  <div class="terminal-header">
+    <div>
+      <h2>Terminal: {{ name }}</h2>
+      <a href="/sandboxes">&larr; Back to sandboxes</a>
+    </div>
+    <span id="ws-status" class="terminal-status status-connecting">Connecting...</span>
+  </div>
+  <div id="terminal-container"></div>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+<script>
+(function() {
+  const CHAN_STDIN  = 0x01;
+  const CHAN_STDOUT = 0x02;
+  const CHAN_STDERR = 0x03;
+  const CHAN_RESIZE = 0x04;
+  const CHAN_EXIT   = 0xFF;
+
+  const sandboxName = "{{ name }}";
+  const statusEl = document.getElementById('ws-status');
+
+  // Create terminal
+  const term = new Terminal({
+    cursorBlink: true,
+    fontSize: 14,
+    fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+    theme: {
+      background: '#1a1a2e',
+      foreground: '#e0e0e0',
+      cursor: '#e0e0e0',
+    },
+  });
+  const fitAddon = new FitAddon.FitAddon();
+  term.loadAddon(fitAddon);
+  term.open(document.getElementById('terminal-container'));
+  fitAddon.fit();
+
+  // Build WebSocket URL (same origin)
+  const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
+  const wsUrl = proto + '//' + location.host + '/api/v1/sandboxes/' + encodeURIComponent(sandboxName) + '/exec?cmd=sh';
+
+  let ws = null;
+
+  function setStatus(text, cls) {
+    statusEl.textContent = text;
+    statusEl.className = 'terminal-status ' + cls;
+  }
+
+  function connect() {
+    setStatus('Connecting...', 'status-connecting');
+    ws = new WebSocket(wsUrl);
+    ws.binaryType = 'arraybuffer';
+
+    ws.onopen = function() {
+      setStatus('Connected', 'status-connected');
+      // Send initial resize
+      sendResize(term.cols, term.rows);
+    };
+
+    ws.onmessage = function(event) {
+      const data = new Uint8Array(event.data);
+      if (data.length === 0) return;
+
+      const channel = data[0];
+      const payload = data.slice(1);
+
+      switch (channel) {
+        case CHAN_STDOUT:
+        case CHAN_STDERR:
+          term.write(payload);
+          break;
+        case CHAN_EXIT:
+          var code = payload.length > 0 ? payload[0] : 0;
+          term.write('\r\n\x1b[33m--- Process exited with code ' + code + ' ---\x1b[0m\r\n');
+          setStatus('Disconnected (exit ' + code + ')', 'status-disconnected');
+          break;
+      }
+    };
+
+    ws.onclose = function() {
+      setStatus('Disconnected', 'status-disconnected');
+      term.write('\r\n\x1b[31m--- Connection closed ---\x1b[0m\r\n');
+    };
+
+    ws.onerror = function() {
+      setStatus('Error', 'status-disconnected');
+    };
+  }
+
+  function sendBinary(data) {
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(new Uint8Array(data).buffer);
+    }
+  }
+
+  function sendResize(cols, rows) {
+    const buf = new ArrayBuffer(5);
+    const view = new DataView(buf);
+    view.setUint8(0, CHAN_RESIZE);
+    view.setUint16(1, cols, false); // big-endian
+    view.setUint16(3, rows, false); // big-endian
+    if (ws && ws.readyState === WebSocket.OPEN) {
+      ws.send(buf);
+    }
+  }
+
+  // Terminal input -> WebSocket
+  term.onData(function(data) {
+    const encoded = new TextEncoder().encode(data);
+    const frame = new Uint8Array(1 + encoded.length);
+    frame[0] = CHAN_STDIN;
+    frame.set(encoded, 1);
+    sendBinary(frame);
+  });
+
+  // Handle resize
+  term.onResize(function(size) {
+    sendResize(size.cols, size.rows);
+  });
+
+  // Auto-fit on window resize
+  window.addEventListener('resize', function() {
+    fitAddon.fit();
+  });
+
+  // Connect
+  connect();
+})();
+</script>
+{% endblock %}


### PR DESCRIPTION
## Summary
- Add a `/sandboxes/{name}/terminal` page with xterm.js that connects via WebSocket to the existing exec proxy
- Implement the binary wire protocol (channel-prefixed frames: stdin 0x01, stdout 0x02, stderr 0x03, resize 0x04, exit 0xFF)
- Auth handled via existing session cookie — no query param token needed for dashboard users
- "Terminal" button appears on sandbox rows only when sandbox phase is Ready
- xterm.js and xterm-addon-fit loaded from CDN, terminal auto-fits to container

## Test plan
- [ ] Navigate to /sandboxes, create a sandbox, wait for Ready
- [ ] Click "Terminal" button — verify xterm.js terminal opens and connects
- [ ] Type commands in terminal — verify stdin/stdout works correctly
- [ ] Resize browser window — verify terminal resizes
- [ ] Close tab / disconnect — verify clean disconnect message
- [ ] Verify unauthenticated users are redirected to login

🤖 Generated with [Claude Code](https://claude.com/claude-code)