### PR TITLE
feat(chat-history): add chat history persistence (Phase 1)

### DIFF
--- a/core/migrations/20260409000001_create_conversations.sql
+++ b/core/migrations/20260409000001_create_conversations.sql
@@ -1,0 +1,31 @@
+-- Chat history: flat SQL tables (not event-sourced) for conversation persistence.
+-- Follows the same pattern as audit_entries — direct insert/query.
+
+CREATE TABLE conversations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id UUID NOT NULL REFERENCES agents(id),
+    user_id UUID NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active',
+    api_messages JSONB,
+    total_tokens BIGINT NOT NULL DEFAULT 0,
+    total_turns INT NOT NULL DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_conversations_agent_id ON conversations(agent_id);
+CREATE INDEX idx_conversations_user_id ON conversations(user_id);
+CREATE INDEX idx_conversations_created_at ON conversations(created_at DESC);
+
+CREATE TABLE conversation_messages (
+    id BIGSERIAL PRIMARY KEY,
+    conversation_id UUID NOT NULL REFERENCES conversations(id),
+    sequence INT NOT NULL,
+    role TEXT NOT NULL,
+    content JSONB NOT NULL,
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(conversation_id, sequence)
+);
+
+CREATE INDEX idx_conv_messages_conversation_id ON conversation_messages(conversation_id);

--- a/core/src/agent/error.rs
+++ b/core/src/agent/error.rs
@@ -32,4 +32,6 @@ pub enum AgentError {
     MaxTurnsReached(usize),
     #[error("AgentError - ChannelClosed")]
     ChannelClosed,
+    #[error("AgentError - ChatHistory: {0}")]
+    ChatHistory(crate::chat_history::ChatHistoryError),
 }

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -16,6 +16,7 @@ pub use error::*;
 use repo::*;
 
 use crate::auth::AuthContext;
+use crate::chat_history::{ChatHistory, ConversationId, ConversationStatus, MessageRole};
 use crate::mcp_creds::McpCredentials;
 use crate::primitives::*;
 use crate::toolset::ToolSets;
@@ -29,6 +30,7 @@ pub struct Agents {
     light_config: config::LightRuntimeConfig,
     toolsets: Arc<ToolSets>,
     mcp_creds: McpCredentials,
+    chat_history: ChatHistory,
 }
 
 impl Agents {
@@ -39,6 +41,7 @@ impl Agents {
         mcp_creds: McpCredentials,
     ) -> Result<Self, AgentError> {
         let repo = AgentRepo::new(pool);
+        let chat_history = ChatHistory::new(pool);
         let sandbox = if config.sandbox.enabled {
             let client = sandbox_client::SandboxClient::try_from_env(
                 config.sandbox.namespace.clone(),
@@ -64,6 +67,7 @@ impl Agents {
             light_config: config.light,
             toolsets,
             mcp_creds,
+            chat_history,
         })
     }
 
@@ -152,6 +156,9 @@ impl Agents {
     ///
     /// - `RuntimeKind::Light` runs an in-process agentic loop via the Anthropic API
     /// - `RuntimeKind::Sandbox` runs the agent harness inside a K8s sandbox pod
+    ///
+    /// Returns the conversation ID and a receiver that streams `AgentMessageEvent`s.
+    /// Each event is also persisted to the chat history.
     #[instrument(name = "domain.agent.send_message", skip(self, prompt))]
     pub async fn send_message(
         &self,
@@ -161,7 +168,26 @@ impl Agents {
     ) -> Result<tokio::sync::mpsc::Receiver<AgentMessageEvent>, AgentError> {
         let agent = self.repo.find_by_id(id).await?;
 
-        match agent.agent_type.runtime_kind() {
+        // Create a conversation record
+        let conversation = self
+            .chat_history
+            .create_conversation(agent.id, user_id)
+            .await
+            .map_err(AgentError::ChatHistory)?;
+        let conversation_id = conversation.id;
+
+        // Record the user's prompt
+        let _ = self
+            .chat_history
+            .record_message(
+                conversation_id,
+                MessageRole::User,
+                serde_json::json!(prompt),
+                serde_json::json!({}),
+            )
+            .await;
+
+        let rx = match agent.agent_type.runtime_kind() {
             RuntimeKind::Light => {
                 let auth = AuthContext::InternalAgent(user_id, agent.id, agent.mcp_creds_id);
                 let catalog = self.toolsets.catalog().with_auth(&auth);
@@ -172,10 +198,18 @@ impl Agents {
                     agent.agent_type.system_prompt(),
                     catalog,
                 )
-                .await
+                .await?
             }
-            RuntimeKind::Sandbox => self.send_message_sandbox(agent, prompt).await,
-        }
+            RuntimeKind::Sandbox => self.send_message_sandbox(agent, prompt).await?,
+        };
+
+        // Wrap receiver with persistence tap
+        Ok(self.wrap_with_persistence(rx, conversation_id))
+    }
+
+    /// Expose chat_history for query access (e.g., from web layer).
+    pub fn chat_history(&self) -> &ChatHistory {
+        &self.chat_history
     }
 
     /// Sandbox-specific send_message path.
@@ -221,5 +255,107 @@ impl Agents {
         });
 
         Ok(rx)
+    }
+
+    /// Wrap an event receiver with a persistence tap that records each event
+    /// to the chat history while forwarding it to the caller.
+    fn wrap_with_persistence(
+        &self,
+        mut rx: tokio::sync::mpsc::Receiver<AgentMessageEvent>,
+        conversation_id: ConversationId,
+    ) -> tokio::sync::mpsc::Receiver<AgentMessageEvent> {
+        let (tx, new_rx) = tokio::sync::mpsc::channel(64);
+        let chat_history = self.chat_history.clone();
+
+        tokio::spawn(async move {
+            while let Some(event) = rx.recv().await {
+                let (role, content, metadata) = event_to_message(&event);
+
+                if let Err(e) = chat_history
+                    .record_message(conversation_id, role, content, metadata)
+                    .await
+                {
+                    tracing::warn!(error = %e, "Failed to persist chat message");
+                }
+
+                // On Done/Error, complete the conversation
+                match &event {
+                    AgentMessageEvent::Done {
+                        turns,
+                        input_tokens,
+                        output_tokens,
+                    } => {
+                        let total_tokens = (*input_tokens as i64) + (*output_tokens as i64);
+                        let _ = chat_history
+                            .complete_conversation(
+                                conversation_id,
+                                ConversationStatus::Completed,
+                                *turns as i32,
+                                total_tokens,
+                            )
+                            .await;
+                    }
+                    AgentMessageEvent::Error { .. } => {
+                        let _ = chat_history
+                            .complete_conversation(
+                                conversation_id,
+                                ConversationStatus::Failed,
+                                0,
+                                0,
+                            )
+                            .await;
+                    }
+                    _ => {}
+                }
+
+                // Forward to caller (SSE)
+                if tx.send(event).await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        new_rx
+    }
+}
+
+/// Map an `AgentMessageEvent` to a (role, content, metadata) tuple for persistence.
+fn event_to_message(
+    event: &AgentMessageEvent,
+) -> (MessageRole, serde_json::Value, serde_json::Value) {
+    match event {
+        AgentMessageEvent::Text { text } => (
+            MessageRole::Assistant,
+            serde_json::json!(text),
+            serde_json::json!({}),
+        ),
+        AgentMessageEvent::ToolCall { name, arguments } => (
+            MessageRole::ToolCall,
+            serde_json::json!(name),
+            serde_json::json!({ "arguments": arguments }),
+        ),
+        AgentMessageEvent::ToolResult { name, is_error } => (
+            MessageRole::ToolResult,
+            serde_json::json!(name),
+            serde_json::json!({ "is_error": is_error }),
+        ),
+        AgentMessageEvent::Done {
+            turns,
+            input_tokens,
+            output_tokens,
+        } => (
+            MessageRole::Done,
+            serde_json::json!(null),
+            serde_json::json!({
+                "turns": turns,
+                "input_tokens": input_tokens,
+                "output_tokens": output_tokens,
+            }),
+        ),
+        AgentMessageEvent::Error { message } => (
+            MessageRole::Error,
+            serde_json::json!(message),
+            serde_json::json!({}),
+        ),
     }
 }

--- a/core/src/chat_history/error.rs
+++ b/core/src/chat_history/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum ChatHistoryError {
+    #[error("ChatHistoryError - Sqlx: {0}")]
+    Sqlx(#[from] sqlx::Error),
+    #[error("ChatHistoryError - ConversationNotFound")]
+    ConversationNotFound,
+}

--- a/core/src/chat_history/mod.rs
+++ b/core/src/chat_history/mod.rs
@@ -1,0 +1,181 @@
+pub mod error;
+pub mod primitives;
+
+use tracing::instrument;
+
+pub use error::*;
+pub use primitives::*;
+
+use crate::primitives::*;
+
+#[derive(Clone)]
+pub struct ChatHistory {
+    pool: sqlx::PgPool,
+}
+
+impl ChatHistory {
+    pub fn new(pool: &sqlx::PgPool) -> Self {
+        Self { pool: pool.clone() }
+    }
+
+    /// Create a new conversation for the given agent and user.
+    #[instrument(name = "chat_history.create_conversation", skip_all)]
+    pub async fn create_conversation(
+        &self,
+        agent_id: AgentId,
+        user_id: UserId,
+    ) -> Result<Conversation, ChatHistoryError> {
+        let id = ConversationId::new();
+
+        let row = sqlx::query_as::<_, Conversation>(
+            r#"INSERT INTO conversations (id, agent_id, user_id)
+            VALUES ($1, $2, $3)
+            RETURNING id, agent_id, user_id, status, total_tokens, total_turns, created_at, updated_at"#,
+        )
+        .bind(id)
+        .bind(agent_id)
+        .bind(user_id)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    /// Append a message to a conversation, auto-incrementing the sequence number.
+    #[instrument(name = "chat_history.record_message", skip_all)]
+    pub async fn record_message(
+        &self,
+        conversation_id: ConversationId,
+        role: MessageRole,
+        content: serde_json::Value,
+        metadata: serde_json::Value,
+    ) -> Result<ConversationMessage, ChatHistoryError> {
+        let role_str = role.as_str();
+
+        let row = sqlx::query_as::<_, ConversationMessage>(
+            r#"INSERT INTO conversation_messages (conversation_id, sequence, role, content, metadata)
+            VALUES (
+                $1,
+                COALESCE((SELECT MAX(sequence) FROM conversation_messages WHERE conversation_id = $1), -1) + 1,
+                $2,
+                $3,
+                $4
+            )
+            RETURNING id, conversation_id, sequence, role, content, metadata, created_at"#,
+        )
+        .bind(conversation_id)
+        .bind(role_str)
+        .bind(&content)
+        .bind(&metadata)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    /// Store the full Anthropic API messages array on the conversation (for light agent resume).
+    #[instrument(name = "chat_history.update_api_messages", skip_all)]
+    pub async fn update_api_messages(
+        &self,
+        conversation_id: ConversationId,
+        messages: &serde_json::Value,
+    ) -> Result<(), ChatHistoryError> {
+        let result = sqlx::query(
+            r#"UPDATE conversations
+            SET api_messages = $1, updated_at = NOW()
+            WHERE id = $2"#,
+        )
+        .bind(messages)
+        .bind(conversation_id)
+        .execute(&self.pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(ChatHistoryError::ConversationNotFound);
+        }
+        Ok(())
+    }
+
+    /// Mark a conversation as completed with final stats.
+    #[instrument(name = "chat_history.complete_conversation", skip_all)]
+    pub async fn complete_conversation(
+        &self,
+        conversation_id: ConversationId,
+        status: ConversationStatus,
+        total_turns: i32,
+        total_tokens: i64,
+    ) -> Result<(), ChatHistoryError> {
+        let status_str = status.as_str();
+
+        let result = sqlx::query(
+            r#"UPDATE conversations
+            SET status = $1, total_turns = $2, total_tokens = $3, updated_at = NOW()
+            WHERE id = $4"#,
+        )
+        .bind(status_str)
+        .bind(total_turns)
+        .bind(total_tokens)
+        .bind(conversation_id)
+        .execute(&self.pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(ChatHistoryError::ConversationNotFound);
+        }
+        Ok(())
+    }
+
+    /// Find a conversation by its ID.
+    #[instrument(name = "chat_history.find_conversation", skip_all)]
+    pub async fn find_conversation(
+        &self,
+        id: ConversationId,
+    ) -> Result<Conversation, ChatHistoryError> {
+        sqlx::query_as::<_, Conversation>(
+            r#"SELECT id, agent_id, user_id, status, total_tokens, total_turns, created_at, updated_at
+            FROM conversations
+            WHERE id = $1"#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or(ChatHistoryError::ConversationNotFound)
+    }
+
+    /// List conversations for an agent (most recent first).
+    #[instrument(name = "chat_history.list_by_agent", skip_all)]
+    pub async fn list_by_agent(
+        &self,
+        agent_id: AgentId,
+        limit: i64,
+    ) -> Result<Vec<Conversation>, ChatHistoryError> {
+        let rows = sqlx::query_as::<_, Conversation>(
+            r#"SELECT id, agent_id, user_id, status, total_tokens, total_turns, created_at, updated_at
+            FROM conversations
+            WHERE agent_id = $1
+            ORDER BY created_at DESC
+            LIMIT $2"#,
+        )
+        .bind(agent_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Get all messages for a conversation, ordered by sequence.
+    #[instrument(name = "chat_history.get_messages", skip_all)]
+    pub async fn get_messages(
+        &self,
+        conversation_id: ConversationId,
+    ) -> Result<Vec<ConversationMessage>, ChatHistoryError> {
+        let rows = sqlx::query_as::<_, ConversationMessage>(
+            r#"SELECT id, conversation_id, sequence, role, content, metadata, created_at
+            FROM conversation_messages
+            WHERE conversation_id = $1
+            ORDER BY sequence ASC"#,
+        )
+        .bind(conversation_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+}

--- a/core/src/chat_history/primitives.rs
+++ b/core/src/chat_history/primitives.rs
@@ -1,0 +1,86 @@
+use serde::{Deserialize, Serialize};
+
+use crate::primitives::*;
+
+es_entity::entity_id! { ConversationId }
+
+/// Status of a conversation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConversationStatus {
+    Active,
+    Completed,
+    Failed,
+}
+
+impl ConversationStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ConversationStatus::Active => "active",
+            ConversationStatus::Completed => "completed",
+            ConversationStatus::Failed => "failed",
+        }
+    }
+}
+
+impl std::fmt::Display for ConversationStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Role of a message in a conversation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MessageRole {
+    User,
+    Assistant,
+    ToolCall,
+    ToolResult,
+    Done,
+    Error,
+}
+
+impl MessageRole {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            MessageRole::User => "user",
+            MessageRole::Assistant => "assistant",
+            MessageRole::ToolCall => "tool_call",
+            MessageRole::ToolResult => "tool_result",
+            MessageRole::Done => "done",
+            MessageRole::Error => "error",
+        }
+    }
+}
+
+impl std::fmt::Display for MessageRole {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A conversation between a user and an agent.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct Conversation {
+    pub id: ConversationId,
+    pub agent_id: AgentId,
+    pub user_id: UserId,
+    pub status: String,
+    pub total_tokens: i64,
+    pub total_turns: i32,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// A single message within a conversation.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ConversationMessage {
+    pub id: i64,
+    pub conversation_id: ConversationId,
+    pub sequence: i32,
+    pub role: String,
+    pub content: serde_json::Value,
+    pub metadata: Option<serde_json::Value>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agent;
 pub mod audit;
 pub mod auth;
+pub mod chat_history;
 pub mod code_assistant;
 mod config;
 pub mod mcp_creds;


### PR DESCRIPTION
## Summary
- Add flat SQL tables (`conversations` + `conversation_messages`) for persisting agent chat history, following the audit module's direct-SQL pattern (not event-sourced)
- Implement `ChatHistory` service with methods for creating conversations, recording messages, completing conversations, and querying history
- Add persistence tap in `Agents::send_message()` that wraps the `mpsc::Receiver<AgentMessageEvent>` to record every event to DB while forwarding to the SSE stream

## Details

### Migration
Two tables with indexes on `agent_id`, `user_id`, `created_at`, and `conversation_id`. The `conversations` table includes an `api_messages` JSONB column for future light-agent resume support.

### ChatHistory service (`core/src/chat_history/`)
- `create_conversation(agent_id, user_id)` — creates a new conversation record
- `record_message(conversation_id, role, content, metadata)` — appends a message with auto-incrementing sequence
- `update_api_messages(conversation_id, messages)` — stores full API messages array for resume
- `complete_conversation(conversation_id, status, turns, tokens)` — marks conversation done
- `find_conversation(id)`, `list_by_agent(agent_id, limit)`, `get_messages(conversation_id)` — query methods

### Persistence tap
The tap intercepts each `AgentMessageEvent` variant and maps it to a stored message:
| Event | Role | Content | Metadata |
|-------|------|---------|----------|
| Text | assistant | text | {} |
| ToolCall | tool_call | name | { arguments } |
| ToolResult | tool_result | name | { is_error } |
| Done | done | null | { turns, input_tokens, output_tokens } |
| Error | error | message | {} |

On `Done`, the conversation is marked `completed` with token/turn stats. On `Error`, it's marked `failed`.

### What's NOT included (Phase 2)
- Dashboard UI for viewing conversation history
- Conversation resume (accepting `conversation_id` in API requests)
- Frontend changes

## Test plan
- [ ] Verify migration runs cleanly on a fresh database
- [ ] Send a message to an agent and verify conversation + messages are persisted in DB
- [ ] Verify SSE stream still works correctly (tap forwards all events)
- [ ] Verify conversation status updates to `completed` on successful run
- [ ] Verify conversation status updates to `failed` on error

🤖 Generated with [Claude Code](https://claude.com/claude-code)