### PR TITLE
feat(web): add label origin stats to code assistant dashboard

### DIFF
--- a/code-assistant/crates/core/src/search.rs
+++ b/code-assistant/crates/core/src/search.rs
@@ -1,6 +1,6 @@
 use crate::embedder::Embedder;
 use crate::request_log::{RequestLogEntry, StatsResponse};
-use crate::store::{AntiPatternResult, SearchResult, VectorStore};
+use crate::store::{AntiPatternResult, LabelOriginCounts, SearchResult, VectorStore};
 
 /// High-level search combining the embedder and vector store.
 #[derive(Debug)]
@@ -69,5 +69,10 @@ impl SearchEngine {
     /// Query aggregated stats from the request log.
     pub fn query_stats(&self, low_score_threshold: f64) -> anyhow::Result<StatsResponse> {
         self.store.query_stats(low_score_threshold)
+    }
+
+    /// Count labelled chunks grouped by their origin.
+    pub fn label_origin_counts(&self) -> anyhow::Result<LabelOriginCounts> {
+        self.store.label_origin_counts()
     }
 }

--- a/code-assistant/crates/core/src/store.rs
+++ b/code-assistant/crates/core/src/store.rs
@@ -123,6 +123,15 @@ pub struct AntiPatternResult {
     pub similarity: f32,
 }
 
+/// Counts of labels grouped by origin (label_source).
+#[derive(Debug, Clone, Default, serde::Serialize)]
+pub struct LabelOriginCounts {
+    pub human: i64,
+    pub model: i64,
+    pub heuristic: i64,
+    pub total: i64,
+}
+
 /// Embedding cache entry stored alongside vector data.
 pub struct CachedEmbedding {
     pub vector: Vec<f32>,
@@ -638,6 +647,38 @@ impl VectorStore {
         let count: i64 =
             conn.query_row("SELECT COUNT(*) FROM chunk_metadata", [], |row| row.get(0))?;
         Ok(count as u64)
+    }
+
+    /// Count labelled chunks grouped by their origin (`label_source`).
+    pub fn label_origin_counts(&self) -> anyhow::Result<LabelOriginCounts> {
+        let conn = self.conn.lock().map_err(|e| anyhow::anyhow!("{e}"))?;
+
+        let mut stmt = conn.prepare(
+            "SELECT COALESCE(label_source, '') AS src, COUNT(*) AS cnt
+             FROM chunk_labels
+             WHERE labels IS NOT NULL AND labels != '[]' AND labels != ''
+             GROUP BY src",
+        )?;
+
+        let mut counts = LabelOriginCounts::default();
+        let rows = stmt.query_map([], |row| {
+            let source: String = row.get(0)?;
+            let count: i64 = row.get(1)?;
+            Ok((source, count))
+        })?;
+
+        for row in rows {
+            let (source, count) = row?;
+            match source.as_str() {
+                "human" => counts.human = count,
+                "ml" | "model" => counts.model += count,
+                "heuristic" => counts.heuristic = count,
+                _ => {}
+            }
+            counts.total += count;
+        }
+
+        Ok(counts)
     }
 
     /// Ensure anti-pattern tables exist (for server startup without full ReviewMiner).

--- a/core/src/audit/mod.rs
+++ b/core/src/audit/mod.rs
@@ -121,6 +121,7 @@ impl Audit {
         Ok(rows)
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn insert(
         &self,
         subject: AuditSubject,

--- a/core/src/code_assistant/mod.rs
+++ b/core/src/code_assistant/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use request_logger::RequestLogger;
 // Re-exports from code-assistant-core
 pub use code_assistant_core::request_log::RequestLogEntry;
 pub use code_assistant_core::search::SearchEngine;
-pub use code_assistant_core::store::{SearchResult, KNOWN_PRIMARY_LABELS};
+pub use code_assistant_core::store::{LabelOriginCounts, SearchResult, KNOWN_PRIMARY_LABELS};
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -96,6 +96,13 @@ pub fn init(
 impl CodeAssistant {
     pub fn logs(&self) -> &Arc<CodeAssistantLogs> {
         &self.logs
+    }
+
+    /// Count labelled chunks grouped by their origin (human / model / heuristic).
+    pub fn label_origin_counts(&self) -> Result<LabelOriginCounts, CodeAssistantError> {
+        self.search_engine
+            .label_origin_counts()
+            .map_err(|e| CodeAssistantError::Search(e.to_string()))
     }
 
     /// Run a search and return the raw results (for the web dashboard).

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -309,14 +309,9 @@ async fn code_assistant_dashboard(State(state): State<AppState>, session: Sessio
         return Redirect::to("/").into_response();
     }
 
-    let stats = match state
-        .app
-        .code_assistant()
-        .unwrap()
-        .logs()
-        .dashboard_stats()
-        .await
-    {
+    let ca = state.app.code_assistant().unwrap();
+
+    let stats = match ca.logs().dashboard_stats().await {
         Ok(stats) => stats,
         Err(e) => {
             tracing::error!(error = %e, "Failed to load code assistant stats");
@@ -324,7 +319,19 @@ async fn code_assistant_dashboard(State(state): State<AppState>, session: Sessio
         }
     };
 
-    CodeAssistantTemplate { stats }.into_response()
+    let label_origins = match ca.label_origin_counts() {
+        Ok(counts) => counts,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to load label origin counts");
+            return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    CodeAssistantTemplate {
+        stats,
+        label_origins,
+    }
+    .into_response()
 }
 
 #[instrument(name = "web.code_assistant_recent", skip_all)]

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -2,6 +2,7 @@ use askama::Template;
 use askama_web::WebTemplate;
 
 use galoy_agents_core::code_assistant::logs::{CodeAssistantRequestRow, DashboardStats};
+use galoy_agents_core::code_assistant::LabelOriginCounts;
 
 pub struct AgentView {
     pub id: String,
@@ -47,6 +48,7 @@ pub struct AgentListTemplate {
 #[template(path = "code_assistant.html")]
 pub struct CodeAssistantTemplate {
     pub stats: DashboardStats,
+    pub label_origins: LabelOriginCounts,
 }
 
 #[derive(Template, WebTemplate)]

--- a/web/templates/code_assistant.html
+++ b/web/templates/code_assistant.html
@@ -67,6 +67,36 @@
   @media (max-width: 900px) {
     .two-col { grid-template-columns: 1fr; }
   }
+  .origin-bar {
+    display: flex;
+    height: 1.2rem;
+    border-radius: var(--pico-border-radius);
+    overflow: hidden;
+    margin: 0.5rem 0;
+  }
+  .origin-bar > div { transition: width 0.3s ease; }
+  .origin-human { background: #388e3c; }
+  .origin-model { background: #1976d2; }
+  .origin-heuristic { background: #f57c00; }
+  .origin-legend {
+    display: flex;
+    gap: 1.5rem;
+    font-size: 0.85rem;
+    color: var(--pico-muted-color);
+    margin-top: 0.25rem;
+  }
+  .origin-legend span::before {
+    content: '';
+    display: inline-block;
+    width: 0.7rem;
+    height: 0.7rem;
+    border-radius: 2px;
+    margin-right: 0.3rem;
+    vertical-align: middle;
+  }
+  .origin-legend .lg-human::before { background: #388e3c; }
+  .origin-legend .lg-model::before { background: #1976d2; }
+  .origin-legend .lg-heuristic::before { background: #f57c00; }
 </style>
 {% endblock %}
 
@@ -129,6 +159,40 @@
     <div class="stat-value">{{ stats.low_score_rate_fmt }}</div>
   </div>
 </div>
+
+<section>
+  <h3>Label Origins</h3>
+  <div class="stats-grid" style="grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));">
+    <div class="stat-card">
+      <div class="stat-label">Human</div>
+      <div class="stat-value">{{ label_origins.human }}</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Model</div>
+      <div class="stat-value">{{ label_origins.model }}</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Heuristic</div>
+      <div class="stat-value">{{ label_origins.heuristic }}</div>
+    </div>
+    <div class="stat-card">
+      <div class="stat-label">Total Labelled</div>
+      <div class="stat-value">{{ label_origins.total }}</div>
+    </div>
+  </div>
+  {% if label_origins.total > 0 %}
+  <div class="origin-bar">
+    <div class="origin-human" style="width: {{ label_origins.human * 100 / label_origins.total }}%;"></div>
+    <div class="origin-model" style="width: {{ label_origins.model * 100 / label_origins.total }}%;"></div>
+    <div class="origin-heuristic" style="width: {{ label_origins.heuristic * 100 / label_origins.total }}%;"></div>
+  </div>
+  <div class="origin-legend">
+    <span class="lg-human">Human ({{ label_origins.human * 100 / label_origins.total }}%)</span>
+    <span class="lg-model">Model ({{ label_origins.model * 100 / label_origins.total }}%)</span>
+    <span class="lg-heuristic">Heuristic ({{ label_origins.heuristic * 100 / label_origins.total }}%)</span>
+  </div>
+  {% endif %}
+</section>
 
 <div class="tab-bar">
   <button class="active"


### PR DESCRIPTION
## Summary
- Add label origin statistics (human / model / heuristic counts) to the code assistant dashboard
- Query `chunk_labels` SQLite table grouped by `label_source` to count how labels were assigned
- Display counts in stat cards with a visual percentage bar breakdown
- Gives visibility into whether the ML classification model is being used vs purely heuristic labels

## Changes
- `code-assistant/crates/core/src/store.rs` — new `LabelOriginCounts` struct and `label_origin_counts()` query on `VectorStore`
- `code-assistant/crates/core/src/search.rs` — delegate `label_origin_counts()` through `SearchEngine`
- `core/src/code_assistant/mod.rs` — expose `label_origin_counts()` on `CodeAssistant` service, re-export struct
- `web/src/routes.rs` — fetch label origin counts in dashboard handler
- `web/src/templates.rs` — add `label_origins` field to `CodeAssistantTemplate`
- `web/templates/code_assistant.html` — new "Label Origins" section with stat cards and percentage bar

## Test plan
- [ ] Verify dashboard loads with label origin stats section visible
- [ ] Verify counts match actual `chunk_labels` data grouped by `label_source`
- [ ] Verify percentage bar renders correctly (green=human, blue=model, orange=heuristic)
- [ ] Verify dashboard still works when all counts are zero (bar hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)