### PR TITLE
feat(github): add GitHub App token auto-provisioning

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1557,6 +1557,7 @@ dependencies = [
  "es-entity",
  "hex",
  "http",
+ "jsonwebtoken",
  "opentelemetry",
  "opentelemetry-http",
  "pgvector",
@@ -2398,6 +2399,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
+dependencies = [
+ "base64 0.22.1",
+ "js-sys",
+ "pem",
+ "ring",
+ "serde",
+ "serde_json",
+ "simple_asn1",
+]
+
+[[package]]
 name = "k8s-openapi"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2793,6 +2809,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
 ]
 
 [[package]]
@@ -4391,6 +4417,18 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simple_asn1"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d585997b0ac10be3c5ee635f1bab02d512760d14b7c468801ac8a01d9ae5f1d"
+dependencies = [
+ "num-bigint",
+ "num-traits",
+ "thiserror 2.0.18",
+ "time",
+]
 
 [[package]]
 name = "sized-chunks"

--- a/charts/galoy-agents/templates/configmap.yaml
+++ b/charts/galoy-agents/templates/configmap.yaml
@@ -82,6 +82,11 @@ data:
             - "resources_get"
       {{- end }}
       {{- end }}
+    {{- if .Values.galoyAgents.githubApp.enabled }}
+    github_app:
+      client_id: {{ .Values.galoyAgents.githubApp.clientId | quote }}
+      installation_id: {{ .Values.galoyAgents.githubApp.installationId | quote }}
+    {{- end }}
     sandbox:
       enabled: {{ .Values.sandbox.enabled }}
       namespace: {{ include "galoyAgents.sandboxNamespace" . | quote }}

--- a/charts/galoy-agents/templates/deployment.yaml
+++ b/charts/galoy-agents/templates/deployment.yaml
@@ -116,6 +116,11 @@ spec:
         - name: code-assistant-data
           mountPath: /data/code-assistant
         {{- end }}
+        {{- if .Values.galoyAgents.githubApp.enabled }}
+        - name: github-app-key
+          mountPath: /secrets/github-app
+          readOnly: true
+        {{- end }}
         env:
         - name: GALOY_AGENTS_CONFIG
           value: "/config/galoy-agents.yml"
@@ -157,6 +162,10 @@ spec:
               name: {{ template "galoyAgents.fullname" . }}
               key: "anthropic-api-key"
               optional: true
+        {{- if .Values.galoyAgents.githubApp.enabled }}
+        - name: GITHUB_APP_PRIVATE_KEY_PATH
+          value: "/secrets/github-app/{{ .Values.galoyAgents.githubApp.privateKeySecretKey }}"
+        {{- end }}
         - name: KUBE_NODE_NAME
           valueFrom:
             fieldRef:
@@ -175,4 +184,12 @@ spec:
       {{- if .Values.galoyAgents.codeAssistant.indexHash }}
       - name: code-assistant-data
         emptyDir: {}
+      {{- end }}
+      {{- if .Values.galoyAgents.githubApp.enabled }}
+      - name: github-app-key
+        secret:
+          secretName: {{ .Values.galoyAgents.githubApp.privateKeySecret }}
+          items:
+            - key: {{ .Values.galoyAgents.githubApp.privateKeySecretKey }}
+              path: {{ .Values.galoyAgents.githubApp.privateKeySecretKey }}
       {{- end }}

--- a/charts/galoy-agents/values.yaml
+++ b/charts/galoy-agents/values.yaml
@@ -68,6 +68,16 @@ galoyAgents:
     #   authHeaderName: x-api-key
     #   category: localization
     #   categoryDescription: "AI-powered localization engine management and translation"
+  ## GitHub App configuration for token auto-provisioning.
+  ## When enabled, sandbox agents receive a `github-token` file secret.
+  githubApp:
+    enabled: false
+    clientId: ""
+    installationId: ""
+    ## Name of a pre-existing K8s Secret containing the PEM private key.
+    ## The key file is mounted read-only into the server pod.
+    privateKeySecret: ""
+    privateKeySecretKey: "private-key.pem"
   secrets:
     create: true
     pgCon: ""

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -18,8 +18,25 @@ pub struct Config {
     pub sandbox: SandboxConfig,
     #[serde(default)]
     pub toolsets: ToolSetsConfig,
+    #[serde(default)]
+    pub github_app: Option<GitHubAppCliConfig>,
     #[serde(skip)]
     pub anthropic_api_key: String,
+}
+
+/// GitHub App config from the YAML config file.
+/// The `private_key_path` field is `#[serde(skip)]` because it's a secret
+/// loaded from an env var / K8s secret mount — never baked into the config file.
+#[derive(Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct GitHubAppCliConfig {
+    #[serde(default)]
+    pub client_id: String,
+    #[serde(default)]
+    pub installation_id: String,
+    /// Filesystem path to the PEM private key (loaded from env: GITHUB_APP_PRIVATE_KEY_PATH).
+    #[serde(skip)]
+    pub private_key_path: String,
 }
 
 #[derive(Clone, Default, Deserialize)]
@@ -153,6 +170,13 @@ impl Config {
             let env_key = format!("{}_AUTH_HEADER", upstream.name.to_uppercase());
             if let Ok(val) = std::env::var(&env_key) {
                 upstream.auth_header = val;
+            }
+        }
+
+        // GitHub App private key path from env (K8s secret mount)
+        if let Some(ref mut gh) = config.github_app {
+            if let Ok(val) = std::env::var("GITHUB_APP_PRIVATE_KEY_PATH") {
+                gh.private_key_path = val;
             }
         }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -62,6 +62,21 @@ async fn main() -> anyhow::Result<()> {
     let pool = sqlx::PgPool::connect(&config.db.pg_con).await?;
     sqlx::migrate!("../core/migrations").run(&pool).await?;
 
+    let github_app_config = config.github_app.as_ref().and_then(|gh| {
+        if gh.client_id.is_empty()
+            || gh.installation_id.is_empty()
+            || gh.private_key_path.is_empty()
+        {
+            None
+        } else {
+            Some(galoy_agents_core::github_app::GitHubAppConfig {
+                client_id: gh.client_id.clone(),
+                installation_id: gh.installation_id.clone(),
+                private_key_path: gh.private_key_path.clone(),
+            })
+        }
+    });
+
     let app_config = galoy_agents_core::AppConfig {
         agents: galoy_agents_core::agent::AgentConfig {
             sandbox: galoy_agents_core::agent::config::SandboxClientConfig {
@@ -82,6 +97,7 @@ async fn main() -> anyhow::Result<()> {
         },
         toolsets: config.toolsets.clone(),
         encryption: Default::default(),
+        github_app: github_app_config,
     };
 
     let app = galoy_agents_core::App::init(&pool, app_config).await?;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -24,6 +24,7 @@ serde_json = "1.0"
 sha2 = "0.10"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "json"] }
 pgvector = { workspace = true }
+jsonwebtoken = { version = "9", default-features = false, features = ["use_pem"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 rmcp = { workspace = true }
 thiserror = "2.0"

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 
 use crate::agent::AgentConfig;
 use crate::encryption::EncryptionKey;
+use crate::github_app::GitHubAppConfig;
 use crate::toolset::ToolSetsConfig;
 
 #[derive(Clone, Debug, Default, Deserialize)]
@@ -12,6 +13,10 @@ pub struct AppConfig {
     pub toolsets: ToolSetsConfig,
     #[serde(default)]
     pub encryption: EncryptionConfig,
+    /// Optional GitHub App config for token auto-provisioning.
+    /// When set, sandbox agents receive a `github-token` file secret.
+    #[serde(default)]
+    pub github_app: Option<GitHubAppConfig>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize)]

--- a/core/src/github_app/config.rs
+++ b/core/src/github_app/config.rs
@@ -1,0 +1,28 @@
+use serde::Deserialize;
+
+/// Configuration for the GitHub App integration.
+/// All fields are required — if any env var is missing, the feature is disabled.
+#[derive(Clone, Debug, Deserialize)]
+pub struct GitHubAppConfig {
+    /// The GitHub App's client ID (used as `iss` in the JWT).
+    pub client_id: String,
+    /// The installation ID for the org where the app is installed.
+    pub installation_id: String,
+    /// Filesystem path to the PEM-encoded RSA private key (K8s secret mount).
+    pub private_key_path: String,
+}
+
+impl GitHubAppConfig {
+    /// Try to build config from environment variables.
+    /// Returns `None` if any required variable is missing (feature disabled).
+    pub fn from_env() -> Option<Self> {
+        let client_id = std::env::var("GITHUB_APP_CLIENT_ID").ok()?;
+        let installation_id = std::env::var("GITHUB_APP_INSTALLATION_ID").ok()?;
+        let private_key_path = std::env::var("GITHUB_APP_PRIVATE_KEY_PATH").ok()?;
+        Some(Self {
+            client_id,
+            installation_id,
+            private_key_path,
+        })
+    }
+}

--- a/core/src/github_app/config.rs
+++ b/core/src/github_app/config.rs
@@ -1,7 +1,8 @@
 use serde::Deserialize;
 
 /// Configuration for the GitHub App integration.
-/// All fields are required — if any env var is missing, the feature is disabled.
+/// Passed through `AppConfig` — non-secret fields come from the YAML config file,
+/// while `private_key_path` is injected from an env var (K8s secret mount).
 #[derive(Clone, Debug, Deserialize)]
 pub struct GitHubAppConfig {
     /// The GitHub App's client ID (used as `iss` in the JWT).
@@ -10,19 +11,4 @@ pub struct GitHubAppConfig {
     pub installation_id: String,
     /// Filesystem path to the PEM-encoded RSA private key (K8s secret mount).
     pub private_key_path: String,
-}
-
-impl GitHubAppConfig {
-    /// Try to build config from environment variables.
-    /// Returns `None` if any required variable is missing (feature disabled).
-    pub fn from_env() -> Option<Self> {
-        let client_id = std::env::var("GITHUB_APP_CLIENT_ID").ok()?;
-        let installation_id = std::env::var("GITHUB_APP_INSTALLATION_ID").ok()?;
-        let private_key_path = std::env::var("GITHUB_APP_PRIVATE_KEY_PATH").ok()?;
-        Some(Self {
-            client_id,
-            installation_id,
-            private_key_path,
-        })
-    }
 }

--- a/core/src/github_app/error.rs
+++ b/core/src/github_app/error.rs
@@ -1,0 +1,13 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum GitHubAppError {
+    #[error("GitHubAppError - Jwt: {0}")]
+    Jwt(#[from] jsonwebtoken::errors::Error),
+    #[error("GitHubAppError - Reqwest: {0}")]
+    Reqwest(#[from] reqwest::Error),
+    #[error("GitHubAppError - ApiError: {status} {message}")]
+    ApiError { status: u16, message: String },
+    #[error("GitHubAppError - PrivateKeyRead: {0}")]
+    PrivateKeyRead(std::io::Error),
+}

--- a/core/src/github_app/mod.rs
+++ b/core/src/github_app/mod.rs
@@ -1,0 +1,112 @@
+pub mod config;
+pub mod error;
+
+use tracing::instrument;
+
+pub use config::*;
+pub use error::*;
+
+/// A successfully generated GitHub installation access token.
+pub struct InstallationToken {
+    pub token: String,
+    pub expires_at: String,
+}
+
+/// Generates GitHub App installation access tokens via the RS256 JWT flow.
+///
+/// Holds the cached `EncodingKey` and HTTP client. Designed to be shared
+/// across requests (put it in `Arc` or `Clone` the wrapper).
+#[derive(Clone)]
+pub struct GitHubAppTokenProvider {
+    client_id: String,
+    installation_id: String,
+    encoding_key: jsonwebtoken::EncodingKey,
+    http_client: reqwest::Client,
+}
+
+impl GitHubAppTokenProvider {
+    /// Create a new provider by reading the PEM private key from disk.
+    /// Returns an error only if the key file cannot be read or parsed.
+    pub fn new(config: &GitHubAppConfig) -> Result<Self, GitHubAppError> {
+        let pem_bytes =
+            std::fs::read(&config.private_key_path).map_err(GitHubAppError::PrivateKeyRead)?;
+        let encoding_key = jsonwebtoken::EncodingKey::from_rsa_pem(&pem_bytes)?;
+        Ok(Self {
+            client_id: config.client_id.clone(),
+            installation_id: config.installation_id.clone(),
+            encoding_key,
+            http_client: reqwest::Client::new(),
+        })
+    }
+
+    /// Generate a fresh installation access token from the GitHub API.
+    ///
+    /// 1. Signs an RS256 JWT (10 min expiry) with the app's client_id as `iss`.
+    /// 2. POSTs to `/app/installations/{id}/access_tokens` with scoped permissions.
+    /// 3. Returns the token string and its expiration timestamp.
+    #[instrument(name = "github_app.generate_token", skip_all)]
+    pub async fn generate_token(&self) -> Result<InstallationToken, GitHubAppError> {
+        let jwt = self.sign_jwt()?;
+        self.exchange_for_installation_token(&jwt).await
+    }
+
+    /// Sign an RS256 JWT for GitHub App authentication.
+    /// Claims: iss = client_id, iat = now - 60s (clock drift), exp = now + 10min.
+    fn sign_jwt(&self) -> Result<String, GitHubAppError> {
+        let now = chrono::Utc::now().timestamp();
+        let claims = serde_json::json!({
+            "iss": self.client_id,
+            "iat": now - 60,
+            "exp": now + (10 * 60),
+        });
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::RS256);
+        let token = jsonwebtoken::encode(&header, &claims, &self.encoding_key)?;
+        Ok(token)
+    }
+
+    /// Exchange the JWT for an installation access token with scoped permissions.
+    async fn exchange_for_installation_token(
+        &self,
+        jwt: &str,
+    ) -> Result<InstallationToken, GitHubAppError> {
+        let url = format!(
+            "https://api.github.com/app/installations/{}/access_tokens",
+            self.installation_id
+        );
+
+        let body = serde_json::json!({
+            "permissions": {
+                "contents": "write",
+                "pull_requests": "write",
+                "issues": "write",
+                "metadata": "read"
+            }
+        });
+
+        let resp = self
+            .http_client
+            .post(&url)
+            .header("Authorization", format!("Bearer {jwt}"))
+            .header("Accept", "application/vnd.github+json")
+            .header("User-Agent", "galoy-agents")
+            .header("X-GitHub-Api-Version", "2022-11-28")
+            .json(&body)
+            .send()
+            .await?;
+
+        if !resp.status().is_success() {
+            let status = resp.status().as_u16();
+            let message = resp
+                .text()
+                .await
+                .unwrap_or_else(|_| "unknown error".to_string());
+            return Err(GitHubAppError::ApiError { status, message });
+        }
+
+        let json: serde_json::Value = resp.json().await?;
+        let token = json["token"].as_str().unwrap_or_default().to_string();
+        let expires_at = json["expires_at"].as_str().unwrap_or_default().to_string();
+
+        Ok(InstallationToken { token, expires_at })
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -98,10 +98,10 @@ impl App {
         let encryption_key = config.encryption.encryption_key();
         let workspace_secrets = WorkspaceSecrets::new(pool, encryption_key);
 
-        // Optionally initialize GitHub App token provider from env vars.
+        // Optionally initialize GitHub App token provider from AppConfig.
         // If not configured, agents simply won't get a github-token secret.
-        let github_app = match github_app::GitHubAppConfig::from_env() {
-            Some(gh_config) => match GitHubAppTokenProvider::new(&gh_config) {
+        let github_app = match config.github_app {
+            Some(ref gh_config) => match GitHubAppTokenProvider::new(gh_config) {
                 Ok(provider) => {
                     tracing::info!("GitHub App token provider initialized");
                     Some(provider)

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -5,6 +5,7 @@ pub mod chat_history;
 pub mod code_assistant;
 mod config;
 pub mod encryption;
+pub mod github_app;
 pub mod mcp_creds;
 pub mod primitives;
 pub mod report;
@@ -20,6 +21,7 @@ use std::sync::Arc;
 use agent::Agents;
 use audit::Audit;
 use code_assistant::CodeAssistant;
+use github_app::GitHubAppTokenProvider;
 use mcp_creds::McpCredentials;
 use report::Reports;
 use toolset::{AdminToolSet, ToolSets, ToolSetsError};
@@ -38,6 +40,7 @@ pub struct App {
     toolsets: Arc<ToolSets>,
     workspaces: Workspaces,
     workspace_secrets: WorkspaceSecrets,
+    github_app: Option<GitHubAppTokenProvider>,
 }
 
 impl App {
@@ -95,6 +98,25 @@ impl App {
         let encryption_key = config.encryption.encryption_key();
         let workspace_secrets = WorkspaceSecrets::new(pool, encryption_key);
 
+        // Optionally initialize GitHub App token provider from env vars.
+        // If not configured, agents simply won't get a github-token secret.
+        let github_app = match github_app::GitHubAppConfig::from_env() {
+            Some(gh_config) => match GitHubAppTokenProvider::new(&gh_config) {
+                Ok(provider) => {
+                    tracing::info!("GitHub App token provider initialized");
+                    Some(provider)
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "GitHub App configured but failed to initialize — skipping");
+                    None
+                }
+            },
+            None => {
+                tracing::info!("GitHub App not configured — token auto-provisioning disabled");
+                None
+            }
+        };
+
         Ok(Self {
             users: Users::new(pool),
             mcp_creds,
@@ -105,6 +127,7 @@ impl App {
             toolsets,
             workspaces,
             workspace_secrets,
+            github_app,
         })
     }
 
@@ -142,6 +165,10 @@ impl App {
 
     pub fn workspace_secrets(&self) -> &WorkspaceSecrets {
         &self.workspace_secrets
+    }
+
+    pub fn github_app(&self) -> Option<&GitHubAppTokenProvider> {
+        self.github_app.as_ref()
     }
 }
 

--- a/images/sandbox-base/agent-harness/src/index.ts
+++ b/images/sandbox-base/agent-harness/src/index.ts
@@ -729,6 +729,21 @@ initTracing();
   }
 })();
 
+// Background refresh loop — re-fetch secrets every 45 minutes so that
+// short-lived tokens (e.g. GitHub App installation tokens, 1hr TTL) stay fresh.
+const SECRET_REFRESH_INTERVAL_MS = 45 * 60 * 1000;
+setInterval(async () => {
+  try {
+    const secrets = await fetchSecrets();
+    if (secrets.length > 0) {
+      injectSecrets(secrets);
+      console.log(`[secrets] Refreshed ${secrets.length} secret(s)`);
+    }
+  } catch (err) {
+    console.error("[secrets] Refresh failed:", err);
+  }
+}, SECRET_REFRESH_INTERVAL_MS);
+
 const server = createServer((req, res) => {
   handleRequest(req, res).catch((err) => {
     console.error("Unhandled error in request handler:", err);

--- a/images/sandbox-base/default.nix
+++ b/images/sandbox-base/default.nix
@@ -38,6 +38,53 @@ let
   agentHarnessWrapper = pkgs.writeShellScriptBin "agent-harness" ''
     exec ${pkgs.nodejs_22}/bin/node ${agentHarness}/lib/index.js "$@"
   '';
+
+  # ── GitHub App token wrappers ──────────────────────────────────────
+
+  # Wrapped `gh` CLI: reads GH_TOKEN from /run/secrets/github-token on
+  # every invocation so mid-session token rotation is transparent.
+  ghWrapped = pkgs.writeShellScriptBin "gh" ''
+    if [ -f /run/secrets/github-token ]; then
+      export GH_TOKEN
+      GH_TOKEN="$(cat /run/secrets/github-token)"
+    fi
+    exec ${pkgs.gh}/bin/gh "$@"
+  '';
+
+  # Git credential helper: reads the token from /run/secrets/github-token
+  # and outputs protocol/host/username/password for github.com HTTPS.
+  gitCredentialHelper = pkgs.writeShellScriptBin "git-credential-github-token" ''
+    case "$1" in
+      get)
+        github=""
+        while IFS= read -r line; do
+          case "$line" in
+            host=github.com) github=1 ;;
+            "") break ;;
+          esac
+        done
+        if [ "$github" = "1" ] && [ -f /run/secrets/github-token ]; then
+          echo "protocol=https"
+          echo "host=github.com"
+          echo "username=x-access-token"
+          echo "password=$(cat /run/secrets/github-token)"
+          echo ""
+        fi
+        ;;
+      store|erase)
+        # No-op — we don't persist credentials
+        ;;
+    esac
+  '';
+
+  # Default .gitconfig with credential helper and bot identity.
+  gitconfig = pkgs.writeTextDir "home/agent/.gitconfig" ''
+    [credential "https://github.com"]
+      helper = ${gitCredentialHelper}/bin/git-credential-github-token
+    [user]
+      name = galoy-agents[bot]
+      email = galoy-agents[bot]@users.noreply.github.com
+  '';
 in
 pkgs.dockerTools.buildLayeredImage {
   name = "sandbox-base";
@@ -61,7 +108,9 @@ pkgs.dockerTools.buildLayeredImage {
     pkgs.gnused
     pkgs.gnugrep
     pkgs.openssh
-    pkgs.gh
+    ghWrapped
+    gitCredentialHelper
+    gitconfig
     pkgs.nodejs_22
     agentHarnessWrapper
   ];

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -1210,28 +1210,45 @@ async fn api_agent_secrets(
         return axum::http::StatusCode::FORBIDDEN.into_response();
     }
 
-    match state
+    let secrets = match state
         .app
         .workspace_secrets()
         .list_decrypted(workspace_id)
         .await
     {
-        Ok(secrets) => {
-            let body: Vec<serde_json::Value> = secrets
-                .iter()
-                .map(|s| {
-                    serde_json::json!({
-                        "name": s.name,
-                        "secret_type": s.secret_type.as_str(),
-                        "value": s.value,
-                    })
-                })
-                .collect();
-            Json(body).into_response()
-        }
+        Ok(s) => s,
         Err(e) => {
             tracing::error!(error = %e, "Failed to list secrets for agent");
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    let mut body: Vec<serde_json::Value> = secrets
+        .iter()
+        .map(|s| {
+            serde_json::json!({
+                "name": s.name,
+                "secret_type": s.secret_type.as_str(),
+                "value": s.value,
+            })
+        })
+        .collect();
+
+    // Auto-provision a GitHub token if the GitHub App is configured.
+    if let Some(github_app) = state.app.github_app() {
+        match github_app.generate_token().await {
+            Ok(token) => {
+                body.push(serde_json::json!({
+                    "name": "github-token",
+                    "secret_type": "file",
+                    "value": token.token,
+                }));
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "Failed to generate GitHub App token — skipping");
+            }
         }
     }
+
+    Json(body).into_response()
 }


### PR DESCRIPTION
## Summary
- **Server-side `GitHubAppTokenProvider`**: Signs RS256 JWTs and exchanges them for scoped GitHub App installation access tokens (contents:write, pull_requests:write, issues:write, metadata:read)
- **Auto-injection via secrets endpoint**: `GET /api/v1/agents/{id}/secrets` now appends a `github-token` file-type secret when `GITHUB_APP_*` env vars are configured — no changes needed to per-workspace secret config
- **Harness 45-min refresh loop**: Background `setInterval` re-fetches secrets to keep 1-hour-TTL tokens fresh with a 15-minute safety margin
- **Nix-wrapped CLI tools**: Wrapped `gh` reads `GH_TOKEN` from `/run/secrets/github-token` on every invocation; custom git credential helper provides transparent HTTPS auth to github.com; default `.gitconfig` sets bot identity

## Configuration

Set these env vars on the galoy-agents server pod to enable:
```
GITHUB_APP_CLIENT_ID=Iv1.abc123
GITHUB_APP_INSTALLATION_ID=12345678
GITHUB_APP_PRIVATE_KEY_PATH=/path/to/private-key.pem
```
If any variable is missing, the feature is gracefully disabled — agents simply won't receive a `github-token` secret.

---

## MCP Gateway Migration: Copilot MCP → GitHub App Token

### Current State

The MCP gateway proxies GitHub tools via the **Copilot MCP** endpoint:

```yaml
# galoy-agents.yml
- name: github
  url: https://api.githubcopilot.com/mcp/readonly
  tool_prefix: github
  category: source-control
  allowed_tools: [get_file_contents, list_commits, pull_request_read, ...]
```

Authentication uses a static `GITHUB_AUTH_HEADER` env var (loaded once at startup from the `{NAME}_AUTH_HEADER` convention in `cli/src/config.rs:151-157`). The Helm chart injects it via:

```yaml
# charts/galoy-agents/templates/deployment.yaml
- name: GITHUB_AUTH_HEADER
  valueFrom:
    secretKeyRef:
      name: galoy-agents
      key: "github-auth-header"
      optional: true
```

**Limitations of current approach:**
- Copilot MCP is **read-only** — no write operations (create PR, push, etc.)
- Requires a separate Copilot API key / PAT
- Static token — no rotation, no scoping

### Target State

Replace the Copilot MCP upstream with an official **GitHub MCP server** instance authenticated via the GitHub App's installation tokens. This gives the gateway **read+write** GitHub tools and unifies auth under a single GitHub App.

### Migration Path

There are two viable approaches. **Option A is recommended** for simplicity.

#### Option A: Self-hosted `github-mcp-server` sidecar (Recommended)

Run GitHub's official [`github/github-mcp-server`](https://github.com/github/github-mcp-server) as a sidecar or separate deployment, configured with the GitHub App installation token.

**Architecture:**
```
galoy-agents server pod
├── galoy-agents (main container)
│   ├── GitHubAppTokenProvider → generates installation tokens
│   └── MCP gateway → proxies to http://localhost:8080/mcp
└── github-mcp-server (sidecar container)
    ├── Reads GITHUB_PERSONAL_ACCESS_TOKEN from /run/secrets/github-mcp-token
    ├── Listens on :8080 (streamable HTTP)
    └── Full read+write GitHub tools
```

**Steps:**

1. **Deploy github-mcp-server sidecar** in the galoy-agents pod:
   ```yaml
   # values.yaml addition
   githubApp:
     enabled: true
     appId: "123456"
     clientId: "Iv1.abc123"
     installationId: "12345678"
     privateKeySecret: "github-app-private-key"
     privateKeySecretKey: "private-key.pem"
   
   githubMcpServer:
     enabled: true
     image: ghcr.io/github/github-mcp-server:latest
     port: 8080
   ```

2. **Add an init container or startup script** that calls the `GitHubAppTokenProvider` to generate an initial token and writes it to a shared emptyDir volume.

3. **Add a refresh sidecar/CronJob** that regenerates the token every 45 minutes (same cadence as the sandbox harness). Write atomically to the shared volume.

4. **Update the `github` upstream config** to point to the local sidecar:
   ```yaml
   # galoy-agents.yml
   - name: github
     url: http://localhost:8080/mcp    # sidecar, not Copilot
     tool_prefix: github
     category: source-control
     category_description: "GitHub repositories, pull requests, issues, and code search"
     # No allowed_tools filter — expose all tools including write ops
   ```

5. **Remove the `GITHUB_AUTH_HEADER` env var** — the sidecar handles its own auth to GitHub API.

6. **Helm chart changes:**
   ```yaml
   # deployment.yaml — add sidecar container
   {{- if .Values.githubMcpServer.enabled }}
   - name: github-mcp-server
     image: {{ .Values.githubMcpServer.image }}
     ports:
       - containerPort: {{ .Values.githubMcpServer.port }}
     env:
       - name: GITHUB_PERSONAL_ACCESS_TOKEN
         valueFrom:
           secretKeyRef:
             name: github-app-token   # refreshed by sidecar
             key: token
     # ... resource limits
   {{- end }}
   ```

**Pros:** Clean separation; github-mcp-server handles all GitHub API complexity; auth is local (no header needed from gateway); write tools available.  
**Cons:** Extra container; token refresh sidecar adds complexity.

#### Option B: Dynamic auth header in upstream proxy

Make the MCP gateway's upstream auth header **dynamic** — refresh it using `GitHubAppTokenProvider` before each request (or on a timer).

**Steps:**

1. **Add `auth_provider` field** to `McpUpstreamConfig`:
   ```rust
   // core/src/toolset/config.rs
   pub enum AuthProvider {
       Static,         // current: read from env var once
       GitHubApp,      // new: generate token from GitHubAppTokenProvider
   }
   ```

2. **Modify `UpstreamToolSet`** to hold an `Option<GitHubAppTokenProvider>` and regenerate the auth header before each `call()`:
   ```rust
   // core/src/toolset/upstream.rs
   async fn call(&self, tool_name: &str, ...) -> Result<...> {
       // If using GitHubApp auth, refresh token before calling
       if let Some(provider) = &self.github_app_provider {
           let token = provider.generate_token().await?;
           // Inject fresh Bearer token into the request...
       }
       self.peer().call_tool(params).await
   }
   ```

3. **Problem:** The `rmcp` transport sets headers at connection init time, not per-request. The `StreamableHttpClientTransport` doesn't support dynamic headers. This would require either:
   - Reconnecting the MCP client before each call (expensive, ~1s per tool call)
   - Forking/extending `rmcp` to support per-request header injection
   - Using a local HTTP proxy that injects the token (essentially Option A)

4. **Switch the upstream URL** to GitHub's official MCP endpoint (if they expose one as HTTP), or continue using Copilot MCP with the installation token as bearer.

**Pros:** No extra containers.  
**Cons:** `rmcp` doesn't support dynamic headers natively; would need reconnection or transport changes; higher implementation effort.

### Recommendation

**Use Option A** (github-mcp-server sidecar). It cleanly separates concerns:
- `GitHubAppTokenProvider` generates tokens (already implemented in this PR)
- `github-mcp-server` handles the GitHub API surface
- The MCP gateway proxies to a localhost endpoint with no auth header needed
- Token refresh is handled by a simple script writing to a shared emptyDir

The alternative (Option B) fights against the `rmcp` transport's static-header design and would require significant plumbing for marginal benefit.

### Future: Write Tools Available to Agents

Once the migration is complete, the gateway will expose **write tools** through the MCP gateway:

| Tool | Permission | Use case |
|------|-----------|----------|
| `create_pull_request` | pull_requests:write | Agent creates PRs |
| `merge_pull_request` | pull_requests:write | Agent merges PRs |
| `create_issue` | issues:write | Agent files issues |
| `add_issue_comment` | issues:write | Agent comments on issues |
| `push_files` | contents:write | Agent pushes code changes |
| `create_branch` | contents:write | Agent creates branches |

These complement the **direct git/gh CLI access** in sandboxes (this PR). Hosted agents without sandboxes can use MCP tools; sandbox agents can use both CLI and MCP.

### Deployment Checklist

- [ ] Register GitHub App on GaloyMoney org with required permissions
- [ ] Generate private key, store as K8s Secret (`github-app-private-key`)
- [ ] Set `GITHUB_APP_CLIENT_ID`, `GITHUB_APP_INSTALLATION_ID`, `GITHUB_APP_PRIVATE_KEY_PATH` on server pod
- [ ] Deploy `github-mcp-server` as sidecar (Option A)
- [ ] Update `galoy-agents.yml` to point `github` upstream to `http://localhost:8080/mcp`
- [ ] Remove `allowed_tools` filter to expose write tools
- [ ] Remove old `GITHUB_AUTH_HEADER` / Copilot MCP PAT
- [ ] Verify: `search_tools(category="source-control")` returns write tools
- [ ] Verify: sandbox agent can `gh pr create` using file-based token
- [ ] Verify: MCP gateway can `create_pull_request` via github-mcp-server

---

## Test plan
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` zero warnings
- [x] `cargo nextest run` — 168/168 tests pass
- [ ] Deploy to staging with GitHub App credentials and verify `gh auth status` works inside a sandbox
- [ ] Verify token refresh: confirm `/run/secrets/github-token` is updated after 45 minutes
- [ ] End-to-end: agent clones repo, creates branch, pushes, opens PR via `gh pr create`

🤖 Generated with [Claude Code](https://claude.com/claude-code)