### PR TITLE
feat(session): add rich session event persistence for light agents

### DIFF
--- a/core/migrations/20260411000002_create_sessions.sql
+++ b/core/migrations/20260411000002_create_sessions.sql
@@ -6,7 +6,6 @@ CREATE TABLE sessions (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     agent_id UUID NOT NULL REFERENCES agents(id),
     workspace_id UUID NOT NULL REFERENCES workspaces(id),
-    model TEXT,
     status TEXT NOT NULL DEFAULT 'active',
     started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     ended_at TIMESTAMPTZ,

--- a/core/migrations/20260411000002_create_sessions.sql
+++ b/core/migrations/20260411000002_create_sessions.sql
@@ -1,0 +1,42 @@
+-- Rich session event persistence for agent interactions.
+-- Follows the same flat SQL pattern as conversations / audit_entries.
+
+-- Sessions: one per agent interaction (light or sandbox).
+CREATE TABLE sessions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    agent_id UUID NOT NULL REFERENCES agents(id),
+    workspace_id UUID NOT NULL REFERENCES workspaces(id),
+    model TEXT,
+    status TEXT NOT NULL DEFAULT 'active',
+    started_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ended_at TIMESTAMPTZ,
+    total_turns INT DEFAULT 0,
+    total_input_tokens BIGINT DEFAULT 0,
+    total_output_tokens BIGINT DEFAULT 0,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_sessions_agent_id ON sessions(agent_id);
+CREATE INDEX idx_sessions_workspace_id ON sessions(workspace_id);
+CREATE INDEX idx_sessions_status ON sessions(status);
+CREATE INDEX idx_sessions_created_at ON sessions(created_at DESC);
+
+-- Session events: every interaction within a session.
+CREATE TABLE session_events (
+    id BIGSERIAL PRIMARY KEY,
+    session_id UUID NOT NULL REFERENCES sessions(id) ON DELETE CASCADE,
+    seq INT NOT NULL,
+    event_type TEXT NOT NULL,
+    role TEXT,
+    tool_name TEXT,
+    tool_use_id TEXT,
+    content JSONB NOT NULL DEFAULT '{}',
+    metadata JSONB DEFAULT '{}',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(session_id, seq)
+);
+
+CREATE INDEX idx_session_events_session_seq ON session_events(session_id, seq);
+CREATE INDEX idx_session_events_event_type ON session_events(session_id, event_type);
+CREATE INDEX idx_session_events_tool_use_id ON session_events(tool_use_id) WHERE tool_use_id IS NOT NULL;

--- a/core/src/agent/error.rs
+++ b/core/src/agent/error.rs
@@ -34,4 +34,6 @@ pub enum AgentError {
     ChannelClosed,
     #[error("AgentError - ChatHistory: {0}")]
     ChatHistory(crate::chat_history::ChatHistoryError),
+    #[error("AgentError - Session: {0}")]
+    Session(crate::session::SessionError),
 }

--- a/core/src/agent/light.rs
+++ b/core/src/agent/light.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use tokio::sync::mpsc;
 use tracing::instrument;
 
+use crate::session::{NewSessionEvent, SessionEventType, SessionId, SessionStats, Sessions};
 use crate::toolset::Catalog;
 
 use super::config::LightRuntimeConfig;
@@ -92,6 +93,8 @@ struct LightSession {
     max_turns: usize,
     tools: Vec<serde_json::Value>,
     system: String,
+    sessions: Sessions,
+    session_id: SessionId,
 }
 
 impl LightSession {
@@ -144,11 +147,40 @@ impl LightSession {
         }
     }
 
+    /// Record a session event, logging any persistence errors without failing.
+    async fn record(&self, event: NewSessionEvent) {
+        if let Err(e) = self.sessions.record_event(self.session_id, event).await {
+            tracing::warn!(error = %e, "Failed to persist session event");
+        }
+    }
+
     async fn run(
         &self,
         prompt: &str,
         tx: &mpsc::Sender<AgentMessageEvent>,
     ) -> Result<(), AgentError> {
+        // Record the system prompt once at session start
+        self.record(NewSessionEvent {
+            event_type: SessionEventType::System,
+            role: Some("system".to_string()),
+            tool_name: None,
+            tool_use_id: None,
+            content: serde_json::json!({ "text": &self.system }),
+            metadata: serde_json::json!({ "model": &self.model }),
+        })
+        .await;
+
+        // Record the user's prompt
+        self.record(NewSessionEvent {
+            event_type: SessionEventType::User,
+            role: Some("user".to_string()),
+            tool_name: None,
+            tool_use_id: None,
+            content: serde_json::json!({ "text": prompt }),
+            metadata: serde_json::json!({}),
+        })
+        .await;
+
         let mut messages: Vec<serde_json::Value> =
             vec![serde_json::json!({ "role": "user", "content": prompt })];
 
@@ -176,6 +208,21 @@ impl LightSession {
                     ApiContentBlock::Text { text } => {
                         assistant_content.push(serde_json::json!({"type": "text", "text": text}));
                         send(tx, AgentMessageEvent::Text { text: text.clone() }).await?;
+
+                        // Persist assistant text event
+                        self.record(NewSessionEvent {
+                            event_type: SessionEventType::Assistant,
+                            role: Some("assistant".to_string()),
+                            tool_name: None,
+                            tool_use_id: None,
+                            content: serde_json::json!({ "text": text }),
+                            metadata: serde_json::json!({
+                                "turn": turn,
+                                "input_tokens": response.usage.input_tokens,
+                                "output_tokens": response.usage.output_tokens,
+                            }),
+                        })
+                        .await;
                     }
                     ApiContentBlock::ToolUse { id, name, input } => {
                         assistant_content.push(serde_json::json!({
@@ -189,6 +236,18 @@ impl LightSession {
                             },
                         )
                         .await?;
+
+                        // Persist tool_call event with full input
+                        self.record(NewSessionEvent {
+                            event_type: SessionEventType::ToolCall,
+                            role: Some("assistant".to_string()),
+                            tool_name: Some(name.clone()),
+                            tool_use_id: Some(id.clone()),
+                            content: serde_json::json!({ "input": input }),
+                            metadata: serde_json::json!({}),
+                        })
+                        .await;
+
                         tool_uses.push((id.clone(), name.clone(), input.clone()));
                     }
                 }
@@ -200,6 +259,16 @@ impl LightSession {
 
             let stop = response.stop_reason.as_deref().unwrap_or("end_turn");
             if stop != "tool_use" || tool_uses.is_empty() {
+                // Session complete — record stats and finalize
+                let stats = SessionStats {
+                    total_turns: turn as u32 + 1,
+                    total_input_tokens: total_input,
+                    total_output_tokens: total_output,
+                };
+                if let Err(e) = self.sessions.complete_session(self.session_id, stats).await {
+                    tracing::warn!(error = %e, "Failed to complete session");
+                }
+
                 send(
                     tx,
                     AgentMessageEvent::Done {
@@ -230,6 +299,18 @@ impl LightSession {
                     },
                 )
                 .await?;
+
+                // Persist tool_result with full output and correlation ID
+                self.record(NewSessionEvent {
+                    event_type: SessionEventType::ToolResult,
+                    role: Some("user".to_string()),
+                    tool_name: Some(name.clone()),
+                    tool_use_id: Some(id.clone()),
+                    content: serde_json::json!({ "output": &text, "is_error": is_error }),
+                    metadata: serde_json::json!({}),
+                })
+                .await;
+
                 let mut result_json = serde_json::json!({
                     "type": "tool_result",
                     "tool_use_id": id,
@@ -255,7 +336,8 @@ impl LightSession {
 /// Run the light (in-process) agentic loop.
 ///
 /// Returns a channel receiver that streams `AgentMessageEvent`s, matching the
-/// same interface used by the sandbox runtime.
+/// same interface used by the sandbox runtime. Rich session events are
+/// persisted to the sessions/session_events tables.
 #[instrument(name = "agent.light.run", skip_all)]
 pub(super) async fn run(
     prompt: String,
@@ -263,6 +345,8 @@ pub(super) async fn run(
     chat_config: &ChatConfig,
     system_prompt: &str,
     catalog: Catalog,
+    sessions: Sessions,
+    session_id: SessionId,
 ) -> Result<mpsc::Receiver<AgentMessageEvent>, AgentError> {
     if config.api_key.is_empty() {
         return Err(AgentError::LightAgentNotConfigured);
@@ -283,6 +367,8 @@ pub(super) async fn run(
         max_turns,
         tools,
         system,
+        sessions: sessions.clone(),
+        session_id,
     };
 
     let (tx, rx) = mpsc::channel::<AgentMessageEvent>(64);
@@ -290,6 +376,10 @@ pub(super) async fn run(
     tokio::spawn(async move {
         if let Err(e) = session.run(&prompt, &tx).await {
             tracing::error!(error = %e, "Light agent loop failed");
+            // Record the error in the session
+            if let Err(se) = sessions.fail_session(session_id, &e.to_string()).await {
+                tracing::warn!(error = %se, "Failed to mark session as failed");
+            }
             let _ = tx
                 .send(AgentMessageEvent::Error {
                     message: e.to_string(),

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -22,6 +22,7 @@ use repo::*;
 use crate::auth::AuthContext;
 use crate::chat_history::{ChatHistory, ConversationId, ConversationStatus, MessageRole};
 use crate::primitives::*;
+use crate::session::Sessions;
 use crate::toolset::ToolSets;
 
 pub use crate::primitives::AgentMessageEvent;
@@ -47,6 +48,7 @@ pub struct Agents {
     default_storage_class: String,
     toolsets: Arc<ToolSets>,
     chat_history: ChatHistory,
+    sessions: Sessions,
     sandbox_cache: Arc<Mutex<HashMap<AgentId, SandboxCacheEntry>>>,
 }
 
@@ -58,6 +60,7 @@ impl Agents {
     ) -> Result<Self, AgentError> {
         let repo = AgentRepo::new(pool);
         let chat_history = ChatHistory::new(pool);
+        let sessions = Sessions::new(pool);
         let sandbox = if config.sandbox.enabled {
             let client = sandbox_client::SandboxClient::try_from_env(
                 config.sandbox.namespace.clone(),
@@ -83,6 +86,7 @@ impl Agents {
             toolsets,
             sandbox_cache: Arc::new(Mutex::new(HashMap::new())),
             chat_history,
+            sessions,
         })
     }
 
@@ -219,6 +223,17 @@ impl Agents {
 
         let rx = match agent.agent_type.runtime_kind() {
             RuntimeKind::Light => {
+                // Create a rich session for the light agent
+                let session = self
+                    .sessions
+                    .create_session(
+                        agent.id,
+                        agent.workspace_id,
+                        Some(agent.chat_config.model.clone()),
+                    )
+                    .await
+                    .map_err(AgentError::Session)?;
+
                 let auth = AuthContext::Agent(agent.workspace_id, agent.id, Vec::new());
                 let catalog = self.toolsets.catalog().with_auth(&auth);
                 light::run(
@@ -227,6 +242,8 @@ impl Agents {
                     &agent.chat_config,
                     agent.agent_type.system_prompt(),
                     catalog,
+                    self.sessions.clone(),
+                    session.id,
                 )
                 .await?
             }
@@ -280,6 +297,11 @@ impl Agents {
     /// Expose chat_history for query access (e.g., from web layer).
     pub fn chat_history(&self) -> &ChatHistory {
         &self.chat_history
+    }
+
+    /// Expose sessions for query access (e.g., from web layer).
+    pub fn sessions(&self) -> &Sessions {
+        &self.sessions
     }
 
     /// Sandbox-specific send_message path.

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -226,11 +226,7 @@ impl Agents {
                 // Create a rich session for the light agent
                 let session = self
                     .sessions
-                    .create_session(
-                        agent.id,
-                        agent.workspace_id,
-                        Some(agent.chat_config.model.clone()),
-                    )
+                    .create_session(agent.id, agent.workspace_id)
                     .await
                     .map_err(AgentError::Session)?;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -9,6 +9,7 @@ pub mod github_app;
 pub mod mcp_creds;
 pub mod primitives;
 pub mod report;
+pub mod session;
 pub mod toolset;
 pub mod user;
 pub mod workspace;

--- a/core/src/session/error.rs
+++ b/core/src/session/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SessionError {
+    #[error("SessionError - Sqlx: {0}")]
+    Sqlx(#[from] sqlx::Error),
+    #[error("SessionError - SessionNotFound")]
+    SessionNotFound,
+}

--- a/core/src/session/mod.rs
+++ b/core/src/session/mod.rs
@@ -1,0 +1,267 @@
+pub mod error;
+pub mod primitives;
+
+use tracing::instrument;
+
+pub use error::*;
+pub use primitives::*;
+
+use crate::primitives::*;
+
+/// Flat SQL service for rich session event persistence.
+///
+/// Sessions capture the full interaction history for light agents, including
+/// system prompts, user messages, assistant responses, tool calls with their
+/// inputs, and tool results with output and correlation IDs.
+#[derive(Clone)]
+pub struct Sessions {
+    pool: sqlx::PgPool,
+}
+
+impl Sessions {
+    pub fn new(pool: &sqlx::PgPool) -> Self {
+        Self { pool: pool.clone() }
+    }
+
+    /// Create a new session for the given agent.
+    #[instrument(name = "session.create", skip_all)]
+    pub async fn create_session(
+        &self,
+        agent_id: AgentId,
+        workspace_id: WorkspaceId,
+        model: Option<String>,
+    ) -> Result<Session, SessionError> {
+        let id = SessionId::new();
+
+        let row = sqlx::query_as::<_, Session>(
+            r#"INSERT INTO sessions (id, agent_id, workspace_id, model)
+            VALUES ($1, $2, $3, $4)
+            RETURNING id, agent_id, workspace_id, model, status,
+                      started_at, ended_at, total_turns,
+                      total_input_tokens, total_output_tokens,
+                      created_at, updated_at"#,
+        )
+        .bind(id)
+        .bind(agent_id)
+        .bind(workspace_id)
+        .bind(&model)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row)
+    }
+
+    /// Append a single event to a session, auto-incrementing the sequence number.
+    #[instrument(name = "session.record_event", skip_all)]
+    pub async fn record_event(
+        &self,
+        session_id: SessionId,
+        event: NewSessionEvent,
+    ) -> Result<(), SessionError> {
+        sqlx::query(
+            r#"INSERT INTO session_events (session_id, seq, event_type, role, tool_name, tool_use_id, content, metadata)
+            VALUES (
+                $1,
+                COALESCE((SELECT MAX(seq) FROM session_events WHERE session_id = $1), -1) + 1,
+                $2, $3, $4, $5, $6, $7
+            )"#,
+        )
+        .bind(session_id)
+        .bind(event.event_type.as_str())
+        .bind(&event.role)
+        .bind(&event.tool_name)
+        .bind(&event.tool_use_id)
+        .bind(&event.content)
+        .bind(&event.metadata)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    /// Append multiple events in a single transaction (preserves ordering).
+    #[instrument(name = "session.record_events", skip_all)]
+    pub async fn record_events(
+        &self,
+        session_id: SessionId,
+        events: Vec<NewSessionEvent>,
+    ) -> Result<(), SessionError> {
+        if events.is_empty() {
+            return Ok(());
+        }
+        let mut tx = self.pool.begin().await?;
+
+        for event in events {
+            sqlx::query(
+                r#"INSERT INTO session_events (session_id, seq, event_type, role, tool_name, tool_use_id, content, metadata)
+                VALUES (
+                    $1,
+                    COALESCE((SELECT MAX(seq) FROM session_events WHERE session_id = $1), -1) + 1,
+                    $2, $3, $4, $5, $6, $7
+                )"#,
+            )
+            .bind(session_id)
+            .bind(event.event_type.as_str())
+            .bind(&event.role)
+            .bind(&event.tool_name)
+            .bind(&event.tool_use_id)
+            .bind(&event.content)
+            .bind(&event.metadata)
+            .execute(&mut *tx)
+            .await?;
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Mark a session as completed with final stats.
+    #[instrument(name = "session.complete", skip_all)]
+    pub async fn complete_session(
+        &self,
+        session_id: SessionId,
+        stats: SessionStats,
+    ) -> Result<(), SessionError> {
+        let result = sqlx::query(
+            r#"UPDATE sessions
+            SET status = 'completed',
+                ended_at = NOW(),
+                total_turns = $1,
+                total_input_tokens = $2,
+                total_output_tokens = $3,
+                updated_at = NOW()
+            WHERE id = $4"#,
+        )
+        .bind(stats.total_turns as i32)
+        .bind(stats.total_input_tokens as i64)
+        .bind(stats.total_output_tokens as i64)
+        .bind(session_id)
+        .execute(&self.pool)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            return Err(SessionError::SessionNotFound);
+        }
+        Ok(())
+    }
+
+    /// Mark a session as failed with an error message.
+    #[instrument(name = "session.fail", skip_all)]
+    pub async fn fail_session(
+        &self,
+        session_id: SessionId,
+        error_message: &str,
+    ) -> Result<(), SessionError> {
+        let mut tx = self.pool.begin().await?;
+
+        // Record the error as a session event
+        sqlx::query(
+            r#"INSERT INTO session_events (session_id, seq, event_type, role, content, metadata)
+            VALUES (
+                $1,
+                COALESCE((SELECT MAX(seq) FROM session_events WHERE session_id = $1), -1) + 1,
+                'error', 'system', $2, '{}'
+            )"#,
+        )
+        .bind(session_id)
+        .bind(serde_json::json!({ "message": error_message }))
+        .execute(&mut *tx)
+        .await?;
+
+        let result = sqlx::query(
+            r#"UPDATE sessions
+            SET status = 'error', ended_at = NOW(), updated_at = NOW()
+            WHERE id = $1"#,
+        )
+        .bind(session_id)
+        .execute(&mut *tx)
+        .await?;
+
+        if result.rows_affected() == 0 {
+            tx.rollback().await?;
+            return Err(SessionError::SessionNotFound);
+        }
+
+        tx.commit().await?;
+        Ok(())
+    }
+
+    /// Get all events for a session, ordered by sequence.
+    #[instrument(name = "session.get_events", skip_all)]
+    pub async fn get_events(
+        &self,
+        session_id: SessionId,
+    ) -> Result<Vec<SessionEventRow>, SessionError> {
+        let rows = sqlx::query_as::<_, SessionEventRow>(
+            r#"SELECT id, session_id, seq, event_type, role, tool_name, tool_use_id,
+                      content, metadata, created_at
+            FROM session_events
+            WHERE session_id = $1
+            ORDER BY seq ASC"#,
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Get display-relevant events for a session (user/assistant/tool/error).
+    /// This provides backward compatibility with the old conversation_messages query.
+    #[instrument(name = "session.get_display_events", skip_all)]
+    pub async fn get_display_events(
+        &self,
+        session_id: SessionId,
+    ) -> Result<Vec<SessionEventRow>, SessionError> {
+        let rows = sqlx::query_as::<_, SessionEventRow>(
+            r#"SELECT id, session_id, seq, event_type, role, tool_name, tool_use_id,
+                      content, metadata, created_at
+            FROM session_events
+            WHERE session_id = $1
+              AND event_type IN ('user', 'assistant', 'tool_call', 'tool_result', 'error')
+            ORDER BY seq ASC"#,
+        )
+        .bind(session_id)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// List sessions for an agent (most recent first).
+    #[instrument(name = "session.list_by_agent", skip_all)]
+    pub async fn list_by_agent(
+        &self,
+        agent_id: AgentId,
+        limit: i64,
+    ) -> Result<Vec<Session>, SessionError> {
+        let rows = sqlx::query_as::<_, Session>(
+            r#"SELECT id, agent_id, workspace_id, model, status,
+                      started_at, ended_at, total_turns,
+                      total_input_tokens, total_output_tokens,
+                      created_at, updated_at
+            FROM sessions
+            WHERE agent_id = $1
+            ORDER BY created_at DESC
+            LIMIT $2"#,
+        )
+        .bind(agent_id)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+        Ok(rows)
+    }
+
+    /// Find a session by its ID.
+    #[instrument(name = "session.find", skip_all)]
+    pub async fn find_session(&self, id: SessionId) -> Result<Session, SessionError> {
+        sqlx::query_as::<_, Session>(
+            r#"SELECT id, agent_id, workspace_id, model, status,
+                      started_at, ended_at, total_turns,
+                      total_input_tokens, total_output_tokens,
+                      created_at, updated_at
+            FROM sessions
+            WHERE id = $1"#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await?
+        .ok_or(SessionError::SessionNotFound)
+    }
+}

--- a/core/src/session/mod.rs
+++ b/core/src/session/mod.rs
@@ -29,14 +29,13 @@ impl Sessions {
         &self,
         agent_id: AgentId,
         workspace_id: WorkspaceId,
-        model: Option<String>,
     ) -> Result<Session, SessionError> {
         let id = SessionId::new();
 
         let row = sqlx::query_as::<_, Session>(
-            r#"INSERT INTO sessions (id, agent_id, workspace_id, model)
-            VALUES ($1, $2, $3, $4)
-            RETURNING id, agent_id, workspace_id, model, status,
+            r#"INSERT INTO sessions (id, agent_id, workspace_id)
+            VALUES ($1, $2, $3)
+            RETURNING id, agent_id, workspace_id, status,
                       started_at, ended_at, total_turns,
                       total_input_tokens, total_output_tokens,
                       created_at, updated_at"#,
@@ -44,7 +43,6 @@ impl Sessions {
         .bind(id)
         .bind(agent_id)
         .bind(workspace_id)
-        .bind(&model)
         .fetch_one(&self.pool)
         .await?;
         Ok(row)
@@ -232,7 +230,7 @@ impl Sessions {
         limit: i64,
     ) -> Result<Vec<Session>, SessionError> {
         let rows = sqlx::query_as::<_, Session>(
-            r#"SELECT id, agent_id, workspace_id, model, status,
+            r#"SELECT id, agent_id, workspace_id, status,
                       started_at, ended_at, total_turns,
                       total_input_tokens, total_output_tokens,
                       created_at, updated_at
@@ -252,7 +250,7 @@ impl Sessions {
     #[instrument(name = "session.find", skip_all)]
     pub async fn find_session(&self, id: SessionId) -> Result<Session, SessionError> {
         sqlx::query_as::<_, Session>(
-            r#"SELECT id, agent_id, workspace_id, model, status,
+            r#"SELECT id, agent_id, workspace_id, status,
                       started_at, ended_at, total_turns,
                       total_input_tokens, total_output_tokens,
                       created_at, updated_at

--- a/core/src/session/primitives.rs
+++ b/core/src/session/primitives.rs
@@ -68,7 +68,6 @@ pub struct Session {
     pub id: SessionId,
     pub agent_id: AgentId,
     pub workspace_id: WorkspaceId,
-    pub model: Option<String>,
     pub status: String,
     pub started_at: chrono::DateTime<chrono::Utc>,
     pub ended_at: Option<chrono::DateTime<chrono::Utc>>,

--- a/core/src/session/primitives.rs
+++ b/core/src/session/primitives.rs
@@ -1,0 +1,114 @@
+use serde::{Deserialize, Serialize};
+
+use crate::primitives::*;
+
+es_entity::entity_id! { SessionId }
+
+/// Status of a session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionStatus {
+    Active,
+    Completed,
+    Error,
+}
+
+impl SessionStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SessionStatus::Active => "active",
+            SessionStatus::Completed => "completed",
+            SessionStatus::Error => "error",
+        }
+    }
+}
+
+impl std::fmt::Display for SessionStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// Type of a session event.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SessionEventType {
+    System,
+    User,
+    Assistant,
+    ToolCall,
+    ToolResult,
+    Error,
+    Compaction,
+}
+
+impl SessionEventType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            SessionEventType::System => "system",
+            SessionEventType::User => "user",
+            SessionEventType::Assistant => "assistant",
+            SessionEventType::ToolCall => "tool_call",
+            SessionEventType::ToolResult => "tool_result",
+            SessionEventType::Error => "error",
+            SessionEventType::Compaction => "compaction",
+        }
+    }
+}
+
+impl std::fmt::Display for SessionEventType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+/// A session record (one per agent interaction).
+#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+pub struct Session {
+    pub id: SessionId,
+    pub agent_id: AgentId,
+    pub workspace_id: WorkspaceId,
+    pub model: Option<String>,
+    pub status: String,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub ended_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub total_turns: Option<i32>,
+    pub total_input_tokens: Option<i64>,
+    pub total_output_tokens: Option<i64>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// A single event within a session.
+#[derive(Debug, Clone, sqlx::FromRow, Serialize)]
+pub struct SessionEventRow {
+    pub id: i64,
+    pub session_id: SessionId,
+    pub seq: i32,
+    pub event_type: String,
+    pub role: Option<String>,
+    pub tool_name: Option<String>,
+    pub tool_use_id: Option<String>,
+    pub content: serde_json::Value,
+    pub metadata: Option<serde_json::Value>,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// A new session event to be inserted.
+#[derive(Debug, Clone)]
+pub struct NewSessionEvent {
+    pub event_type: SessionEventType,
+    pub role: Option<String>,
+    pub tool_name: Option<String>,
+    pub tool_use_id: Option<String>,
+    pub content: serde_json::Value,
+    pub metadata: serde_json::Value,
+}
+
+/// Stats recorded when a session completes.
+#[derive(Debug, Clone)]
+pub struct SessionStats {
+    pub total_turns: u32,
+    pub total_input_tokens: u32,
+    pub total_output_tokens: u32,
+}


### PR DESCRIPTION
## Summary
- Add `sessions` and `session_events` tables for rich interaction history
- Implement `Sessions` flat SQL service with create/record/complete/fail/query methods
- Wire session recording into the light agent conversation loop, capturing system prompts, user messages, assistant text, tool calls (with full input), tool results (with full output + `tool_use_id` correlation), and errors
- Existing `chat_history` dual-write preserved for backward compatibility
- Heavy (sandbox) agents unchanged

## Event types captured
| event_type | role | description |
|---|---|---|
| `system` | system | System prompt at session start |
| `user` | user | User prompt |
| `assistant` | assistant | Model text response |
| `tool_call` | assistant | Tool invocation with full input JSON |
| `tool_result` | user | Tool output with `tool_use_id` correlation |
| `error` | system | Error during conversation |
| `compaction` | — | Reserved for context management |

## Test plan
- [ ] Verify migration applies cleanly on a fresh database
- [ ] Send a message to a light agent and confirm session + events are persisted
- [ ] Verify tool_call and tool_result events are correlated via `tool_use_id`
- [ ] Confirm sandbox agents are unaffected (no session created)
- [ ] Confirm existing chat_history records still written (dual-write)

🤖 Generated with [Claude Code](https://claude.com/claude-code)