### PR TITLE
fix(otel): correct collector namespace in prod values

### DIFF
--- a/ci/deploy/galoy-agents/prod-values.yml.tmpl
+++ b/ci/deploy/galoy-agents/prod-values.yml.tmpl
@@ -68,7 +68,7 @@ galoyAgents:
       memory: 512Mi
   tracing:
     serviceName: galoy-agents
-    otelExporterOtlpEndpoint: "http://opentelemetry-collector.otel.svc.cluster.local:4317"
+    otelExporterOtlpEndpoint: "http://opentelemetry-collector.galoy-agents-otel.svc.cluster.local:4317"
 
 sandbox:
   enabled: true


### PR DESCRIPTION
Fix OTEL_EXPORTER_OTLP_ENDPOINT pointing to wrong namespace (otel → galoy-agents-otel). BatchSpanProcessor was logging DNS errors every ~5s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)