### PR TITLE
feat(sandbox): add Claude agent harness with SDK integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,6 +1557,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tokio-stream",
  "tower-http",
  "tower-service",
  "tower-sessions",

--- a/images/sandbox-base/agent-harness/package.json
+++ b/images/sandbox-base/agent-harness/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "agent-harness",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.1.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "@types/node": "^22.0.0"
+  }
+}

--- a/images/sandbox-base/agent-harness/src/index.ts
+++ b/images/sandbox-base/agent-harness/src/index.ts
@@ -4,24 +4,29 @@
  * Agent Harness — thin wrapper around @anthropic-ai/claude-agent-sdk
  *
  * Protocol:
- *   stdin  (JSON-lines): { "prompt": "...", "session_id": "optional" }
+ *   stdin  (JSON-lines): { "prompt": "...", "session_id": "...", "model": "...", "max_turns": 10 }
  *   stdout (JSON-lines): SDK events — { "type": "assistant"|"result"|"system"|... , ... }
  *
  * Environment:
  *   ANTHROPIC_API_KEY — required
- *   AGENT_CWD        — working directory for Claude (default: /workspace)
- *   AGENT_MODEL       — model override (default: claude-sonnet-4-6)
- *   AGENT_MAX_TURNS   — max agentic turns (default: 50)
  */
 
 import { query } from "@anthropic-ai/claude-agent-sdk";
 import { createInterface } from "node:readline";
+
+// ── Constants ─────────────────────────────────────────────────────────
+
+const CWD = "/workspace";
+const DEFAULT_MODEL = "claude-sonnet-4-6";
+const DEFAULT_MAX_TURNS = 10;
 
 // ── Types ──────────────────────────────────────────────────────────────
 
 interface HarnessInput {
   prompt: string;
   session_id?: string;
+  model?: string;
+  max_turns?: number;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -37,9 +42,8 @@ function emitError(message: string, details?: string): void {
 // ── Main loop ──────────────────────────────────────────────────────────
 
 async function handleMessage(input: HarnessInput): Promise<void> {
-  const cwd = process.env.AGENT_CWD ?? "/workspace";
-  const model = process.env.AGENT_MODEL ?? "claude-sonnet-4-6";
-  const maxTurns = parseInt(process.env.AGENT_MAX_TURNS ?? "50", 10);
+  const model = input.model ?? DEFAULT_MODEL;
+  const maxTurns = input.max_turns ?? DEFAULT_MAX_TURNS;
 
   try {
     const result = query({
@@ -47,7 +51,7 @@ async function handleMessage(input: HarnessInput): Promise<void> {
       options: {
         permissionMode: "bypassPermissions",
         allowDangerouslySkipPermissions: true,
-        cwd,
+        cwd: CWD,
         model,
         maxTurns,
         resume: input.session_id,

--- a/images/sandbox-base/agent-harness/src/index.ts
+++ b/images/sandbox-base/agent-harness/src/index.ts
@@ -1,0 +1,99 @@
+#!/usr/bin/env node
+
+/**
+ * Agent Harness — thin wrapper around @anthropic-ai/claude-agent-sdk
+ *
+ * Protocol:
+ *   stdin  (JSON-lines): { "prompt": "...", "session_id": "optional" }
+ *   stdout (JSON-lines): SDK events — { "type": "assistant"|"result"|"system"|... , ... }
+ *
+ * Environment:
+ *   ANTHROPIC_API_KEY — required
+ *   AGENT_CWD        — working directory for Claude (default: /workspace)
+ *   AGENT_MODEL       — model override (default: claude-sonnet-4-6)
+ *   AGENT_MAX_TURNS   — max agentic turns (default: 50)
+ */
+
+import { query } from "@anthropic-ai/claude-agent-sdk";
+import { createInterface } from "node:readline";
+
+// ── Types ──────────────────────────────────────────────────────────────
+
+interface HarnessInput {
+  prompt: string;
+  session_id?: string;
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+function emit(event: Record<string, unknown>): void {
+  process.stdout.write(JSON.stringify(event) + "\n");
+}
+
+function emitError(message: string, details?: string): void {
+  emit({ type: "error", message, details });
+}
+
+// ── Main loop ──────────────────────────────────────────────────────────
+
+async function handleMessage(input: HarnessInput): Promise<void> {
+  const cwd = process.env.AGENT_CWD ?? "/workspace";
+  const model = process.env.AGENT_MODEL ?? "claude-sonnet-4-6";
+  const maxTurns = parseInt(process.env.AGENT_MAX_TURNS ?? "50", 10);
+
+  try {
+    const result = query({
+      prompt: input.prompt,
+      options: {
+        permissionMode: "bypassPermissions",
+        allowDangerouslySkipPermissions: true,
+        cwd,
+        model,
+        maxTurns,
+        resume: input.session_id,
+        includePartialMessages: true,
+      },
+    });
+
+    for await (const message of result) {
+      emit(message as unknown as Record<string, unknown>);
+    }
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    emitError("query_failed", msg);
+  }
+}
+
+async function main(): Promise<void> {
+  if (!process.env.ANTHROPIC_API_KEY) {
+    emitError("missing_api_key", "ANTHROPIC_API_KEY environment variable is required");
+    process.exit(1);
+  }
+
+  const rl = createInterface({ input: process.stdin });
+
+  for await (const line of rl) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    let input: HarnessInput;
+    try {
+      input = JSON.parse(trimmed) as HarnessInput;
+    } catch {
+      emitError("invalid_json", `Failed to parse: ${trimmed}`);
+      continue;
+    }
+
+    if (!input.prompt) {
+      emitError("missing_prompt", "Input must have a 'prompt' field");
+      continue;
+    }
+
+    await handleMessage(input);
+  }
+}
+
+main().catch((err) => {
+  emitError("harness_crash", String(err));
+  process.exit(1);
+});

--- a/images/sandbox-base/agent-harness/tsconfig.json
+++ b/images/sandbox-base/agent-harness/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "declaration": true,
+    "sourceMap": false
+  },
+  "include": ["src/**/*"]
+}

--- a/images/sandbox-base/default.nix
+++ b/images/sandbox-base/default.nix
@@ -27,6 +27,20 @@ let
     connect-timeout = 5
     fallback = true
   '';
+
+  # Wrapper script for running the agent harness.
+  # On first invocation it installs npm dependencies and compiles TypeScript.
+  agentHarnessWrapper = pkgs.writeShellScriptBin "agent-harness" ''
+    set -euo pipefail
+    HARNESS_DIR=/opt/agent-harness
+    if [ ! -d "$HARNESS_DIR/node_modules" ]; then
+      (cd "$HARNESS_DIR" && ${pkgs.nodejs_22}/bin/npm install --no-fund --no-audit 2>&1 >&2)
+    fi
+    if [ ! -f "$HARNESS_DIR/dist/index.js" ]; then
+      (cd "$HARNESS_DIR" && ${pkgs.nodejs_22}/bin/npx tsc 2>&1 >&2)
+    fi
+    exec ${pkgs.nodejs_22}/bin/node "$HARNESS_DIR/dist/index.js" "$@"
+  '';
 in
 pkgs.dockerTools.buildLayeredImage {
   name = "sandbox-base";
@@ -51,12 +65,22 @@ pkgs.dockerTools.buildLayeredImage {
     pkgs.gnugrep
     pkgs.openssh
     pkgs.gh
+    pkgs.nodejs_22
+    agentHarnessWrapper
   ];
   fakeRootCommands = ''
     mkdir -p ./home/agent
     chown 1000:1000 ./home/agent
     mkdir -p ./tmp
     chmod 1777 ./tmp
+
+    # Install agent harness source to /opt.
+    # npm install + tsc happen on first invocation inside the sandbox.
+    mkdir -p ./opt/agent-harness/src
+    cp ${./agent-harness/package.json} ./opt/agent-harness/package.json
+    cp ${./agent-harness/tsconfig.json} ./opt/agent-harness/tsconfig.json
+    cp ${./agent-harness/src/index.ts} ./opt/agent-harness/src/index.ts
+    chmod -R 777 ./opt/agent-harness
   '';
   config = {
     Cmd = [ "/bin/bash" ];

--- a/lib/sandbox-client/src/client.rs
+++ b/lib/sandbox-client/src/client.rs
@@ -488,6 +488,37 @@ impl SandboxClient {
         Ok(attached)
     }
 
+    /// Exec into a Sandbox pod without TTY allocation.
+    ///
+    /// Unlike [`exec_sandbox`](Self::exec_sandbox), this uses raw stdin/stdout
+    /// without a pseudo-terminal.  Suitable for programmatic communication
+    /// (e.g. JSON-lines) where TTY escape codes would corrupt the data stream.
+    #[instrument(name = "sandbox_client.exec_sandbox_raw", skip_all, fields(%sandbox_name))]
+    pub async fn exec_sandbox_raw(
+        &self,
+        sandbox_name: &str,
+        command: Vec<String>,
+    ) -> Result<AttachedProcess, SandboxError> {
+        let pod_name = self.resolve_sandbox_pod(sandbox_name).await?;
+
+        let pods: Api<Pod> = Api::namespaced(self.client.clone(), &self.namespace);
+        let ap = AttachParams {
+            stdin: true,
+            stdout: true,
+            stderr: true,
+            tty: false,
+            ..Default::default()
+        };
+        let attached = pods.exec(&pod_name, &command, &ap).await?;
+
+        tracing::info!(
+            sandbox = %sandbox_name,
+            pod = %pod_name,
+            "Raw exec session started (direct)"
+        );
+        Ok(attached)
+    }
+
     fn summary_from_sandbox(sandbox: &Sandbox) -> SandboxSummary {
         let name = sandbox
             .metadata

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -27,6 +27,7 @@ tower-http = { version = "0.6", features = ["cors"] }
 tower-service = "0.3"
 futures = { workspace = true }
 tokio = { version = "1", features = ["net", "io-util"] }
+tokio-stream = "0.1"
 tower-sessions = "0.15"
 tracing = "0.1"
 uuid = { version = "1", features = ["v4"] }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -922,6 +922,8 @@ async fn exec_proxy(
 struct AgentMessageRequest {
     prompt: String,
     session_id: Option<String>,
+    model: Option<String>,
+    max_turns: Option<u32>,
 }
 
 /// Send a prompt to the Claude agent harness running inside a sandbox pod.
@@ -942,9 +944,7 @@ async fn api_agent_message(
 
     // Spawn the relay task that bridges pod stdout → SSE events.
     tokio::spawn(async move {
-        if let Err(e) =
-            agent_message_relay(client, &name, &body.prompt, &body.session_id, tx.clone()).await
-        {
+        if let Err(e) = agent_message_relay(client, &name, &body, tx.clone()).await {
             tracing::error!(error = %e, sandbox = %name, "Agent message relay failed");
             let _ = tx
                 .send(Ok(Event::default().event("error").data(
@@ -964,8 +964,7 @@ async fn api_agent_message(
 async fn agent_message_relay(
     client: std::sync::Arc<sandbox_client::SandboxClient>,
     sandbox_name: &str,
-    prompt: &str,
-    session_id: &Option<String>,
+    request: &AgentMessageRequest,
     tx: tokio::sync::mpsc::Sender<Result<Event, Infallible>>,
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
     // Build the harness command.
@@ -974,9 +973,12 @@ async fn agent_message_relay(
     let mut process = client.exec_sandbox_raw(sandbox_name, command).await?;
 
     // Write the prompt as a JSON-line to stdin.
+    // All fields are forwarded — the harness applies its own defaults for omitted ones.
     let input_line = serde_json::json!({
-        "prompt": prompt,
-        "session_id": session_id,
+        "prompt": request.prompt,
+        "session_id": request.session_id,
+        "model": request.model,
+        "max_turns": request.max_turns,
     });
 
     let mut stdin = process

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -1,14 +1,20 @@
+use std::convert::Infallible;
+
 use axum::{
     extract::{
         ws::{Message, WebSocket, WebSocketUpgrade},
         Path, Query, State,
     },
-    response::{IntoResponse, Redirect, Response},
+    response::{
+        sse::{Event, KeepAlive, Sse},
+        IntoResponse, Redirect, Response,
+    },
     routing::{delete, get, post},
     Extension, Form, Json, Router,
 };
 use serde::Deserialize;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_stream::wrappers::ReceiverStream;
 use tower_sessions::Session;
 use tracing::instrument;
 
@@ -638,6 +644,10 @@ pub fn api_router() -> Router<AppState> {
         .route("/api/v1/sandboxes/{name}", get(api_get_sandbox))
         .route("/api/v1/sandboxes/{name}", delete(api_delete_sandbox))
         .route("/api/v1/sandboxes/{name}/exec", get(api_exec_sandbox))
+        .route(
+            "/api/v1/sandboxes/{name}/agent/message",
+            post(api_agent_message),
+        )
 }
 
 macro_rules! require_auth {
@@ -901,4 +911,134 @@ async fn exec_proxy(
     }
 
     tracing::info!(sandbox = %sandbox_name, "Exec proxy: session ended");
+}
+
+// ---------------------------------------------------------------------------
+// Agent harness – POST /api/v1/sandboxes/{name}/agent/message
+// ---------------------------------------------------------------------------
+
+/// Request body for the agent message endpoint.
+#[derive(Deserialize)]
+struct AgentMessageRequest {
+    prompt: String,
+    session_id: Option<String>,
+}
+
+/// Send a prompt to the Claude agent harness running inside a sandbox pod.
+///
+/// The harness is exec'd via the Kubernetes API (non-TTY). The prompt is
+/// written as a JSON-line to stdin; SDK events are streamed back as SSE.
+#[instrument(name = "api.sandbox.agent_message", skip_all, fields(%name))]
+async fn api_agent_message(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Json(body): Json<AgentMessageRequest>,
+) -> Response {
+    require_auth!(auth);
+    let client = require_sandbox!(state).clone();
+
+    let (tx, rx) = tokio::sync::mpsc::channel::<Result<Event, Infallible>>(64);
+
+    // Spawn the relay task that bridges pod stdout → SSE events.
+    tokio::spawn(async move {
+        if let Err(e) =
+            agent_message_relay(client, &name, &body.prompt, &body.session_id, tx.clone()).await
+        {
+            tracing::error!(error = %e, sandbox = %name, "Agent message relay failed");
+            let _ = tx
+                .send(Ok(Event::default().event("error").data(
+                    serde_json::json!({"type":"error","message": e.to_string()}).to_string(),
+                )))
+                .await;
+        }
+    });
+
+    let stream = ReceiverStream::new(rx);
+    Sse::new(stream)
+        .keep_alive(KeepAlive::default())
+        .into_response()
+}
+
+/// Execute the agent harness inside the pod and relay stdout → SSE channel.
+async fn agent_message_relay(
+    client: std::sync::Arc<sandbox_client::SandboxClient>,
+    sandbox_name: &str,
+    prompt: &str,
+    session_id: &Option<String>,
+    tx: tokio::sync::mpsc::Sender<Result<Event, Infallible>>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Build the harness command.
+    let command = vec!["agent-harness".to_string()];
+
+    let mut process = client.exec_sandbox_raw(sandbox_name, command).await?;
+
+    // Write the prompt as a JSON-line to stdin.
+    let input_line = serde_json::json!({
+        "prompt": prompt,
+        "session_id": session_id,
+    });
+
+    let mut stdin = process
+        .stdin()
+        .ok_or("no stdin stream from agent harness")?;
+
+    let payload = format!("{}\n", input_line);
+    stdin.write_all(payload.as_bytes()).await?;
+    // Close stdin so the harness knows the message is complete.
+    drop(stdin);
+
+    // Read stdout line by line and emit SSE events.
+    let mut stdout = process
+        .stdout()
+        .ok_or("no stdout stream from agent harness")?;
+
+    let mut buf = Vec::with_capacity(4096);
+    let mut tmp = [0u8; 4096];
+
+    loop {
+        match stdout.read(&mut tmp).await {
+            Ok(0) => break,
+            Ok(n) => {
+                buf.extend_from_slice(&tmp[..n]);
+
+                // Process complete lines from the buffer.
+                while let Some(pos) = buf.iter().position(|&b| b == b'\n') {
+                    let line: Vec<u8> = buf.drain(..=pos).collect();
+                    let line_str = String::from_utf8_lossy(&line).trim().to_string();
+                    if line_str.is_empty() {
+                        continue;
+                    }
+
+                    // Determine event type from the JSON if possible.
+                    let event_type = serde_json::from_str::<serde_json::Value>(&line_str)
+                        .ok()
+                        .and_then(|v| v.get("type").and_then(|t| t.as_str()).map(String::from))
+                        .unwrap_or_else(|| "message".to_string());
+
+                    let event = Event::default().event(&event_type).data(line_str);
+
+                    if tx.send(Ok(event)).await.is_err() {
+                        // Client disconnected.
+                        return Ok(());
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Agent harness stdout error");
+                break;
+            }
+        }
+    }
+
+    // Flush any remaining partial line in the buffer.
+    if !buf.is_empty() {
+        let line_str = String::from_utf8_lossy(&buf).trim().to_string();
+        if !line_str.is_empty() {
+            let event = Event::default().event("message").data(line_str);
+            let _ = tx.send(Ok(event)).await;
+        }
+    }
+
+    Ok(())
 }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -55,6 +55,7 @@ pub fn router() -> Router<AppState> {
         .route("/sandboxes/{name}/delete", post(sandbox_delete))
         .route("/sandboxes/{name}/status", get(sandbox_status))
         .route("/sandboxes/{name}/terminal", get(sandbox_terminal))
+        .route("/sandboxes/{name}/agent", get(sandbox_agent))
 }
 
 async fn extract_user_id(session: &Session) -> Option<UserId> {
@@ -620,6 +621,21 @@ async fn sandbox_terminal(
         return Redirect::to("/sandboxes").into_response();
     }
     SandboxTerminalTemplate { name }.into_response()
+}
+
+#[instrument(name = "web.sandbox_agent", skip_all)]
+async fn sandbox_agent(
+    State(state): State<AppState>,
+    session: Session,
+    Path(name): Path<String>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return Redirect::to("/").into_response();
+    }
+    if state.sandbox.is_none() {
+        return Redirect::to("/sandboxes").into_response();
+    }
+    SandboxAgentTemplate { name }.into_response()
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -136,3 +136,9 @@ pub struct SandboxCreatedTemplate {
 pub struct SandboxTerminalTemplate {
     pub name: String,
 }
+
+#[derive(Template, WebTemplate)]
+#[template(path = "sandbox_agent.html")]
+pub struct SandboxAgentTemplate {
+    pub name: String,
+}

--- a/web/templates/sandbox_agent.html
+++ b/web/templates/sandbox_agent.html
@@ -1,0 +1,282 @@
+{% extends "base.html" %}
+
+{% block title %}Agent — {{ name }} — Galoy Agents{% endblock %}
+
+{% block nav_sandboxes %}class="active"{% endblock %}
+
+{% block head %}
+<style>
+  .agent-wrapper {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 4rem);
+  }
+  .agent-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 0.5rem;
+    flex-shrink: 0;
+  }
+  .agent-header h2 { margin: 0; }
+  .agent-status {
+    font-size: 0.85em;
+    padding: 0.25rem 0.75rem;
+    border-radius: var(--pico-border-radius);
+  }
+  .status-idle { color: var(--pico-muted-color); }
+  .status-streaming { color: #e89f0c; }
+  .status-done { color: var(--pico-ins-color); }
+  .status-error { color: var(--pico-del-color); }
+
+  #messages {
+    flex: 1;
+    overflow-y: auto;
+    background: var(--pico-code-background-color);
+    border-radius: var(--pico-border-radius);
+    padding: 1rem;
+    margin-bottom: 0.5rem;
+    font-family: 'Menlo', 'Monaco', 'Courier New', monospace;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    min-height: 0;
+    white-space: pre-wrap;
+    word-wrap: break-word;
+  }
+  #messages .msg-user {
+    color: var(--pico-primary);
+    margin-bottom: 0.5rem;
+  }
+  #messages .msg-assistant {
+    color: var(--pico-color);
+    margin-bottom: 0.5rem;
+  }
+  #messages .msg-tool {
+    color: var(--pico-muted-color);
+    font-size: 0.8rem;
+    margin-bottom: 0.25rem;
+  }
+  #messages .msg-error {
+    color: var(--pico-del-color);
+    margin-bottom: 0.5rem;
+  }
+  #messages .msg-result {
+    color: var(--pico-ins-color);
+    border-top: 1px solid var(--pico-muted-border-color);
+    padding-top: 0.5rem;
+    margin-top: 0.5rem;
+  }
+
+  .input-row {
+    display: flex;
+    gap: 0.5rem;
+    flex-shrink: 0;
+  }
+  .input-row textarea {
+    flex: 1;
+    resize: none;
+    margin: 0;
+    min-height: 2.5rem;
+    max-height: 8rem;
+    font-family: inherit;
+  }
+  .input-row button {
+    width: auto;
+    margin: 0;
+    align-self: flex-end;
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="agent-wrapper">
+  <div class="agent-header">
+    <div>
+      <h2>Agent: {{ name }}</h2>
+      <a href="/sandboxes">&larr; Back to sandboxes</a>
+    </div>
+    <span id="agent-status" class="agent-status status-idle">Idle</span>
+  </div>
+
+  <div id="messages"></div>
+
+  <div class="input-row">
+    <textarea id="prompt-input" placeholder="Send a message to the agent..." rows="2"
+      onkeydown="if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendMessage()}"></textarea>
+    <button id="send-btn" onclick="sendMessage()">Send</button>
+  </div>
+</div>
+
+<script>
+(function() {
+  const sandboxName = "{{ name }}";
+  const messagesEl = document.getElementById('messages');
+  const promptEl = document.getElementById('prompt-input');
+  const sendBtn = document.getElementById('send-btn');
+  const statusEl = document.getElementById('agent-status');
+
+  let sessionId = null;
+  let eventSource = null;
+
+  function setStatus(text, cls) {
+    statusEl.textContent = text;
+    statusEl.className = 'agent-status ' + cls;
+  }
+
+  function appendMessage(cls, text) {
+    const div = document.createElement('div');
+    div.className = cls;
+    div.textContent = text;
+    messagesEl.appendChild(div);
+    messagesEl.scrollTop = messagesEl.scrollHeight;
+    return div;
+  }
+
+  function setInputEnabled(enabled) {
+    promptEl.disabled = !enabled;
+    sendBtn.disabled = !enabled;
+    sendBtn.setAttribute('aria-busy', !enabled);
+  }
+
+  window.sendMessage = function() {
+    const prompt = promptEl.value.trim();
+    if (!prompt) return;
+
+    appendMessage('msg-user', '> ' + prompt);
+    promptEl.value = '';
+    setInputEnabled(false);
+    setStatus('Streaming...', 'status-streaming');
+
+    // Build request body
+    const body = { prompt: prompt };
+    if (sessionId) body.session_id = sessionId;
+
+    // Use fetch + ReadableStream to consume SSE manually,
+    // since EventSource only supports GET.
+    fetch('/api/v1/sandboxes/' + encodeURIComponent(sandboxName) + '/agent/message', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }).then(function(response) {
+      if (!response.ok) {
+        throw new Error('HTTP ' + response.status);
+      }
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let currentAssistantDiv = null;
+      let currentText = '';
+
+      function processLine(line) {
+        if (line.startsWith('event: ')) return; // We parse from the data line
+        if (!line.startsWith('data: ')) return;
+
+        const jsonStr = line.slice(6); // strip "data: "
+        if (!jsonStr) return;
+
+        let event;
+        try {
+          event = JSON.parse(jsonStr);
+        } catch(e) {
+          return;
+        }
+
+        switch (event.type) {
+          case 'system':
+            if (event.session_id) sessionId = event.session_id;
+            break;
+
+          case 'assistant':
+            // Full assistant message — extract text content
+            if (event.message && event.message.content) {
+              const texts = event.message.content
+                .filter(function(b) { return b.type === 'text'; })
+                .map(function(b) { return b.text; })
+                .join('');
+              if (texts) {
+                currentText = texts;
+                if (!currentAssistantDiv) {
+                  currentAssistantDiv = appendMessage('msg-assistant', texts);
+                } else {
+                  currentAssistantDiv.textContent = texts;
+                }
+              }
+              // Show tool use
+              const tools = event.message.content
+                .filter(function(b) { return b.type === 'tool_use'; });
+              tools.forEach(function(t) {
+                const inputStr = JSON.stringify(t.input || {});
+                const preview = inputStr.length > 120 ? inputStr.slice(0, 120) + '...' : inputStr;
+                appendMessage('msg-tool', '  ↳ ' + t.name + '(' + preview + ')');
+              });
+              // Reset for next assistant message
+              currentAssistantDiv = null;
+              currentText = '';
+            }
+            break;
+
+          case 'result':
+            if (event.session_id) sessionId = event.session_id;
+            let info = '✓ Done';
+            if (event.total_cost_usd !== undefined) {
+              info += ' · $' + event.total_cost_usd.toFixed(4);
+            }
+            if (event.num_turns !== undefined) {
+              info += ' · ' + event.num_turns + ' turns';
+            }
+            if (event.duration_ms !== undefined) {
+              info += ' · ' + (event.duration_ms / 1000).toFixed(1) + 's';
+            }
+            appendMessage('msg-result', info);
+            setStatus('Done', 'status-done');
+            setInputEnabled(true);
+            break;
+
+          case 'error':
+            appendMessage('msg-error', '✗ Error: ' + (event.message || event.details || 'unknown'));
+            setStatus('Error', 'status-error');
+            setInputEnabled(true);
+            break;
+
+          default:
+            // Ignore other event types (partial messages, etc.)
+            break;
+        }
+
+        messagesEl.scrollTop = messagesEl.scrollHeight;
+      }
+
+      function pump() {
+        return reader.read().then(function(result) {
+          if (result.done) {
+            // Process any remaining buffer
+            if (buffer.trim()) {
+              buffer.split('\n').forEach(processLine);
+            }
+            if (sendBtn.disabled) {
+              setStatus('Done', 'status-done');
+              setInputEnabled(true);
+            }
+            return;
+          }
+          buffer += decoder.decode(result.value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() || '';
+          lines.forEach(processLine);
+          return pump();
+        });
+      }
+
+      return pump();
+    }).catch(function(err) {
+      appendMessage('msg-error', '✗ ' + err.message);
+      setStatus('Error', 'status-error');
+      setInputEnabled(true);
+    });
+  };
+
+  // Focus input on load
+  promptEl.focus();
+})();
+</script>
+{% endblock %}

--- a/web/templates/sandbox_row.html
+++ b/web/templates/sandbox_row.html
@@ -12,6 +12,10 @@
       href="/sandboxes/{{ sb.name }}/terminal">
       Terminal
     </a>
+    <a role="button" class="outline"
+      href="/sandboxes/{{ sb.name }}/agent">
+      Agent
+    </a>
     {% endif %}
     <button class="secondary outline"
       hx-get="/sandboxes/{{ sb.name }}/status"


### PR DESCRIPTION
## Summary
- Adds a TypeScript agent harness (`images/sandbox-base/agent-harness/`) that wraps `@anthropic-ai/claude-agent-sdk` for running Claude Code programmatically inside sandbox pods
- Updates the sandbox base image (`default.nix`) to include Node.js 22 and the harness source files
- Adds `exec_sandbox_raw()` to `SandboxClient` for non-TTY programmatic stdin/stdout communication
- Adds `POST /api/v1/sandboxes/{name}/agent/message` API endpoint that execs the harness in a pod and streams SDK events back as SSE

## How it works

1. Client sends `POST /api/v1/sandboxes/{name}/agent/message` with `{"prompt": "...", "session_id": "optional"}`
2. Server execs `agent-harness` in the sandbox pod (non-TTY mode for clean JSON)
3. Prompt is sent as JSON-line to harness stdin
4. Harness calls `query()` from the Agent SDK with `bypassPermissions` (pod is gVisor-sandboxed)
5. SDK events stream back via stdout → parsed as JSON-lines → relayed as SSE events to the client
6. Session support: pass `session_id` to resume previous conversations via the SDK's `resume` option

## Architecture

```
Client → POST /agent/message → galoy-agents server
  → k8s exec (non-TTY) → agent-harness process in pod
    → @anthropic-ai/claude-agent-sdk query()
      → Claude Code CLI → api.anthropic.com
    ← SDK events (JSON-lines on stdout)
  ← SSE stream back to client
```

## Test plan
- [ ] Verify `nix flake check` passes (fmt, clippy, nextest) ✅
- [ ] Deploy to staging with a sandbox that has `ANTHROPIC_API_KEY` set
- [ ] Test `POST /api/v1/sandboxes/{name}/agent/message` with a simple prompt
- [ ] Verify SSE events stream back with correct SDK event types
- [ ] Test session resumption by passing `session_id` from a previous result

🤖 Generated with [Claude Code](https://claude.com/claude-code)