### PR TITLE
feat(secrets): add workspace-scoped secret provisioning

### DIFF
--- a/.sqlx/query-06bde76267c65737738246337eb39c38bb92359f17e24e228f152951462d0fc3.json
+++ b/.sqlx/query-06bde76267c65737738246337eb39c38bb92359f17e24e228f152951462d0fc3.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE workspace_secrets SET workspace_id = $2, name = $3 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "06bde76267c65737738246337eb39c38bb92359f17e24e228f152951462d0fc3"
+}

--- a/.sqlx/query-1b0508f48c94ad00e450843a4d3606575c35a7830948126e7a1f1e2119ee6db0.json
+++ b/.sqlx/query-1b0508f48c94ad00e450843a4d3606575c35a7830948126e7a1f1e2119ee6db0.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO workspace_secret_events (id, recorded_at, sequence, event_type, event) SELECT $1, COALESCE($2, NOW()), ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM UNNEST($4::TEXT[], $5::JSONB[]) AS unnested(event_type, event) RETURNING recorded_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int8",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "1b0508f48c94ad00e450843a4d3606575c35a7830948126e7a1f1e2119ee6db0"
+}

--- a/.sqlx/query-1e3f090d12db389e494bb7f4aef0773c93705d8a25dba927766e283d55cf76ce.json
+++ b/.sqlx/query-1e3f090d12db389e494bb7f4aef0773c93705d8a25dba927766e283d55cf76ce.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM workspace_secrets WHERE COALESCE(workspace_id = $1, $1 IS NULL) AND (COALESCE(id < $3, true)) AND deleted = FALSE ORDER BY id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "1e3f090d12db389e494bb7f4aef0773c93705d8a25dba927766e283d55cf76ce"
+}

--- a/.sqlx/query-2ab4fe12c4dd2c8e4d567b9467e80a149d1c8e2f25cc7f62e523efc034507ea1.json
+++ b/.sqlx/query-2ab4fe12c4dd2c8e4d567b9467e80a149d1c8e2f25cc7f62e523efc034507ea1.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT workspace_id, created_at, id FROM workspace_secrets WHERE ((workspace_id = $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "2ab4fe12c4dd2c8e4d567b9467e80a149d1c8e2f25cc7f62e523efc034507ea1"
+}

--- a/.sqlx/query-33f810d17a3a031b8418b2ba17d853a33fbe3928831a94114328edde0115074f.json
+++ b/.sqlx/query-33f810d17a3a031b8418b2ba17d853a33fbe3928831a94114328edde0115074f.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM workspace_secrets WHERE workspace_id = $1 AND deleted = FALSE) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "33f810d17a3a031b8418b2ba17d853a33fbe3928831a94114328edde0115074f"
+}

--- a/.sqlx/query-6222a3c785f1f6dc68f6af09bbb87934c0e744cc28caf9c773b413c87b7c1e76.json
+++ b/.sqlx/query-6222a3c785f1f6dc68f6af09bbb87934c0e744cc28caf9c773b413c87b7c1e76.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM workspace_secrets WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "6222a3c785f1f6dc68f6af09bbb87934c0e744cc28caf9c773b413c87b7c1e76"
+}

--- a/.sqlx/query-72456d7e9070d2694f494753169b77039cec56050ee5475713f5e7c096df63a0.json
+++ b/.sqlx/query-72456d7e9070d2694f494753169b77039cec56050ee5475713f5e7c096df63a0.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM workspace_secrets WHERE name = $1 AND deleted = FALSE) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "72456d7e9070d2694f494753169b77039cec56050ee5475713f5e7c096df63a0"
+}

--- a/.sqlx/query-89501e89dea50bda9107ffd1a43534def3647c00a671fd777ec86091260ddd6a.json
+++ b/.sqlx/query-89501e89dea50bda9107ffd1a43534def3647c00a671fd777ec86091260ddd6a.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM workspace_secrets WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "89501e89dea50bda9107ffd1a43534def3647c00a671fd777ec86091260ddd6a"
+}

--- a/.sqlx/query-a12909c00fd04ccee47c10e3ef1c91f8f95f1a43a4f0ed4f7db7674b2c2001a7.json
+++ b/.sqlx/query-a12909c00fd04ccee47c10e3ef1c91f8f95f1a43a4f0ed4f7db7674b2c2001a7.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE workspace_secrets SET workspace_id = $2, name = $3, deleted = TRUE WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "a12909c00fd04ccee47c10e3ef1c91f8f95f1a43a4f0ed4f7db7674b2c2001a7"
+}

--- a/.sqlx/query-a429b901be62ad18daa2c45060fc2c5885c0a436b2a356043182817b8d619594.json
+++ b/.sqlx/query-a429b901be62ad18daa2c45060fc2c5885c0a436b2a356043182817b8d619594.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id, created_at FROM workspaces WHERE NOT deleted ORDER BY created_at DESC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_events e ON i.id = e.id ORDER BY i.created_at desc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT id FROM workspace_secrets WHERE COALESCE(workspace_id = $1, $1 IS NULL) AND (COALESCE(id > $3, true)) AND deleted = FALSE ORDER BY id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,7 +31,9 @@
     ],
     "parameters": {
       "Left": [
+        "Uuid",
         "Int8",
+        "Uuid",
         "Bool"
       ]
     },
@@ -43,5 +45,5 @@
       false
     ]
   },
-  "hash": "dc0f55be28218cd0f969dea0f1685802ea48f33e210f74ebc384dd1ecc9848e6"
+  "hash": "a429b901be62ad18daa2c45060fc2c5885c0a436b2a356043182817b8d619594"
 }

--- a/.sqlx/query-aa277a19e4f22bf065f12963351feed75ce65459e8c2713350ff1b419c547461.json
+++ b/.sqlx/query-aa277a19e4f22bf065f12963351feed75ce65459e8c2713350ff1b419c547461.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM workspace_secrets WHERE (COALESCE(id < $2, true)) AND deleted = FALSE ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "aa277a19e4f22bf065f12963351feed75ce65459e8c2713350ff1b419c547461"
+}

--- a/.sqlx/query-b21c205a17e16fba4c068ee48abb35a9d1397615c05672646402d8e87e27131c.json
+++ b/.sqlx/query-b21c205a17e16fba4c068ee48abb35a9d1397615c05672646402d8e87e27131c.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO workspace_secrets (id, workspace_id, name, created_at) VALUES ($1, $2, $3, COALESCE($4, NOW()))",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "b21c205a17e16fba4c068ee48abb35a9d1397615c05672646402d8e87e27131c"
+}

--- a/.sqlx/query-b34aaffd20d5343b37f146ba96a17b3d3b08d92d33963d0ba92f0bd16200ca7c.json
+++ b/.sqlx/query-b34aaffd20d5343b37f146ba96a17b3d3b08d92d33963d0ba92f0bd16200ca7c.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM workspace_secrets WHERE id = $1 AND deleted = FALSE) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "b34aaffd20d5343b37f146ba96a17b3d3b08d92d33963d0ba92f0bd16200ca7c"
+}

--- a/.sqlx/query-cddfa782fa9cda27135eea5fab791313e32e0baecc8d9fc5ee3f4438140203cf.json
+++ b/.sqlx/query-cddfa782fa9cda27135eea5fab791313e32e0baecc8d9fc5ee3f4438140203cf.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM workspace_secrets WHERE (COALESCE(id > $2, true)) AND deleted = FALSE ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "cddfa782fa9cda27135eea5fab791313e32e0baecc8d9fc5ee3f4438140203cf"
+}

--- a/.sqlx/query-cfe33918c9ba5e62d09a71530e7d9595a92272823fac50ef34128c665af433a9.json
+++ b/.sqlx/query-cfe33918c9ba5e62d09a71530e7d9595a92272823fac50ef34128c665af433a9.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM workspace_secrets WHERE id = ANY($1)) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "cfe33918c9ba5e62d09a71530e7d9595a92272823fac50ef34128c665af433a9"
+}

--- a/.sqlx/query-dda082d454de47e69cd702cf0b27b13cfd8cf89bd942588af6e706e5424cae40.json
+++ b/.sqlx/query-dda082d454de47e69cd702cf0b27b13cfd8cf89bd942588af6e706e5424cae40.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM workspace_secrets WHERE COALESCE(workspace_id = $1, $1 IS NULL) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL)) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "dda082d454de47e69cd702cf0b27b13cfd8cf89bd942588af6e706e5424cae40"
+}

--- a/.sqlx/query-e10e4c912bbff3990a4fad6694c31e940bc3a52146b177b3952678789f31ba10.json
+++ b/.sqlx/query-e10e4c912bbff3990a4fad6694c31e940bc3a52146b177b3952678789f31ba10.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM workspace_secrets WHERE COALESCE(workspace_id = $1, $1 IS NULL) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL)) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "e10e4c912bbff3990a4fad6694c31e940bc3a52146b177b3952678789f31ba10"
+}

--- a/.sqlx/query-e57933db17f8cbfb763b36b11f2d5949cdd8fb21fb3dfec13d0b616a12a171ca.json
+++ b/.sqlx/query-e57933db17f8cbfb763b36b11f2d5949cdd8fb21fb3dfec13d0b616a12a171ca.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT workspace_id, created_at, id FROM workspace_secrets WHERE ((workspace_id = $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN workspace_secret_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "e57933db17f8cbfb763b36b11f2d5949cdd8fb21fb3dfec13d0b616a12a171ca"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common",
+ "generic-array",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,6 +510,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chacha20"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3613f74bd2eac03dad61bd53dbe620703d4371614fe0bc3b9f04dd36fe4e818"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "chacha20"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
@@ -507,6 +528,19 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "rand_core 0.10.0",
+]
+
+[[package]]
+name = "chacha20poly1305"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10cd79432192d1c0f4e1a0fef9527696cc039165d729fb41b3f4f4f354c2dc35"
+dependencies = [
+ "aead",
+ "chacha20 0.9.1",
+ "cipher",
+ "poly1305",
+ "zeroize",
 ]
 
 [[package]]
@@ -521,6 +555,17 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common",
+ "inout",
+ "zeroize",
 ]
 
 [[package]]
@@ -869,6 +914,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1503,11 +1549,13 @@ dependencies = [
  "anyhow",
  "async-trait",
  "base64 0.22.1",
+ "chacha20poly1305",
  "chrono",
  "code-assistant-core",
  "concourse-client",
  "derive_builder",
  "es-entity",
+ "hex",
  "http",
  "opentelemetry",
  "opentelemetry-http",
@@ -2169,6 +2217,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -2869,6 +2926,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3186,6 +3249,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "poly1305"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8159bd90725d2df49889a078b54f4f79e87f1f8a8444194cdca81d38f5393abf"
+dependencies = [
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3401,7 +3475,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc266eb313df6c5c09c1c7b1fbe2510961e5bcd3add930c1e31f7ed9da0feff8"
 dependencies = [
- "chacha20",
+ "chacha20 0.10.0",
  "getrandom 0.4.2",
  "rand_core 0.10.0",
 ]
@@ -5460,6 +5534,16 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -81,6 +81,7 @@ async fn main() -> anyhow::Result<()> {
             },
         },
         toolsets: config.toolsets.clone(),
+        encryption: Default::default(),
     };
 
     let app = galoy_agents_core::App::init(&pool, app_config).await?;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -10,10 +10,12 @@ code-assistant-core = { workspace = true }
 anyhow = { workspace = true }
 async-trait = "0.1"
 base64 = "0.22"
+chacha20poly1305 = "0.10"
 concourse-client = { workspace = true }
 chrono = { version = "0.4", features = ["clock", "serde"], default-features = false }
 derive_builder = "0.20"
 es-entity = "0.10"
+hex = "0.4"
 http = "1"
 rand = "0.9"
 regex = "1"

--- a/core/migrations/20260411000001_create_workspace_secrets.sql
+++ b/core/migrations/20260411000001_create_workspace_secrets.sql
@@ -1,0 +1,15 @@
+-- Workspace secrets: flat SQL table (not event-sourced) for user-provisioned secrets.
+-- Follows the same pattern as conversations — direct insert/query.
+
+CREATE TABLE workspace_secrets (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    workspace_id UUID NOT NULL REFERENCES workspaces(id),
+    name VARCHAR(255) NOT NULL,
+    secret_type VARCHAR(50) NOT NULL,
+    encrypted_value TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(workspace_id, name)
+);
+
+CREATE INDEX idx_workspace_secrets_workspace_id ON workspace_secrets(workspace_id);

--- a/core/migrations/20260411000001_create_workspace_secrets.sql
+++ b/core/migrations/20260411000001_create_workspace_secrets.sql
@@ -1,15 +1,23 @@
--- Workspace secrets: flat SQL table (not event-sourced) for user-provisioned secrets.
--- Follows the same pattern as conversations — direct insert/query.
+-- Workspace secrets: event-sourced entity for user-provisioned secrets.
+-- Follows the same pattern as workspaces — es-entity with events table.
 
-CREATE TABLE workspace_secrets (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+CREATE TABLE IF NOT EXISTS workspace_secrets (
+    id UUID PRIMARY KEY,
     workspace_id UUID NOT NULL REFERENCES workspaces(id),
-    name VARCHAR(255) NOT NULL,
-    secret_type VARCHAR(50) NOT NULL,
-    encrypted_value TEXT NOT NULL,
-    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    name VARCHAR NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    deleted BOOLEAN NOT NULL DEFAULT FALSE,
     UNIQUE(workspace_id, name)
 );
 
 CREATE INDEX idx_workspace_secrets_workspace_id ON workspace_secrets(workspace_id);
+
+CREATE TABLE IF NOT EXISTS workspace_secret_events (
+    id UUID NOT NULL REFERENCES workspace_secrets(id),
+    sequence INT NOT NULL,
+    event_type VARCHAR NOT NULL,
+    event JSONB NOT NULL,
+    context JSONB DEFAULT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+    UNIQUE(id, sequence)
+);

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 
 use crate::agent::AgentConfig;
+use crate::encryption::EncryptionKey;
 use crate::toolset::ToolSetsConfig;
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -9,4 +10,28 @@ pub struct AppConfig {
     pub agents: AgentConfig,
     #[serde(default)]
     pub toolsets: ToolSetsConfig,
+    #[serde(default)]
+    pub encryption: EncryptionConfig,
+}
+
+#[derive(Clone, Debug, Default, Deserialize)]
+pub struct EncryptionConfig {
+    /// Hex-encoded 32-byte encryption key for workspace secrets.
+    /// If not provided, a zeroed key is used (development only).
+    #[serde(default)]
+    pub secret_key_hex: Option<String>,
+}
+
+impl EncryptionConfig {
+    pub fn encryption_key(&self) -> EncryptionKey {
+        match &self.secret_key_hex {
+            Some(hex) => {
+                let bytes = hex::decode(hex).expect("ENCRYPTION_SECRET_KEY_HEX must be valid hex");
+                let mut key = [0u8; 32];
+                key.copy_from_slice(&bytes);
+                EncryptionKey::new(key)
+            }
+            None => EncryptionKey::default(),
+        }
+    }
 }

--- a/core/src/encryption.rs
+++ b/core/src/encryption.rs
@@ -1,0 +1,137 @@
+use chacha20poly1305::{
+    aead::{Aead, OsRng},
+    AeadCore, ChaCha20Poly1305, KeyInit,
+};
+use serde::{Deserialize, Serialize};
+
+/// Identifies which key was used to encrypt a value, enabling key rotation detection.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct EncryptionKeyId([u8; 4]);
+
+/// A ChaCha20-Poly1305 encryption key with a derived ID for rotation tracking.
+#[derive(Clone)]
+pub struct EncryptionKey {
+    key: chacha20poly1305::Key,
+    id: EncryptionKeyId,
+}
+
+impl std::fmt::Debug for EncryptionKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("EncryptionKey")
+            .field("id", &self.id)
+            .field("key", &"<redacted>")
+            .finish()
+    }
+}
+
+impl EncryptionKey {
+    pub fn new(raw: [u8; 32]) -> Self {
+        let key = chacha20poly1305::Key::from(raw);
+        // Derive a 4-byte ID from the key material for rotation tracking
+        let hash = <sha2::Sha256 as sha2::Digest>::digest(raw);
+        let mut id = [0u8; 4];
+        id.copy_from_slice(&hash[..4]);
+        Self {
+            key,
+            id: EncryptionKeyId(id),
+        }
+    }
+
+    /// Encrypt arbitrary bytes, returning an `Encrypted` envelope.
+    pub fn encrypt(&self, plaintext: &[u8]) -> Encrypted {
+        let cipher = ChaCha20Poly1305::new(&self.key);
+        let nonce = ChaCha20Poly1305::generate_nonce(&mut OsRng);
+        let ciphertext = cipher
+            .encrypt(&nonce, plaintext)
+            .expect("encryption should not fail");
+        Encrypted {
+            ciphertext,
+            nonce: nonce.to_vec(),
+            key_id: self.id.clone(),
+        }
+    }
+
+    /// Decrypt an `Encrypted` envelope back to plaintext bytes.
+    pub fn decrypt(&self, encrypted: &Encrypted) -> Result<Vec<u8>, EncryptionError> {
+        if encrypted.key_id != self.id {
+            return Err(EncryptionError::KeyMismatch);
+        }
+        let cipher = ChaCha20Poly1305::new(&self.key);
+        let nonce = chacha20poly1305::Nonce::from_slice(&encrypted.nonce);
+        cipher
+            .decrypt(nonce, encrypted.ciphertext.as_ref())
+            .map_err(|_| EncryptionError::DecryptionFailed)
+    }
+
+    /// Encrypt a string value.
+    pub fn encrypt_string(&self, value: &str) -> Encrypted {
+        self.encrypt(value.as_bytes())
+    }
+
+    /// Decrypt to a UTF-8 string.
+    pub fn decrypt_string(&self, encrypted: &Encrypted) -> Result<String, EncryptionError> {
+        let bytes = self.decrypt(encrypted)?;
+        String::from_utf8(bytes).map_err(|_| EncryptionError::DecryptionFailed)
+    }
+}
+
+impl Default for EncryptionKey {
+    fn default() -> Self {
+        Self::new([0u8; 32])
+    }
+}
+
+/// An encrypted value with its nonce and key ID.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct Encrypted {
+    ciphertext: Vec<u8>,
+    nonce: Vec<u8>,
+    key_id: EncryptionKeyId,
+}
+
+impl Encrypted {
+    /// Check whether this value was encrypted with the given key.
+    pub fn matches_key(&self, key: &EncryptionKey) -> bool {
+        self.key_id == key.id
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum EncryptionError {
+    #[error("EncryptionError - KeyMismatch: ciphertext was encrypted with a different key")]
+    KeyMismatch,
+    #[error("EncryptionError - DecryptionFailed")]
+    DecryptionFailed,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip() {
+        let key = EncryptionKey::new([42u8; 32]);
+        let plaintext = "super-secret-value";
+        let encrypted = key.encrypt_string(plaintext);
+        let decrypted = key.decrypt_string(&encrypted).unwrap();
+        assert_eq!(decrypted, plaintext);
+    }
+
+    #[test]
+    fn wrong_key_fails() {
+        let key1 = EncryptionKey::new([1u8; 32]);
+        let key2 = EncryptionKey::new([2u8; 32]);
+        let encrypted = key1.encrypt_string("secret");
+        assert!(key2.decrypt_string(&encrypted).is_err());
+    }
+
+    #[test]
+    fn matches_key_works() {
+        let key = EncryptionKey::new([99u8; 32]);
+        let encrypted = key.encrypt_string("test");
+        assert!(encrypted.matches_key(&key));
+
+        let other = EncryptionKey::new([100u8; 32]);
+        assert!(!encrypted.matches_key(&other));
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -4,6 +4,7 @@ pub mod auth;
 pub mod chat_history;
 pub mod code_assistant;
 mod config;
+pub mod encryption;
 pub mod mcp_creds;
 pub mod primitives;
 pub mod report;
@@ -91,7 +92,8 @@ impl App {
         // Register admin toolset after agents/workspaces to break circular dep
         toolsets.register(AdminToolSet::new(workspaces.clone(), Arc::clone(&agents)));
 
-        let workspace_secrets = WorkspaceSecrets::new(pool);
+        let encryption_key = config.encryption.encryption_key();
+        let workspace_secrets = WorkspaceSecrets::new(pool, encryption_key);
 
         Ok(Self {
             users: Users::new(pool),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod report;
 pub mod toolset;
 pub mod user;
 pub mod workspace;
+pub mod workspace_secret;
 
 pub use config::*;
 
@@ -23,6 +24,7 @@ use report::Reports;
 use toolset::{AdminToolSet, ToolSets, ToolSetsError};
 use user::Users;
 use workspace::Workspaces;
+use workspace_secret::WorkspaceSecrets;
 
 #[derive(Clone)]
 pub struct App {
@@ -34,6 +36,7 @@ pub struct App {
     reports: Option<Arc<Reports>>,
     toolsets: Arc<ToolSets>,
     workspaces: Workspaces,
+    workspace_secrets: WorkspaceSecrets,
 }
 
 impl App {
@@ -88,6 +91,8 @@ impl App {
         // Register admin toolset after agents/workspaces to break circular dep
         toolsets.register(AdminToolSet::new(workspaces.clone(), Arc::clone(&agents)));
 
+        let workspace_secrets = WorkspaceSecrets::new(pool);
+
         Ok(Self {
             users: Users::new(pool),
             mcp_creds,
@@ -97,6 +102,7 @@ impl App {
             reports,
             toolsets,
             workspaces,
+            workspace_secrets,
         })
     }
 
@@ -130,6 +136,10 @@ impl App {
 
     pub fn workspaces(&self) -> &Workspaces {
         &self.workspaces
+    }
+
+    pub fn workspace_secrets(&self) -> &WorkspaceSecrets {
+        &self.workspace_secrets
     }
 }
 

--- a/core/src/primitives.rs
+++ b/core/src/primitives.rs
@@ -4,6 +4,7 @@ es_entity::entity_id! {
     McpCredsOwnerId,
     ReportId,
     WorkspaceId,
+    WorkspaceSecretId,
     AgentId;
 
     UserId => McpCredsOwnerId,

--- a/core/src/workspace_secret/entity.rs
+++ b/core/src/workspace_secret/entity.rs
@@ -42,10 +42,11 @@ impl WorkspaceSecret {
             .expect("entity_first_persisted_at not found")
     }
 
-    pub(super) fn update_value(&mut self, encrypted_value: Encrypted) {
+    pub(super) fn update_value(&mut self, encrypted_value: Encrypted) -> Idempotent<()> {
         self.encrypted_value = encrypted_value.clone();
         self.events
             .push(WorkspaceSecretEvent::ValueUpdated { encrypted_value });
+        Idempotent::Executed(())
     }
 
     /// Access the encrypted value (for decryption by the service layer).

--- a/core/src/workspace_secret/entity.rs
+++ b/core/src/workspace_secret/entity.rs
@@ -1,0 +1,132 @@
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use es_entity::*;
+
+use crate::encryption::Encrypted;
+use crate::primitives::*;
+
+use super::primitives::SecretType;
+
+#[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[es_event(id = "WorkspaceSecretId")]
+pub enum WorkspaceSecretEvent {
+    Initialized {
+        id: WorkspaceSecretId,
+        workspace_id: WorkspaceId,
+        name: String,
+        secret_type: SecretType,
+        encrypted_value: Encrypted,
+    },
+    ValueUpdated {
+        encrypted_value: Encrypted,
+    },
+}
+
+#[derive(EsEntity, Builder)]
+#[builder(pattern = "owned", build_fn(error = "EntityHydrationError"))]
+pub struct WorkspaceSecret {
+    pub id: WorkspaceSecretId,
+    pub workspace_id: WorkspaceId,
+    pub name: String,
+    pub secret_type: SecretType,
+    pub(super) encrypted_value: Encrypted,
+    events: EntityEvents<WorkspaceSecretEvent>,
+}
+
+impl WorkspaceSecret {
+    pub fn created_at(&self) -> chrono::DateTime<chrono::Utc> {
+        self.events
+            .entity_first_persisted_at()
+            .expect("entity_first_persisted_at not found")
+    }
+
+    pub(super) fn update_value(&mut self, encrypted_value: Encrypted) {
+        self.encrypted_value = encrypted_value.clone();
+        self.events
+            .push(WorkspaceSecretEvent::ValueUpdated { encrypted_value });
+    }
+
+    /// Access the encrypted value (for decryption by the service layer).
+    pub(super) fn encrypted_value(&self) -> &Encrypted {
+        &self.encrypted_value
+    }
+}
+
+impl core::fmt::Display for WorkspaceSecret {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "WorkspaceSecret: {}, name: {}, type: {}",
+            self.id, self.name, self.secret_type
+        )
+    }
+}
+
+impl TryFromEvents<WorkspaceSecretEvent> for WorkspaceSecret {
+    fn try_from_events(
+        events: EntityEvents<WorkspaceSecretEvent>,
+    ) -> Result<Self, EntityHydrationError> {
+        let mut builder = WorkspaceSecretBuilder::default();
+
+        for event in events.iter_all() {
+            match event {
+                WorkspaceSecretEvent::Initialized {
+                    id,
+                    workspace_id,
+                    name,
+                    secret_type,
+                    encrypted_value,
+                } => {
+                    builder = builder
+                        .id(*id)
+                        .workspace_id(*workspace_id)
+                        .name(name.clone())
+                        .secret_type(*secret_type)
+                        .encrypted_value(encrypted_value.clone());
+                }
+                WorkspaceSecretEvent::ValueUpdated { encrypted_value } => {
+                    builder = builder.encrypted_value(encrypted_value.clone());
+                }
+            }
+        }
+
+        builder.events(events).build()
+    }
+}
+
+#[derive(Debug, Builder)]
+pub struct NewWorkspaceSecret {
+    #[builder(setter(into))]
+    pub(super) id: WorkspaceSecretId,
+    #[builder(setter(into))]
+    pub(super) workspace_id: WorkspaceId,
+    #[builder(setter(into))]
+    pub(super) name: String,
+    pub(super) secret_type: SecretType,
+    pub(super) encrypted_value: Encrypted,
+}
+
+impl NewWorkspaceSecret {
+    pub fn builder() -> NewWorkspaceSecretBuilder {
+        let mut builder = NewWorkspaceSecretBuilder::default();
+        builder.id(WorkspaceSecretId::new());
+        builder
+    }
+}
+
+impl IntoEvents<WorkspaceSecretEvent> for NewWorkspaceSecret {
+    fn into_events(self) -> EntityEvents<WorkspaceSecretEvent> {
+        EntityEvents::init(
+            self.id,
+            [WorkspaceSecretEvent::Initialized {
+                id: self.id,
+                workspace_id: self.workspace_id,
+                name: self.name,
+                secret_type: self.secret_type,
+                encrypted_value: self.encrypted_value,
+            }],
+        )
+    }
+}

--- a/core/src/workspace_secret/error.rs
+++ b/core/src/workspace_secret/error.rs
@@ -1,11 +1,22 @@
 use thiserror::Error;
 
+use crate::encryption::EncryptionError;
+
+use super::repo::{
+    WorkspaceSecretCreateError, WorkspaceSecretFindError, WorkspaceSecretModifyError,
+    WorkspaceSecretQueryError,
+};
+
 #[derive(Error, Debug)]
 pub enum WorkspaceSecretError {
-    #[error("WorkspaceSecretError - Sqlx: {0}")]
-    Sqlx(#[from] sqlx::Error),
-    #[error("WorkspaceSecretError - SecretNotFound")]
-    SecretNotFound,
-    #[error("WorkspaceSecretError - InvalidSecretType: {0}")]
-    InvalidSecretType(String),
+    #[error("WorkspaceSecretError - Create: {0}")]
+    Create(#[from] WorkspaceSecretCreateError),
+    #[error("WorkspaceSecretError - Modify: {0}")]
+    Modify(#[from] WorkspaceSecretModifyError),
+    #[error("WorkspaceSecretError - Find: {0}")]
+    Find(#[from] WorkspaceSecretFindError),
+    #[error("WorkspaceSecretError - Query: {0}")]
+    Query(#[from] WorkspaceSecretQueryError),
+    #[error("WorkspaceSecretError - Encryption: {0}")]
+    Encryption(#[from] EncryptionError),
 }

--- a/core/src/workspace_secret/error.rs
+++ b/core/src/workspace_secret/error.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum WorkspaceSecretError {
+    #[error("WorkspaceSecretError - Sqlx: {0}")]
+    Sqlx(#[from] sqlx::Error),
+    #[error("WorkspaceSecretError - SecretNotFound")]
+    SecretNotFound,
+    #[error("WorkspaceSecretError - InvalidSecretType: {0}")]
+    InvalidSecretType(String),
+}

--- a/core/src/workspace_secret/mod.rs
+++ b/core/src/workspace_secret/mod.rs
@@ -1,24 +1,42 @@
+mod entity;
 pub mod error;
 pub mod primitives;
+pub(crate) mod repo;
 
 use tracing::instrument;
 
+pub use entity::WorkspaceSecret;
+use entity::*;
 pub use error::*;
 pub use primitives::*;
+use repo::*;
 
+use crate::encryption::EncryptionKey;
 use crate::primitives::*;
+
+/// A decrypted secret ready for harness injection.
+pub struct DecryptedSecret {
+    pub name: String,
+    pub secret_type: SecretType,
+    pub value: String,
+}
 
 #[derive(Clone)]
 pub struct WorkspaceSecrets {
-    pool: sqlx::PgPool,
+    repo: WorkspaceSecretRepo,
+    encryption_key: EncryptionKey,
 }
 
 impl WorkspaceSecrets {
-    pub fn new(pool: &sqlx::PgPool) -> Self {
-        Self { pool: pool.clone() }
+    pub fn new(pool: &sqlx::PgPool, encryption_key: EncryptionKey) -> Self {
+        let repo = WorkspaceSecretRepo::new(pool);
+        Self {
+            repo,
+            encryption_key,
+        }
     }
 
-    /// Create a new secret for a workspace.
+    /// Create a new secret (or update if name already exists in workspace).
     #[instrument(name = "workspace_secret.create", skip_all)]
     pub async fn create(
         &self,
@@ -27,61 +45,65 @@ impl WorkspaceSecrets {
         secret_type: SecretType,
         value: &str,
     ) -> Result<WorkspaceSecret, WorkspaceSecretError> {
-        let id = WorkspaceSecretId::new();
-        let secret_type_str = secret_type.as_str();
+        let encrypted_value = self.encryption_key.encrypt_string(value);
 
-        let row = sqlx::query_as::<_, WorkspaceSecret>(
-            r#"INSERT INTO workspace_secrets (id, workspace_id, name, secret_type, encrypted_value)
-            VALUES ($1, $2, $3, $4, $5)
-            ON CONFLICT (workspace_id, name) DO UPDATE
-                SET encrypted_value = EXCLUDED.encrypted_value,
-                    secret_type = EXCLUDED.secret_type,
-                    updated_at = NOW()
-            RETURNING id, workspace_id, name, secret_type, created_at, updated_at"#,
-        )
-        .bind(id)
-        .bind(workspace_id)
-        .bind(name)
-        .bind(secret_type_str)
-        .bind(value)
-        .fetch_one(&self.pool)
-        .await?;
-        Ok(row)
+        // Check if secret with this name already exists — update if so
+        let existing = self.list_all_for_workspace(workspace_id).await?;
+        let existing = existing.into_iter().find(|s| s.name == name);
+
+        if let Some(mut secret) = existing {
+            secret.update_value(encrypted_value);
+            self.repo.update(&mut secret).await?;
+            return Ok(secret);
+        }
+
+        let new = NewWorkspaceSecret::builder()
+            .workspace_id(workspace_id)
+            .name(name)
+            .secret_type(secret_type)
+            .encrypted_value(encrypted_value)
+            .build()
+            .expect("Could not build new workspace secret");
+
+        let secret = self.repo.create(new).await?;
+        Ok(secret)
     }
 
-    /// List secrets for a workspace (metadata only, no values).
+    /// List secrets for a workspace (metadata only, no decrypted values).
     #[instrument(name = "workspace_secret.list_by_workspace", skip_all)]
     pub async fn list_by_workspace(
         &self,
         workspace_id: WorkspaceId,
     ) -> Result<Vec<WorkspaceSecret>, WorkspaceSecretError> {
-        let rows = sqlx::query_as::<_, WorkspaceSecret>(
-            r#"SELECT id, workspace_id, name, secret_type, created_at, updated_at
-            FROM workspace_secrets
-            WHERE workspace_id = $1
-            ORDER BY name ASC"#,
-        )
-        .bind(workspace_id)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(rows)
+        self.list_all_for_workspace(workspace_id).await
     }
 
-    /// Find a secret by ID (metadata only).
+    async fn list_all_for_workspace(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<Vec<WorkspaceSecret>, WorkspaceSecretError> {
+        let query = es_entity::PaginatedQueryArgs {
+            first: 100,
+            after: None,
+        };
+        let result = self
+            .repo
+            .list_for_workspace_id_by_created_at(
+                workspace_id,
+                query,
+                es_entity::ListDirection::Descending,
+            )
+            .await?;
+        Ok(result.entities)
+    }
+
+    /// Find a secret by ID.
     #[instrument(name = "workspace_secret.find_by_id", skip_all)]
     pub async fn find_by_id(
         &self,
         id: WorkspaceSecretId,
     ) -> Result<WorkspaceSecret, WorkspaceSecretError> {
-        sqlx::query_as::<_, WorkspaceSecret>(
-            r#"SELECT id, workspace_id, name, secret_type, created_at, updated_at
-            FROM workspace_secrets
-            WHERE id = $1"#,
-        )
-        .bind(id)
-        .fetch_optional(&self.pool)
-        .await?
-        .ok_or(WorkspaceSecretError::SecretNotFound)
+        Ok(self.repo.find_by_id(id).await?)
     }
 
     /// Update a secret's value.
@@ -91,49 +113,40 @@ impl WorkspaceSecrets {
         id: WorkspaceSecretId,
         value: &str,
     ) -> Result<WorkspaceSecret, WorkspaceSecretError> {
-        let row = sqlx::query_as::<_, WorkspaceSecret>(
-            r#"UPDATE workspace_secrets
-            SET encrypted_value = $1, updated_at = NOW()
-            WHERE id = $2
-            RETURNING id, workspace_id, name, secret_type, created_at, updated_at"#,
-        )
-        .bind(value)
-        .bind(id)
-        .fetch_optional(&self.pool)
-        .await?
-        .ok_or(WorkspaceSecretError::SecretNotFound)?;
-        Ok(row)
+        let mut secret = self.repo.find_by_id(id).await?;
+        let encrypted_value = self.encryption_key.encrypt_string(value);
+        secret.update_value(encrypted_value);
+        self.repo.update(&mut secret).await?;
+        Ok(secret)
     }
 
-    /// Delete a secret.
+    /// Delete a secret (soft delete via archive).
     #[instrument(name = "workspace_secret.delete", skip_all)]
     pub async fn delete(&self, id: WorkspaceSecretId) -> Result<(), WorkspaceSecretError> {
-        let result = sqlx::query(r#"DELETE FROM workspace_secrets WHERE id = $1"#)
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-
-        if result.rows_affected() == 0 {
-            return Err(WorkspaceSecretError::SecretNotFound);
-        }
+        let secret = self.repo.find_by_id(id).await?;
+        self.repo.delete(secret).await?;
         Ok(())
     }
 
-    /// List secrets with values for a workspace (internal use — harness injection).
-    #[instrument(name = "workspace_secret.list_with_values", skip_all)]
-    pub async fn list_with_values(
+    /// List secrets with decrypted values for a workspace (internal use — harness injection).
+    #[instrument(name = "workspace_secret.list_decrypted", skip_all)]
+    pub async fn list_decrypted(
         &self,
         workspace_id: WorkspaceId,
-    ) -> Result<Vec<WorkspaceSecretWithValue>, WorkspaceSecretError> {
-        let rows = sqlx::query_as::<_, WorkspaceSecretWithValue>(
-            r#"SELECT id, workspace_id, name, secret_type, encrypted_value, created_at, updated_at
-            FROM workspace_secrets
-            WHERE workspace_id = $1
-            ORDER BY name ASC"#,
-        )
-        .bind(workspace_id)
-        .fetch_all(&self.pool)
-        .await?;
-        Ok(rows)
+    ) -> Result<Vec<DecryptedSecret>, WorkspaceSecretError> {
+        let secrets = self.list_all_for_workspace(workspace_id).await?;
+
+        let mut result = Vec::with_capacity(secrets.len());
+        for secret in secrets {
+            let value = self
+                .encryption_key
+                .decrypt_string(secret.encrypted_value())?;
+            result.push(DecryptedSecret {
+                name: secret.name.clone(),
+                secret_type: secret.secret_type,
+                value,
+            });
+        }
+        Ok(result)
     }
 }

--- a/core/src/workspace_secret/mod.rs
+++ b/core/src/workspace_secret/mod.rs
@@ -1,0 +1,139 @@
+pub mod error;
+pub mod primitives;
+
+use tracing::instrument;
+
+pub use error::*;
+pub use primitives::*;
+
+use crate::primitives::*;
+
+#[derive(Clone)]
+pub struct WorkspaceSecrets {
+    pool: sqlx::PgPool,
+}
+
+impl WorkspaceSecrets {
+    pub fn new(pool: &sqlx::PgPool) -> Self {
+        Self { pool: pool.clone() }
+    }
+
+    /// Create a new secret for a workspace.
+    #[instrument(name = "workspace_secret.create", skip_all)]
+    pub async fn create(
+        &self,
+        workspace_id: WorkspaceId,
+        name: &str,
+        secret_type: SecretType,
+        value: &str,
+    ) -> Result<WorkspaceSecret, WorkspaceSecretError> {
+        let id = WorkspaceSecretId::new();
+        let secret_type_str = secret_type.as_str();
+
+        let row = sqlx::query_as::<_, WorkspaceSecret>(
+            r#"INSERT INTO workspace_secrets (id, workspace_id, name, secret_type, encrypted_value)
+            VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (workspace_id, name) DO UPDATE
+                SET encrypted_value = EXCLUDED.encrypted_value,
+                    secret_type = EXCLUDED.secret_type,
+                    updated_at = NOW()
+            RETURNING id, workspace_id, name, secret_type, created_at, updated_at"#,
+        )
+        .bind(id)
+        .bind(workspace_id)
+        .bind(name)
+        .bind(secret_type_str)
+        .bind(value)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    /// List secrets for a workspace (metadata only, no values).
+    #[instrument(name = "workspace_secret.list_by_workspace", skip_all)]
+    pub async fn list_by_workspace(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<Vec<WorkspaceSecret>, WorkspaceSecretError> {
+        let rows = sqlx::query_as::<_, WorkspaceSecret>(
+            r#"SELECT id, workspace_id, name, secret_type, created_at, updated_at
+            FROM workspace_secrets
+            WHERE workspace_id = $1
+            ORDER BY name ASC"#,
+        )
+        .bind(workspace_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Find a secret by ID (metadata only).
+    #[instrument(name = "workspace_secret.find_by_id", skip_all)]
+    pub async fn find_by_id(
+        &self,
+        id: WorkspaceSecretId,
+    ) -> Result<WorkspaceSecret, WorkspaceSecretError> {
+        sqlx::query_as::<_, WorkspaceSecret>(
+            r#"SELECT id, workspace_id, name, secret_type, created_at, updated_at
+            FROM workspace_secrets
+            WHERE id = $1"#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or(WorkspaceSecretError::SecretNotFound)
+    }
+
+    /// Update a secret's value.
+    #[instrument(name = "workspace_secret.update_value", skip_all)]
+    pub async fn update_value(
+        &self,
+        id: WorkspaceSecretId,
+        value: &str,
+    ) -> Result<WorkspaceSecret, WorkspaceSecretError> {
+        let row = sqlx::query_as::<_, WorkspaceSecret>(
+            r#"UPDATE workspace_secrets
+            SET encrypted_value = $1, updated_at = NOW()
+            WHERE id = $2
+            RETURNING id, workspace_id, name, secret_type, created_at, updated_at"#,
+        )
+        .bind(value)
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or(WorkspaceSecretError::SecretNotFound)?;
+        Ok(row)
+    }
+
+    /// Delete a secret.
+    #[instrument(name = "workspace_secret.delete", skip_all)]
+    pub async fn delete(&self, id: WorkspaceSecretId) -> Result<(), WorkspaceSecretError> {
+        let result = sqlx::query(r#"DELETE FROM workspace_secrets WHERE id = $1"#)
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(WorkspaceSecretError::SecretNotFound);
+        }
+        Ok(())
+    }
+
+    /// List secrets with values for a workspace (internal use — harness injection).
+    #[instrument(name = "workspace_secret.list_with_values", skip_all)]
+    pub async fn list_with_values(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<Vec<WorkspaceSecretWithValue>, WorkspaceSecretError> {
+        let rows = sqlx::query_as::<_, WorkspaceSecretWithValue>(
+            r#"SELECT id, workspace_id, name, secret_type, encrypted_value, created_at, updated_at
+            FROM workspace_secrets
+            WHERE workspace_id = $1
+            ORDER BY name ASC"#,
+        )
+        .bind(workspace_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+}

--- a/core/src/workspace_secret/mod.rs
+++ b/core/src/workspace_secret/mod.rs
@@ -36,7 +36,7 @@ impl WorkspaceSecrets {
         }
     }
 
-    /// Create a new secret (or update if name already exists in workspace).
+    /// Create a new secret. Fails if a secret with the same name already exists in the workspace.
     #[instrument(name = "workspace_secret.create", skip_all)]
     pub async fn create(
         &self,
@@ -46,16 +46,6 @@ impl WorkspaceSecrets {
         value: &str,
     ) -> Result<WorkspaceSecret, WorkspaceSecretError> {
         let encrypted_value = self.encryption_key.encrypt_string(value);
-
-        // Check if secret with this name already exists — update if so
-        let existing = self.list_all_for_workspace(workspace_id).await?;
-        let existing = existing.into_iter().find(|s| s.name == name);
-
-        if let Some(mut secret) = existing {
-            secret.update_value(encrypted_value);
-            self.repo.update(&mut secret).await?;
-            return Ok(secret);
-        }
 
         let new = NewWorkspaceSecret::builder()
             .workspace_id(workspace_id)
@@ -115,8 +105,9 @@ impl WorkspaceSecrets {
     ) -> Result<WorkspaceSecret, WorkspaceSecretError> {
         let mut secret = self.repo.find_by_id(id).await?;
         let encrypted_value = self.encryption_key.encrypt_string(value);
-        secret.update_value(encrypted_value);
-        self.repo.update(&mut secret).await?;
+        if secret.update_value(encrypted_value).did_execute() {
+            self.repo.update(&mut secret).await?;
+        }
         Ok(secret)
     }
 

--- a/core/src/workspace_secret/primitives.rs
+++ b/core/src/workspace_secret/primitives.rs
@@ -1,7 +1,5 @@
 use serde::{Deserialize, Serialize};
 
-use crate::primitives::*;
-
 /// The type of secret, determining how the harness injects it.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -37,27 +35,4 @@ impl std::str::FromStr for SecretType {
             other => Err(format!("invalid secret type: {other}")),
         }
     }
-}
-
-/// A workspace-scoped secret (metadata view — no value).
-#[derive(Debug, Clone, sqlx::FromRow)]
-pub struct WorkspaceSecret {
-    pub id: WorkspaceSecretId,
-    pub workspace_id: WorkspaceId,
-    pub name: String,
-    pub secret_type: String,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    pub updated_at: chrono::DateTime<chrono::Utc>,
-}
-
-/// A workspace secret with its decrypted value (internal use only).
-#[derive(Debug, Clone, sqlx::FromRow)]
-pub struct WorkspaceSecretWithValue {
-    pub id: WorkspaceSecretId,
-    pub workspace_id: WorkspaceId,
-    pub name: String,
-    pub secret_type: String,
-    pub encrypted_value: String,
-    pub created_at: chrono::DateTime<chrono::Utc>,
-    pub updated_at: chrono::DateTime<chrono::Utc>,
 }

--- a/core/src/workspace_secret/primitives.rs
+++ b/core/src/workspace_secret/primitives.rs
@@ -1,0 +1,63 @@
+use serde::{Deserialize, Serialize};
+
+use crate::primitives::*;
+
+/// The type of secret, determining how the harness injects it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SecretType {
+    /// Injected as an environment variable.
+    EnvVar,
+    /// Written to `/run/secrets/<name>`.
+    File,
+}
+
+impl SecretType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SecretType::EnvVar => "env_var",
+            SecretType::File => "file",
+        }
+    }
+}
+
+impl std::fmt::Display for SecretType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl std::str::FromStr for SecretType {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "env_var" => Ok(SecretType::EnvVar),
+            "file" => Ok(SecretType::File),
+            other => Err(format!("invalid secret type: {other}")),
+        }
+    }
+}
+
+/// A workspace-scoped secret (metadata view — no value).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct WorkspaceSecret {
+    pub id: WorkspaceSecretId,
+    pub workspace_id: WorkspaceId,
+    pub name: String,
+    pub secret_type: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// A workspace secret with its decrypted value (internal use only).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct WorkspaceSecretWithValue {
+    pub id: WorkspaceSecretId,
+    pub workspace_id: WorkspaceId,
+    pub name: String,
+    pub secret_type: String,
+    pub encrypted_value: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}

--- a/core/src/workspace_secret/repo.rs
+++ b/core/src/workspace_secret/repo.rs
@@ -1,0 +1,27 @@
+use sqlx::PgPool;
+
+use es_entity::*;
+
+use crate::primitives::*;
+
+use super::entity::*;
+
+#[derive(EsRepo, Clone)]
+#[es_repo(
+    entity = "WorkspaceSecret",
+    columns(
+        workspace_id(ty = "WorkspaceId", list_for(by(created_at))),
+        name(ty = "String")
+    ),
+    delete = "soft_without_queries"
+)]
+pub struct WorkspaceSecretRepo {
+    #[allow(dead_code)]
+    pool: PgPool,
+}
+
+impl WorkspaceSecretRepo {
+    pub fn new(pool: &PgPool) -> Self {
+        Self { pool: pool.clone() }
+    }
+}

--- a/images/sandbox-base/agent-harness/src/index.ts
+++ b/images/sandbox-base/agent-harness/src/index.ts
@@ -68,14 +68,21 @@ interface HarnessInput {
   disallowed_tools?: string[];
 }
 
+interface WorkspaceSecret {
+  name: string;
+  secret_type: string; // "env_var" | "file"
+  value: string;
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────
 
 function sendSSE(
   res: ServerResponse,
   event: Record<string, unknown>,
 ): void {
-  const eventType = (event.type as string) ?? "message";
-  res.write(`event: ${eventType}\ndata: ${JSON.stringify(event)}\n\n`);
+  const scrubbed = scrubEvent(event);
+  const eventType = (scrubbed.type as string) ?? "message";
+  res.write(`event: ${eventType}\ndata: ${JSON.stringify(scrubbed)}\n\n`);
 }
 
 function readBody(req: IncomingMessage): Promise<string> {
@@ -155,6 +162,117 @@ function getMcpServersFromSaToken(): Record<string, McpHttpServerConfig> | undef
     // Token file not mounted (e.g. local dev) — run without MCP
     return undefined;
   }
+}
+
+// ── Workspace Secrets ────────────────────────────────────────────────
+
+/** Base URL for the galoy-agents server (derived from MCP_GATEWAY_URL). */
+const AGENT_SERVER_URL = MCP_GATEWAY_URL
+  ? MCP_GATEWAY_URL.replace(/\/mcp\/?$/, "")
+  : undefined;
+
+/** Agent ID extracted from pod hostname (format: agent-<uuid-prefix>-<hash>). */
+const AGENT_ID = process.env.AGENT_ID;
+
+/** Secrets fetched from the server — values used for output scrubbing. */
+let injectedSecrets: WorkspaceSecret[] = [];
+
+/** Extra environment variables injected from secrets. */
+const secretEnvVars: Record<string, string> = {};
+
+const SECRETS_DIR = "/run/secrets";
+
+/**
+ * Fetch workspace secrets from the galoy-agents server using SA token auth.
+ * Called on startup and can be called again for refresh.
+ */
+async function fetchSecrets(): Promise<WorkspaceSecret[]> {
+  if (!AGENT_SERVER_URL || !AGENT_ID) {
+    console.log("Secrets fetch skipped: AGENT_SERVER_URL or AGENT_ID not set");
+    return [];
+  }
+
+  let token: string;
+  try {
+    token = readFileSync(SA_TOKEN_PATH, "utf-8").trim();
+    if (!token) return [];
+  } catch {
+    return [];
+  }
+
+  const url = `${AGENT_SERVER_URL}/api/v1/agents/${AGENT_ID}/secrets`;
+  try {
+    const resp = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!resp.ok) {
+      console.error(`Secrets fetch failed: ${resp.status} ${resp.statusText}`);
+      return [];
+    }
+    return (await resp.json()) as WorkspaceSecret[];
+  } catch (err) {
+    console.error("Secrets fetch error:", err);
+    return [];
+  }
+}
+
+/**
+ * Inject secrets into the pod environment:
+ * - env_var: stored in secretEnvVars, passed to CLI subprocess
+ * - file: written to /run/secrets/<name>
+ */
+function injectSecrets(secrets: WorkspaceSecret[]): void {
+  for (const secret of secrets) {
+    if (secret.secret_type === "env_var") {
+      secretEnvVars[secret.name] = secret.value;
+      console.log(`[secrets] Injected env var: ${secret.name}`);
+    } else if (secret.secret_type === "file") {
+      try {
+        mkdirSync(SECRETS_DIR, { recursive: true });
+        writeFileSync(join(SECRETS_DIR, secret.name), secret.value, { mode: 0o600 });
+        console.log(`[secrets] Wrote file: ${SECRETS_DIR}/${secret.name}`);
+      } catch (err) {
+        console.error(`[secrets] Failed to write ${secret.name}:`, err);
+      }
+    }
+  }
+  injectedSecrets = secrets;
+}
+
+/**
+ * Scrub known secret values from a string.
+ * Replaces any occurrence of a secret value with [REDACTED].
+ */
+function scrubSecrets(text: string): string {
+  let scrubbed = text;
+  for (const secret of injectedSecrets) {
+    if (secret.value.length >= 4 && scrubbed.includes(secret.value)) {
+      scrubbed = scrubbed.split(secret.value).join("[REDACTED]");
+    }
+  }
+  return scrubbed;
+}
+
+/**
+ * Deep-scrub an event object: walk all string values and replace secret occurrences.
+ */
+function scrubEvent(event: Record<string, unknown>): Record<string, unknown> {
+  if (injectedSecrets.length === 0) return event;
+
+  const scrubValue = (val: unknown): unknown => {
+    if (typeof val === "string") return scrubSecrets(val);
+    if (Array.isArray(val)) return val.map(scrubValue);
+    if (val && typeof val === "object") {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(val)) {
+        out[k] = scrubValue(v);
+      }
+      return out;
+    }
+    return val;
+  };
+
+  return scrubValue(event) as Record<string, unknown>;
 }
 
 // ── Persistent CLI subprocess ────────────────────────────────────────
@@ -259,6 +377,7 @@ function spawnCli(config: SpawnConfig): ChildProcess {
     stdio: ["pipe", "pipe", "pipe"],
     env: {
       ...process.env,
+      ...secretEnvVars,
       HOME: CWD, // Store session data on the PVC, not ephemeral $HOME
       DISABLE_AUTOUPDATER: "1",
     },
@@ -596,6 +715,19 @@ if (!process.env.ANTHROPIC_API_KEY) {
 
 // Initialize OpenTelemetry before starting the server
 initTracing();
+
+// Fetch and inject workspace secrets before starting
+(async () => {
+  try {
+    const secrets = await fetchSecrets();
+    if (secrets.length > 0) {
+      injectSecrets(secrets);
+      console.log(`[secrets] Injected ${secrets.length} workspace secret(s)`);
+    }
+  } catch (err) {
+    console.error("[secrets] Failed to fetch secrets on startup:", err);
+  }
+})();
 
 const server = createServer((req, res) => {
   handleRequest(req, res).catch((err) => {

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -867,8 +867,8 @@ fn secret_to_view(s: &domain::workspace_secret::WorkspaceSecret) -> WorkspaceSec
         id: s.id.to_string(),
         workspace_id: s.workspace_id.to_string(),
         name: s.name.clone(),
-        secret_type: s.secret_type.clone(),
-        updated_at: s.updated_at.format("%Y-%m-%d %H:%M UTC").to_string(),
+        secret_type: s.secret_type.to_string(),
+        updated_at: s.created_at().format("%Y-%m-%d %H:%M UTC").to_string(),
     }
 }
 
@@ -1216,7 +1216,7 @@ async fn api_agent_secrets(
     match state
         .app
         .workspace_secrets()
-        .list_with_values(workspace_id)
+        .list_decrypted(workspace_id)
         .await
     {
         Ok(secrets) => {
@@ -1225,8 +1225,8 @@ async fn api_agent_secrets(
                 .map(|s| {
                     serde_json::json!({
                         "name": s.name,
-                        "secret_type": s.secret_type,
-                        "value": s.encrypted_value,
+                        "secret_type": s.secret_type.as_str(),
+                        "value": s.value,
                     })
                 })
                 .collect();

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -19,7 +19,7 @@ use galoy_agents_core as domain;
 use domain::auth::AuthContext;
 use domain::mcp_creds::token::generate_token;
 use domain::mcp_creds::McpCreds;
-use domain::primitives::{AgentId, McpCredsId, UserId};
+use domain::primitives::{AgentId, McpCredsId, UserId, WorkspaceSecretId};
 
 use crate::templates::*;
 use crate::AppState;
@@ -57,6 +57,12 @@ pub fn router() -> Router<AppState> {
         .route("/workspaces/{id}", get(workspace_detail))
         .route("/workspaces/{id}", post(workspace_update))
         .route("/workspaces/{id}/delete", post(workspace_delete))
+        .route("/workspaces/{id}/secrets", post(workspace_secret_create))
+        .route("/workspaces/{id}/secrets/list", get(workspace_secrets_list))
+        .route(
+            "/workspaces/{id}/secrets/{secret_id}/delete",
+            post(workspace_secret_delete),
+        )
         .route("/agents/{id}/config", get(agent_config_panel))
         .route("/agents/{id}/config", post(agent_config_update))
 }
@@ -766,13 +772,29 @@ async fn workspace_detail(
     }
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
-    match state.app.workspaces().find_by_id(workspace_id).await {
-        Ok(ws) => WorkspaceDetailTemplate {
-            workspace: workspace_to_view(&ws),
-        }
-        .into_response(),
-        Err(_) => Redirect::to("/workspaces").into_response(),
+    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+        Ok(ws) => ws,
+        Err(_) => return Redirect::to("/workspaces").into_response(),
+    };
+
+    let agents = state
+        .app
+        .agents()
+        .list_for_workspace(workspace_id)
+        .await
+        .unwrap_or_default();
+
+    let agent_id = agents
+        .iter()
+        .find(|a| a.agent_type == domain::primitives::AgentType::WorkspaceLead)
+        .map(|a| a.id.to_string())
+        .unwrap_or_default();
+
+    WorkspaceDetailTemplate {
+        workspace: workspace_to_view(&ws),
+        agent_id,
     }
+    .into_response()
 }
 
 #[instrument(name = "web.workspace_update", skip_all)]
@@ -833,6 +855,130 @@ async fn workspace_delete(
             tracing::error!(error = %e, "Failed to delete workspace");
             axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Workspace Secrets
+// ---------------------------------------------------------------------------
+
+fn secret_to_view(s: &domain::workspace_secret::WorkspaceSecret) -> WorkspaceSecretView {
+    WorkspaceSecretView {
+        id: s.id.to_string(),
+        workspace_id: s.workspace_id.to_string(),
+        name: s.name.clone(),
+        secret_type: s.secret_type.clone(),
+        updated_at: s.updated_at.format("%Y-%m-%d %H:%M UTC").to_string(),
+    }
+}
+
+#[instrument(name = "web.workspace_secrets_list", skip_all)]
+async fn workspace_secrets_list(
+    State(state): State<AppState>,
+    session: Session,
+    Path(id): Path<uuid::Uuid>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(id);
+    match state
+        .app
+        .workspace_secrets()
+        .list_by_workspace(workspace_id)
+        .await
+    {
+        Ok(secrets) => WorkspaceSecretsListTemplate {
+            secrets: secrets.iter().map(secret_to_view).collect(),
+        }
+        .into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to list workspace secrets");
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+#[derive(Deserialize)]
+struct CreateSecretForm {
+    name: String,
+    secret_type: String,
+    value: String,
+}
+
+#[instrument(name = "web.workspace_secret_create", skip_all)]
+async fn workspace_secret_create(
+    State(state): State<AppState>,
+    session: Session,
+    Path(id): Path<uuid::Uuid>,
+    Form(form): Form<CreateSecretForm>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(id);
+    let secret_type: domain::workspace_secret::SecretType = match form.secret_type.parse() {
+        Ok(t) => t,
+        Err(_) => return axum::http::StatusCode::BAD_REQUEST.into_response(),
+    };
+
+    if let Err(e) = state
+        .app
+        .workspace_secrets()
+        .create(workspace_id, &form.name, secret_type, &form.value)
+        .await
+    {
+        tracing::error!(error = %e, "Failed to create workspace secret");
+        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    // Return updated list
+    match state
+        .app
+        .workspace_secrets()
+        .list_by_workspace(workspace_id)
+        .await
+    {
+        Ok(secrets) => WorkspaceSecretsListTemplate {
+            secrets: secrets.iter().map(secret_to_view).collect(),
+        }
+        .into_response(),
+        Err(_) => axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response(),
+    }
+}
+
+#[instrument(name = "web.workspace_secret_delete", skip_all)]
+async fn workspace_secret_delete(
+    State(state): State<AppState>,
+    session: Session,
+    Path((id, secret_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(id);
+    let secret_id = WorkspaceSecretId::from(secret_id);
+
+    if let Err(e) = state.app.workspace_secrets().delete(secret_id).await {
+        tracing::error!(error = %e, "Failed to delete workspace secret");
+        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    // Return updated list
+    match state
+        .app
+        .workspace_secrets()
+        .list_by_workspace(workspace_id)
+        .await
+    {
+        Ok(secrets) => WorkspaceSecretsListTemplate {
+            secrets: secrets.iter().map(secret_to_view).collect(),
+        }
+        .into_response(),
+        Err(_) => axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
 }
 
@@ -971,7 +1117,9 @@ async fn agent_config_update(
 // ---------------------------------------------------------------------------
 
 pub fn api_router() -> Router<AppState> {
-    Router::new().route("/api/v1/agents/{id}/message", post(api_agent_message))
+    Router::new()
+        .route("/api/v1/agents/{id}/message", post(api_agent_message))
+        .route("/api/v1/agents/{id}/secrets", get(api_agent_secrets))
 }
 
 #[derive(Deserialize)]
@@ -1033,4 +1181,60 @@ async fn api_agent_message(
     Sse::new(stream)
         .keep_alive(KeepAlive::default())
         .into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Internal API — Agent Secrets (for harness injection)
+// ---------------------------------------------------------------------------
+
+/// Internal endpoint: returns secret values for an agent's workspace.
+/// Secured via SA token auth (AuthContext::Agent) — same pattern as MCP gateway.
+#[instrument(name = "api.agent.secrets", skip_all)]
+async fn api_agent_secrets(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Path(id): Path<uuid::Uuid>,
+) -> Response {
+    // Only allow Agent auth (SA token from sandbox pods)
+    let workspace_id = match &auth {
+        AuthContext::Agent(workspace_id, _, _) => *workspace_id,
+        _ => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
+    };
+
+    let agent_id = AgentId::from(id);
+
+    // Verify the agent belongs to the authenticated workspace
+    let agent = match state.app.agents().find_by_id(agent_id).await {
+        Ok(a) => a,
+        Err(_) => return axum::http::StatusCode::NOT_FOUND.into_response(),
+    };
+
+    if agent.workspace_id != workspace_id {
+        return axum::http::StatusCode::FORBIDDEN.into_response();
+    }
+
+    match state
+        .app
+        .workspace_secrets()
+        .list_with_values(workspace_id)
+        .await
+    {
+        Ok(secrets) => {
+            let body: Vec<serde_json::Value> = secrets
+                .iter()
+                .map(|s| {
+                    serde_json::json!({
+                        "name": s.name,
+                        "secret_type": s.secret_type,
+                        "value": s.encrypted_value,
+                    })
+                })
+                .collect();
+            Json(body).into_response()
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to list secrets for agent");
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
 }

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -178,6 +178,23 @@ pub struct WorkspaceNewTemplate {}
 #[template(path = "workspace_detail.html")]
 pub struct WorkspaceDetailTemplate {
     pub workspace: WorkspaceView,
+    pub agent_id: String,
+}
+
+// ── Workspace Secrets ────────────────────────────────────────────────
+
+pub struct WorkspaceSecretView {
+    pub id: String,
+    pub workspace_id: String,
+    pub name: String,
+    pub secret_type: String,
+    pub updated_at: String,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "workspace_secrets_list.html")]
+pub struct WorkspaceSecretsListTemplate {
+    pub secrets: Vec<WorkspaceSecretView>,
 }
 
 #[derive(Template, WebTemplate)]

--- a/web/templates/workspace_detail.html
+++ b/web/templates/workspace_detail.html
@@ -24,6 +24,54 @@
 </form>
 
 <hr>
+
+<h3>Secrets</h3>
+<p><small>Secrets are injected into the agent sandbox as environment variables or files. Values are never displayed after creation.</small></p>
+
+<div id="secrets-list"
+     hx-get="/workspaces/{{ workspace.id }}/secrets/list"
+     hx-trigger="load"
+     hx-swap="innerHTML">
+  <p aria-busy="true">Loading secrets...</p>
+</div>
+
+<details>
+  <summary>Add Secret</summary>
+  <form hx-post="/workspaces/{{ workspace.id }}/secrets"
+        hx-target="#secrets-list"
+        hx-swap="innerHTML"
+        hx-on::after-request="if(event.detail.successful) this.reset()">
+    <label>
+      Name
+      <input type="text" name="name" required placeholder="e.g. GITHUB_TOKEN" pattern="[A-Za-z_][A-Za-z0-9_]*">
+    </label>
+    <label>
+      Type
+      <select name="secret_type" required>
+        <option value="env_var">Environment Variable</option>
+        <option value="file">File (/run/secrets/&lt;name&gt;)</option>
+      </select>
+    </label>
+    <label>
+      Value
+      <input type="password" name="value" required placeholder="Secret value">
+    </label>
+    <button type="submit">Add Secret</button>
+  </form>
+</details>
+
+<hr>
+<details>
+  <summary>Agent Configuration</summary>
+  <div id="agent-config-panel"
+       hx-get="/agents/{{ agent_id }}/config"
+       hx-trigger="load"
+       hx-swap="innerHTML">
+    <p aria-busy="true">Loading configuration...</p>
+  </div>
+</details>
+
+<hr>
 <details>
   <summary>Danger Zone</summary>
   <p>Deleting a workspace will archive it and revoke MCP credentials for all its agents.</p>

--- a/web/templates/workspace_secrets_list.html
+++ b/web/templates/workspace_secrets_list.html
@@ -1,0 +1,33 @@
+{% if secrets.is_empty() %}
+<p><em>No secrets configured.</em></p>
+{% else %}
+<table>
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Type</th>
+      <th>Updated</th>
+      <th></th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for secret in secrets %}
+    <tr>
+      <td><code>{{ secret.name }}</code></td>
+      <td>{{ secret.secret_type }}</td>
+      <td><small>{{ secret.updated_at }}</small></td>
+      <td>
+        <button
+          hx-post="/workspaces/{{ secret.workspace_id }}/secrets/{{ secret.id }}/delete"
+          hx-target="#secrets-list"
+          hx-swap="innerHTML"
+          hx-confirm="Delete secret '{{ secret.name }}'?"
+          class="outline secondary"
+          style="padding: 0.25rem 0.5rem; margin: 0;"
+        >Delete</button>
+      </td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}


### PR DESCRIPTION
## Summary

- **Phase 1 — Storage + API + UI**: Adds `workspace_secrets` table (flat SQL), `WorkspaceSecrets` service with CRUD, REST endpoints for dashboard management, and internal SA-token-authed API endpoint for harness to fetch secret values
- **Phase 2 — Harness injection + scrubbing**: Harness fetches secrets on startup, injects `env_var` types into CLI subprocess environment and `file` types to `/run/secrets/<name>`, scrubs all SSE output for leaked secret values (replaced with `[REDACTED]`)
- **Dashboard UI**: Secrets section on workspace detail page with add/delete forms (HTMX partials)

## Test plan

- [ ] Verify migration runs cleanly against Postgres
- [ ] Create a workspace, add env_var and file secrets via dashboard UI
- [ ] Confirm secret values are never returned in list API responses
- [ ] Confirm internal endpoint (`GET /api/v1/agents/:id/secrets`) returns values only for SA-token-authed agents in the correct workspace
- [ ] Deploy to sandbox, verify harness injects env vars and files
- [ ] Send a message that would leak a secret value, verify it appears as `[REDACTED]` in SSE stream

🤖 Generated with [Claude Code](https://claude.com/claude-code)