### PR TITLE
fix(style-agent): two-pass indexing pipeline to prevent CI OOM

### DIFF
--- a/style-agent/crates/cli/src/commands/build_index.rs
+++ b/style-agent/crates/cli/src/commands/build_index.rs
@@ -10,8 +10,13 @@ use crate::indexer;
 
 /// Build the search index from pre-cloned repos on disk (for CI).
 ///
-/// Scans `repos_dir` for subdirectories, indexes each one, then replays
-/// human labels from `labels.jsonl`.
+/// Uses a two-phase pipeline so the embedder and classifier ONNX models
+/// are never loaded at the same time, keeping peak memory low enough for
+/// memory-constrained CI workers.
+///
+/// - Phase 1 — embed all repos (only embedder loaded), then drop it.
+/// - Phase 2 — classify all stored chunks (only classifier loaded).
+/// - Phase 3 — replay human labels from `labels.jsonl`.
 pub async fn run(config: &Config, repos_dir_arg: &str) -> anyhow::Result<()> {
     let repos_dir = Path::new(repos_dir_arg);
     anyhow::ensure!(
@@ -37,45 +42,56 @@ pub async fn run(config: &Config, repos_dir_arg: &str) -> anyhow::Result<()> {
         repos_dir.display()
     );
 
-    // Initialize indexing resources
-    let embedder = Embedder::new()?;
     let db_path = config.db_path();
     let store = VectorStore::new(&db_path)?;
     store.ensure_collection()?;
 
-    let mut classifier = indexer::try_load_classifier(config);
-    let threshold = config.services.classifier_confidence_threshold;
-
-    // Index each repo
+    // ── Phase 1: embed + store (only embedder ONNX model in memory) ──
+    println!("\n=== Phase 1: Embedding ===");
     let mut total_chunks = 0usize;
-    for entry in &repo_dirs {
-        let repo_name = entry.file_name().to_string_lossy().to_string();
-        let repo_path = entry.path();
+    {
+        let embedder = Embedder::new()?;
+        let mut no_classifier = None;
 
-        // Look up per-repo config for exclude_dirs / paths
-        let repo_config = config.repos.iter().find(|r| r.name == repo_name);
+        for entry in &repo_dirs {
+            let repo_name = entry.file_name().to_string_lossy().to_string();
+            let repo_path = entry.path();
 
-        let (subpaths, exclude_dirs): (Option<&[String]>, &[String]) = match repo_config {
-            Some(rc) => (rc.paths.as_deref(), &rc.exclude_dirs),
-            None => (None, &[]),
-        };
+            // Look up per-repo config for exclude_dirs / paths
+            let repo_config = config.repos.iter().find(|r| r.name == repo_name);
 
-        println!("Indexing {repo_name}...");
-        let chunks = indexer::index_repo(
-            &repo_path,
-            &repo_name,
-            subpaths,
-            exclude_dirs,
-            &store,
-            &embedder,
-            &mut classifier,
-            threshold,
-        )
-        .await?;
-        total_chunks += chunks;
+            let (subpaths, exclude_dirs): (Option<&[String]>, &[String]) = match repo_config {
+                Some(rc) => (rc.paths.as_deref(), &rc.exclude_dirs),
+                None => (None, &[]),
+            };
+
+            println!("Indexing {repo_name}...");
+            let chunks = indexer::index_repo(
+                &repo_path,
+                &repo_name,
+                subpaths,
+                exclude_dirs,
+                &store,
+                &embedder,
+                &mut no_classifier,
+                config.services.classifier_confidence_threshold,
+            )
+            .await?;
+            total_chunks += chunks;
+        }
+        // `embedder` (and its ONNX session) is dropped here
     }
 
-    // Replay human labels
+    // ── Phase 2: classify from DB (only classifier ONNX model in memory) ──
+    println!("\n=== Phase 2: Classification ===");
+    {
+        let mut classifier = indexer::try_load_classifier(config);
+        let threshold = config.services.classifier_confidence_threshold;
+        indexer::classify_all_chunks(&store, &mut classifier, threshold)?;
+        // `classifier` (and its ONNX session) is dropped here
+    }
+
+    // ── Phase 3: replay human labels ──
     let labels_path = config.labels_dir().join("labels.jsonl");
     if labels_path.exists() {
         println!("\nReplaying human labels from {}...", labels_path.display());

--- a/style-agent/crates/cli/src/indexer.rs
+++ b/style-agent/crates/cli/src/indexer.rs
@@ -270,6 +270,53 @@ pub(crate) fn classify_with_fallback(
     (cls, source)
 }
 
+/// Classify all chunks already stored in the database.
+///
+/// Used by the two-phase CI pipeline: after all chunks have been embedded and
+/// stored (Phase 1), this function loads them back from SQLite and runs
+/// classification (Phase 2). This allows the embedder ONNX model to be dropped
+/// before the classifier is loaded, halving peak memory.
+pub fn classify_all_chunks(
+    store: &VectorStore,
+    classifier: &mut Option<Classifier>,
+    confidence_threshold: f32,
+) -> anyhow::Result<()> {
+    let points = store.scroll_all()?;
+    let total = points.len();
+
+    if total == 0 {
+        println!("  No chunks to classify.");
+        return Ok(());
+    }
+
+    println!("  Classifying {total} chunks...");
+    let mut ml_count = 0usize;
+    let mut heuristic_count = 0usize;
+
+    let label_updates: Vec<_> = points
+        .iter()
+        .map(|pt| {
+            let (cls, source) = classify_with_fallback(classifier, &pt.chunk, confidence_threshold);
+            match source.as_str() {
+                "ml" => ml_count += 1,
+                _ => heuristic_count += 1,
+            }
+            (pt.point_id.clone(), cls, source)
+        })
+        .collect();
+
+    store.set_labels(&label_updates)?;
+
+    let source_info = if classifier.is_some() {
+        format!(" (ml: {ml_count}, heuristic: {heuristic_count})")
+    } else {
+        format!(" (heuristic: {heuristic_count})")
+    };
+    println!("  Classified {total} chunks{source_info}");
+
+    Ok(())
+}
+
 /// Intermediate struct holding chunk data before embedding.
 struct ChunkData {
     content: String,


### PR DESCRIPTION
## Summary
- The `build-style-index` CI job (builds 33-37) was OOM-killed because both ONNX models (embedder ~300MB + classifier ~300MB) were loaded simultaneously, exceeding the CI worker's memory limit
- Process consistently died around chunk 6400-6500 with no error (silent kernel OOM kill)
- Split `build_index.rs` into a two-phase pipeline so only one model is in memory at a time:
  - **Phase 1**: Load embedder → embed all repos → store in SQLite → drop embedder
  - **Phase 2**: Load classifier → read chunks from SQLite → classify all → drop classifier

## Changes
- `style-agent/crates/cli/src/commands/build_index.rs` — restructured with explicit scope blocks for each phase
- `style-agent/crates/cli/src/indexer.rs` — added `classify_all_chunks()` that reads stored chunks via `scroll_all()` and classifies in bulk

Other callers (`index`, `bootstrap`, `reindex`) are unchanged — they run on local machines with more memory and keep the simpler single-pass approach.

## Context
A similar fix was implemented at commit e2dac30 but was accidentally reverted by a later commit (8547a42) during a rebase. This re-applies the same approach.

## Test plan
- [x] `nix flake check` passes (fmt, clippy, nextest)
- [ ] Verify `build-style-index` CI job completes without OOM after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)