### PR TITLE
feat(mcp-gateway): add configurable auth header and Lingo.dev upstream

### DIFF
--- a/charts/galoy-agents/templates/configmap.yaml
+++ b/charts/galoy-agents/templates/configmap.yaml
@@ -31,6 +31,9 @@ data:
       {{- range .Values.galoyAgents.config.mcpUpstreams }}
         - name: {{ .name | quote }}
           url: {{ .url | quote }}
+          {{- if .authHeaderName }}
+          auth_header_name: {{ .authHeaderName | quote }}
+          {{- end }}
           {{- if .category }}
           category: {{ .category | quote }}
           {{- end }}

--- a/charts/galoy-agents/values.yaml
+++ b/charts/galoy-agents/values.yaml
@@ -61,6 +61,11 @@ galoyAgents:
     #     - issue_read
     #     - list_issues
     #     - search_issues
+    # - name: lingo
+    #   url: https://mcp.lingo.dev/account
+    #   authHeaderName: x-api-key
+    #   category: localization
+    #   categoryDescription: "AI-powered localization engine management and translation"
   secrets:
     create: true
     pgCon: ""

--- a/core/src/toolset/config.rs
+++ b/core/src/toolset/config.rs
@@ -22,6 +22,8 @@ pub struct McpUpstreamConfig {
     pub url: String,
     #[serde(skip)]
     pub auth_header: String,
+    #[serde(default = "default_auth_header_name")]
+    pub auth_header_name: String,
     #[serde(default)]
     pub category: Option<String>,
     #[serde(default)]
@@ -32,6 +34,10 @@ pub struct McpUpstreamConfig {
     /// Optional whitelist of tool names to expose from this upstream.
     #[serde(default)]
     pub allowed_tools: Option<Vec<String>>,
+}
+
+fn default_auth_header_name() -> String {
+    "authorization".to_string()
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/core/src/toolset/upstream.rs
+++ b/core/src/toolset/upstream.rs
@@ -27,7 +27,8 @@ impl UpstreamToolSet {
     ) -> Result<UpstreamToolSet, ToolSetsError> {
         let mut headers = HashMap::new();
         headers.insert(
-            HeaderName::from_static("authorization"),
+            HeaderName::from_bytes(upstream.auth_header_name.as_bytes())
+                .map_err(|e| ToolSetsError::InvalidHeader(e.to_string()))?,
             HeaderValue::from_str(&upstream.auth_header)
                 .map_err(|e| ToolSetsError::InvalidHeader(e.to_string()))?,
         );

--- a/core/tests/toolset.rs
+++ b/core/tests/toolset.rs
@@ -17,6 +17,7 @@ async fn init_toolsets() {
             name: "honeycomb".to_string(),
             url: "https://mcp.honeycomb.io/mcp".to_string(),
             auth_header,
+            auth_header_name: "authorization".to_string(),
             category: Some("observability".to_string()),
             category_description: Some("Distributed traces, SLOs, and query analysis".to_string()),
             tool_prefix: None,

--- a/galoy-agents.yml
+++ b/galoy-agents.yml
@@ -37,3 +37,8 @@ toolsets:
         - issue_read
         - list_issues
         - search_issues
+    - name: lingo
+      url: https://mcp.lingo.dev/account
+      auth_header_name: x-api-key
+      category: localization
+      category_description: "AI-powered localization engine management and translation"


### PR DESCRIPTION
## Summary
- **Generalize upstream auth header**: Added `auth_header_name` field to `McpUpstreamConfig` (defaults to `"authorization"`), so each upstream MCP server can specify its own auth header name. This replaces the hardcoded `HeaderName::from_static("authorization")` in `upstream.rs`.
- **Add Lingo.dev upstream**: Configured `https://mcp.lingo.dev/account` as an MCP upstream using `x-api-key` header for authentication. All tools exposed by the Lingo.dev platform MCP (translation, glossary management, engine config, etc.) are available through the progressive disclosure pattern (`search_tools` → `describe_tool` → `call_tool`).
- **Helm chart support**: Updated configmap template to propagate `authHeaderName` and added Lingo.dev as a commented-out example in `values.yaml` (disabled by default). The existing deployment template already handles `LINGO_AUTH_HEADER` env var injection automatically via the upstream range loop.

## Details
Lingo.dev is an AI-powered localization platform. Its MCP server requires `x-api-key` as the auth header (not `Authorization`). Rather than special-casing this, the auth header name is now configurable per upstream — useful for any future MCP upstream that uses non-standard auth headers.

**Auth at runtime**: Set `LINGO_AUTH_HEADER=<api-key>` env var (or via K8s secret key `lingo-auth-header`).

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes
- [x] `cargo fmt` passes
- [x] `nix flake check` passes (fmt + clippy + nextest)
- [ ] Existing Honeycomb upstream still works (default `authorization` header unchanged)
- [ ] Lingo.dev upstream initializes when `LINGO_AUTH_HEADER` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)