### PR TITLE
fix(mcp-gateway): remove non-default GitHub MCP tools from allowlist

### DIFF
--- a/charts/galoy-agents/values.yaml
+++ b/charts/galoy-agents/values.yaml
@@ -47,7 +47,7 @@ galoyAgents:
     #   url: https://api.githubcopilot.com/mcp/readonly
     #   toolPrefix: github
     #   category: source-control
-    #   categoryDescription: "GitHub repositories, pull requests, issues, and actions"
+    #   categoryDescription: "GitHub repositories, pull requests, issues, and code search"
     #   allowedTools:
     #     - get_file_contents
     #     - get_commit
@@ -61,11 +61,6 @@ galoyAgents:
     #     - issue_read
     #     - list_issues
     #     - search_issues
-    #     - actions_get
-    #     - actions_list
-    #     - get_job_logs
-    #     - list_code_scanning_alerts
-    #     - list_dependabot_alerts
   secrets:
     create: true
     pgCon: ""

--- a/ci/deploy/galoy-agents/prod-values.yml.tmpl
+++ b/ci/deploy/galoy-agents/prod-values.yml.tmpl
@@ -26,7 +26,7 @@ galoyAgents:
         url: https://api.githubcopilot.com/mcp/readonly
         toolPrefix: github
         category: source-control
-        categoryDescription: "GitHub repositories, pull requests, issues, and actions"
+        categoryDescription: "GitHub repositories, pull requests, issues, and code search"
         allowedTools:
           - get_file_contents
           - get_commit
@@ -40,11 +40,6 @@ galoyAgents:
           - issue_read
           - list_issues
           - search_issues
-          - actions_get
-          - actions_list
-          - get_job_logs
-          - list_code_scanning_alerts
-          - list_dependabot_alerts
   ingress:
     enabled: true
     host: dashboard.agents.galoy.io

--- a/galoy-agents.yml
+++ b/galoy-agents.yml
@@ -23,7 +23,7 @@ toolsets:
       url: https://api.githubcopilot.com/mcp/readonly
       tool_prefix: github
       category: source-control
-      category_description: "GitHub repositories, pull requests, issues, and actions"
+      category_description: "GitHub repositories, pull requests, issues, and code search"
       allowed_tools:
         - get_file_contents
         - get_commit
@@ -37,8 +37,3 @@ toolsets:
         - issue_read
         - list_issues
         - search_issues
-        - actions_get
-        - actions_list
-        - get_job_logs
-        - list_code_scanning_alerts
-        - list_dependabot_alerts


### PR DESCRIPTION
## Summary
- Remove 5 tools from the GitHub MCP allowlist that the remote hosted server doesn't expose (non-default toolsets: actions, code_security, dependabot)
- The remaining 12 tools are confirmed working in production

## Removed tools
- `actions_get`, `actions_list`, `get_job_logs` (actions toolset — not a default)
- `list_code_scanning_alerts` (code_security toolset — not a default)
- `list_dependabot_alerts` (dependabot toolset — not a default)

## Test plan
- [x] Verified via live `search_tools(category="source-control")` — 12 tools working
- [x] Verified via `github_get_file_contents` smoke test
- [x] `nix flake check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)