### PR TITLE
feat(dashboard): expand workspace form with sandbox and model config

### DIFF
--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -736,6 +736,14 @@ async fn workspace_new(session: Session) -> Response {
 pub struct WorkspaceForm {
     name: String,
     description: Option<String>,
+    // Sandbox config
+    pvc_size: Option<String>,
+    resource_cpu: Option<String>,
+    resource_mem: Option<String>,
+    // Chat/model config
+    model: Option<String>,
+    max_tokens: Option<u32>,
+    max_turns: Option<u32>,
 }
 
 #[instrument(name = "web.workspace_create", skip_all)]
@@ -750,18 +758,63 @@ async fn workspace_create(
     };
 
     let description = form.description.filter(|d| !d.is_empty());
-    match state
+    let workspace = match state
         .app
         .workspaces()
         .create(user_id, &form.name, description)
         .await
     {
-        Ok(_) => Redirect::to("/workspaces").into_response(),
+        Ok(ws) => ws,
         Err(e) => {
             tracing::error!(error = %e, "Failed to create workspace");
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
+            return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    // Apply custom sandbox/model config to the workspace's agent
+    let has_custom_config = form.pvc_size.is_some()
+        || form.resource_cpu.is_some()
+        || form.resource_mem.is_some()
+        || form.model.is_some()
+        || form.max_tokens.is_some()
+        || form.max_turns.is_some();
+
+    if has_custom_config {
+        if let Ok(agents) = state.app.agents().list_for_workspace(workspace.id).await {
+            if let Some(lead) = agents
+                .iter()
+                .find(|a| a.agent_type == domain::primitives::AgentType::WorkspaceLead)
+            {
+                let sandbox_config = domain::agent::SandboxConfig {
+                    pvc_size: form
+                        .pvc_size
+                        .unwrap_or_else(|| lead.sandbox_config.pvc_size.clone()),
+                    resource_cpu: form
+                        .resource_cpu
+                        .unwrap_or_else(|| lead.sandbox_config.resource_cpu.clone()),
+                    resource_mem: form
+                        .resource_mem
+                        .unwrap_or_else(|| lead.sandbox_config.resource_mem.clone()),
+                    disallowed_tools: lead.sandbox_config.disallowed_tools.clone(),
+                };
+                let chat_config = domain::agent::ChatConfig {
+                    model: form.model.unwrap_or_else(|| lead.chat_config.model.clone()),
+                    max_tokens: form.max_tokens.unwrap_or(lead.chat_config.max_tokens),
+                    max_turns: form.max_turns.unwrap_or(lead.chat_config.max_turns),
+                };
+                if let Err(e) = state
+                    .app
+                    .agents()
+                    .update_config(lead.id, chat_config, sandbox_config)
+                    .await
+                {
+                    tracing::warn!(error = %e, "Failed to apply custom config to new workspace agent");
+                }
+            }
         }
     }
+
+    Redirect::to("/workspaces").into_response()
 }
 
 #[instrument(name = "web.workspace_detail", skip_all)]

--- a/web/templates/workspace_chat.html
+++ b/web/templates/workspace_chat.html
@@ -57,7 +57,7 @@
   <div class="chat-main">
     <div class="chat-header">
       <div class="chat-header-left">
-        <a href="/workspaces/{{ workspace.id }}">&larr; {{ workspace.name }}</a>
+        <a href="/workspaces">&larr; {{ workspace.name }}</a>
         <h2>Workspace Lead</h2>
       </div>
       <button class="config-toggle" id="config-toggle-btn" onclick="toggleConfig()" title="Agent config">&#9881;</button>

--- a/web/templates/workspace_new.html
+++ b/web/templates/workspace_new.html
@@ -4,6 +4,18 @@
 
 {% block nav_workspaces %}class="active"{% endblock %}
 
+{% block head %}
+<style>
+  details.config-section { margin-bottom: 1rem; }
+  details.config-section summary {
+    cursor: pointer; font-weight: 600; font-size: 0.95rem;
+    padding: 0.5rem 0; color: var(--pico-muted-color);
+  }
+  details.config-section summary:hover { color: var(--pico-color); }
+  details.config-section .config-fields { padding-top: 0.5rem; }
+</style>
+{% endblock %}
+
 {% block content %}
 <h2>New Workspace</h2>
 
@@ -16,6 +28,59 @@
     Description
     <textarea name="description" rows="3" placeholder="What is this workspace for?"></textarea>
   </label>
+
+  <details class="config-section">
+    <summary>Sandbox Resources</summary>
+    <div class="config-fields">
+      <label>
+        PVC Size
+        <input type="text" name="pvc_size" value="10Gi" placeholder="e.g. 10Gi">
+      </label>
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem;">
+        <label>
+          CPU
+          <select name="resource_cpu">
+            <option value="500m" selected>0.5 CPU</option>
+            <option value="1">1 CPU</option>
+            <option value="2">2 CPU</option>
+          </select>
+        </label>
+        <label>
+          RAM
+          <select name="resource_mem">
+            <option value="512Mi" selected>512 Mi</option>
+            <option value="1Gi">1 Gi</option>
+            <option value="2Gi">2 Gi</option>
+          </select>
+        </label>
+      </div>
+    </div>
+  </details>
+
+  <details class="config-section">
+    <summary>Model Configuration</summary>
+    <div class="config-fields">
+      <label>
+        Model
+        <select name="model">
+          <option value="claude-haiku-4-5-20251001" selected>Claude Haiku 4.5</option>
+          <option value="claude-sonnet-4-6-20250514">Claude Sonnet 4.6</option>
+          <option value="claude-opus-4-6-20250514">Claude Opus 4.6</option>
+        </select>
+      </label>
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem;">
+        <label>
+          Max tokens
+          <input type="number" name="max_tokens" min="256" max="65536" value="4096">
+        </label>
+        <label>
+          Max turns
+          <input type="number" name="max_turns" min="1" max="200" value="25">
+        </label>
+      </div>
+    </div>
+  </details>
+
   <div style="display: flex; gap: 1rem;">
     <button type="submit">Create Workspace</button>
     <a href="/workspaces" role="button" class="outline">Cancel</a>


### PR DESCRIPTION
## Summary
- Add collapsible sandbox config section (PVC size, CPU, RAM) and model config section (model, max tokens, max turns) to the new workspace form
- After workspace creation, apply custom config to the lead agent via `update_config()`
- Fix chat page breadcrumb to link back to workspace list instead of edit page

## Test plan
- [ ] Open `/workspaces/new` and verify the form shows Name + Description with two collapsed sections
- [ ] Expand "Sandbox Resources" — verify defaults: PVC 10Gi, CPU 0.5, RAM 512Mi
- [ ] Expand "Model Configuration" — verify defaults: Haiku 4.5, 4096 tokens, 25 turns
- [ ] Submit with defaults only — workspace created with default agent config
- [ ] Submit with custom values (e.g. Sonnet 4.6, 1 CPU, 1Gi RAM) — verify agent config reflects choices
- [ ] Open workspace chat, verify back breadcrumb goes to `/workspaces` list

🤖 Generated with [Claude Code](https://claude.com/claude-code)