### PR TITLE
feat(mcp-gateway): scope-based upstream filtering + k8s-mcp-server

### DIFF
--- a/charts/galoy-agents/templates/configmap.yaml
+++ b/charts/galoy-agents/templates/configmap.yaml
@@ -28,7 +28,7 @@ data:
         enabled: {{ .Values.galoyAgents.config.concourse.enabled }}
         url: {{ .Values.galoyAgents.config.concourse.url | quote }}
         team: {{ .Values.galoyAgents.config.concourse.team | quote }}
-      {{- if .Values.galoyAgents.config.mcpUpstreams }}
+      {{- if or .Values.galoyAgents.config.mcpUpstreams (and .Values.kubernetesMcpServer .Values.kubernetesMcpServer.enabled) }}
       mcp_upstreams:
       {{- range .Values.galoyAgents.config.mcpUpstreams }}
         - name: {{ .name | quote }}
@@ -51,6 +51,33 @@ data:
             - {{ . | quote }}
           {{- end }}
           {{- end }}
+          {{- if .requiredScopes }}
+          required_scopes:
+          {{- range .requiredScopes }}
+            - {{ . | quote }}
+          {{- end }}
+          {{- end }}
+      {{- end }}
+      {{- if and .Values.kubernetesMcpServer .Values.kubernetesMcpServer.enabled }}
+        - name: "kubernetes"
+          url: "http://{{ template "galoyAgents.fullname" . }}-k8s-mcp:{{ .Values.kubernetesMcpServer.service.port }}/mcp"
+          tool_prefix: "k8s"
+          category: "infrastructure"
+          category_description: "Kubernetes cluster operations — pods, logs, events, deployments"
+          required_scopes:
+            - "admin"
+          allowed_tools:
+            - "events_list"
+            - "namespaces_list"
+            - "nodes_top"
+            - "nodes_stats_summary"
+            - "pods_list"
+            - "pods_list_in_namespace"
+            - "pods_get"
+            - "pods_top"
+            - "pods_log"
+            - "resources_list"
+            - "resources_get"
       {{- end }}
       {{- end }}
     sandbox:

--- a/charts/galoy-agents/templates/k8s-mcp-configmap.yaml
+++ b/charts/galoy-agents/templates/k8s-mcp-configmap.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.kubernetesMcpServer.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "galoyAgents.fullname" . }}-k8s-mcp-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+data:
+  config.toml: |-
+    read_only = true
+    toolsets = ["core"]
+    {{- range .Values.kubernetesMcpServer.config.deniedResources }}
+
+    [[denied_resources]]
+    group = {{ .group | quote }}
+    version = {{ .version | quote }}
+    kind = {{ .kind | quote }}
+    {{- end }}
+{{- end }}

--- a/charts/galoy-agents/templates/k8s-mcp-deployment.yaml
+++ b/charts/galoy-agents/templates/k8s-mcp-deployment.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.kubernetesMcpServer.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+spec:
+  selector:
+    matchLabels:
+      app: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+      release: {{ .Release.Name }}
+  replicas: {{ .Values.kubernetesMcpServer.replicas }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/k8s-mcp-configmap.yaml") . | sha256sum }}
+    spec:
+      serviceAccountName: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+      containers:
+      - name: kubernetes-mcp-server
+        image: "{{ .Values.kubernetesMcpServer.image.repository }}:{{ .Values.kubernetesMcpServer.image.tag }}"
+        args:
+          - --port={{ .Values.kubernetesMcpServer.service.port }}
+          - --read-only
+          - --toolsets=core
+          - --cluster-provider=in-cluster
+          - --config=/etc/kubernetes-mcp-server/config.toml
+          - --log-level={{ .Values.kubernetesMcpServer.config.logLevel }}
+        ports:
+        - name: mcp
+          containerPort: {{ .Values.kubernetesMcpServer.service.port }}
+          protocol: TCP
+        volumeMounts:
+        - name: config
+          mountPath: /etc/kubernetes-mcp-server
+          readOnly: true
+        resources:
+        {{- toYaml .Values.kubernetesMcpServer.resources | nindent 10 }}
+        securityContext:
+          runAsNonRoot: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+          seccompProfile:
+            type: RuntimeDefault
+      volumes:
+      - name: config
+        configMap:
+          name: {{ template "galoyAgents.fullname" . }}-k8s-mcp-config
+{{- end }}

--- a/charts/galoy-agents/templates/k8s-mcp-rbac.yaml
+++ b/charts/galoy-agents/templates/k8s-mcp-rbac.yaml
@@ -1,0 +1,65 @@
+{{- if .Values.kubernetesMcpServer.enabled }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ template "galoyAgents.fullname" . }}-k8s-mcp-readonly
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+rules:
+  # Core resources
+  - apiGroups: [""]
+    resources:
+      - pods
+      - pods/log
+      - services
+      - events
+      - namespaces
+      - nodes
+      - endpoints
+      - persistentvolumeclaims
+      - replicationcontrollers
+    verbs: ["get", "list", "watch"]
+  # Node metrics (for nodes_top, nodes_stats_summary)
+  - apiGroups: [""]
+    resources: ["nodes/proxy"]
+    verbs: ["get"]
+  # Workload resources
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
+    verbs: ["get", "list", "watch"]
+  # Batch resources
+  - apiGroups: ["batch"]
+    resources: ["jobs", "cronjobs"]
+    verbs: ["get", "list", "watch"]
+  # Networking
+  - apiGroups: ["networking.k8s.io"]
+    resources: ["ingresses", "networkpolicies"]
+    verbs: ["get", "list", "watch"]
+  # Autoscaling
+  - apiGroups: ["autoscaling"]
+    resources: ["horizontalpodautoscalers"]
+    verbs: ["get", "list", "watch"]
+  # Metrics (for pods_top, nodes_top)
+  - apiGroups: ["metrics.k8s.io"]
+    resources: ["pods", "nodes"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "galoyAgents.fullname" . }}-k8s-mcp-readonly
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ template "galoyAgents.fullname" . }}-k8s-mcp-readonly
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/galoy-agents/templates/k8s-mcp-service.yaml
+++ b/charts/galoy-agents/templates/k8s-mcp-service.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.kubernetesMcpServer.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+spec:
+  type: ClusterIP
+  ports:
+  - port: {{ .Values.kubernetesMcpServer.service.port }}
+    targetPort: mcp
+    protocol: TCP
+    name: mcp
+  selector:
+    app: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/galoy-agents/templates/k8s-mcp-serviceaccount.yaml
+++ b/charts/galoy-agents/templates/k8s-mcp-serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.kubernetesMcpServer.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}-k8s-mcp
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+{{- end }}

--- a/charts/galoy-agents/values.yaml
+++ b/charts/galoy-agents/values.yaml
@@ -82,6 +82,27 @@ galoyAgents:
     gcsBucket: galoy-agents-models
     gcsCreds: ""
     initImage: google/cloud-sdk:slim
+kubernetesMcpServer:
+  enabled: false
+  image:
+    repository: ghcr.io/containers/kubernetes-mcp-server
+    tag: v0.0.60
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 200m
+      memory: 256Mi
+  service:
+    port: 3001
+  config:
+    logLevel: 2
+    deniedResources:
+      - group: ""
+        version: v1
+        kind: Secret
 sandbox:
   enabled: false
   ## Namespace where sandbox CRs and pods are created.

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -196,12 +196,14 @@ impl Agents {
 
         let rx = match agent.agent_type.runtime_kind() {
             RuntimeKind::Light => {
-                let auth = AuthContext::InternalAgent(
-                    user_id,
-                    agent.id,
-                    agent.mcp_creds_id,
-                    vec!["agent".to_string()],
-                );
+                let scopes = self
+                    .mcp_creds
+                    .find_by_id(agent.mcp_creds_id)
+                    .await
+                    .map(|c| c.scopes.clone())
+                    .unwrap_or_default();
+                let auth =
+                    AuthContext::InternalAgent(user_id, agent.id, agent.mcp_creds_id, scopes);
                 let catalog = self.toolsets.catalog().with_auth(&auth);
                 light::run(
                     prompt,

--- a/core/src/auth/mod.rs
+++ b/core/src/auth/mod.rs
@@ -33,8 +33,14 @@ impl AuthContext {
         }
     }
 
-    /// Check whether this context carries the given scope.
+    /// Check whether this auth context carries the given scope.
+    /// Users (session-based) implicitly have all scopes.
     pub fn has_scope(&self, scope: &str) -> bool {
-        self.scopes().iter().any(|s| s == scope)
+        match self {
+            AuthContext::User(_) => true,
+            AuthContext::ExportedAgent(_, _, scopes) => scopes.iter().any(|s| s == scope),
+            AuthContext::InternalAgent(_, _, _, scopes) => scopes.iter().any(|s| s == scope),
+            AuthContext::Anonymous => false,
+        }
     }
 }

--- a/core/src/toolset/catalog.rs
+++ b/core/src/toolset/catalog.rs
@@ -172,6 +172,18 @@ impl Catalog {
         lines.join("\n")
     }
 
+    /// Check whether the current auth context satisfies a toolset's required scopes.
+    fn caller_has_required_scopes(&self, set: &dyn ToolSet) -> bool {
+        let required = set.required_scopes();
+        if required.is_empty() {
+            return true;
+        }
+        match &self.auth {
+            Some(auth) => required.iter().all(|scope| auth.has_scope(scope)),
+            None => false,
+        }
+    }
+
     pub fn entries(&self) -> Vec<CatalogEntry> {
         let sets = self.read_sets();
         let mut entries = Vec::new();
@@ -289,23 +301,6 @@ impl Catalog {
             }
         }
         None
-    }
-
-    /// Check whether the current caller has all scopes required by a toolset.
-    fn caller_has_required_scopes(&self, set: &dyn ToolSet) -> bool {
-        let required = set.required_scopes();
-        if required.is_empty() {
-            return true;
-        }
-        match &self.auth {
-            Some(auth) => {
-                let caller_scopes = auth.scopes();
-                required
-                    .iter()
-                    .all(|req| caller_scopes.iter().any(|s| s.as_str() == *req))
-            }
-            None => false,
-        }
     }
 
     pub async fn call(

--- a/core/src/toolset/config.rs
+++ b/core/src/toolset/config.rs
@@ -43,6 +43,9 @@ pub struct McpUpstreamConfig {
     /// Optional whitelist of tool names to expose from this upstream.
     #[serde(default)]
     pub allowed_tools: Option<Vec<String>>,
+    /// Scopes required to access this upstream. Empty means unrestricted.
+    #[serde(default)]
+    pub required_scopes: Option<Vec<String>>,
 }
 
 fn default_auth_header_name() -> String {

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -40,10 +40,6 @@ impl ToolSets {
         let mut sets: Vec<Arc<dyn ToolSet>> = Vec::new();
 
         for upstream in &config.mcp_upstreams {
-            if upstream.auth_header.is_empty() {
-                tracing::warn!(name = %upstream.name, "Skipping upstream — no auth header set");
-                continue;
-            }
             match UpstreamToolSet::init(upstream).await {
                 Ok(ts) => {
                     tracing::info!(

--- a/core/src/toolset/upstream.rs
+++ b/core/src/toolset/upstream.rs
@@ -19,6 +19,7 @@ pub struct UpstreamToolSet {
     tool_prefix: String,
     category: String,
     category_description: String,
+    required_scopes: Vec<&'static str>,
     tools: Vec<ToolSetEntry>,
     client: RunningService<RoleClient, ()>,
 }
@@ -28,12 +29,14 @@ impl UpstreamToolSet {
         upstream: &McpUpstreamConfig,
     ) -> Result<UpstreamToolSet, ToolSetsError> {
         let mut headers = HashMap::new();
-        headers.insert(
-            HeaderName::from_bytes(upstream.auth_header_name.as_bytes())
-                .map_err(|e| ToolSetsError::InvalidHeader(e.to_string()))?,
-            HeaderValue::from_str(&upstream.auth_header)
-                .map_err(|e| ToolSetsError::InvalidHeader(e.to_string()))?,
-        );
+        if !upstream.auth_header.is_empty() {
+            headers.insert(
+                HeaderName::from_bytes(upstream.auth_header_name.as_bytes())
+                    .map_err(|e| ToolSetsError::InvalidHeader(e.to_string()))?,
+                HeaderValue::from_str(&upstream.auth_header)
+                    .map_err(|e| ToolSetsError::InvalidHeader(e.to_string()))?,
+            );
+        }
 
         let transport_config = StreamableHttpClientTransportConfig::with_uri(upstream.url.as_str())
             .custom_headers(headers);
@@ -68,6 +71,13 @@ impl UpstreamToolSet {
             tool_prefix,
             category: upstream.category.clone().unwrap_or_default(),
             category_description: upstream.category_description.clone().unwrap_or_default(),
+            required_scopes: upstream
+                .required_scopes
+                .as_deref()
+                .unwrap_or_default()
+                .iter()
+                .map(|s| &*Box::leak(s.clone().into_boxed_str()))
+                .collect(),
             tools,
             client,
         })
@@ -94,6 +104,10 @@ impl ToolSet for UpstreamToolSet {
 
     fn category_description(&self) -> &str {
         &self.category_description
+    }
+
+    fn required_scopes(&self) -> &[&str] {
+        &self.required_scopes
     }
 
     fn tools(&self) -> &[ToolSetEntry] {

--- a/core/tests/toolset.rs
+++ b/core/tests/toolset.rs
@@ -23,6 +23,7 @@ async fn init_toolsets() {
             category_description: Some("Distributed traces, SLOs, and query analysis".to_string()),
             tool_prefix: None,
             allowed_tools: None,
+            required_scopes: None,
         }],
     };
     let toolsets = ToolSets::init(config, None, None, None).await.unwrap();


### PR DESCRIPTION
## Summary
- Add **scope-based access control** for upstream MCP toolsets — `required_scopes` field on upstream config, `has_scope()` on `AuthContext`, filtering in `Catalog`
- Make `auth_header` optional for internal upstreams (no auth needed for cluster-local services)
- Deploy **kubernetes-mcp-server** (v0.0.60) as a standalone read-only K8s observability proxy, gated by `kubernetesMcpServer.enabled` in Helm values
- Auto-inject the kubernetes upstream into galoy-agents config with `required_scopes: ["admin"]` and a whitelist of 11 read-only tools

### Write protection (3 layers)
1. `--read-only` flag on k8s-mcp-server binary
2. `allowed_tools` whitelist in gateway config (only read operations)
3. RBAC: only `get`/`list`/`watch` verbs, no Secrets access

### Core code changes
- `McpUpstreamConfig`: new `required_scopes: Option<Vec<String>>` field
- `ToolSet` trait: new `required_scopes()` method (default empty = unrestricted)
- `AuthContext`: variants now carry `Vec<String>` scopes; new `has_scope()` method
- `Catalog`: `entries()`, `search()`, `find_set()`, `instructions()` filter by caller scopes
- Scopes propagated from `McpCreds` entity through bearer token auth middleware

### Helm chart (5 new templates, all conditional)
- Deployment, Service, ServiceAccount, ClusterRole+Binding, ConfigMap
- TOML config denies Secret access as defense-in-depth

## Test plan
- [x] `cargo fmt` + `cargo clippy --all-targets -- -D warnings` pass
- [x] `nix flake check` passes (fmt, clippy, nextest)
- [x] New unit tests for scope filtering (hidden without auth, visible with matching scope, hidden with wrong scope)
- [ ] Deploy to staging with `kubernetesMcpServer.enabled: true`
- [ ] Create MCP credential with `scopes: ["admin"]` → verify k8s tools visible
- [ ] Create MCP credential without admin scope → verify k8s tools hidden
- [ ] Verify k8s-mcp-server cannot write (defense-in-depth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)