### PR TITLE
test(harness): add integration tests for HTTP server

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -14,6 +14,7 @@ groups:
   - build-code-assistant-index
 - name: sandbox-base
   jobs:
+  - test-harness
   - build-sandbox-base-image
 
 jobs:
@@ -300,11 +301,38 @@ jobs:
       repository: repo-updated
       rebase: true
 
+- name: test-harness
+  serial: true
+  plan:
+  - get: repo-sandbox-image
+    trigger: true
+  - task: harness-integration-test
+    config:
+      platform: linux
+      image_resource: #@ nix_flake_cachix_image_config()
+      inputs:
+      - name: repo-sandbox-image
+        path: repo
+      params:
+        CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
+        CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
+      run:
+        path: sh
+        args:
+          - -exc
+          - |
+            set -euo pipefail
+            cd repo
+            cachix use $CACHIX_CACHE_NAME
+            cachix watch-exec $CACHIX_CACHE_NAME -- \
+              nix build .#checks.x86_64-linux.harness-test
+
 - name: build-sandbox-base-image
   serial: true
   plan:
   - get: repo-sandbox-image
     trigger: true
+    passed: [test-harness]
   - task: build-image
     config:
       platform: linux

--- a/flake.nix
+++ b/flake.nix
@@ -123,6 +123,7 @@
 
           exec bats bats/*.bats
         '';
+        agentHarness = import ./images/sandbox-base/harness.nix { inherit pkgs; };
       in
       {
         checks = {
@@ -137,6 +138,20 @@
             inherit cargoArtifacts;
             cargoNextestExtraArgs = "--no-tests=pass";
           });
+
+          harness-test = pkgs.runCommand "harness-test" {
+            nativeBuildInputs = [ pkgs.nodejs_22 pkgs.curl pkgs.jq ];
+          } ''
+            export ANTHROPIC_API_KEY=mock-test-key
+            export HARNESS_PORT=3123
+            export HARNESS_CLI_PATH="${agentHarness}/test/mock-cli.mjs"
+            export HARNESS_CWD="$(mktemp -d)"
+            export HARNESS_JS="${agentHarness}/lib/index.js"
+
+            bash ${agentHarness}/test/test-harness.sh
+
+            touch $out
+          '';
         };
 
         packages.galoy-agents-unwrapped = galoy-agents;

--- a/images/sandbox-base/agent-harness/src/index.ts
+++ b/images/sandbox-base/agent-harness/src/index.ts
@@ -14,6 +14,8 @@
  * Environment:
  *   ANTHROPIC_API_KEY — required
  *   HARNESS_PORT      — optional (default 3000)
+ *   HARNESS_CLI_PATH  — optional (default: bundled cli.js)
+ *   HARNESS_CWD       — optional (default: /workspace)
  */
 
 import { spawn, type ChildProcess } from "node:child_process";
@@ -25,14 +27,14 @@ import { mkdirSync, writeFileSync, existsSync, readFileSync } from "node:fs";
 
 // ── Constants ─────────────────────────────────────────────────────────
 
-const CWD = "/workspace";
+const CWD = process.env.HARNESS_CWD ?? "/workspace";
 const DEFAULT_MODEL = "claude-sonnet-4-6";
 const DEFAULT_MAX_TURNS = 10;
 const PORT = parseInt(process.env.HARNESS_PORT ?? "3000", 10);
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const CLI_JS_PATH = join(__dirname, "sdk", "cli.js");
+const CLI_JS_PATH = process.env.HARNESS_CLI_PATH ?? join(__dirname, "sdk", "cli.js");
 const SESSION_FILE = join(CWD, ".claude", ".harness-session-id");
 
 // ── Types ──────────────────────────────────────────────────────────────

--- a/images/sandbox-base/agent-harness/test/mock-cli.mjs
+++ b/images/sandbox-base/agent-harness/test/mock-cli.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+/**
+ * Mock cli.js — speaks the Claude Code stream-json NDJSON protocol.
+ *
+ * For each "user" message on stdin it emits:
+ *   1. system init event (first message only)
+ *   2. assistant text event
+ *   3. result event (terminal)
+ *
+ * Stays alive between messages (persistent subprocess, same as real cli.js).
+ * Exits cleanly on stdin close / EOF.
+ */
+
+import { createInterface } from "node:readline";
+
+const rl = createInterface({ input: process.stdin, crlfDelay: Infinity });
+let messageCount = 0;
+const SESSION_ID = "mock-session-001";
+
+rl.on("line", (line) => {
+  let msg;
+  try {
+    msg = JSON.parse(line);
+  } catch {
+    return; // skip non-JSON
+  }
+  if (msg.type !== "user") return;
+
+  messageCount++;
+  const prompt = msg.message?.content?.[0]?.text ?? "";
+
+  // Emit system init on first message
+  if (messageCount === 1) {
+    console.log(
+      JSON.stringify({
+        type: "system",
+        subtype: "init",
+        session_id: SESSION_ID,
+        model: "mock-model",
+        tools: [],
+        mcp_servers: [],
+      }),
+    );
+  }
+
+  // Emit assistant response
+  console.log(
+    JSON.stringify({
+      type: "assistant",
+      session_id: SESSION_ID,
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: `Mock response to: ${prompt}` }],
+      },
+    }),
+  );
+
+  // Emit terminal result
+  console.log(
+    JSON.stringify({
+      type: "result",
+      subtype: "success",
+      session_id: SESSION_ID,
+      is_error: false,
+      duration_ms: 100,
+      total_cost_usd: messageCount * 0.001,
+      result: `Mock response to: ${prompt}`,
+    }),
+  );
+});
+
+rl.on("close", () => process.exit(0));

--- a/images/sandbox-base/agent-harness/test/test-harness.sh
+++ b/images/sandbox-base/agent-harness/test/test-harness.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ── Configuration ─────────────────────────────────────────────────────
+HARNESS_PORT="${HARNESS_PORT:-3123}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+HARNESS_JS="${HARNESS_JS:-$SCRIPT_DIR/../dist/index.js}"
+WORK="$(mktemp -d)"
+
+cleanup() {
+  kill "$HARNESS_PID" 2>/dev/null || true
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+# ── Start harness with mock cli.js ───────────────────────────────────
+export ANTHROPIC_API_KEY=mock-test-key
+export HARNESS_PORT
+export HARNESS_CLI_PATH="${HARNESS_CLI_PATH:-$SCRIPT_DIR/mock-cli.mjs}"
+export HARNESS_CWD="$WORK"
+
+node "$HARNESS_JS" &
+HARNESS_PID=$!
+
+# Wait for server to be ready
+for _ in $(seq 1 50); do
+  if curl -sf "http://localhost:$HARNESS_PORT/health" > /dev/null 2>&1; then
+    break
+  fi
+  sleep 0.1
+done
+
+BASE="http://localhost:$HARNESS_PORT"
+PASS=0
+FAIL=0
+
+assert() {
+  local name="$1"; shift
+  if eval "$@" > /dev/null 2>&1; then
+    PASS=$((PASS + 1))
+    echo "  PASS  $name"
+  else
+    FAIL=$((FAIL + 1))
+    echo "  FAIL  $name"
+  fi
+}
+
+# ── Test 1: GET /health ──────────────────────────────────────────────
+echo "--- GET /health ---"
+HEALTH=$(curl -sf "$BASE/health")
+assert "returns 200"        "test -n '$HEALTH'"
+assert "has status=ok"      "echo '$HEALTH' | jq -e '.status == \"ok\"'"
+assert "has busy=false"     "echo '$HEALTH' | jq -e '.busy == false'"
+# cli_alive is false before the first message (CLI spawns lazily)
+assert "has cli_alive field" "echo '$HEALTH' | jq -e 'has(\"cli_alive\")'"
+
+# ── Test 2: POST /message with valid prompt ──────────────────────────
+echo "--- POST /message (valid) ---"
+SSE=$(curl -sf -X POST "$BASE/message" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"hello world"}')
+
+# Write SSE to a temp file so grep works reliably
+echo "$SSE" > "$WORK/sse1.txt"
+assert "returns SSE data"        "grep -q '^event:' '$WORK/sse1.txt'"
+assert "has system event"        "grep -q '^event: system' '$WORK/sse1.txt'"
+assert "has assistant event"     "grep -q '^event: assistant' '$WORK/sse1.txt'"
+assert "has result event"        "grep -q '^event: result' '$WORK/sse1.txt'"
+assert "result has session_id"   "grep '^event: result' -A1 '$WORK/sse1.txt' | grep -q 'mock-session-001'"
+assert "assistant has mock text" "grep '^event: assistant' -A1 '$WORK/sse1.txt' | grep -q 'Mock response to: hello world'"
+
+# ── Test 2b: GET /health after message (cli should be alive now) ─────
+echo "--- GET /health (post-message) ---"
+HEALTH2=$(curl -sf "$BASE/health")
+assert "cli_alive=true after message" "echo '$HEALTH2' | jq -e '.cli_alive == true'"
+assert "session_id is set"            "echo '$HEALTH2' | jq -e '.session_id != null'"
+
+# ── Test 3: POST /message with missing prompt ────────────────────────
+echo "--- POST /message (missing prompt) ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+  "$BASE/message" \
+  -H "Content-Type: application/json" -d '{}')
+assert "returns 400" "test '$HTTP_CODE' = '400'"
+
+# ── Test 4: POST /message with invalid JSON ──────────────────────────
+echo "--- POST /message (invalid JSON) ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" -X POST \
+  "$BASE/message" \
+  -H "Content-Type: application/json" -d 'not-json')
+assert "returns 400" "test '$HTTP_CODE' = '400'"
+
+# ── Test 5: Unknown route ────────────────────────────────────────────
+echo "--- GET /nonexistent ---"
+HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" "$BASE/nonexistent")
+assert "returns 404" "test '$HTTP_CODE' = '404'"
+
+# ── Test 6: Second message reuses session (cost delta) ───────────────
+echo "--- POST /message (second message — cost delta) ---"
+SSE2=$(curl -sf -X POST "$BASE/message" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"second message"}')
+echo "$SSE2" > "$WORK/sse2.txt"
+assert "second message returns result" "grep -q '^event: result' '$WORK/sse2.txt'"
+# Cost delta: total_cost_usd for msg2 is 0.002 cumulative, msg1 was 0.001, so delta = 0.001
+assert "result has cost delta"         "grep '^event: result' -A1 '$WORK/sse2.txt' | grep -q '0.001'"
+
+# ── Summary ──────────────────────────────────────────────────────────
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+test "$FAIL" -eq 0

--- a/images/sandbox-base/default.nix
+++ b/images/sandbox-base/default.nix
@@ -32,42 +32,7 @@ let
   # Bypasses the Claude Agent SDK: the harness spawns cli.js directly as a
   # persistent subprocess (stdin/stdout stream-json) instead of using the
   # SDK's query() which spawns a new process per message (~25s in gVisor).
-  agentHarness = pkgs.buildNpmPackage {
-    pname = "agent-harness";
-    version = "0.1.0";
-    src = ./agent-harness;
-    npmDepsHash = "sha256-y1jTok6cf0uWMK6S64H7QMswLTpmLOh8Xo2Bl8EzHVU=";
-
-    nativeBuildInputs = [ pkgs.esbuild ];
-
-    # Skip the default `npm run build`; we bundle with esbuild instead.
-    dontNpmBuild = true;
-
-    buildPhase = ''
-      runHook preBuild
-      esbuild src/index.ts \
-        --bundle \
-        --platform=node \
-        --target=node22 \
-        --format=esm \
-        --outfile=dist/index.js
-      runHook postBuild
-    '';
-
-    installPhase = ''
-      runHook preInstall
-      mkdir -p $out/lib
-      cp dist/index.js $out/lib/index.js
-
-      # cli.js is the Claude Code CLI binary — spawned as a persistent
-      # subprocess by the harness.  It cannot be bundled by esbuild.
-      mkdir -p $out/lib/sdk
-      cp node_modules/@anthropic-ai/claude-agent-sdk/cli.js $out/lib/sdk/
-      cp node_modules/@anthropic-ai/claude-agent-sdk/*.wasm  $out/lib/sdk/ 2>/dev/null || true
-      cp -r node_modules/@anthropic-ai/claude-agent-sdk/vendor $out/lib/sdk/ 2>/dev/null || true
-      runHook postInstall
-    '';
-  };
+  agentHarness = import ./harness.nix { inherit pkgs; };
 
   # Thin wrapper — just exec node with the pre-built bundle.
   agentHarnessWrapper = pkgs.writeShellScriptBin "agent-harness" ''

--- a/images/sandbox-base/harness.nix
+++ b/images/sandbox-base/harness.nix
@@ -1,0 +1,42 @@
+{ pkgs }:
+pkgs.buildNpmPackage {
+  pname = "agent-harness";
+  version = "0.1.0";
+  src = ./agent-harness;
+  npmDepsHash = "sha256-y1jTok6cf0uWMK6S64H7QMswLTpmLOh8Xo2Bl8EzHVU=";
+
+  nativeBuildInputs = [ pkgs.esbuild ];
+
+  # Skip the default `npm run build`; we bundle with esbuild instead.
+  dontNpmBuild = true;
+
+  buildPhase = ''
+    runHook preBuild
+    esbuild src/index.ts \
+      --bundle \
+      --platform=node \
+      --target=node22 \
+      --format=esm \
+      --outfile=dist/index.js
+    runHook postBuild
+  '';
+
+  installPhase = ''
+    runHook preInstall
+    mkdir -p $out/lib
+    cp dist/index.js $out/lib/index.js
+
+    # cli.js is the Claude Code CLI binary — spawned as a persistent
+    # subprocess by the harness.  It cannot be bundled by esbuild.
+    mkdir -p $out/lib/sdk
+    cp node_modules/@anthropic-ai/claude-agent-sdk/cli.js $out/lib/sdk/
+    cp node_modules/@anthropic-ai/claude-agent-sdk/*.wasm  $out/lib/sdk/ 2>/dev/null || true
+    cp -r node_modules/@anthropic-ai/claude-agent-sdk/vendor $out/lib/sdk/ 2>/dev/null || true
+
+    # Install test fixtures for integration tests
+    mkdir -p $out/test
+    cp test/mock-cli.mjs $out/test/
+    cp test/test-harness.sh $out/test/
+    runHook postInstall
+  '';
+}


### PR DESCRIPTION
## Summary
- Add end-to-end integration tests for the sandbox harness HTTP server using a mock cli.js subprocess
- Make CLI path and working directory configurable via env vars (`HARNESS_CLI_PATH`, `HARNESS_CWD`) for testability
- Extract `agentHarness` Nix derivation into `harness.nix` (shared by `default.nix` and `flake.nix`)
- Wire as `checks.harness-test` in `nix flake check` — runs automatically in CI
- Add separate `test-harness` Concourse job gating `build-sandbox-base-image`

## Test coverage (17 assertions)
- `GET /health` — returns 200, correct JSON schema, `cli_alive` transitions
- `POST /message` — SSE stream with system/assistant/result events, session persistence, cost deltas
- Error paths: missing prompt → 400, invalid JSON → 400, unknown route → 404

## Test plan
- [x] `nix flake check` passes locally (all 4 checks: fmt, clippy, nextest, harness-test)
- [ ] CI `check-code` job passes (runs `nix flake check`)
- [ ] Verify Concourse `test-harness` job runs before `build-sandbox-base-image`

🤖 Generated with [Claude Code](https://claude.com/claude-code)