### PR TITLE
feat(agent): add chat config panel to agent UI

### DIFF
--- a/core/src/agent/entity.rs
+++ b/core/src/agent/entity.rs
@@ -6,7 +6,7 @@ use es_entity::*;
 use crate::primitives::*;
 
 /// Configuration for an agent's sandbox environment (infrastructure).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct SandboxConfig {
     /// PVC size (e.g., "10Gi").
     #[serde(default = "SandboxConfig::default_pvc_size")]
@@ -49,7 +49,7 @@ impl SandboxConfig {
 }
 
 /// Configuration for agent chat behavior (LLM interaction).
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct ChatConfig {
     /// LLM model (e.g., "claude-sonnet-4-6").
     #[serde(default = "ChatConfig::default_model")]
@@ -102,6 +102,12 @@ pub enum AgentEvent {
         sandbox_config: SandboxConfig,
         chat_config: ChatConfig,
     },
+    ChatConfigUpdated {
+        chat_config: ChatConfig,
+    },
+    SandboxConfigUpdated {
+        sandbox_config: SandboxConfig,
+    },
     SandboxProvisioned {},
     SandboxReady {},
     SandboxLost {},
@@ -142,6 +148,36 @@ impl Agent {
     /// Deterministic sandbox name derived from the agent ID.
     pub fn sandbox_name(&self) -> String {
         format!("agent-{}", &self.id.to_string()[..8])
+    }
+
+    pub(super) fn update_chat_config(&mut self, new_config: ChatConfig) -> Idempotent<()> {
+        idempotency_guard!(
+            self.events.iter_all().rev(),
+            already_applied: AgentEvent::ChatConfigUpdated { chat_config }
+                if *chat_config == new_config,
+            resets_on: AgentEvent::ChatConfigUpdated { .. }
+        );
+
+        self.chat_config = new_config.clone();
+        self.events.push(AgentEvent::ChatConfigUpdated {
+            chat_config: new_config,
+        });
+        Idempotent::Executed(())
+    }
+
+    pub(super) fn update_sandbox_config(&mut self, new_config: SandboxConfig) -> Idempotent<()> {
+        idempotency_guard!(
+            self.events.iter_all().rev(),
+            already_applied: AgentEvent::SandboxConfigUpdated { sandbox_config }
+                if *sandbox_config == new_config,
+            resets_on: AgentEvent::SandboxConfigUpdated { .. }
+        );
+
+        self.sandbox_config = new_config.clone();
+        self.events.push(AgentEvent::SandboxConfigUpdated {
+            sandbox_config: new_config,
+        });
+        Idempotent::Executed(())
     }
 
     pub(super) fn sandbox_provisioned(&mut self) -> Idempotent<()> {
@@ -213,6 +249,12 @@ impl TryFromEvents<AgentEvent> for Agent {
                         .sandbox_config(sandbox_config.clone())
                         .chat_config(chat_config.clone())
                         .sandbox_state(SandboxState::None);
+                }
+                AgentEvent::ChatConfigUpdated { chat_config } => {
+                    builder = builder.chat_config(chat_config.clone());
+                }
+                AgentEvent::SandboxConfigUpdated { sandbox_config } => {
+                    builder = builder.sandbox_config(sandbox_config.clone());
                 }
                 AgentEvent::SandboxProvisioned {} => {
                     builder = builder.sandbox_state(SandboxState::Provisioning);
@@ -310,5 +352,40 @@ mod tests {
         assert!(agent.sandbox_name().starts_with("agent-"));
         assert_eq!(agent.chat_config.model, "claude-sonnet-4-6");
         assert_eq!(agent.chat_config.max_turns, 10);
+    }
+
+    #[test]
+    fn agent_update_chat_config() {
+        let mut agent = new_agent();
+        let new_config = ChatConfig {
+            model: "claude-opus-4-6".to_string(),
+            max_tokens: 8192,
+            max_turns: 50,
+        };
+        assert!(agent.update_chat_config(new_config.clone()).did_execute());
+        assert_eq!(agent.chat_config.model, "claude-opus-4-6");
+        assert_eq!(agent.chat_config.max_tokens, 8192);
+        assert_eq!(agent.chat_config.max_turns, 50);
+
+        // Idempotent: same config again should be a no-op
+        assert!(!agent.update_chat_config(new_config).did_execute());
+    }
+
+    #[test]
+    fn agent_update_sandbox_config() {
+        let mut agent = new_agent();
+        let new_config = SandboxConfig {
+            resource_cpu: "2".to_string(),
+            resource_mem: "2Gi".to_string(),
+            ..Default::default()
+        };
+        assert!(agent
+            .update_sandbox_config(new_config.clone())
+            .did_execute());
+        assert_eq!(agent.sandbox_config.resource_cpu, "2");
+        assert_eq!(agent.sandbox_config.resource_mem, "2Gi");
+
+        // Idempotent: same config again should be a no-op
+        assert!(!agent.update_sandbox_config(new_config).did_execute());
     }
 }

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -178,6 +178,8 @@ impl Agents {
     /// Update the chat and sandbox configuration for an agent.
     ///
     /// Takes effect on the next message — does not affect in-flight conversations.
+    /// When sandbox resource config changes, the running sandbox is destroyed so
+    /// the next message triggers re-provisioning with the new resources.
     #[instrument(name = "domain.agent.update_config", skip(self))]
     pub async fn update_config(
         &self,
@@ -190,6 +192,11 @@ impl Agents {
         let sandbox_changed = agent.update_sandbox_config(sandbox_config).did_execute();
         if chat_changed || sandbox_changed {
             self.repo.update(&mut agent).await?;
+        }
+        // Destroy running sandbox so the next message re-provisions with new config
+        if sandbox_changed {
+            self.sandbox_cache.lock().await.remove(&id);
+            self.destroy_sandbox(id).await?;
         }
         Ok(agent)
     }

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -175,6 +175,25 @@ impl Agents {
         Ok(result.entities)
     }
 
+    /// Update the chat and sandbox configuration for an agent.
+    ///
+    /// Takes effect on the next message — does not affect in-flight conversations.
+    #[instrument(name = "domain.agent.update_config", skip(self))]
+    pub async fn update_config(
+        &self,
+        id: AgentId,
+        chat_config: ChatConfig,
+        sandbox_config: SandboxConfig,
+    ) -> Result<Agent, AgentError> {
+        let mut agent = self.repo.find_by_id(id).await?;
+        let chat_changed = agent.update_chat_config(chat_config).did_execute();
+        let sandbox_changed = agent.update_sandbox_config(sandbox_config).did_execute();
+        if chat_changed || sandbox_changed {
+            self.repo.update(&mut agent).await?;
+        }
+        Ok(agent)
+    }
+
     /// Send a message to an agent, dispatching to the appropriate runtime
     /// based on the agent's type.
     ///

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -57,6 +57,8 @@ pub fn router() -> Router<AppState> {
         .route("/workspaces/{id}", get(workspace_detail))
         .route("/workspaces/{id}", post(workspace_update))
         .route("/workspaces/{id}/delete", post(workspace_delete))
+        .route("/agents/{id}/config", get(agent_config_panel))
+        .route("/agents/{id}/config", post(agent_config_update))
 }
 
 async fn extract_user_id(session: &Session) -> Option<UserId> {
@@ -668,6 +670,16 @@ async fn reports_detail(
 // Workspaces
 // ---------------------------------------------------------------------------
 
+fn agent_to_config_view(agent: &domain::agent::Agent) -> AgentConfigView {
+    AgentConfigView {
+        model: agent.chat_config.model.clone(),
+        max_tokens: agent.chat_config.max_tokens,
+        max_turns: agent.chat_config.max_turns,
+        resource_cpu: agent.sandbox_config.resource_cpu.clone(),
+        resource_mem: agent.sandbox_config.resource_mem.clone(),
+    }
+}
+
 fn workspace_to_view(ws: &domain::workspace::Workspace) -> WorkspaceView {
     WorkspaceView {
         id: ws.id.to_string(),
@@ -865,6 +877,93 @@ async fn workspace_chat(
         agent_id,
     }
     .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Agent Config
+// ---------------------------------------------------------------------------
+
+#[instrument(name = "web.agent_config_panel", skip_all)]
+async fn agent_config_panel(
+    State(state): State<AppState>,
+    session: Session,
+    Path(id): Path<uuid::Uuid>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    let agent_id = AgentId::from(id);
+    let agent = match state.app.agents().find_by_id(agent_id).await {
+        Ok(a) => a,
+        Err(_) => return axum::http::StatusCode::NOT_FOUND.into_response(),
+    };
+
+    AgentConfigPanelTemplate {
+        agent_id: agent.id.to_string(),
+        config: agent_to_config_view(&agent),
+        saved: false,
+    }
+    .into_response()
+}
+
+#[derive(Deserialize)]
+struct AgentConfigForm {
+    model: String,
+    max_tokens: u32,
+    max_turns: u32,
+    resource_cpu: String,
+    resource_mem: String,
+}
+
+#[instrument(name = "web.agent_config_update", skip_all)]
+async fn agent_config_update(
+    State(state): State<AppState>,
+    session: Session,
+    Path(id): Path<uuid::Uuid>,
+    Form(form): Form<AgentConfigForm>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    let agent_id = AgentId::from(id);
+
+    // Fetch current agent to preserve non-editable sandbox fields
+    let current = match state.app.agents().find_by_id(agent_id).await {
+        Ok(a) => a,
+        Err(_) => return axum::http::StatusCode::NOT_FOUND.into_response(),
+    };
+
+    let chat_config = domain::agent::ChatConfig {
+        model: form.model,
+        max_tokens: form.max_tokens,
+        max_turns: form.max_turns,
+    };
+    let sandbox_config = domain::agent::SandboxConfig {
+        resource_cpu: form.resource_cpu,
+        resource_mem: form.resource_mem,
+        pvc_size: current.sandbox_config.pvc_size.clone(),
+        disallowed_tools: current.sandbox_config.disallowed_tools.clone(),
+    };
+
+    match state
+        .app
+        .agents()
+        .update_config(agent_id, chat_config, sandbox_config)
+        .await
+    {
+        Ok(agent) => AgentConfigPanelTemplate {
+            agent_id: agent.id.to_string(),
+            config: agent_to_config_view(&agent),
+            saved: true,
+        }
+        .into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to update agent config");
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -186,3 +186,19 @@ pub struct WorkspaceChatTemplate {
     pub workspace: WorkspaceView,
     pub agent_id: String,
 }
+
+pub struct AgentConfigView {
+    pub model: String,
+    pub max_tokens: u32,
+    pub max_turns: u32,
+    pub resource_cpu: String,
+    pub resource_mem: String,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "agent_config_panel.html")]
+pub struct AgentConfigPanelTemplate {
+    pub agent_id: String,
+    pub config: AgentConfigView,
+    pub saved: bool,
+}

--- a/web/templates/agent_config_panel.html
+++ b/web/templates/agent_config_panel.html
@@ -1,0 +1,53 @@
+<div id="config-panel">
+  {% if saved %}
+  <div role="alert" style="padding: 0.5rem 1rem; margin-bottom: 1rem; background: var(--pico-ins-color); color: white; border-radius: var(--pico-border-radius); font-size: 0.85rem;">
+    Config saved — takes effect on next message.
+  </div>
+  {% endif %}
+  <form
+    hx-post="/agents/{{ agent_id }}/config"
+    hx-target="#config-panel"
+    hx-swap="outerHTML"
+  >
+    <label>
+      Model
+      <select name="model">
+        <option value="claude-haiku-4-5-20251001" {% if config.model == "claude-haiku-4-5-20251001" %}selected{% endif %}>Claude Haiku 4.5</option>
+        <option value="claude-sonnet-4-6-20250514" {% if config.model == "claude-sonnet-4-6-20250514" %}selected{% endif %}>Claude Sonnet 4.6</option>
+        <option value="claude-opus-4-6-20250514" {% if config.model == "claude-opus-4-6-20250514" %}selected{% endif %}>Claude Opus 4.6</option>
+      </select>
+    </label>
+
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem;">
+      <label>
+        Max tokens
+        <input type="number" name="max_tokens" min="256" max="65536" value="{{ config.max_tokens }}">
+      </label>
+      <label>
+        Max turns
+        <input type="number" name="max_turns" min="1" max="200" value="{{ config.max_turns }}">
+      </label>
+    </div>
+
+    <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem;">
+      <label>
+        CPU
+        <select name="resource_cpu">
+          <option value="500m" {% if config.resource_cpu == "500m" %}selected{% endif %}>0.5 CPU</option>
+          <option value="1" {% if config.resource_cpu == "1" %}selected{% endif %}>1 CPU</option>
+          <option value="2" {% if config.resource_cpu == "2" %}selected{% endif %}>2 CPU</option>
+        </select>
+      </label>
+      <label>
+        RAM
+        <select name="resource_mem">
+          <option value="512Mi" {% if config.resource_mem == "512Mi" %}selected{% endif %}>512 Mi</option>
+          <option value="1Gi" {% if config.resource_mem == "1Gi" %}selected{% endif %}>1 Gi</option>
+          <option value="2Gi" {% if config.resource_mem == "2Gi" %}selected{% endif %}>2 Gi</option>
+        </select>
+      </label>
+    </div>
+
+    <button type="submit" style="width: 100%;">Save</button>
+  </form>
+</div>

--- a/web/templates/workspace_chat.html
+++ b/web/templates/workspace_chat.html
@@ -6,9 +6,30 @@
 
 {% block head %}
 <style>
-  .chat-container { display: flex; flex-direction: column; height: calc(100vh - 6rem); }
-  .chat-header { margin-bottom: 1rem; }
+  .chat-layout { display: flex; height: calc(100vh - 6rem); gap: 1rem; }
+  .chat-main { display: flex; flex-direction: column; flex: 1; min-width: 0; }
+  .chat-header { margin-bottom: 1rem; display: flex; align-items: center; justify-content: space-between; }
   .chat-header a { font-size: 0.85rem; }
+  .chat-header-left { display: flex; flex-direction: column; }
+  .config-toggle {
+    background: none; border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius); padding: 0.4rem 0.6rem;
+    cursor: pointer; font-size: 1.1rem; width: auto; margin: 0; line-height: 1;
+  }
+  .config-toggle:hover { background: var(--pico-primary-background); color: var(--pico-primary-inverse); }
+  .config-toggle.active { background: var(--pico-primary-background); color: var(--pico-primary-inverse); }
+  .config-sidebar {
+    width: 280px; flex-shrink: 0;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    padding: 1rem; overflow-y: auto;
+    display: none;
+  }
+  .config-sidebar.open { display: block; }
+  .config-sidebar h4 { margin-top: 0; margin-bottom: 0.75rem; font-size: 0.95rem; }
+  .config-sidebar label { font-size: 0.85rem; margin-bottom: 0.25rem; }
+  .config-sidebar input, .config-sidebar select { font-size: 0.85rem; padding: 0.35rem 0.5rem; }
+  .config-sidebar button { font-size: 0.85rem; padding: 0.4rem 0.75rem; }
   .messages {
     flex: 1;
     overflow-y: auto;
@@ -32,23 +53,45 @@
 {% endblock %}
 
 {% block content %}
-<div class="chat-container">
-  <div class="chat-header">
-    <a href="/workspaces/{{ workspace.id }}">&larr; {{ workspace.name }}</a>
-    <h2>Workspace Lead</h2>
+<div class="chat-layout">
+  <div class="chat-main">
+    <div class="chat-header">
+      <div class="chat-header-left">
+        <a href="/workspaces/{{ workspace.id }}">&larr; {{ workspace.name }}</a>
+        <h2>Workspace Lead</h2>
+      </div>
+      <button class="config-toggle" id="config-toggle-btn" onclick="toggleConfig()" title="Agent config">&#9881;</button>
+    </div>
+
+    <div class="messages" id="messages"></div>
+
+    <div class="chat-input">
+      <textarea id="prompt" rows="3" placeholder="Type a message..."></textarea>
+      <button id="send-btn" onclick="sendMessage()">Send</button>
+    </div>
   </div>
 
-  <div class="messages" id="messages"></div>
-
-  <div class="chat-input">
-    <textarea id="prompt" rows="3" placeholder="Type a message..."></textarea>
-    <button id="send-btn" onclick="sendMessage()">Send</button>
-  </div>
+  <aside class="config-sidebar" id="config-sidebar">
+    <h4>Agent Config</h4>
+    <div id="config-panel-container"
+         hx-get="/agents/{{ agent_id }}/config"
+         hx-trigger="load"
+         hx-swap="innerHTML">
+      <p aria-busy="true">Loading config...</p>
+    </div>
+  </aside>
 </div>
 
 <script>
 const agentId = '{{ agent_id }}';
 let sessionId = null;
+
+function toggleConfig() {
+  const sidebar = document.getElementById('config-sidebar');
+  const btn = document.getElementById('config-toggle-btn');
+  sidebar.classList.toggle('open');
+  btn.classList.toggle('active');
+}
 
 function appendMsg(cls, text) {
   const el = document.createElement('div');


### PR DESCRIPTION
## Summary
- Add a config sidebar to the workspace chat page with a gear icon toggle
- Users can edit agent runtime parameters: model (dropdown), max tokens, max turns, CPU, and RAM
- Config is persisted via idempotent event-sourced commands (`ChatConfigUpdated`, `SandboxConfigUpdated`) and takes effect on the next message
- Backend: `update_config()` service method, GET/POST `/agents/{id}/config` HTMX routes
- UI: config panel loaded via HTMX on toggle, with save confirmation banner

## Test plan
- [x] Unit tests for `update_chat_config` and `update_sandbox_config` (including idempotency)
- [x] Clippy clean, `cargo fmt` clean
- [ ] Manual: open workspace chat, click gear icon, verify config panel opens
- [ ] Manual: change model/tokens/turns, click Save, verify confirmation banner
- [ ] Manual: send a message after config change, verify new settings take effect

🤖 Generated with [Claude Code](https://claude.com/claude-code)