### PR TITLE
feat(mcp): add admin-scoped toolset with workspace CRUD and agent messaging

### DIFF
--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -196,7 +196,12 @@ impl Agents {
 
         let rx = match agent.agent_type.runtime_kind() {
             RuntimeKind::Light => {
-                let auth = AuthContext::InternalAgent(user_id, agent.id, agent.mcp_creds_id);
+                let auth = AuthContext::InternalAgent(
+                    user_id,
+                    agent.id,
+                    agent.mcp_creds_id,
+                    vec!["agent".to_string()],
+                );
                 let catalog = self.toolsets.catalog().with_auth(&auth);
                 light::run(
                     prompt,

--- a/core/src/audit/primitives.rs
+++ b/core/src/audit/primitives.rs
@@ -72,11 +72,11 @@ impl From<&AuthContext> for AuditSubject {
     fn from(ctx: &AuthContext) -> Self {
         match ctx {
             AuthContext::User(user_id) => AuditSubject::User { user_id: *user_id },
-            AuthContext::ExportedAgent(user_id, mcp_creds_id) => AuditSubject::ExportedAgent {
+            AuthContext::ExportedAgent(user_id, mcp_creds_id, _) => AuditSubject::ExportedAgent {
                 mcp_creds_id: *mcp_creds_id,
                 user_id: *user_id,
             },
-            AuthContext::InternalAgent(user_id, agent_id, mcp_creds_id) => {
+            AuthContext::InternalAgent(user_id, agent_id, mcp_creds_id, _) => {
                 AuditSubject::InternalAgent {
                     user_id: *user_id,
                     agent_id: *agent_id,

--- a/core/src/auth/mod.rs
+++ b/core/src/auth/mod.rs
@@ -7,9 +7,9 @@ pub enum AuthContext {
     /// Authenticated via session cookie (human user in browser).
     User(UserId),
     /// Authenticated via bearer token issued to a user (exported agent credential).
-    ExportedAgent(UserId, McpCredsId),
+    ExportedAgent(UserId, McpCredsId, Vec<String>),
     /// Internal light-agent dispatch — the agent acts on behalf of the user.
-    InternalAgent(UserId, AgentId, McpCredsId),
+    InternalAgent(UserId, AgentId, McpCredsId, Vec<String>),
     /// No authentication provided.
     Anonymous,
 }
@@ -18,9 +18,23 @@ impl AuthContext {
     pub fn user_id(&self) -> Result<UserId, &'static str> {
         match self {
             AuthContext::User(user_id) => Ok(*user_id),
-            AuthContext::ExportedAgent(_, _) => Err("ExportedAgent auth not allowed here"),
-            AuthContext::InternalAgent(_, _, _) => Err("InternalAgent auth not allowed here"),
+            AuthContext::ExportedAgent(_, _, _) => Err("ExportedAgent auth not allowed here"),
+            AuthContext::InternalAgent(_, _, _, _) => Err("InternalAgent auth not allowed here"),
             AuthContext::Anonymous => Err("Authentication required"),
         }
+    }
+
+    /// Return the scopes associated with this auth context.
+    pub fn scopes(&self) -> &[String] {
+        match self {
+            AuthContext::ExportedAgent(_, _, scopes) => scopes,
+            AuthContext::InternalAgent(_, _, _, scopes) => scopes,
+            _ => &[],
+        }
+    }
+
+    /// Check whether this context carries the given scope.
+    pub fn has_scope(&self, scope: &str) -> bool {
+        self.scopes().iter().any(|s| s == scope)
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -20,7 +20,7 @@ use audit::Audit;
 use code_assistant::CodeAssistant;
 use mcp_creds::McpCredentials;
 use report::Reports;
-use toolset::{ToolSets, ToolSetsError};
+use toolset::{AdminToolSet, ToolSets, ToolSetsError};
 use user::Users;
 use workspace::Workspaces;
 
@@ -91,6 +91,11 @@ impl App {
             )
             .await?,
         );
+        let workspaces = Workspaces::new(pool, Arc::clone(&agents));
+
+        // Register admin toolset after agents/workspaces to break circular dep
+        toolsets.register(AdminToolSet::new(workspaces.clone(), Arc::clone(&agents)));
+
         Ok(Self {
             users: Users::new(pool),
             mcp_creds,
@@ -99,7 +104,7 @@ impl App {
             code_assistant,
             reports,
             toolsets,
-            workspaces: Workspaces::new(pool, agents),
+            workspaces,
         })
     }
 

--- a/core/src/toolset/admin.rs
+++ b/core/src/toolset/admin.rs
@@ -1,0 +1,374 @@
+use std::sync::Arc;
+
+use rmcp::model::{CallToolResult, Content, JsonObject, Tool};
+use tracing::instrument;
+
+use crate::agent::Agents;
+use crate::auth::AuthContext;
+use crate::primitives::*;
+use crate::workspace::Workspaces;
+
+use super::{ToolSet, ToolSetEntry, ToolSetsError};
+
+pub struct AdminToolSet {
+    workspaces: Workspaces,
+    agents: Arc<Agents>,
+    tools: Vec<ToolSetEntry>,
+}
+
+impl AdminToolSet {
+    pub fn new(workspaces: Workspaces, agents: Arc<Agents>) -> Self {
+        let tools = vec![
+            tool_entry(
+                "list_workspaces",
+                "List all workspaces. Returns workspace IDs, names, descriptions, and creation dates.",
+                serde_json::json!({"type": "object", "properties": {}}),
+            ),
+            tool_entry(
+                "create_workspace",
+                "Create a new workspace (and its lead agent). Returns the created workspace.",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "name": {"type": "string", "description": "Workspace name"},
+                        "description": {"type": "string", "description": "Optional workspace description"}
+                    },
+                    "required": ["name"]
+                }),
+            ),
+            tool_entry(
+                "get_workspace",
+                "Get workspace details by ID.",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {"type": "string", "description": "The workspace UUID"}
+                    },
+                    "required": ["workspace_id"]
+                }),
+            ),
+            tool_entry(
+                "update_workspace",
+                "Update a workspace's name and/or description.",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {"type": "string", "description": "The workspace UUID"},
+                        "name": {"type": "string", "description": "New workspace name"},
+                        "description": {"type": "string", "description": "New workspace description (omit to clear)"}
+                    },
+                    "required": ["workspace_id", "name"]
+                }),
+            ),
+            tool_entry(
+                "list_agents",
+                "List agents in a workspace. Returns agent IDs, names, types, and status.",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "workspace_id": {"type": "string", "description": "The workspace UUID"}
+                    },
+                    "required": ["workspace_id"]
+                }),
+            ),
+            tool_entry(
+                "get_agent",
+                "Get agent details by ID.",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "agent_id": {"type": "string", "description": "The agent UUID"}
+                    },
+                    "required": ["agent_id"]
+                }),
+            ),
+            tool_entry(
+                "send_agent_message",
+                "Send a message to an agent and wait for the full response. Blocks until the agent completes (up to 120 seconds). Returns the agent's text response.",
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "agent_id": {"type": "string", "description": "The agent UUID"},
+                        "message": {"type": "string", "description": "The prompt to send to the agent"}
+                    },
+                    "required": ["agent_id", "message"]
+                }),
+            ),
+        ];
+
+        Self {
+            workspaces,
+            agents,
+            tools,
+        }
+    }
+
+    fn extract_user_id(auth: Option<&AuthContext>) -> Result<UserId, ToolSetsError> {
+        match auth {
+            Some(AuthContext::ExportedAgent(user_id, _, _)) => Ok(*user_id),
+            Some(AuthContext::InternalAgent(user_id, _, _, _)) => Ok(*user_id),
+            Some(AuthContext::User(user_id)) => Ok(*user_id),
+            _ => Err(ToolSetsError::Unauthorized),
+        }
+    }
+
+    #[instrument(name = "toolset.admin.list_workspaces", skip_all)]
+    async fn handle_list_workspaces(&self) -> Result<CallToolResult, ToolSetsError> {
+        let workspaces = self
+            .workspaces
+            .list_all()
+            .await
+            .map_err(|e| ToolSetsError::Admin(e.to_string()))?;
+        let summary: Vec<serde_json::Value> = workspaces
+            .iter()
+            .map(|ws| {
+                serde_json::json!({
+                    "id": ws.id.to_string(),
+                    "name": ws.name,
+                    "description": ws.description,
+                    "created_at": ws.created_at().to_rfc3339(),
+                })
+            })
+            .collect();
+        Ok(text_result(&summary))
+    }
+
+    #[instrument(name = "toolset.admin.create_workspace", skip_all)]
+    async fn handle_create_workspace(
+        &self,
+        args: &JsonObject,
+        auth: Option<&AuthContext>,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        let user_id = Self::extract_user_id(auth)?;
+        let name = str_arg(args, "name")?;
+        let description = args
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let ws = self
+            .workspaces
+            .create(user_id, name, description)
+            .await
+            .map_err(|e| ToolSetsError::Admin(e.to_string()))?;
+        let result = serde_json::json!({
+            "id": ws.id.to_string(),
+            "name": ws.name,
+            "description": ws.description,
+            "created_at": ws.created_at().to_rfc3339(),
+        });
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap_or_default(),
+        )]))
+    }
+
+    #[instrument(name = "toolset.admin.get_workspace", skip_all)]
+    async fn handle_get_workspace(
+        &self,
+        args: &JsonObject,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        let workspace_id = parse_uuid_arg(args, "workspace_id")?;
+        let ws = self
+            .workspaces
+            .find_by_id(WorkspaceId::from(workspace_id))
+            .await
+            .map_err(|e| ToolSetsError::Admin(e.to_string()))?;
+        let result = serde_json::json!({
+            "id": ws.id.to_string(),
+            "name": ws.name,
+            "description": ws.description,
+            "created_at": ws.created_at().to_rfc3339(),
+        });
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap_or_default(),
+        )]))
+    }
+
+    #[instrument(name = "toolset.admin.update_workspace", skip_all)]
+    async fn handle_update_workspace(
+        &self,
+        args: &JsonObject,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        let workspace_id = parse_uuid_arg(args, "workspace_id")?;
+        let name = str_arg(args, "name")?;
+        let description = args
+            .get("description")
+            .and_then(|v| v.as_str())
+            .map(String::from);
+        let ws = self
+            .workspaces
+            .update(WorkspaceId::from(workspace_id), name, description)
+            .await
+            .map_err(|e| ToolSetsError::Admin(e.to_string()))?;
+        let result = serde_json::json!({
+            "id": ws.id.to_string(),
+            "name": ws.name,
+            "description": ws.description,
+        });
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap_or_default(),
+        )]))
+    }
+
+    #[instrument(name = "toolset.admin.list_agents", skip_all)]
+    async fn handle_list_agents(&self, args: &JsonObject) -> Result<CallToolResult, ToolSetsError> {
+        let workspace_id = parse_uuid_arg(args, "workspace_id")?;
+        let agents = self
+            .agents
+            .list_for_workspace(WorkspaceId::from(workspace_id))
+            .await
+            .map_err(|e| ToolSetsError::Admin(e.to_string()))?;
+        let summary: Vec<serde_json::Value> = agents
+            .iter()
+            .map(|a| {
+                serde_json::json!({
+                    "id": a.id.to_string(),
+                    "name": a.name,
+                    "agent_type": a.agent_type,
+                    "workspace_id": a.workspace_id.to_string(),
+                })
+            })
+            .collect();
+        Ok(text_result(&summary))
+    }
+
+    #[instrument(name = "toolset.admin.get_agent", skip_all)]
+    async fn handle_get_agent(&self, args: &JsonObject) -> Result<CallToolResult, ToolSetsError> {
+        let agent_id = parse_uuid_arg(args, "agent_id")?;
+        let agent = self
+            .agents
+            .find_by_id(AgentId::from(agent_id))
+            .await
+            .map_err(|e| ToolSetsError::Admin(e.to_string()))?;
+        let result = serde_json::json!({
+            "id": agent.id.to_string(),
+            "name": agent.name,
+            "agent_type": agent.agent_type,
+            "workspace_id": agent.workspace_id.to_string(),
+        });
+        Ok(CallToolResult::success(vec![Content::text(
+            serde_json::to_string_pretty(&result).unwrap_or_default(),
+        )]))
+    }
+
+    #[instrument(name = "toolset.admin.send_agent_message", skip(self, args, auth))]
+    async fn handle_send_agent_message(
+        &self,
+        args: &JsonObject,
+        auth: Option<&AuthContext>,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        let user_id = Self::extract_user_id(auth)?;
+        let agent_id = parse_uuid_arg(args, "agent_id")?;
+        let message = str_arg(args, "message")?;
+
+        let mut rx = self
+            .agents
+            .send_message(AgentId::from(agent_id), user_id, message.to_string())
+            .await
+            .map_err(|e| ToolSetsError::Admin(e.to_string()))?;
+
+        // Collect all text events until Done or Error, with a timeout
+        let mut texts = Vec::new();
+        let timeout = tokio::time::Duration::from_secs(120);
+        let result = tokio::time::timeout(timeout, async {
+            while let Some(event) = rx.recv().await {
+                match event {
+                    AgentMessageEvent::Text { text } => texts.push(text),
+                    AgentMessageEvent::Done { .. } => break,
+                    AgentMessageEvent::Error { message } => {
+                        return Err(ToolSetsError::Admin(format!("Agent error: {message}")));
+                    }
+                    _ => {} // skip tool calls, service events
+                }
+            }
+            Ok(())
+        })
+        .await;
+
+        match result {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => return Err(e),
+            Err(_) => {
+                return Err(ToolSetsError::Admin(
+                    "Agent response timed out after 120 seconds".to_string(),
+                ));
+            }
+        }
+
+        Ok(CallToolResult::success(vec![Content::text(texts.join(""))]))
+    }
+}
+
+#[async_trait::async_trait]
+impl ToolSet for AdminToolSet {
+    fn name(&self) -> &str {
+        "admin"
+    }
+
+    fn category(&self) -> &str {
+        "admin"
+    }
+
+    fn category_description(&self) -> &str {
+        "Privileged operations: workspace management, agent control, environment verification"
+    }
+
+    fn tools(&self) -> &[ToolSetEntry] {
+        &self.tools
+    }
+
+    fn required_scopes(&self) -> &[&str] {
+        &["admin"]
+    }
+
+    async fn call(
+        &self,
+        tool_name: &str,
+        arguments: Option<JsonObject>,
+        auth: Option<&AuthContext>,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        let args = arguments.unwrap_or_default();
+        match tool_name {
+            "list_workspaces" => self.handle_list_workspaces().await,
+            "create_workspace" => self.handle_create_workspace(&args, auth).await,
+            "get_workspace" => self.handle_get_workspace(&args).await,
+            "update_workspace" => self.handle_update_workspace(&args).await,
+            "list_agents" => self.handle_list_agents(&args).await,
+            "get_agent" => self.handle_get_agent(&args).await,
+            "send_agent_message" => self.handle_send_agent_message(&args, auth).await,
+            _ => Err(ToolSetsError::ToolNotFound(tool_name.to_string())),
+        }
+    }
+}
+
+fn tool_entry(name: &str, description: &str, schema: serde_json::Value) -> ToolSetEntry {
+    let input_schema: JsonObject = match schema {
+        serde_json::Value::Object(m) => m,
+        _ => Default::default(),
+    };
+    let mut tool = Tool::default();
+    tool.name = name.to_string().into();
+    tool.description = Some(description.to_string().into());
+    tool.input_schema = Arc::new(input_schema);
+    ToolSetEntry {
+        name: name.to_string(),
+        description: tool,
+    }
+}
+
+fn text_result(value: &[serde_json::Value]) -> CallToolResult {
+    CallToolResult::success(vec![Content::text(
+        serde_json::to_string_pretty(value).unwrap_or_default(),
+    )])
+}
+
+fn str_arg<'a>(args: &'a JsonObject, key: &str) -> Result<&'a str, ToolSetsError> {
+    args.get(key)
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| ToolSetsError::MissingArgument(key.to_string()))
+}
+
+fn parse_uuid_arg(args: &JsonObject, key: &str) -> Result<uuid::Uuid, ToolSetsError> {
+    let s = str_arg(args, key)?;
+    s.parse::<uuid::Uuid>()
+        .map_err(|e| ToolSetsError::InvalidArgument(format!("invalid UUID for '{key}': {e}")))
+}

--- a/core/src/toolset/catalog.rs
+++ b/core/src/toolset/catalog.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use rmcp::model::{CallToolResult, JsonObject, Tool};
 
@@ -19,8 +19,11 @@ pub struct CatalogEntry {
 
 /// Shared catalog of tool sets. Use [`Catalog::with_auth`] to create a
 /// request-scoped handle that records audit entries automatically.
+///
+/// Toolsets are stored as `Arc<dyn ToolSet>` so they can be cloned out
+/// from behind the `RwLock` without holding the lock across `.await`.
 pub struct Catalog {
-    pub(super) sets: Arc<Vec<Box<dyn ToolSet>>>,
+    pub(super) sets: Arc<RwLock<Vec<Arc<dyn ToolSet>>>>,
     pub(super) audit: Option<Arc<Audit>>,
     pub(super) auth: Option<AuthContext>,
 }
@@ -34,6 +37,11 @@ impl Catalog {
             audit: self.audit.clone(),
             auth: Some(auth.clone()),
         }
+    }
+
+    /// Acquire a read lock on the toolset registry.
+    fn read_sets(&self) -> std::sync::RwLockReadGuard<'_, Vec<Arc<dyn ToolSet>>> {
+        self.sets.read().expect("toolset lock poisoned")
     }
 
     /// The 3 meta-tool definitions for progressive disclosure.
@@ -137,6 +145,7 @@ impl Catalog {
     }
 
     pub fn instructions(&self) -> String {
+        let sets = self.read_sets();
         let mut lines = vec![
             "Tools from upstream services are available via progressive disclosure:".to_string(),
             "1. search_tools — discover tools by keyword or category".to_string(),
@@ -145,7 +154,10 @@ impl Catalog {
             String::new(),
             "Available toolsets:".to_string(),
         ];
-        for set in self.sets.iter() {
+        for set in sets.iter() {
+            if !self.caller_has_required_scopes(set.as_ref()) {
+                continue;
+            }
             let cat = set.category();
             let desc = set.category_description();
             let tool_count = set.tools().len();
@@ -161,8 +173,12 @@ impl Catalog {
     }
 
     pub fn entries(&self) -> Vec<CatalogEntry> {
+        let sets = self.read_sets();
         let mut entries = Vec::new();
-        for set in self.sets.iter() {
+        for set in sets.iter() {
+            if !self.caller_has_required_scopes(set.as_ref()) {
+                continue;
+            }
             for tool in set.tools() {
                 let desc = &tool.description;
                 let brief = desc
@@ -257,16 +273,39 @@ impl Catalog {
         result
     }
 
-    fn find_set<'a>(&'a self, prefixed_name: &'a str) -> Option<(&'a dyn ToolSet, &'a str)> {
-        for set in self.sets.iter() {
+    /// Find the toolset and stripped tool name for a prefixed tool name.
+    /// Returns an `Arc` clone so the lock is not held across `.await`.
+    fn find_set(&self, prefixed_name: &str) -> Option<(Arc<dyn ToolSet>, String)> {
+        let sets = self.read_sets();
+        for set in sets.iter() {
+            if !self.caller_has_required_scopes(set.as_ref()) {
+                continue;
+            }
             let prefix = format!("{}_", set.prefix());
             if let Some(tool_name) = prefixed_name.strip_prefix(&prefix) {
                 if set.tools().iter().any(|t| t.name == tool_name) {
-                    return Some((set.as_ref(), tool_name));
+                    return Some((Arc::clone(set), tool_name.to_string()));
                 }
             }
         }
         None
+    }
+
+    /// Check whether the current caller has all scopes required by a toolset.
+    fn caller_has_required_scopes(&self, set: &dyn ToolSet) -> bool {
+        let required = set.required_scopes();
+        if required.is_empty() {
+            return true;
+        }
+        match &self.auth {
+            Some(auth) => {
+                let caller_scopes = auth.scopes();
+                required
+                    .iter()
+                    .all(|req| caller_scopes.iter().any(|s| s.as_str() == *req))
+            }
+            None => false,
+        }
     }
 
     pub async fn call(
@@ -279,7 +318,9 @@ impl Catalog {
             .ok_or_else(|| ToolSetsError::ToolNotFound(prefixed_name.to_string()))?;
 
         let start = std::time::Instant::now();
-        let result = set.call(tool_name, arguments.clone()).await;
+        let result = set
+            .call(&tool_name, arguments.clone(), self.auth.as_ref())
+            .await;
         let duration_ms = start.elapsed().as_millis() as u64;
 
         let (outcome, tokens_returned) = match &result {
@@ -429,14 +470,15 @@ mod tests {
             &self,
             _tool_name: &str,
             _arguments: Option<JsonObject>,
+            _auth: Option<&AuthContext>,
         ) -> Result<CallToolResult, ToolSetsError> {
             unimplemented!()
         }
     }
 
-    fn test_catalog(sets: Vec<Box<dyn ToolSet>>) -> Catalog {
+    fn test_catalog(sets: Vec<Arc<dyn ToolSet>>) -> Catalog {
         Catalog {
-            sets: Arc::new(sets),
+            sets: Arc::new(RwLock::new(sets)),
             audit: None,
             auth: None,
         }
@@ -444,7 +486,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_ranks_by_keyword_hits() {
-        let catalog = test_catalog(vec![Box::new(StubToolSet::with_tools(vec![
+        let catalog = test_catalog(vec![Arc::new(StubToolSet::with_tools(vec![
             ("get_pipeline_status", "Get pipeline build status"),
             ("list_pipelines", "List CI pipelines"),
             ("search_code", "Semantic search over indexed codebases"),
@@ -460,7 +502,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_individual_keywords_match_across_name() {
-        let catalog = test_catalog(vec![Box::new(StubToolSet::with_tool(
+        let catalog = test_catalog(vec![Arc::new(StubToolSet::with_tool(
             "get_pipeline_status",
             "Returns the current status of a CI pipeline",
         ))]);
@@ -473,7 +515,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_normalizes_underscores_and_hyphens() {
-        let catalog = test_catalog(vec![Box::new(StubToolSet::with_tool(
+        let catalog = test_catalog(vec![Arc::new(StubToolSet::with_tool(
             "search_code",
             "Semantic search over indexed codebases",
         ))]);
@@ -488,7 +530,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_single_keyword_matches() {
-        let catalog = test_catalog(vec![Box::new(StubToolSet::with_tools(vec![
+        let catalog = test_catalog(vec![Arc::new(StubToolSet::with_tools(vec![
             ("list_pipelines", "List CI pipelines"),
             ("get_build_log", "Get build output"),
         ]))]);
@@ -500,7 +542,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_no_match_returns_empty() {
-        let catalog = test_catalog(vec![Box::new(StubToolSet::with_tool(
+        let catalog = test_catalog(vec![Arc::new(StubToolSet::with_tool(
             "search_code",
             "Semantic search over indexed codebases",
         ))]);
@@ -515,5 +557,132 @@ mod tests {
         assert_eq!(normalize("list-pipelines"), "list pipelines");
         assert_eq!(normalize("Search_Code"), "search code");
         assert_eq!(normalize("no changes"), "no changes");
+    }
+
+    // ── Scope-filtering tests ─────────────────────────────────────────
+
+    struct ScopedStubToolSet {
+        entries: Vec<ToolSetEntry>,
+        scopes: Vec<&'static str>,
+    }
+
+    impl ScopedStubToolSet {
+        fn new(name: &str, description: &str, scopes: Vec<&'static str>) -> Self {
+            let tool = Tool::new(
+                name.to_string(),
+                description.to_string(),
+                JsonObject::default(),
+            );
+            Self {
+                entries: vec![ToolSetEntry {
+                    name: name.to_string(),
+                    description: tool,
+                }],
+                scopes,
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ToolSet for ScopedStubToolSet {
+        fn name(&self) -> &str {
+            "scoped"
+        }
+        fn category(&self) -> &str {
+            "admin"
+        }
+        fn category_description(&self) -> &str {
+            "Admin tools"
+        }
+        fn tools(&self) -> &[ToolSetEntry] {
+            &self.entries
+        }
+        fn required_scopes(&self) -> &[&str] {
+            &self.scopes
+        }
+        async fn call(
+            &self,
+            _tool_name: &str,
+            _arguments: Option<JsonObject>,
+            _auth: Option<&AuthContext>,
+        ) -> Result<CallToolResult, ToolSetsError> {
+            Ok(CallToolResult::success(vec![]))
+        }
+    }
+
+    use crate::primitives::{McpCredsId, UserId};
+
+    fn admin_auth() -> AuthContext {
+        AuthContext::ExportedAgent(UserId::new(), McpCredsId::new(), vec!["admin".to_string()])
+    }
+
+    fn unprivileged_auth() -> AuthContext {
+        AuthContext::ExportedAgent(UserId::new(), McpCredsId::new(), vec![])
+    }
+
+    #[tokio::test]
+    async fn scoped_toolset_visible_with_matching_scope() {
+        let catalog = test_catalog(vec![Arc::new(ScopedStubToolSet::new(
+            "list_workspaces",
+            "List all workspaces",
+            vec!["admin"],
+        ))]);
+        let catalog = catalog.with_auth(&admin_auth());
+
+        let entries = catalog.entries();
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].tool_name, "list_workspaces");
+    }
+
+    #[tokio::test]
+    async fn scoped_toolset_hidden_without_scope() {
+        let catalog = test_catalog(vec![Arc::new(ScopedStubToolSet::new(
+            "list_workspaces",
+            "List all workspaces",
+            vec!["admin"],
+        ))]);
+        let catalog = catalog.with_auth(&unprivileged_auth());
+
+        let entries = catalog.entries();
+        assert!(entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn scoped_toolset_hidden_without_auth() {
+        let catalog = test_catalog(vec![Arc::new(ScopedStubToolSet::new(
+            "list_workspaces",
+            "List all workspaces",
+            vec!["admin"],
+        ))]);
+
+        // No auth at all
+        let entries = catalog.entries();
+        assert!(entries.is_empty());
+    }
+
+    #[tokio::test]
+    async fn search_respects_scopes() {
+        let catalog = test_catalog(vec![
+            Arc::new(StubToolSet::with_tool(
+                "list_pipelines",
+                "List CI pipelines",
+            )),
+            Arc::new(ScopedStubToolSet::new(
+                "list_workspaces",
+                "List all workspaces",
+                vec!["admin"],
+            )),
+        ]);
+
+        // Unprivileged: only sees pipelines
+        let catalog_unpriv = catalog.with_auth(&unprivileged_auth());
+        let results = catalog_unpriv.search(Some("list"), None).await;
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].tool_name, "list_pipelines");
+
+        // Admin: sees both
+        let catalog_admin = catalog.with_auth(&admin_auth());
+        let results = catalog_admin.search(Some("list"), None).await;
+        assert_eq!(results.len(), 2);
     }
 }

--- a/core/src/toolset/code_assistant.rs
+++ b/core/src/toolset/code_assistant.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use crate::code_assistant::{CodeAssistant, SearchCodeParams};
 use rmcp::model::{CallToolResult, Content, JsonObject, Tool};
 
+use crate::auth::AuthContext;
+
 use super::{ToolSet, ToolSetEntry, ToolSetsError};
 
 pub struct CodeAssistantToolSet {
@@ -76,6 +78,7 @@ impl ToolSet for CodeAssistantToolSet {
         &self,
         tool_name: &str,
         arguments: Option<JsonObject>,
+        _auth: Option<&AuthContext>,
     ) -> Result<CallToolResult, ToolSetsError> {
         match tool_name {
             "search_code" => {

--- a/core/src/toolset/concourse.rs
+++ b/core/src/toolset/concourse.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use concourse_client::ConcourseClient;
 use rmcp::model::{CallToolResult, Content, JsonObject, Tool};
 
+use crate::auth::AuthContext;
+
 use super::{ToolSet, ToolSetEntry, ToolSetsError};
 
 pub struct ConcourseToolSet {
@@ -134,6 +136,7 @@ impl ToolSet for ConcourseToolSet {
         &self,
         tool_name: &str,
         arguments: Option<JsonObject>,
+        _auth: Option<&AuthContext>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let args = arguments.unwrap_or_default();
         match tool_name {

--- a/core/src/toolset/error.rs
+++ b/core/src/toolset/error.rs
@@ -20,4 +20,8 @@ pub enum ToolSetsError {
     CodeAssistant(String),
     #[error("ToolSetsError - Report: {0}")]
     Report(String),
+    #[error("ToolSetsError - Admin: {0}")]
+    Admin(String),
+    #[error("ToolSetsError - Unauthorized")]
+    Unauthorized,
 }

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -1,3 +1,4 @@
+pub mod admin;
 mod catalog;
 pub mod code_assistant;
 pub mod concourse;
@@ -7,6 +8,7 @@ pub mod report;
 mod traits;
 mod upstream;
 
+pub use admin::AdminToolSet;
 pub use catalog::{Catalog, CatalogEntry};
 pub use code_assistant::CodeAssistantToolSet;
 pub use concourse::ConcourseToolSet;
@@ -16,14 +18,15 @@ pub use report::ReportToolSet;
 pub use traits::*;
 pub use upstream::*;
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use crate::audit::Audit;
 use crate::code_assistant::CodeAssistant;
 use crate::report::Reports;
 
 pub struct ToolSets {
-    catalog: Catalog,
+    sets: Arc<RwLock<Vec<Arc<dyn ToolSet>>>>,
+    audit: Option<Arc<Audit>>,
 }
 
 impl ToolSets {
@@ -34,7 +37,7 @@ impl ToolSets {
         reports: Option<Arc<Reports>>,
         audit: Option<Arc<Audit>>,
     ) -> Result<Self, ToolSetsError> {
-        let mut sets: Vec<Box<dyn ToolSet>> = Vec::new();
+        let mut sets: Vec<Arc<dyn ToolSet>> = Vec::new();
 
         for upstream in &config.mcp_upstreams {
             if upstream.auth_header.is_empty() {
@@ -49,7 +52,7 @@ impl ToolSets {
                         tools = ts.tools().len(),
                         "MCP upstream toolset initialized"
                     );
-                    sets.push(Box::new(ts));
+                    sets.push(Arc::new(ts));
                 }
                 Err(e) => {
                     tracing::warn!(name = %upstream.name, error = %e, "Failed to initialize MCP upstream, skipping");
@@ -67,30 +70,45 @@ impl ToolSets {
                 config.concourse.username.clone(),
                 config.concourse.password.clone(),
             )?;
-            sets.push(Box::new(ConcourseToolSet::new(client)));
+            sets.push(Arc::new(ConcourseToolSet::new(client)));
             tracing::info!(url = %config.concourse.url, "Concourse toolset initialized");
         }
 
         if let Some(ca) = code_assistant {
-            sets.push(Box::new(CodeAssistantToolSet::new(ca)));
+            sets.push(Arc::new(CodeAssistantToolSet::new(ca)));
             tracing::info!("Code assistant toolset initialized");
         }
 
         if let Some(rpt) = reports {
-            sets.push(Box::new(ReportToolSet::new(rpt)));
+            sets.push(Arc::new(ReportToolSet::new(rpt)));
             tracing::info!("Report toolset initialized");
         }
 
         Ok(Self {
-            catalog: Catalog {
-                sets: Arc::new(sets),
-                audit,
-                auth: None,
-            },
+            sets: Arc::new(RwLock::new(sets)),
+            audit,
         })
     }
 
-    pub fn catalog(&self) -> &Catalog {
-        &self.catalog
+    /// Register a toolset after initialization (e.g. for breaking circular deps).
+    pub fn register(&self, toolset: impl ToolSet + 'static) {
+        let toolset: Arc<dyn ToolSet> = Arc::new(toolset);
+        let mut sets = self.sets.write().expect("toolset lock poisoned");
+        tracing::info!(
+            name = toolset.name(),
+            category = toolset.category(),
+            tools = toolset.tools().len(),
+            "Late-registered toolset"
+        );
+        sets.push(toolset);
+    }
+
+    /// Build a catalog handle that shares the toolset registry.
+    pub fn catalog(&self) -> Catalog {
+        Catalog {
+            sets: Arc::clone(&self.sets),
+            audit: self.audit.clone(),
+            auth: None,
+        }
     }
 }

--- a/core/src/toolset/report.rs
+++ b/core/src/toolset/report.rs
@@ -3,6 +3,8 @@ use std::sync::Arc;
 use crate::report::{Reports, StoreReportParams};
 use rmcp::model::{CallToolResult, Content, JsonObject, Tool};
 
+use crate::auth::AuthContext;
+
 use super::{ToolSet, ToolSetEntry, ToolSetsError};
 
 pub struct ReportToolSet {
@@ -209,6 +211,7 @@ impl ToolSet for ReportToolSet {
         &self,
         tool_name: &str,
         arguments: Option<JsonObject>,
+        _auth: Option<&AuthContext>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let args = arguments.unwrap_or_default();
         match tool_name {

--- a/core/src/toolset/traits.rs
+++ b/core/src/toolset/traits.rs
@@ -1,5 +1,7 @@
 use rmcp::model::{CallToolResult, JsonObject, Tool};
 
+use crate::auth::AuthContext;
+
 use super::ToolSetsError;
 
 pub struct ToolSetEntry {
@@ -17,9 +19,16 @@ pub trait ToolSet: Send + Sync {
     fn category(&self) -> &str;
     fn category_description(&self) -> &str;
     fn tools(&self) -> &[ToolSetEntry];
+
+    /// Scopes required to access this toolset. Empty means unrestricted.
+    fn required_scopes(&self) -> &[&str] {
+        &[]
+    }
+
     async fn call(
         &self,
         tool_name: &str,
         arguments: Option<JsonObject>,
+        auth: Option<&AuthContext>,
     ) -> Result<CallToolResult, ToolSetsError>;
 }

--- a/core/src/toolset/upstream.rs
+++ b/core/src/toolset/upstream.rs
@@ -10,6 +10,8 @@ use rmcp::{
     Peer, RoleClient, ServiceExt,
 };
 
+use crate::auth::AuthContext;
+
 use super::{McpUpstreamConfig, ToolSet, ToolSetEntry, ToolSetsError};
 
 pub struct UpstreamToolSet {
@@ -102,6 +104,7 @@ impl ToolSet for UpstreamToolSet {
         &self,
         tool_name: &str,
         arguments: Option<JsonObject>,
+        _auth: Option<&AuthContext>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let mut params = CallToolRequestParams::new(tool_name.to_string());
         if let Some(args) = arguments {

--- a/mcp-gateway/src/lib.rs
+++ b/mcp-gateway/src/lib.rs
@@ -38,7 +38,7 @@ impl McpGateway {
 
     fn require_auth(parts: &http::request::Parts) -> Result<&AuthContext, ErrorData> {
         match parts.extensions.get::<AuthContext>() {
-            Some(auth @ AuthContext::ExportedAgent(_, _)) => Ok(auth),
+            Some(auth @ AuthContext::ExportedAgent(_, _, _)) => Ok(auth),
             _ => Err(ErrorData::new(
                 ErrorCode::INVALID_REQUEST,
                 "Authentication required: provide a valid Bearer token",
@@ -47,7 +47,7 @@ impl McpGateway {
         }
     }
 
-    fn catalog(&self) -> &galoy_agents_core::toolset::Catalog {
+    fn catalog(&self) -> galoy_agents_core::toolset::Catalog {
         self.app.toolsets().catalog()
     }
 }

--- a/web/src/auth/mod.rs
+++ b/web/src/auth/mod.rs
@@ -67,7 +67,7 @@ async fn resolve_auth_context(
         if let Ok(Some(creds)) = state.app.mcp_creds().find_by_token_hash(&token_hash).await {
             if !creds.is_revoked() {
                 if let Some(user_id) = creds.owner.user_id() {
-                    return AuthContext::ExportedAgent(user_id, creds.id);
+                    return AuthContext::ExportedAgent(user_id, creds.id, creds.scopes.clone());
                 }
                 // Agent-owned creds cannot be used as external bearer tokens
             }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -113,6 +113,8 @@ async fn dashboard(State(state): State<AppState>, session: Session) -> Response 
 #[derive(serde::Deserialize)]
 pub struct CreateMcpCredsForm {
     name: String,
+    #[serde(default)]
+    admin: Option<String>,
 }
 
 fn build_mcp_config(mcp_endpoint: &str, token: &str) -> (String, String) {
@@ -147,10 +149,16 @@ async fn create_mcp_creds(
 
     let (raw_token, token_hash) = generate_token();
 
+    let scopes = if form.admin.as_deref() == Some("true") {
+        vec!["admin".to_string()]
+    } else {
+        vec![]
+    };
+
     match state
         .app
         .mcp_creds()
-        .create_for_user(user_id, &form.name, token_hash, vec![])
+        .create_for_user(user_id, &form.name, token_hash, scopes)
         .await
     {
         Ok(_) => {
@@ -846,8 +854,8 @@ async fn api_agent_message(
 ) -> Response {
     let user_id = match &auth {
         AuthContext::User(id) => *id,
-        AuthContext::ExportedAgent(id, _) => *id,
-        AuthContext::InternalAgent(id, _, _) => *id,
+        AuthContext::ExportedAgent(id, _, _) => *id,
+        AuthContext::InternalAgent(id, _, _, _) => *id,
         AuthContext::Anonymous => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
     };
 

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -14,6 +14,10 @@
       Name
       <input type="text" name="name" required placeholder="my-creds">
     </label>
+    <label>
+      <input type="checkbox" name="admin" value="true">
+      Admin scope (grants access to workspace &amp; agent management tools)
+    </label>
     <button type="submit">Create Credentials</button>
   </form>
   <div id="creds-result"></div>


### PR DESCRIPTION
Adds scope enforcement to MCP gateway: required_scopes() on ToolSet trait with catalog filtering, admin-scoped toolset (7 tools: workspace CRUD + agent messaging), late registration pattern for circular dep avoidance, admin scope checkbox in credential creation UI. Scopes field in McpCreds was already persisted but never checked — now enforced.