### PR TITLE
feat(concourse): add grep filter to build logs MCP tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1507,6 +1507,7 @@ dependencies = [
  "es-entity",
  "http",
  "rand 0.9.2",
+ "regex",
  "reqwest 0.13.2",
  "rmcp",
  "serde",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -16,6 +16,7 @@ derive_builder = "0.20"
 es-entity = "0.10"
 http = "1"
 rand = "0.9"
+regex = "1"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"

--- a/core/src/toolset/concourse.rs
+++ b/core/src/toolset/concourse.rs
@@ -43,12 +43,15 @@ impl ConcourseToolSet {
             ),
             tool_entry(
                 "get_build_logs",
-                "Get build output/logs for a Concourse build by its numeric build ID. Returns log output as plain text. For in-flight builds, returns partial output — use get_build_status first to check if the build has finished.",
+                "Get build output/logs for a Concourse build by its numeric build ID. Returns log output as plain text. For in-flight builds, returns partial output — use get_build_status first to check if the build has finished. Supports server-side grep filtering to reduce output size.",
                 serde_json::json!({
                     "type": "object",
                     "properties": {
                         "build_id": {"type": "integer", "description": "The numeric build ID"},
-                        "tail": {"type": "integer", "description": "Number of lines to return from the end of the log (default: 150)"}
+                        "tail": {"type": "integer", "description": "Number of lines to return from the end of the log (default: 150)"},
+                        "grep_pattern": {"type": "string", "description": "Regex pattern to filter log lines (only matching lines are returned). Applied before tail."},
+                        "invert_match": {"type": "boolean", "description": "When true, exclude lines matching grep_pattern instead of including them (like grep -v). Default: false"},
+                        "context_lines": {"type": "integer", "description": "Number of lines to show before and after each match (like grep -C). Only used with grep_pattern."}
                     },
                     "required": ["build_id"]
                 }),
@@ -198,21 +201,43 @@ impl ToolSet for ConcourseToolSet {
             "get_build_logs" => {
                 let build_id = int_arg(&args, "build_id")?;
                 let tail = args.get("tail").and_then(|v| v.as_i64()).unwrap_or(150) as usize;
+                let grep_pattern = args.get("grep_pattern").and_then(|v| v.as_str());
+                let invert_match = args
+                    .get("invert_match")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+                let context_lines = args
+                    .get("context_lines")
+                    .and_then(|v| v.as_i64())
+                    .map(|n| n.max(0) as usize);
+
                 let logs = self.client.get_build_logs(build_id).await?;
                 if logs.is_empty() {
                     return Ok(CallToolResult::success(vec![Content::text(
                         "No log output available for this build.",
                     )]));
                 }
+
                 let lines: Vec<&str> = logs.lines().collect();
-                let output = if lines.len() > tail {
-                    let skipped = lines.len() - tail;
+
+                // Apply grep filter if provided
+                let filtered: Vec<&str> = if let Some(pattern) = grep_pattern {
+                    let re = regex::Regex::new(pattern).map_err(|e| {
+                        ToolSetsError::InvalidArgument(format!("invalid grep_pattern regex: {e}"))
+                    })?;
+                    filter_lines(&lines, &re, invert_match, context_lines)
+                } else {
+                    lines
+                };
+
+                let output = if filtered.len() > tail {
+                    let skipped = filtered.len() - tail;
                     format!(
                         "... ({skipped} lines omitted, showing last {tail})\n{}",
-                        lines[lines.len() - tail..].join("\n")
+                        filtered[filtered.len() - tail..].join("\n")
                     )
                 } else {
-                    logs
+                    filtered.join("\n")
                 };
                 Ok(CallToolResult::success(vec![Content::text(output)]))
             }
@@ -323,6 +348,57 @@ fn int_arg(args: &JsonObject, key: &str) -> Result<i64, ToolSetsError> {
                 .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
         })
         .ok_or_else(|| ToolSetsError::MissingArgument(key.to_string()))
+}
+
+/// Filter log lines by regex pattern with optional context lines.
+///
+/// When `invert` is false, returns lines that match the pattern (grep).
+/// When `invert` is true, returns lines that do NOT match (grep -v).
+/// When `context` is Some(n), includes n lines before/after each match (grep -C).
+fn filter_lines<'a>(
+    lines: &[&'a str],
+    re: &regex::Regex,
+    invert: bool,
+    context: Option<usize>,
+) -> Vec<&'a str> {
+    if context.is_none() || invert {
+        // Simple filter: no context lines, or inverted match (context + invert is unusual, skip context)
+        return lines
+            .iter()
+            .filter(|line| re.is_match(line) != invert)
+            .copied()
+            .collect();
+    }
+
+    let ctx = context.unwrap_or(0);
+    let mut included = vec![false; lines.len()];
+
+    for (i, line) in lines.iter().enumerate() {
+        if re.is_match(line) {
+            let start = i.saturating_sub(ctx);
+            let end = (i + ctx + 1).min(lines.len());
+            for flag in &mut included[start..end] {
+                *flag = true;
+            }
+        }
+    }
+
+    // Collect included lines, inserting "--" separators between non-contiguous groups
+    let mut result = Vec::new();
+    let mut prev_included = false;
+    for (i, line) in lines.iter().enumerate() {
+        if included[i] {
+            if !prev_included && !result.is_empty() {
+                result.push("--");
+            }
+            result.push(line);
+            prev_included = true;
+        } else {
+            prev_included = false;
+        }
+    }
+
+    result
 }
 
 fn extract_get_steps(plan: &[serde_json::Value], out: &mut Vec<serde_json::Value>) {

--- a/core/src/toolset/error.rs
+++ b/core/src/toolset/error.rs
@@ -14,6 +14,8 @@ pub enum ToolSetsError {
     MissingArgument(String),
     #[error("ToolSetsError - Concourse: {0}")]
     Concourse(#[from] concourse_client::ConcourseError),
+    #[error("ToolSetsError - InvalidArgument: {0}")]
+    InvalidArgument(String),
     #[error("ToolSetsError - CodeAssistant: {0}")]
     CodeAssistant(String),
 }


### PR DESCRIPTION
## Summary
- Add optional `grep_pattern` (regex), `invert_match` (bool), and `context_lines` (u32) parameters to the `get_build_logs` Concourse MCP tool
- Server-side log filtering reduces token usage for agents that currently pipe `fly` output through grep
- Context lines support inserts `--` separators between non-contiguous groups (matching grep -C behavior)

## Test plan
- [ ] Call `get_build_logs` without filter params — behavior unchanged (tail-based truncation)
- [ ] Call with `grep_pattern: "error|fail"` — only matching lines returned
- [ ] Call with `grep_pattern: "SUCCESS", invert_match: true` — lines NOT matching returned
- [ ] Call with `grep_pattern: "error", context_lines: 3` — matching lines plus 3 lines of context
- [ ] Call with invalid regex in `grep_pattern` — returns clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)