### PR TITLE
feat(sandbox): provision MCP gateway credentials to sandbox agents

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -77,6 +77,7 @@ async fn main() -> anyhow::Result<()> {
                         mount_path: p.mount_path.clone(),
                     }
                 }),
+                mcp_gateway_url: config.server.mcp_endpoint.clone(),
             },
             light: galoy_agents_core::agent::config::LightRuntimeConfig {
                 api_key: config.anthropic_api_key.clone(),

--- a/core/migrations/20260409000002_add_mcp_token_to_agents.sql
+++ b/core/migrations/20260409000002_add_mcp_token_to_agents.sql
@@ -1,0 +1,3 @@
+-- Agent events now include mcp_token in Initialized.
+-- Wipe existing agents (no prod data yet) to avoid hydration errors.
+TRUNCATE TABLE agent_events, agents;

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -18,6 +18,9 @@ pub struct SandboxClientConfig {
     pub template_name: String,
     #[serde(default)]
     pub persistence: Option<PersistenceConfig>,
+    /// MCP gateway URL that sandbox agents connect to (e.g. "http://galoy-agents:4200/mcp").
+    #[serde(default)]
+    pub mcp_gateway_url: String,
 }
 
 #[derive(Clone, Debug, Deserialize)]

--- a/core/src/agent/entity.rs
+++ b/core/src/agent/entity.rs
@@ -89,6 +89,7 @@ impl ChatConfig {
 #[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[es_event(id = "AgentId")]
+#[allow(clippy::large_enum_variant)]
 pub enum AgentEvent {
     Initialized {
         id: AgentId,
@@ -96,6 +97,8 @@ pub enum AgentEvent {
         agent_type: AgentType,
         name: String,
         mcp_creds_id: McpCredsId,
+        /// Raw MCP token for authenticating to the MCP gateway.
+        mcp_token: String,
         sandbox_config: SandboxConfig,
         chat_config: ChatConfig,
     },
@@ -121,6 +124,8 @@ pub struct Agent {
     pub agent_type: AgentType,
     pub name: String,
     pub mcp_creds_id: McpCredsId,
+    /// Raw MCP token for authenticating to the MCP gateway.
+    pub mcp_token: String,
     pub sandbox_config: SandboxConfig,
     pub chat_config: ChatConfig,
     pub sandbox_state: SandboxState,
@@ -194,6 +199,7 @@ impl TryFromEvents<AgentEvent> for Agent {
                     agent_type,
                     name,
                     mcp_creds_id,
+                    mcp_token,
                     sandbox_config,
                     chat_config,
                 } => {
@@ -203,6 +209,7 @@ impl TryFromEvents<AgentEvent> for Agent {
                         .agent_type(*agent_type)
                         .name(name.clone())
                         .mcp_creds_id(*mcp_creds_id)
+                        .mcp_token(mcp_token.clone())
                         .sandbox_config(sandbox_config.clone())
                         .chat_config(chat_config.clone())
                         .sandbox_state(SandboxState::None);
@@ -232,6 +239,8 @@ pub struct NewAgent {
     #[builder(setter(into))]
     pub(super) name: String,
     pub(super) mcp_creds_id: McpCredsId,
+    #[builder(setter(into))]
+    pub(super) mcp_token: String,
     #[builder(default)]
     pub(super) sandbox_config: SandboxConfig,
     #[builder(default)]
@@ -256,6 +265,7 @@ impl IntoEvents<AgentEvent> for NewAgent {
                 agent_type: self.agent_type,
                 name: self.name,
                 mcp_creds_id: self.mcp_creds_id,
+                mcp_token: self.mcp_token,
                 sandbox_config: self.sandbox_config,
                 chat_config: self.chat_config,
             }],
@@ -278,6 +288,7 @@ mod tests {
             .agent_type(AgentType::WorkspaceLead)
             .name("workspace-lead")
             .mcp_creds_id(McpCredsId::new())
+            .mcp_token("test-token-abc123")
             .sandbox_config(SandboxConfig::default())
             .chat_config(ChatConfig {
                 model: "claude-sonnet-4-6".to_string(),

--- a/core/src/agent/harness_pool.rs
+++ b/core/src/agent/harness_pool.rs
@@ -44,6 +44,8 @@ pub(super) struct HarnessMessage {
     pub model: Option<String>,
     pub max_turns: Option<u32>,
     pub disallowed_tools: Vec<String>,
+    /// MCP server configurations to pass to the harness (sent only on the first message).
+    pub mcp_servers: Option<serde_json::Value>,
 }
 
 /// Pool of active harness exec sessions keyed by [`AgentId`].
@@ -85,13 +87,16 @@ impl HarnessPool {
             .await?;
         let mut guard = session.lock().await;
 
-        let input_line = serde_json::json!({
+        let mut input_line = serde_json::json!({
             "prompt": msg.prompt,
             "session_id": msg.session_id,
             "model": msg.model,
             "max_turns": msg.max_turns,
             "disallowed_tools": msg.disallowed_tools,
         });
+        if let Some(mcp_servers) = msg.mcp_servers {
+            input_line["mcp_servers"] = mcp_servers;
+        }
         let payload = format!("{}\n", input_line);
 
         // Write prompt — if the exec session is dead we'll find out here.

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -30,6 +30,7 @@ pub struct Agents {
     sandbox: Option<Arc<sandbox_client::SandboxClient>>,
     harness_pool: harness_pool::HarnessPool,
     light_config: config::LightRuntimeConfig,
+    mcp_gateway_url: String,
     toolsets: Arc<ToolSets>,
     mcp_creds: McpCredentials,
     chat_history: ChatHistory,
@@ -54,11 +55,13 @@ impl Agents {
         } else {
             None
         };
+        let mcp_gateway_url = config.sandbox.mcp_gateway_url.clone();
         Ok(Self {
             repo,
             sandbox,
             harness_pool: harness_pool::HarnessPool::new(),
             light_config: config.light,
+            mcp_gateway_url,
             toolsets,
             mcp_creds,
             chat_history,
@@ -92,7 +95,7 @@ impl Agents {
     ) -> Result<Agent, AgentError> {
         let agent_name = name.into();
         let agent_id = AgentId::new();
-        let (_, token_hash) = crate::mcp_creds::token::generate_token();
+        let (raw_token, token_hash) = crate::mcp_creds::token::generate_token();
         let creds = self
             .mcp_creds
             .create_in_op(
@@ -111,6 +114,7 @@ impl Agents {
             .agent_type(agent_type)
             .name(agent_name)
             .mcp_creds_id(creds.id)
+            .mcp_token(raw_token)
             .build()
             .expect("Could not build new agent");
 
@@ -233,6 +237,21 @@ impl Agents {
         let disallowed_tools = agent.sandbox_config.disallowed_tools.clone();
         let agent_id = agent.id;
 
+        // Build MCP server config if gateway URL and token are available
+        let mcp_servers = if !self.mcp_gateway_url.is_empty() && !agent.mcp_token.is_empty() {
+            Some(serde_json::json!({
+                "galoy-agents": {
+                    "type": "http",
+                    "url": self.mcp_gateway_url,
+                    "headers": {
+                        "Authorization": format!("Bearer {}", agent.mcp_token)
+                    }
+                }
+            }))
+        } else {
+            None
+        };
+
         tokio::spawn(async move {
             // Ensure sandbox is provisioned, streaming status to the UI
             let sandbox_name = match sandbox::ensure_sandbox(&client, agent, &repo, &tx).await {
@@ -257,6 +276,7 @@ impl Agents {
                 model,
                 max_turns,
                 disallowed_tools,
+                mcp_servers,
             };
 
             if let Err(e) = pool.send_message(msg, tx.clone()).await {

--- a/images/sandbox-base/agent-harness/src/index.ts
+++ b/images/sandbox-base/agent-harness/src/index.ts
@@ -29,12 +29,20 @@ const CLI_JS_PATH = join(__dirname, "sdk", "cli.js");
 
 // ── Types ──────────────────────────────────────────────────────────────
 
+interface McpHttpServerConfig {
+  type: "http";
+  url: string;
+  headers?: Record<string, string>;
+}
+
 interface HarnessInput {
   prompt: string;
   session_id?: string;
   model?: string;
   max_turns?: number;
   disallowed_tools?: string[];
+  /** MCP server configurations keyed by server name. */
+  mcp_servers?: Record<string, McpHttpServerConfig>;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -76,6 +84,7 @@ async function handleMessage(input: HarnessInput): Promise<void> {
         resume: activeSessionId,
         disallowedTools: input.disallowed_tools,
         includePartialMessages: true,
+        mcpServers: input.mcp_servers,
       },
     });
 


### PR DESCRIPTION
Wires MCP gateway URL and per-agent credentials into sandbox harness so agents can call back to the dashboard MCP endpoint.

## Summary
- Store raw MCP token in Agent entity alongside the hash in mcp_creds
- Add `mcp_gateway_url` to `SandboxClientConfig`, wired from `server.mcp_endpoint`
- Pass MCP server config (URL + bearer token) through `HarnessMessage` to agent-harness stdin
- Update agent-harness TypeScript to accept `mcp_servers` and forward to Claude Agent SDK `query()` options
- Migration to wipe agents (schema change, no prod data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)