### PR TITLE
fix(harness): clean up workspace dir before bats temp-dir removal

### DIFF
--- a/bats/harness-helpers.bash
+++ b/bats/harness-helpers.bash
@@ -45,6 +45,11 @@ stop_harness() {
     kill "$(cat "$HARNESS_PID_FILE")" 2>/dev/null || true
     rm -f "$HARNESS_PID_FILE"
   fi
+
+  # Clean up workspace before bats removes BATS_FILE_TMPDIR.
+  # Claude Code writes files here during tests; leftover contents cause
+  # bats' own temp-dir cleanup to fail with "Directory not empty".
+  rm -rf "$HARNESS_WORK"
 }
 
 harness_url() {


### PR DESCRIPTION
## Summary
- Adds explicit `rm -rf "$HARNESS_WORK"` in `stop_harness()` to remove the workspace directory before bats attempts its own temp-dir cleanup
- Fixes CI build 19 of `test-harness` job failing with `rm: cannot remove '/tmp/bats-run-…/workspace': Directory not empty` despite all 7 bats tests passing
- Claude Code writes files into `HARNESS_CWD` during tests, and bats' built-in cleanup can't remove the non-empty directory

## Test plan
- [ ] Verify `test-harness` CI job passes (all 7 tests pass AND exit code is 0)
- [ ] Confirm no "Directory not empty" errors in CI logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)