### PR TITLE
feat(light): add OpenAI Chat Completions provider for light agents

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -22,6 +22,10 @@ pub struct Config {
     pub github_app: Option<GitHubAppCliConfig>,
     #[serde(skip)]
     pub anthropic_api_key: String,
+    #[serde(skip)]
+    pub openai_api_key: String,
+    #[serde(skip)]
+    pub openai_model: String,
 }
 
 /// GitHub App config from the YAML config file.
@@ -135,6 +139,8 @@ pub struct EnvSecrets {
     pub github_client_secret: String,
     pub github_allowed_teams: Vec<String>,
     pub anthropic_api_key: String,
+    pub openai_api_key: String,
+    pub openai_model: String,
 }
 
 impl Config {
@@ -153,6 +159,8 @@ impl Config {
         config.db.pg_con = secrets.pg_con;
         config.oauth.github_client_secret = secrets.github_client_secret;
         config.anthropic_api_key = secrets.anthropic_api_key;
+        config.openai_api_key = secrets.openai_api_key;
+        config.openai_model = secrets.openai_model;
         if !secrets.github_allowed_teams.is_empty() {
             config.oauth.github_allowed_teams = secrets.github_allowed_teams;
         }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -28,6 +28,14 @@ struct Cli {
     /// Anthropic API key for the light agent runtime.
     #[arg(long, env = "ANTHROPIC_API_KEY", default_value = "")]
     anthropic_api_key: String,
+
+    /// OpenAI API key for the light agent runtime (takes priority over Anthropic).
+    #[arg(long, env = "OPENAI_API_KEY", default_value = "")]
+    openai_api_key: String,
+
+    /// OpenAI model to use (default: gpt-4.1).
+    #[arg(long, env = "OPENAI_MODEL", default_value = "")]
+    openai_model: String,
 }
 
 #[tokio::main]
@@ -56,6 +64,8 @@ async fn main() -> anyhow::Result<()> {
             github_client_secret: cli.github_client_secret,
             github_allowed_teams: allowed_teams,
             anthropic_api_key: cli.anthropic_api_key,
+            openai_api_key: cli.openai_api_key,
+            openai_model: cli.openai_model,
         },
     )?;
 
@@ -93,6 +103,8 @@ async fn main() -> anyhow::Result<()> {
             },
             light: galoy_agents_core::agent::config::LightRuntimeConfig {
                 api_key: config.anthropic_api_key.clone(),
+                openai_api_key: config.openai_api_key.clone(),
+                openai_model: config.openai_model.clone(),
             },
         },
         toolsets: config.toolsets.clone(),

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -31,4 +31,6 @@ pub struct PersistenceConfig {
 #[derive(Clone, Debug, Default)]
 pub struct LightRuntimeConfig {
     pub api_key: String,
+    pub openai_api_key: String,
+    pub openai_model: String,
 }

--- a/core/src/agent/error.rs
+++ b/core/src/agent/error.rs
@@ -24,9 +24,11 @@ pub enum AgentError {
     SandboxExec(String),
     #[error("AgentError - AnthropicApi: status={status}, message={message}")]
     AnthropicApi { status: u16, message: String },
+    #[error("AgentError - OpenaiApi: status={status}, message={message}")]
+    OpenaiApi { status: u16, message: String },
     #[error("AgentError - Http: {0}")]
     Http(reqwest::Error),
-    #[error("Light agent is not configured. Set ANTHROPIC_API_KEY and provide a catalog.")]
+    #[error("Light agent is not configured. Set OPENAI_API_KEY (or ANTHROPIC_API_KEY) and provide a catalog.")]
     LightAgentNotConfigured,
     #[error("AgentError - MaxTurnsReached: {0}")]
     MaxTurnsReached(usize),

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -3,6 +3,7 @@ mod entity;
 pub mod error;
 mod harness_client;
 mod light;
+mod openai_light;
 pub(crate) mod repo;
 mod sandbox;
 
@@ -197,14 +198,26 @@ impl Agents {
             RuntimeKind::Light => {
                 let auth = AuthContext::Agent(agent.workspace_id, agent.id, Vec::new());
                 let catalog = self.toolsets.catalog().with_auth(&auth);
-                light::run(
-                    prompt,
-                    &self.light_config,
-                    &agent.chat_config,
-                    agent.agent_type.system_prompt(),
-                    catalog,
-                )
-                .await?
+                // Prefer OpenAI provider when OPENAI_API_KEY is configured
+                if !self.light_config.openai_api_key.is_empty() {
+                    openai_light::run(
+                        prompt,
+                        &self.light_config,
+                        &agent.chat_config,
+                        agent.agent_type.system_prompt(),
+                        catalog,
+                    )
+                    .await?
+                } else {
+                    light::run(
+                        prompt,
+                        &self.light_config,
+                        &agent.chat_config,
+                        agent.agent_type.system_prompt(),
+                        catalog,
+                    )
+                    .await?
+                }
             }
             RuntimeKind::Sandbox => self.send_message_sandbox(agent, prompt).await?,
         };

--- a/core/src/agent/openai_light.rs
+++ b/core/src/agent/openai_light.rs
@@ -1,0 +1,404 @@
+use serde::Deserialize;
+use tokio::sync::mpsc;
+use tracing::instrument;
+
+use crate::toolset::Catalog;
+
+use super::config::LightRuntimeConfig;
+use super::entity::ChatConfig;
+use super::error::AgentError;
+use super::AgentMessageEvent;
+
+// ---------------------------------------------------------------------------
+// OpenAI Chat Completions API types
+// ---------------------------------------------------------------------------
+
+const API_URL: &str = "https://api.openai.com/v1/chat/completions";
+
+#[derive(Deserialize)]
+struct ApiResponse {
+    choices: Vec<ApiChoice>,
+    usage: ApiUsage,
+}
+
+#[derive(Deserialize)]
+struct ApiChoice {
+    message: ApiMessage,
+    finish_reason: Option<String>,
+}
+
+#[derive(Deserialize, Clone)]
+struct ApiMessage {
+    content: Option<String>,
+    #[serde(default)]
+    tool_calls: Option<Vec<ApiToolCall>>,
+}
+
+#[derive(Deserialize, Clone)]
+struct ApiToolCall {
+    id: String,
+    function: ApiFunction,
+}
+
+#[derive(Deserialize, Clone)]
+struct ApiFunction {
+    name: String,
+    arguments: String, // JSON string — must serde_json::from_str()
+}
+
+#[derive(Deserialize, Clone)]
+struct ApiUsage {
+    prompt_tokens: u32,
+    completion_tokens: u32,
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI HTTP client
+// ---------------------------------------------------------------------------
+
+struct OpenaiClient {
+    http: reqwest::Client,
+    api_key: String,
+}
+
+impl OpenaiClient {
+    fn new(api_key: String) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            api_key,
+        }
+    }
+
+    async fn create_message(&self, body: serde_json::Value) -> Result<ApiResponse, AgentError> {
+        let resp = self
+            .http
+            .post(API_URL)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("content-type", "application/json")
+            .json(&body)
+            .send()
+            .await
+            .map_err(AgentError::Http)?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let text = resp.text().await.unwrap_or_default();
+            return Err(AgentError::OpenaiApi {
+                status: status.as_u16(),
+                message: text,
+            });
+        }
+
+        resp.json().await.map_err(AgentError::Http)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI light agent session
+// ---------------------------------------------------------------------------
+
+struct OpenaiLightSession {
+    client: OpenaiClient,
+    catalog: Catalog,
+    model: String,
+    max_tokens: u32,
+    max_turns: usize,
+    tools: Vec<serde_json::Value>,
+    system: String,
+}
+
+impl OpenaiLightSession {
+    /// Route a tool call to the appropriate handler (same dispatch as Anthropic).
+    async fn dispatch_tool(
+        &self,
+        name: &str,
+        input: &serde_json::Value,
+    ) -> Result<String, AgentError> {
+        match name {
+            "search_tools" => {
+                let query = input.get("query").and_then(|v| v.as_str());
+                let category = input.get("category").and_then(|v| v.as_str());
+                let results = self.catalog.search(query, category).await;
+                Ok(Catalog::format_search_results(&results))
+            }
+            "describe_tool" => {
+                let tool_name = input
+                    .get("tool_name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let entry = self.catalog.describe(tool_name).await.ok_or_else(|| {
+                    AgentError::SandboxExec(format!(
+                        "Tool '{tool_name}' not found. Use search_tools to find available tools."
+                    ))
+                })?;
+                Ok(Catalog::format_describe(&entry))
+            }
+            "call_tool" => {
+                let tool_name = input
+                    .get("tool_name")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let args: Option<rmcp::model::JsonObject> = input
+                    .get("arguments")
+                    .and_then(|v| serde_json::from_value(v.clone()).ok());
+                let output_filter = input
+                    .get("output_filter")
+                    .and_then(|v| serde_json::from_value(v.clone()).ok());
+                let result = self
+                    .catalog
+                    .call_with_filter(tool_name, args, output_filter)
+                    .await
+                    .map_err(|e| AgentError::SandboxExec(e.to_string()))?;
+                Ok(call_result_to_text(&result))
+            }
+            _ => Err(AgentError::SandboxExec(format!(
+                "Unknown tool: {name}. Use search_tools, describe_tool, or call_tool."
+            ))),
+        }
+    }
+
+    async fn run(
+        &self,
+        prompt: &str,
+        tx: &mpsc::Sender<AgentMessageEvent>,
+    ) -> Result<(), AgentError> {
+        // OpenAI: system prompt is a message in the array (not a top-level field)
+        let mut messages: Vec<serde_json::Value> = vec![
+            serde_json::json!({ "role": "system", "content": self.system }),
+            serde_json::json!({ "role": "user", "content": prompt }),
+        ];
+
+        let mut total_input = 0u32;
+        let mut total_output = 0u32;
+
+        for turn in 0..self.max_turns {
+            let body = serde_json::json!({
+                "model": self.model,
+                "max_tokens": self.max_tokens,
+                "tools": self.tools,
+                "messages": messages,
+            });
+
+            let response = self.client.create_message(body).await?;
+            total_input += response.usage.prompt_tokens;
+            total_output += response.usage.completion_tokens;
+
+            let choice =
+                response
+                    .choices
+                    .into_iter()
+                    .next()
+                    .ok_or_else(|| AgentError::OpenaiApi {
+                        status: 0,
+                        message: "No choices in OpenAI response".to_string(),
+                    })?;
+
+            // Emit text content if present
+            if let Some(ref text) = choice.message.content {
+                if !text.is_empty() {
+                    send(tx, AgentMessageEvent::Text { text: text.clone() }).await?;
+                }
+            }
+
+            let tool_calls = choice.message.tool_calls.clone().unwrap_or_default();
+
+            // Emit tool call events (parse arguments from JSON string)
+            for tc in &tool_calls {
+                let args: serde_json::Value =
+                    serde_json::from_str(&tc.function.arguments).unwrap_or_default();
+                send(
+                    tx,
+                    AgentMessageEvent::ToolCall {
+                        name: tc.function.name.clone(),
+                        arguments: Some(args),
+                    },
+                )
+                .await?;
+            }
+
+            // Append assistant message to conversation history.
+            // Must include tool_calls verbatim so the API can match tool results.
+            let mut assistant_msg = serde_json::json!({ "role": "assistant" });
+            assistant_msg["content"] = match &choice.message.content {
+                Some(text) => serde_json::json!(text),
+                None => serde_json::Value::Null,
+            };
+            if !tool_calls.is_empty() {
+                let tc_json: Vec<serde_json::Value> = tool_calls
+                    .iter()
+                    .map(|tc| {
+                        serde_json::json!({
+                            "id": tc.id,
+                            "type": "function",
+                            "function": {
+                                "name": tc.function.name,
+                                "arguments": tc.function.arguments,
+                            }
+                        })
+                    })
+                    .collect();
+                assistant_msg["tool_calls"] = serde_json::json!(tc_json);
+            }
+            messages.push(assistant_msg);
+
+            // OpenAI: finish_reason "stop" = done, "tool_calls" = execute tools
+            let finish = choice.finish_reason.as_deref().unwrap_or("stop");
+            if finish != "tool_calls" || tool_calls.is_empty() {
+                send(
+                    tx,
+                    AgentMessageEvent::Done {
+                        turns: turn as u32 + 1,
+                        input_tokens: total_input,
+                        output_tokens: total_output,
+                        duration_ms: None,
+                        cost_usd: None,
+                    },
+                )
+                .await?;
+                return Ok(());
+            }
+
+            // Execute tools and send results back as separate role:"tool" messages
+            for tc in &tool_calls {
+                let args: serde_json::Value =
+                    serde_json::from_str(&tc.function.arguments).unwrap_or_default();
+                let result = self.dispatch_tool(&tc.function.name, &args).await;
+                let (text, is_error) = match &result {
+                    Ok(t) => (t.clone(), false),
+                    Err(e) => (e.to_string(), true),
+                };
+                send(
+                    tx,
+                    AgentMessageEvent::ToolResult {
+                        name: tc.function.name.clone(),
+                        is_error,
+                    },
+                )
+                .await?;
+
+                // OpenAI: each tool result is a separate message with role: "tool"
+                messages.push(serde_json::json!({
+                    "role": "tool",
+                    "tool_call_id": tc.id,
+                    "content": text,
+                }));
+            }
+        }
+
+        Err(AgentError::MaxTurnsReached(self.max_turns))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+/// Run the OpenAI-backed light (in-process) agentic loop.
+///
+/// Same interface as `light::run` — returns a channel receiver that streams
+/// `AgentMessageEvent`s. Uses OpenAI Chat Completions API instead of Anthropic.
+#[instrument(name = "agent.openai_light.run", skip_all)]
+pub(super) async fn run(
+    prompt: String,
+    config: &LightRuntimeConfig,
+    chat_config: &ChatConfig,
+    system_prompt: &str,
+    catalog: Catalog,
+) -> Result<mpsc::Receiver<AgentMessageEvent>, AgentError> {
+    if config.openai_api_key.is_empty() {
+        return Err(AgentError::LightAgentNotConfigured);
+    }
+
+    // Use configured model or default to gpt-4.1
+    let model = if config.openai_model.is_empty() {
+        "gpt-4.1".to_string()
+    } else {
+        config.openai_model.clone()
+    };
+    let max_tokens = chat_config.max_tokens;
+    let max_turns = chat_config.max_turns as usize;
+
+    // Convert Anthropic-format tool definitions to OpenAI function calling format
+    let tools = convert_tools_for_openai(&Catalog::meta_tool_definitions());
+    let system = build_system_prompt(system_prompt, &catalog);
+
+    let session = OpenaiLightSession {
+        client: OpenaiClient::new(config.openai_api_key.clone()),
+        catalog,
+        model,
+        max_tokens,
+        max_turns,
+        tools,
+        system,
+    };
+
+    let (tx, rx) = mpsc::channel::<AgentMessageEvent>(64);
+
+    tokio::spawn(async move {
+        if let Err(e) = session.run(&prompt, &tx).await {
+            tracing::error!(error = %e, "OpenAI light agent loop failed");
+            let _ = tx
+                .send(AgentMessageEvent::Error {
+                    message: e.to_string(),
+                })
+                .await;
+        }
+    });
+
+    Ok(rx)
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async fn send(
+    tx: &mpsc::Sender<AgentMessageEvent>,
+    event: AgentMessageEvent,
+) -> Result<(), AgentError> {
+    tx.send(event)
+        .await
+        .map_err(|_| AgentError::ChannelClosed)?;
+    Ok(())
+}
+
+fn build_system_prompt(base: &str, catalog: &Catalog) -> String {
+    let instructions = catalog.instructions();
+    if instructions.is_empty() {
+        base.to_string()
+    } else {
+        format!("{base}\n\n{instructions}")
+    }
+}
+
+fn call_result_to_text(result: &rmcp::model::CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|c| match &c.raw {
+            rmcp::model::RawContent::Text(t) => Some(t.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Convert Anthropic-format tool definitions to OpenAI function calling format.
+///
+/// Anthropic: `{name, description, input_schema: {...}}`
+/// OpenAI:    `{type: "function", function: {name, description, parameters: {...}}}`
+fn convert_tools_for_openai(anthropic_tools: &[serde_json::Value]) -> Vec<serde_json::Value> {
+    anthropic_tools
+        .iter()
+        .map(|tool| {
+            serde_json::json!({
+                "type": "function",
+                "function": {
+                    "name": tool["name"],
+                    "description": tool["description"],
+                    "parameters": tool["input_schema"],
+                }
+            })
+        })
+        .collect()
+}


### PR DESCRIPTION
## Summary
- Add parallel OpenAI-backed agentic loop (`openai_light.rs`) alongside existing Anthropic implementation
- When `OPENAI_API_KEY` is set, light agents use OpenAI Chat Completions API (default model: `gpt-4.1`); otherwise fall back to Anthropic
- Converts Anthropic tool format (`input_schema`) to OpenAI function calling format (`parameters`), handles JSON string arguments, and uses `role: "tool"` result messages
- Fully additive — Anthropic path preserved, sandbox/heavy agents untouched

## Key files
| File | Change |
|------|--------|
| `core/src/agent/openai_light.rs` | **New** — OpenAI client, response types, agentic loop with tool calling |
| `core/src/agent/config.rs` | Add `openai_api_key` + `openai_model` to `LightRuntimeConfig` |
| `core/src/agent/mod.rs` | Provider switch: prefer OpenAI when key is configured |
| `core/src/agent/error.rs` | Add `OpenaiApi` error variant |
| `cli/src/main.rs` | `OPENAI_API_KEY` and `OPENAI_MODEL` env vars |
| `cli/src/config.rs` | Pass OpenAI config through |

## Config
```sh
# Enable OpenAI provider (takes priority over Anthropic)
export OPENAI_API_KEY=sk-proj-...
export OPENAI_MODEL=gpt-4.1          # optional, defaults to gpt-4.1

# Anthropic still works as fallback
export ANTHROPIC_API_KEY=sk-ant-...   # used when OPENAI_API_KEY is empty
```

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` — zero warnings
- [x] `cargo fmt -- --check` — clean
- [x] `cargo nextest run` — 168/168 tests pass
- [ ] Manual: set `OPENAI_API_KEY`, send message to light agent, verify tool calling works end-to-end

> ⚠️ **POC — do not merge without manual validation against live OpenAI API**

🤖 Generated with [Claude Code](https://claude.com/claude-code)