### PR TITLE
fix(harness): add SSE keepalive heartbeats for long-running commands

### DIFF
--- a/core/src/agent/harness_client.rs
+++ b/core/src/agent/harness_client.rs
@@ -11,7 +11,9 @@ use super::AgentMessageEvent;
 
 const HARNESS_PORT: u16 = 3000;
 /// Maximum time a single agentic run can take (many tool calls).
-const REQUEST_TIMEOUT: Duration = Duration::from_secs(600);
+/// Set to 30 minutes — with SSE keepalive heartbeats preventing idle-stream
+/// closure, this acts as a safety-net upper bound.
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(1800);
 
 /// HTTP client for the agent harness running inside sandbox pods.
 ///

--- a/images/sandbox-base/agent-harness/src/index.ts
+++ b/images/sandbox-base/agent-harness/src/index.ts
@@ -137,6 +137,34 @@ function writeMcpSettings(
   writeFileSync(settingsPath, JSON.stringify(existing, null, 2));
 }
 
+// ── CLI settings ────────────────────────────────────────────────────
+
+/**
+ * Write CLI-level settings to .claude/settings.json.
+ * Extends the Bash tool timeout so long builds (nix flake check) don't get killed.
+ */
+function writeCliSettings(): void {
+  const settingsDir = join(CWD, ".claude");
+  mkdirSync(settingsDir, { recursive: true });
+  const settingsPath = join(settingsDir, "settings.json");
+
+  let existing: Record<string, unknown> = {};
+  try {
+    if (existsSync(settingsPath)) {
+      existing = JSON.parse(readFileSync(settingsPath, "utf-8"));
+    }
+  } catch {
+    /* start fresh */
+  }
+
+  const env = (existing.env ?? {}) as Record<string, string>;
+  env.BASH_DEFAULT_TIMEOUT_MS = "600000"; // 10 min default per command
+  env.BASH_MAX_TIMEOUT_MS = "1800000"; // 30 min max per command
+  existing.env = env;
+
+  writeFileSync(settingsPath, JSON.stringify(existing, null, 2));
+}
+
 // ── SA token MCP config ──────────────────────────────────────────────
 
 /**
@@ -683,6 +711,14 @@ async function handleRequest(
         },
         async (span: Span) => {
           busy = true;
+          // Send SSE comment keepalives every 15s to prevent idle-stream
+          // closure by network intermediaries (Istio/Envoy, cloud LBs).
+          // SSE comments (lines starting with ':') are ignored by parsers.
+          const heartbeatInterval = setInterval(() => {
+            if (!res.writableEnded) {
+              res.write(`: heartbeat\n\n`);
+            }
+          }, 15_000);
           try {
             await handleMessage(input, (event) => sendSSE(res, event));
             span.setStatus({ code: SpanStatusCode.OK });
@@ -693,6 +729,7 @@ async function handleRequest(
             });
             throw err;
           } finally {
+            clearInterval(heartbeatInterval);
             busy = false;
             span.end();
           }
@@ -716,6 +753,9 @@ if (!process.env.ANTHROPIC_API_KEY) {
 
 // Initialize OpenTelemetry before starting the server
 initTracing();
+
+// Write CLI settings (extended Bash timeout for long builds)
+writeCliSettings();
 
 // Fetch and inject workspace secrets before starting
 (async () => {


### PR DESCRIPTION
## Summary

- **Harness heartbeat**: Sends `: heartbeat` SSE comments every 15s during message handling to prevent idle-stream closure by network intermediaries (Istio/Envoy, cloud LBs)
- **Extended reqwest timeout**: `REQUEST_TIMEOUT` increased from 600s (10 min) to 1800s (30 min) as a safety-net upper bound now that heartbeats keep the connection alive
- **CLI bash timeout config**: Writes `BASH_DEFAULT_TIMEOUT_MS` (10 min) and `BASH_MAX_TIMEOUT_MS` (30 min) to `.claude/settings.json` at startup so long builds aren't killed prematurely

## Context

When Claude Code runs long Bash commands (e.g. `nix flake check` on lana-bank, ~5–15 min), no SSE events flow from the harness. An intermediary or reqwest itself closes the idle TCP connection, causing `SSE stream read error: error decoding response body`.

SSE comment lines (`: heartbeat`) are defined in the WHATWG SSE spec and ignored by all conformant parsers. The Rust-side SSE parser already skips non-data lines via `find(|l| l.starts_with("data: "))`, so no parser changes are needed.

## Test plan

- [ ] Deploy to staging and run an agent task that executes `nix flake check` on a large repo
- [ ] Verify heartbeat comments appear in the SSE stream every ~15s during idle periods
- [ ] Confirm the Rust server receives the full response without `SSE stream read error`
- [ ] Verify CLI does not kill Bash commands under 30 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)