### PR TITLE
feat(project): add projects entity with CRUD and agent association

### DIFF
--- a/.sqlx/query-0a5fb4026063ba1b5543f99d2bee53c2505af6043cf04e738222a4669abc9308.json
+++ b/.sqlx/query-0a5fb4026063ba1b5543f99d2bee53c2505af6043cf04e738222a4669abc9308.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM projects WHERE id = $1 AND deleted = FALSE) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "0a5fb4026063ba1b5543f99d2bee53c2505af6043cf04e738222a4669abc9308"
+}

--- a/.sqlx/query-25732c8cf9f35216d5c1bfad80648314acf51686ec19d1623162f8cda1436d30.json
+++ b/.sqlx/query-25732c8cf9f35216d5c1bfad80648314acf51686ec19d1623162f8cda1436d30.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE projects SET workspace_id = $2, name = $3, deleted = TRUE WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "25732c8cf9f35216d5c1bfad80648314acf51686ec19d1623162f8cda1436d30"
+}

--- a/.sqlx/query-35d7cb97d706baac7ad4c412339091654cc8dd425ffa59282077bd6d6cc13f69.json
+++ b/.sqlx/query-35d7cb97d706baac7ad4c412339091654cc8dd425ffa59282077bd6d6cc13f69.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE projects SET workspace_id = $2, name = $3 WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "35d7cb97d706baac7ad4c412339091654cc8dd425ffa59282077bd6d6cc13f69"
+}

--- a/.sqlx/query-3a6eaa8d56f0a6677db5f2b9067dffcda9ec525a0abeff561e155a7247631b08.json
+++ b/.sqlx/query-3a6eaa8d56f0a6677db5f2b9067dffcda9ec525a0abeff561e155a7247631b08.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM projects WHERE COALESCE(workspace_id = $1, $1 IS NULL) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL)) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "3a6eaa8d56f0a6677db5f2b9067dffcda9ec525a0abeff561e155a7247631b08"
+}

--- a/.sqlx/query-406a6f7bff891c2fd2c05ff8d4d001fbfc366769b8a1ef2aa3f06cf2b3453cf6.json
+++ b/.sqlx/query-406a6f7bff891c2fd2c05ff8d4d001fbfc366769b8a1ef2aa3f06cf2b3453cf6.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, id FROM projects WHERE COALESCE(workspace_id = $1, $1 IS NULL) AND (COALESCE((name, id) > ($4, $3), $3 IS NULL)) AND deleted = FALSE ORDER BY name ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.name asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "406a6f7bff891c2fd2c05ff8d4d001fbfc366769b8a1ef2aa3f06cf2b3453cf6"
+}

--- a/.sqlx/query-443e796c23d72b26b454c3107e9e833d309d85540be3f6ace950e7ac7b08ff90.json
+++ b/.sqlx/query-443e796c23d72b26b454c3107e9e833d309d85540be3f6ace950e7ac7b08ff90.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT workspace_id, created_at, id FROM projects WHERE ((workspace_id = $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "443e796c23d72b26b454c3107e9e833d309d85540be3f6ace950e7ac7b08ff90"
+}

--- a/.sqlx/query-46a2a139915d09f2143e515963f4cf443c881f8334e79a0c02d2e3dd47ef29aa.json
+++ b/.sqlx/query-46a2a139915d09f2143e515963f4cf443c881f8334e79a0c02d2e3dd47ef29aa.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM projects WHERE COALESCE(workspace_id = $1, $1 IS NULL) AND (COALESCE(id < $3, true)) AND deleted = FALSE ORDER BY id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "46a2a139915d09f2143e515963f4cf443c881f8334e79a0c02d2e3dd47ef29aa"
+}

--- a/.sqlx/query-47e1f2db1d8da923e773bafaef41c34d9cff3410a1d73f90f99b04b818000c8f.json
+++ b/.sqlx/query-47e1f2db1d8da923e773bafaef41c34d9cff3410a1d73f90f99b04b818000c8f.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM projects WHERE workspace_id = $1 AND deleted = FALSE) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "47e1f2db1d8da923e773bafaef41c34d9cff3410a1d73f90f99b04b818000c8f"
+}

--- a/.sqlx/query-4992d12af3a4652be3e0f02fd2205012650d49e921a4a2a04cb194bbd37b4bcc.json
+++ b/.sqlx/query-4992d12af3a4652be3e0f02fd2205012650d49e921a4a2a04cb194bbd37b4bcc.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM projects WHERE COALESCE(workspace_id = $1, $1 IS NULL) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL)) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "4992d12af3a4652be3e0f02fd2205012650d49e921a4a2a04cb194bbd37b4bcc"
+}

--- a/.sqlx/query-539407d6a8dfba46fcbcfe0d332348508a175b0931bd139235c5ea613037ef3f.json
+++ b/.sqlx/query-539407d6a8dfba46fcbcfe0d332348508a175b0931bd139235c5ea613037ef3f.json
@@ -1,0 +1,26 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO project_events (id, recorded_at, sequence, event_type, event) SELECT $1, COALESCE($2, NOW()), ROW_NUMBER() OVER () + $3, unnested.event_type, unnested.event FROM UNNEST($4::TEXT[], $5::JSONB[]) AS unnested(event_type, event) RETURNING recorded_at",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Timestamptz",
+        "Int8",
+        "TextArray",
+        "JsonbArray"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "539407d6a8dfba46fcbcfe0d332348508a175b0931bd139235c5ea613037ef3f"
+}

--- a/.sqlx/query-7f8f55d06603487735a1d5d7356eaf21791fff579ef14c72add4e4736f1908d8.json
+++ b/.sqlx/query-7f8f55d06603487735a1d5d7356eaf21791fff579ef14c72add4e4736f1908d8.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, id FROM projects WHERE COALESCE(workspace_id = $1, $1 IS NULL) AND (COALESCE((name, id) < ($4, $3), $3 IS NULL)) AND deleted = FALSE ORDER BY name DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.name desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "7f8f55d06603487735a1d5d7356eaf21791fff579ef14c72add4e4736f1908d8"
+}

--- a/.sqlx/query-7fe8bc465c04c41540a68432273516b6bbfb75bb73ae69b50fb1487857e1d316.json
+++ b/.sqlx/query-7fe8bc465c04c41540a68432273516b6bbfb75bb73ae69b50fb1487857e1d316.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM projects WHERE name = $1 AND deleted = FALSE) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "7fe8bc465c04c41540a68432273516b6bbfb75bb73ae69b50fb1487857e1d316"
+}

--- a/.sqlx/query-8fc94f363feb08e1e1d29d5cefce060723e912351b9dda1187a14b062cf5d37c.json
+++ b/.sqlx/query-8fc94f363feb08e1e1d29d5cefce060723e912351b9dda1187a14b062cf5d37c.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM projects WHERE (COALESCE(id > $2, true)) AND deleted = FALSE ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "8fc94f363feb08e1e1d29d5cefce060723e912351b9dda1187a14b062cf5d37c"
+}

--- a/.sqlx/query-b461828222070d71935381a35720be1921bb578a0a461325d6f968e4e96be605.json
+++ b/.sqlx/query-b461828222070d71935381a35720be1921bb578a0a461325d6f968e4e96be605.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT workspace_id, created_at, id FROM projects WHERE ((workspace_id = $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "b461828222070d71935381a35720be1921bb578a0a461325d6f968e4e96be605"
+}

--- a/.sqlx/query-bf5cf774ea66daa38ad9ea467868ffca21d9bdb92b65ce3280476b245cb536d7.json
+++ b/.sqlx/query-bf5cf774ea66daa38ad9ea467868ffca21d9bdb92b65ce3280476b245cb536d7.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM projects WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "bf5cf774ea66daa38ad9ea467868ffca21d9bdb92b65ce3280476b245cb536d7"
+}

--- a/.sqlx/query-d71a797ef169875250e78cb2a9a96a2c3ab40dec9d1c6331d7acb93c58666531.json
+++ b/.sqlx/query-d71a797ef169875250e78cb2a9a96a2c3ab40dec9d1c6331d7acb93c58666531.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, id FROM projects WHERE (COALESCE((name, id) < ($3, $2), $2 IS NULL)) AND deleted = FALSE ORDER BY name DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.name desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "d71a797ef169875250e78cb2a9a96a2c3ab40dec9d1c6331d7acb93c58666531"
+}

--- a/.sqlx/query-d75e6598e88c4e8d3b42f2f8700c1ab3a2d8a7baee50b99dd3fe31d450173adc.json
+++ b/.sqlx/query-d75e6598e88c4e8d3b42f2f8700c1ab3a2d8a7baee50b99dd3fe31d450173adc.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO projects (id, workspace_id, name, created_at) VALUES ($1, $2, $3, COALESCE($4, NOW()))",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "d75e6598e88c4e8d3b42f2f8700c1ab3a2d8a7baee50b99dd3fe31d450173adc"
+}

--- a/.sqlx/query-daf08f498ff5f74ada3d451a82322e8f4c0753390cd61daf92d53313bdb1caf4.json
+++ b/.sqlx/query-daf08f498ff5f74ada3d451a82322e8f4c0753390cd61daf92d53313bdb1caf4.json
@@ -1,0 +1,48 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM projects WHERE (COALESCE(id < $2, true)) AND deleted = FALSE ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "daf08f498ff5f74ada3d451a82322e8f4c0753390cd61daf92d53313bdb1caf4"
+}

--- a/.sqlx/query-ea01bbed88d630fd5db338e1a3baabb7cc9a755dae0d3cbe93449e5e89495aac.json
+++ b/.sqlx/query-ea01bbed88d630fd5db338e1a3baabb7cc9a755dae0d3cbe93449e5e89495aac.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT name, id FROM projects WHERE (COALESCE((name, id) > ($3, $2), $2 IS NULL)) AND deleted = FALSE ORDER BY name ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.name asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "ea01bbed88d630fd5db338e1a3baabb7cc9a755dae0d3cbe93449e5e89495aac"
+}

--- a/.sqlx/query-eaad4416fef59952f1baf02dba46f9937cb579465b32c874c7923b0484cd75e1.json
+++ b/.sqlx/query-eaad4416fef59952f1baf02dba46f9937cb579465b32c874c7923b0484cd75e1.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM projects WHERE id = ANY($1)) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "UuidArray",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "eaad4416fef59952f1baf02dba46f9937cb579465b32c874c7923b0484cd75e1"
+}

--- a/.sqlx/query-efe66a9c2912d19e9295cd3e0496821710db93dff981b175bcecf64d3f85582a.json
+++ b/.sqlx/query-efe66a9c2912d19e9295cd3e0496821710db93dff981b175bcecf64d3f85582a.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM projects WHERE COALESCE(workspace_id = $1, $1 IS NULL) AND (COALESCE(id > $3, true)) AND deleted = FALSE ORDER BY id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "efe66a9c2912d19e9295cd3e0496821710db93dff981b175bcecf64d3f85582a"
+}

--- a/.sqlx/query-f179e1c2e774c422b306a2c18ec9f655adcfd343565b4da07dd15fba37134d65.json
+++ b/.sqlx/query-f179e1c2e774c422b306a2c18ec9f655adcfd343565b4da07dd15fba37134d65.json
@@ -1,0 +1,49 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM projects WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN project_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "f179e1c2e774c422b306a2c18ec9f655adcfd343565b4da07dd15fba37134d65"
+}

--- a/core/migrations/20260412000001_create_projects.sql
+++ b/core/migrations/20260412000001_create_projects.sql
@@ -1,0 +1,25 @@
+-- Project entity tables (event-sourced)
+CREATE TABLE IF NOT EXISTS projects (
+    id UUID PRIMARY KEY,
+    workspace_id UUID NOT NULL REFERENCES workspaces(id),
+    name VARCHAR NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL,
+    deleted BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+CREATE INDEX idx_projects_workspace_id ON projects(workspace_id);
+CREATE UNIQUE INDEX idx_projects_workspace_name ON projects(workspace_id, name) WHERE NOT deleted;
+
+CREATE TABLE IF NOT EXISTS project_events (
+    id UUID NOT NULL REFERENCES projects(id),
+    sequence INT NOT NULL,
+    event_type VARCHAR NOT NULL,
+    event JSONB NOT NULL,
+    context JSONB DEFAULT NULL,
+    recorded_at TIMESTAMPTZ NOT NULL,
+    UNIQUE(id, sequence)
+);
+
+-- Add project_id to agents (nullable, backward compatible)
+ALTER TABLE agents ADD COLUMN IF NOT EXISTS project_id UUID REFERENCES projects(id) ON DELETE SET NULL;
+CREATE INDEX idx_agents_project_id ON agents(project_id);

--- a/core/src/agent/entity.rs
+++ b/core/src/agent/entity.rs
@@ -108,6 +108,9 @@ pub enum AgentEvent {
     SandboxProvisioned {},
     SandboxReady {},
     SandboxLost {},
+    ProjectChanged {
+        project_id: Option<ProjectId>,
+    },
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -129,6 +132,8 @@ pub struct Agent {
     pub sandbox_config: SandboxConfig,
     pub chat_config: ChatConfig,
     pub sandbox_state: SandboxState,
+    #[builder(default)]
+    pub project_id: Option<ProjectId>,
     events: EntityEvents<AgentEvent>,
 }
 
@@ -209,6 +214,19 @@ impl Agent {
         self.events.push(AgentEvent::SandboxLost {});
         Idempotent::Executed(())
     }
+
+    pub(super) fn change_project(&mut self, project_id: Option<ProjectId>) -> Idempotent<()> {
+        idempotency_guard!(
+            self.events.iter_all().rev(),
+            already_applied: AgentEvent::ProjectChanged { project_id: pid }
+                if *pid == project_id,
+            resets_on: AgentEvent::ProjectChanged { .. }
+        );
+
+        self.project_id = project_id;
+        self.events.push(AgentEvent::ProjectChanged { project_id });
+        Idempotent::Executed(())
+    }
 }
 
 impl core::fmt::Display for Agent {
@@ -254,6 +272,9 @@ impl TryFromEvents<AgentEvent> for Agent {
                 }
                 AgentEvent::SandboxLost {} => {
                     builder = builder.sandbox_state(SandboxState::None);
+                }
+                AgentEvent::ProjectChanged { project_id } => {
+                    builder = builder.project_id(*project_id);
                 }
             }
         }
@@ -304,7 +325,7 @@ impl IntoEvents<AgentEvent> for NewAgent {
 mod tests {
     use es_entity::{IntoEvents as _, TryFromEvents as _};
 
-    use crate::primitives::{AgentId, AgentType, WorkspaceId};
+    use crate::primitives::{AgentId, AgentType, ProjectId, WorkspaceId};
 
     use super::{Agent, ChatConfig, NewAgent, SandboxConfig, SandboxState};
 
@@ -352,6 +373,23 @@ mod tests {
 
         // Idempotent: same config again should be a no-op
         assert!(!agent.update_chat_config(new_config).did_execute());
+    }
+
+    #[test]
+    fn agent_change_project() {
+        let mut agent = new_agent();
+        assert_eq!(agent.project_id, None);
+
+        let pid = ProjectId::new();
+        assert!(agent.change_project(Some(pid)).did_execute());
+        assert_eq!(agent.project_id, Some(pid));
+
+        // Idempotent: same project again
+        assert!(!agent.change_project(Some(pid)).did_execute());
+
+        // Unassign
+        assert!(agent.change_project(None).did_execute());
+        assert_eq!(agent.project_id, None);
     }
 
     #[test]

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -212,6 +212,20 @@ impl Agents {
         Ok(rx)
     }
 
+    /// Change the project assignment for an agent.
+    #[instrument(name = "domain.agent.change_project", skip(self))]
+    pub async fn change_project(
+        &self,
+        id: AgentId,
+        project_id: Option<crate::primitives::ProjectId>,
+    ) -> Result<Agent, AgentError> {
+        let mut agent = self.repo.find_by_id(id).await?;
+        if agent.change_project(project_id).did_execute() {
+            self.repo.update(&mut agent).await?;
+        }
+        Ok(agent)
+    }
+
     /// Soft-delete an agent and destroy its sandbox.
     #[instrument(name = "domain.agent.delete_in_op", skip(self, op))]
     pub async fn delete_in_op(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod encryption;
 pub mod github_app;
 pub mod mcp_creds;
 pub mod primitives;
+pub mod project;
 pub mod report;
 pub mod toolset;
 pub mod user;
@@ -22,6 +23,7 @@ use audit::Audit;
 use code_assistant::CodeAssistant;
 use github_app::GitHubAppTokenProvider;
 use mcp_creds::McpCredentials;
+use project::Projects;
 use report::Reports;
 use toolset::{AdminToolSet, ToolSets, ToolSetsError};
 use user::Users;
@@ -37,6 +39,7 @@ pub struct App {
     code_assistant: Option<Arc<CodeAssistant>>,
     reports: Option<Arc<Reports>>,
     toolsets: Arc<ToolSets>,
+    projects: Projects,
     workspaces: Workspaces,
     workspace_secrets: WorkspaceSecrets,
     github_app: Option<GitHubAppTokenProvider>,
@@ -89,6 +92,7 @@ impl App {
         let toolsets = Arc::new(toolsets);
         let mcp_creds = McpCredentials::new(pool);
         let agents = Arc::new(Agents::init(pool, config.agents, Arc::clone(&toolsets)).await?);
+        let projects = Projects::new(pool);
         let workspaces = Workspaces::new(pool, Arc::clone(&agents));
 
         // Register admin toolset after agents/workspaces to break circular dep
@@ -125,6 +129,7 @@ impl App {
             code_assistant,
             reports,
             toolsets,
+            projects,
             workspaces,
             workspace_secrets,
             github_app,
@@ -157,6 +162,10 @@ impl App {
 
     pub fn toolsets(&self) -> &ToolSets {
         &self.toolsets
+    }
+
+    pub fn projects(&self) -> &Projects {
+        &self.projects
     }
 
     pub fn workspaces(&self) -> &Workspaces {

--- a/core/src/primitives.rs
+++ b/core/src/primitives.rs
@@ -5,10 +5,42 @@ es_entity::entity_id! {
     ReportId,
     WorkspaceId,
     WorkspaceSecretId,
-    AgentId;
+    AgentId,
+    ProjectId;
 
     UserId => McpCredsOwnerId,
     AgentId => McpCredsOwnerId
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, sqlx::Type)]
+#[serde(rename_all = "snake_case")]
+#[sqlx(type_name = "VARCHAR", rename_all = "snake_case")]
+pub enum ProjectStatus {
+    Active,
+    Completed,
+    Archived,
+}
+
+impl std::fmt::Display for ProjectStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProjectStatus::Active => write!(f, "active"),
+            ProjectStatus::Completed => write!(f, "completed"),
+            ProjectStatus::Archived => write!(f, "archived"),
+        }
+    }
+}
+
+impl std::str::FromStr for ProjectStatus {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "active" => Ok(ProjectStatus::Active),
+            "completed" => Ok(ProjectStatus::Completed),
+            "archived" => Ok(ProjectStatus::Archived),
+            _ => Err(format!("unknown project status: {s}")),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize, sqlx::Type)]

--- a/core/src/project/entity.rs
+++ b/core/src/project/entity.rs
@@ -1,0 +1,220 @@
+use chrono::{DateTime, Utc};
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+
+use es_entity::*;
+
+use crate::primitives::*;
+
+#[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[es_event(id = "ProjectId")]
+pub enum ProjectEvent {
+    Initialized {
+        id: ProjectId,
+        workspace_id: WorkspaceId,
+        name: String,
+        description: Option<String>,
+        status: ProjectStatus,
+    },
+    Updated {
+        name: String,
+        description: Option<String>,
+    },
+    StatusChanged {
+        status: ProjectStatus,
+    },
+}
+
+#[derive(EsEntity, Builder)]
+#[builder(pattern = "owned", build_fn(error = "EntityHydrationError"))]
+pub struct Project {
+    pub id: ProjectId,
+    pub workspace_id: WorkspaceId,
+    pub name: String,
+    #[builder(setter(strip_option), default)]
+    pub description: Option<String>,
+    pub status: ProjectStatus,
+    events: EntityEvents<ProjectEvent>,
+}
+
+impl Project {
+    pub fn created_at(&self) -> DateTime<Utc> {
+        self.events
+            .entity_first_persisted_at()
+            .expect("entity_first_persisted_at not found")
+    }
+
+    pub fn is_archived(&self) -> bool {
+        self.status == ProjectStatus::Archived
+    }
+
+    pub(super) fn update(&mut self, name: impl Into<String>, description: Option<String>) {
+        let name = name.into();
+        self.name = name.clone();
+        self.description = description.clone();
+        self.events
+            .push(ProjectEvent::Updated { name, description });
+    }
+
+    pub(super) fn change_status(&mut self, status: ProjectStatus) -> Idempotent<()> {
+        idempotency_guard!(
+            self.events.iter_all().rev(),
+            already_applied: ProjectEvent::StatusChanged { status: s } if *s == status,
+            resets_on: ProjectEvent::StatusChanged { .. }
+        );
+
+        self.status = status;
+        self.events.push(ProjectEvent::StatusChanged { status });
+        Idempotent::Executed(())
+    }
+}
+
+impl core::fmt::Display for Project {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Project: {}, name: {}", self.id, self.name)
+    }
+}
+
+impl TryFromEvents<ProjectEvent> for Project {
+    fn try_from_events(events: EntityEvents<ProjectEvent>) -> Result<Self, EntityHydrationError> {
+        let mut builder = ProjectBuilder::default();
+
+        for event in events.iter_all() {
+            match event {
+                ProjectEvent::Initialized {
+                    id,
+                    workspace_id,
+                    name,
+                    description,
+                    status,
+                } => {
+                    builder = builder
+                        .id(*id)
+                        .workspace_id(*workspace_id)
+                        .name(name.clone())
+                        .status(*status);
+                    if let Some(desc) = description {
+                        builder = builder.description(desc.clone());
+                    }
+                }
+                ProjectEvent::Updated { name, description } => {
+                    builder = builder.name(name.clone());
+                    if let Some(desc) = description {
+                        builder = builder.description(desc.clone());
+                    }
+                }
+                ProjectEvent::StatusChanged { status } => {
+                    builder = builder.status(*status);
+                }
+            }
+        }
+
+        builder.events(events).build()
+    }
+}
+
+#[derive(Debug, Builder)]
+pub struct NewProject {
+    #[builder(setter(into))]
+    pub(super) id: ProjectId,
+    pub(super) workspace_id: WorkspaceId,
+    #[builder(setter(into))]
+    pub(super) name: String,
+    #[builder(setter(into, strip_option), default)]
+    pub(super) description: Option<String>,
+}
+
+impl NewProject {
+    pub fn builder() -> NewProjectBuilder {
+        let mut builder = NewProjectBuilder::default();
+        builder.id(ProjectId::new());
+        builder
+    }
+}
+
+impl IntoEvents<ProjectEvent> for NewProject {
+    fn into_events(self) -> EntityEvents<ProjectEvent> {
+        EntityEvents::init(
+            self.id,
+            [ProjectEvent::Initialized {
+                id: self.id,
+                workspace_id: self.workspace_id,
+                name: self.name,
+                description: self.description,
+                status: ProjectStatus::Active,
+            }],
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use es_entity::{IntoEvents as _, TryFromEvents as _};
+
+    use crate::primitives::{ProjectId, ProjectStatus, WorkspaceId};
+
+    use super::{NewProject, Project};
+
+    fn new_project() -> Project {
+        let new = NewProject::builder()
+            .id(ProjectId::new())
+            .workspace_id(WorkspaceId::new())
+            .name("test-project")
+            .description("A test project".to_string())
+            .build()
+            .unwrap();
+
+        Project::try_from_events(new.into_events()).unwrap()
+    }
+
+    #[test]
+    fn project_hydration() {
+        let project = new_project();
+        assert_eq!(project.name, "test-project");
+        assert_eq!(project.description, Some("A test project".to_string()));
+        assert_eq!(project.status, ProjectStatus::Active);
+    }
+
+    #[test]
+    fn project_update() {
+        let mut project = new_project();
+        project.update("renamed", Some("new desc".to_string()));
+        assert_eq!(project.name, "renamed");
+        assert_eq!(project.description, Some("new desc".to_string()));
+    }
+
+    #[test]
+    fn project_change_status() {
+        let mut project = new_project();
+        assert_eq!(project.status, ProjectStatus::Active);
+
+        assert!(project
+            .change_status(ProjectStatus::Completed)
+            .did_execute());
+        assert_eq!(project.status, ProjectStatus::Completed);
+
+        // Idempotent: same status again
+        assert!(!project
+            .change_status(ProjectStatus::Completed)
+            .did_execute());
+
+        // Can change again
+        assert!(project.change_status(ProjectStatus::Archived).did_execute());
+        assert!(project.is_archived());
+    }
+
+    #[test]
+    fn project_hydration_without_description() {
+        let new = NewProject::builder()
+            .id(ProjectId::new())
+            .workspace_id(WorkspaceId::new())
+            .name("minimal")
+            .build()
+            .unwrap();
+
+        let project = Project::try_from_events(new.into_events()).unwrap();
+        assert_eq!(project.name, "minimal");
+        assert_eq!(project.description, None);
+    }
+}

--- a/core/src/project/error.rs
+++ b/core/src/project/error.rs
@@ -1,0 +1,19 @@
+use thiserror::Error;
+
+use super::repo::{ProjectCreateError, ProjectFindError, ProjectModifyError, ProjectQueryError};
+
+#[derive(Error, Debug)]
+pub enum ProjectError {
+    #[error("ProjectError - Sqlx: {0}")]
+    Sqlx(#[from] sqlx::Error),
+    #[error("ProjectError - Create: {0}")]
+    Create(#[from] ProjectCreateError),
+    #[error("ProjectError - Modify: {0}")]
+    Modify(#[from] ProjectModifyError),
+    #[error("ProjectError - Find: {0}")]
+    Find(#[from] ProjectFindError),
+    #[error("ProjectError - Query: {0}")]
+    Query(#[from] ProjectQueryError),
+    #[error("ProjectError - NameAlreadyExists: {0}")]
+    NameAlreadyExists(String),
+}

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -1,0 +1,167 @@
+mod entity;
+pub mod error;
+pub(crate) mod repo;
+
+use tracing::instrument;
+
+pub use entity::Project;
+use entity::*;
+pub use error::*;
+use repo::*;
+
+use crate::primitives::*;
+
+#[derive(Clone)]
+pub struct Projects {
+    repo: ProjectRepo,
+}
+
+impl Projects {
+    pub fn new(pool: &sqlx::PgPool) -> Self {
+        let repo = ProjectRepo::new(pool);
+        Self { repo }
+    }
+
+    #[instrument(name = "domain.project.create", skip(self))]
+    pub async fn create(
+        &self,
+        workspace_id: WorkspaceId,
+        name: impl Into<String> + std::fmt::Debug,
+        description: Option<String>,
+    ) -> Result<Project, ProjectError> {
+        let mut op = self.repo.begin_op().await?;
+        let project = self
+            .create_in_op(&mut op, workspace_id, name, description)
+            .await?;
+        op.commit().await?;
+        Ok(project)
+    }
+
+    #[instrument(name = "domain.project.create_in_op", skip(self, op))]
+    pub async fn create_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        workspace_id: WorkspaceId,
+        name: impl Into<String> + std::fmt::Debug,
+        description: Option<String>,
+    ) -> Result<Project, ProjectError> {
+        let name = name.into();
+
+        // Check name uniqueness within workspace
+        let existing = self.list_for_workspace(workspace_id).await?;
+        if existing.iter().any(|p| p.name == name) {
+            return Err(ProjectError::NameAlreadyExists(name));
+        }
+
+        let new_project = build_new_project(workspace_id, &name, description);
+        let project = self.repo.create_in_op(op, new_project).await?;
+        Ok(project)
+    }
+
+    #[instrument(name = "domain.project.find_by_id", skip(self))]
+    pub async fn find_by_id(
+        &self,
+        id: impl Into<ProjectId> + std::fmt::Debug,
+    ) -> Result<Project, ProjectError> {
+        Ok(self.repo.find_by_id(id.into()).await?)
+    }
+
+    #[instrument(name = "domain.project.list_for_workspace", skip(self))]
+    pub async fn list_for_workspace(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<Vec<Project>, ProjectError> {
+        let query = es_entity::PaginatedQueryArgs {
+            first: 100,
+            after: None,
+        };
+        let result = self
+            .repo
+            .list_for_workspace_id_by_created_at(
+                workspace_id,
+                query,
+                es_entity::ListDirection::Descending,
+            )
+            .await?;
+        Ok(result
+            .entities
+            .into_iter()
+            .filter(|p| !p.is_archived())
+            .collect())
+    }
+
+    #[instrument(name = "domain.project.update", skip(self))]
+    pub async fn update(
+        &self,
+        id: impl Into<ProjectId> + std::fmt::Debug,
+        name: impl Into<String> + std::fmt::Debug,
+        description: Option<String>,
+    ) -> Result<Project, ProjectError> {
+        let id = id.into();
+        let name = name.into();
+
+        // Check name uniqueness (excluding self)
+        let project = self.repo.find_by_id(id).await?;
+        let existing = self.list_for_workspace(project.workspace_id).await?;
+        if existing.iter().any(|p| p.name == name && p.id != id) {
+            return Err(ProjectError::NameAlreadyExists(name));
+        }
+
+        let mut project = project;
+        project.update(name, description);
+        self.repo.update(&mut project).await?;
+        Ok(project)
+    }
+
+    #[instrument(name = "domain.project.archive", skip(self))]
+    pub async fn archive(
+        &self,
+        id: impl Into<ProjectId> + std::fmt::Debug,
+    ) -> Result<Project, ProjectError> {
+        let mut project = self.repo.find_by_id(id.into()).await?;
+        if project.change_status(ProjectStatus::Archived).did_execute() {
+            self.repo.update(&mut project).await?;
+        }
+        Ok(project)
+    }
+
+    #[instrument(name = "domain.project.archive_in_op", skip(self, op))]
+    pub async fn archive_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        id: impl Into<ProjectId> + std::fmt::Debug,
+    ) -> Result<Project, ProjectError> {
+        let mut project = self.repo.find_by_id(id.into()).await?;
+        if project.change_status(ProjectStatus::Archived).did_execute() {
+            self.repo.update_in_op(op, &mut project).await?;
+        }
+        Ok(project)
+    }
+
+    #[instrument(name = "domain.project.change_status", skip(self))]
+    pub async fn change_status(
+        &self,
+        id: impl Into<ProjectId> + std::fmt::Debug,
+        status: ProjectStatus,
+    ) -> Result<Project, ProjectError> {
+        let mut project = self.repo.find_by_id(id.into()).await?;
+        if project.change_status(status).did_execute() {
+            self.repo.update(&mut project).await?;
+        }
+        Ok(project)
+    }
+}
+
+fn build_new_project(
+    workspace_id: WorkspaceId,
+    name: impl Into<String>,
+    description: Option<String>,
+) -> NewProject {
+    let mut builder = NewProject::builder();
+    builder.workspace_id(workspace_id);
+    builder.name(name);
+    if let Some(desc) = description {
+        builder.description(desc);
+    }
+    builder.build().expect("Could not build new project")
+}

--- a/core/src/project/repo.rs
+++ b/core/src/project/repo.rs
@@ -1,0 +1,27 @@
+use sqlx::PgPool;
+
+use es_entity::*;
+
+use crate::primitives::*;
+
+use super::entity::*;
+
+#[derive(EsRepo, Clone)]
+#[es_repo(
+    entity = "Project",
+    columns(
+        workspace_id(ty = "WorkspaceId", list_for(by(created_at))),
+        name(ty = "String", list_by),
+    ),
+    delete = "soft_without_queries"
+)]
+pub struct ProjectRepo {
+    #[allow(dead_code)]
+    pool: PgPool,
+}
+
+impl ProjectRepo {
+    pub fn new(pool: &PgPool) -> Self {
+        Self { pool: pool.clone() }
+    }
+}

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -19,7 +19,7 @@ use galoy_agents_core as domain;
 use domain::auth::AuthContext;
 use domain::mcp_creds::token::generate_token;
 use domain::mcp_creds::McpCreds;
-use domain::primitives::{AgentId, McpCredsId, UserId, WorkspaceSecretId};
+use domain::primitives::{AgentId, McpCredsId, ProjectId, UserId, WorkspaceSecretId};
 
 use crate::templates::*;
 use crate::AppState;
@@ -62,6 +62,32 @@ pub fn router() -> Router<AppState> {
         .route(
             "/workspaces/{id}/secrets/{secret_id}/delete",
             post(workspace_secret_delete),
+        )
+        .route("/workspaces/{id}/projects/list", get(project_list))
+        .route("/workspaces/{id}/projects", post(project_create))
+        .route(
+            "/workspaces/{ws_id}/projects/{project_id}",
+            get(project_detail),
+        )
+        .route(
+            "/workspaces/{ws_id}/projects/{project_id}",
+            post(project_update),
+        )
+        .route(
+            "/workspaces/{ws_id}/projects/{project_id}/archive",
+            post(project_archive),
+        )
+        .route(
+            "/workspaces/{ws_id}/projects/{project_id}/agents",
+            get(project_agents_list),
+        )
+        .route(
+            "/workspaces/{ws_id}/projects/{project_id}/assign",
+            post(project_assign_agent),
+        )
+        .route(
+            "/workspaces/{ws_id}/projects/{project_id}/unassign/{agent_id}",
+            post(project_unassign_agent),
         )
         .route("/agents/{id}/config", get(agent_config_panel))
         .route("/agents/{id}/config", post(agent_config_update))
@@ -1036,6 +1062,383 @@ async fn workspace_secret_delete(
         .into_response(),
         Err(_) => axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response(),
     }
+}
+
+// ---------------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------------
+
+fn project_to_view(p: &domain::project::Project, agent_count: usize) -> ProjectView {
+    ProjectView {
+        id: p.id.to_string(),
+        workspace_id: p.workspace_id.to_string(),
+        name: p.name.clone(),
+        description: p.description.clone().unwrap_or_default(),
+        status: p.status.to_string(),
+        agent_count,
+        created_at: p.created_at().format("%Y-%m-%d %H:%M UTC").to_string(),
+    }
+}
+
+#[instrument(name = "web.project_list", skip_all)]
+async fn project_list(
+    State(state): State<AppState>,
+    session: Session,
+    Path(id): Path<uuid::Uuid>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(id);
+    let projects = match state.app.projects().list_for_workspace(workspace_id).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to list projects");
+            return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+    };
+
+    let agents = state
+        .app
+        .agents()
+        .list_for_workspace(workspace_id)
+        .await
+        .unwrap_or_default();
+
+    let views: Vec<ProjectView> = projects
+        .iter()
+        .map(|p| {
+            let count = agents.iter().filter(|a| a.project_id == Some(p.id)).count();
+            project_to_view(p, count)
+        })
+        .collect();
+
+    ProjectListTemplate { projects: views }.into_response()
+}
+
+#[derive(Deserialize)]
+struct ProjectForm {
+    name: String,
+    description: Option<String>,
+    status: Option<String>,
+}
+
+#[instrument(name = "web.project_create", skip_all)]
+async fn project_create(
+    State(state): State<AppState>,
+    session: Session,
+    Path(id): Path<uuid::Uuid>,
+    Form(form): Form<ProjectForm>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(id);
+    let description = form.description.filter(|d| !d.is_empty());
+    if let Err(e) = state
+        .app
+        .projects()
+        .create(workspace_id, &form.name, description)
+        .await
+    {
+        tracing::error!(error = %e, "Failed to create project");
+        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    // Return updated project list
+    return_project_list(&state, workspace_id).await
+}
+
+#[instrument(name = "web.project_detail", skip_all)]
+async fn project_detail(
+    State(state): State<AppState>,
+    session: Session,
+    Path((ws_id, project_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return Redirect::to("/").into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(ws_id);
+    let project_id = ProjectId::from(project_id);
+
+    let project = match state.app.projects().find_by_id(project_id).await {
+        Ok(p) => p,
+        Err(_) => return Redirect::to(&format!("/workspaces/{ws_id}")).into_response(),
+    };
+
+    let agents = state
+        .app
+        .agents()
+        .list_for_workspace(workspace_id)
+        .await
+        .unwrap_or_default();
+
+    let agent_count = agents
+        .iter()
+        .filter(|a| a.project_id == Some(project_id))
+        .count();
+
+    let unassigned: Vec<ProjectAgentView> = agents
+        .iter()
+        .filter(|a| a.project_id.is_none())
+        .map(|a| ProjectAgentView {
+            id: a.id.to_string(),
+            name: a.name.clone(),
+            agent_type: format_agent_type(&a.agent_type),
+        })
+        .collect();
+
+    ProjectDetailTemplate {
+        project: project_to_view(&project, agent_count),
+        unassigned_agents: unassigned,
+    }
+    .into_response()
+}
+
+#[instrument(name = "web.project_update", skip_all)]
+async fn project_update(
+    State(state): State<AppState>,
+    session: Session,
+    Path((ws_id, project_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+    Form(form): Form<ProjectForm>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return Redirect::to("/").into_response();
+    }
+
+    let project_id = ProjectId::from(project_id);
+    let description = form.description.filter(|d| !d.is_empty());
+
+    if let Err(e) = state
+        .app
+        .projects()
+        .update(project_id, &form.name, description)
+        .await
+    {
+        tracing::error!(error = %e, "Failed to update project");
+        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    // If status changed
+    if let Some(status_str) = &form.status {
+        if let Ok(status) = status_str.parse::<domain::primitives::ProjectStatus>() {
+            if let Err(e) = state.app.projects().change_status(project_id, status).await {
+                tracing::error!(error = %e, "Failed to change project status");
+            }
+        }
+    }
+
+    Redirect::to(&format!("/workspaces/{ws_id}")).into_response()
+}
+
+#[instrument(name = "web.project_archive", skip_all)]
+async fn project_archive(
+    State(state): State<AppState>,
+    session: Session,
+    Path((ws_id, project_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+    headers: axum::http::HeaderMap,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return Redirect::to("/").into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(ws_id);
+    let project_id = ProjectId::from(project_id);
+
+    // Unassign all agents from this project
+    let agents = state
+        .app
+        .agents()
+        .list_for_workspace(workspace_id)
+        .await
+        .unwrap_or_default();
+
+    for agent in agents.iter().filter(|a| a.project_id == Some(project_id)) {
+        if let Err(e) = state.app.agents().change_project(agent.id, None).await {
+            tracing::warn!(agent_id = %agent.id, error = %e, "Failed to unassign agent from project");
+        }
+    }
+
+    if let Err(e) = state.app.projects().archive(project_id).await {
+        tracing::error!(error = %e, "Failed to archive project");
+        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    if headers.contains_key("hx-request") {
+        return return_project_list(&state, workspace_id).await;
+    }
+    Redirect::to(&format!("/workspaces/{ws_id}")).into_response()
+}
+
+#[instrument(name = "web.project_agents_list", skip_all)]
+async fn project_agents_list(
+    State(state): State<AppState>,
+    session: Session,
+    Path((ws_id, project_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(ws_id);
+    let project_id = ProjectId::from(project_id);
+
+    let agents = state
+        .app
+        .agents()
+        .list_for_workspace(workspace_id)
+        .await
+        .unwrap_or_default();
+
+    let assigned: Vec<ProjectAgentView> = agents
+        .iter()
+        .filter(|a| a.project_id == Some(project_id))
+        .map(|a| ProjectAgentView {
+            id: a.id.to_string(),
+            name: a.name.clone(),
+            agent_type: format_agent_type(&a.agent_type),
+        })
+        .collect();
+
+    ProjectAgentsListTemplate {
+        agents: assigned,
+        workspace_id: ws_id.to_string(),
+        project_id: project_id.to_string(),
+    }
+    .into_response()
+}
+
+#[derive(Deserialize)]
+struct AssignAgentForm {
+    agent_id: uuid::Uuid,
+}
+
+#[instrument(name = "web.project_assign_agent", skip_all)]
+async fn project_assign_agent(
+    State(state): State<AppState>,
+    session: Session,
+    Path((ws_id, project_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+    Form(form): Form<AssignAgentForm>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(ws_id);
+    let project_id = ProjectId::from(project_id);
+    let agent_id = AgentId::from(form.agent_id);
+
+    if let Err(e) = state
+        .app
+        .agents()
+        .change_project(agent_id, Some(project_id))
+        .await
+    {
+        tracing::error!(error = %e, "Failed to assign agent to project");
+        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    // Return updated agents list
+    let agents = state
+        .app
+        .agents()
+        .list_for_workspace(workspace_id)
+        .await
+        .unwrap_or_default();
+
+    let assigned: Vec<ProjectAgentView> = agents
+        .iter()
+        .filter(|a| a.project_id == Some(project_id))
+        .map(|a| ProjectAgentView {
+            id: a.id.to_string(),
+            name: a.name.clone(),
+            agent_type: format_agent_type(&a.agent_type),
+        })
+        .collect();
+
+    ProjectAgentsListTemplate {
+        agents: assigned,
+        workspace_id: ws_id.to_string(),
+        project_id: project_id.to_string(),
+    }
+    .into_response()
+}
+
+#[instrument(name = "web.project_unassign_agent", skip_all)]
+async fn project_unassign_agent(
+    State(state): State<AppState>,
+    session: Session,
+    Path((ws_id, project_id, agent_id)): Path<(uuid::Uuid, uuid::Uuid, uuid::Uuid)>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return axum::http::StatusCode::UNAUTHORIZED.into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(ws_id);
+    let project_id = ProjectId::from(project_id);
+    let agent_id = AgentId::from(agent_id);
+
+    if let Err(e) = state.app.agents().change_project(agent_id, None).await {
+        tracing::error!(error = %e, "Failed to unassign agent from project");
+        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    // Return updated agents list
+    let agents = state
+        .app
+        .agents()
+        .list_for_workspace(workspace_id)
+        .await
+        .unwrap_or_default();
+
+    let assigned: Vec<ProjectAgentView> = agents
+        .iter()
+        .filter(|a| a.project_id == Some(project_id))
+        .map(|a| ProjectAgentView {
+            id: a.id.to_string(),
+            name: a.name.clone(),
+            agent_type: format_agent_type(&a.agent_type),
+        })
+        .collect();
+
+    ProjectAgentsListTemplate {
+        agents: assigned,
+        workspace_id: ws_id.to_string(),
+        project_id: project_id.to_string(),
+    }
+    .into_response()
+}
+
+async fn return_project_list(
+    state: &AppState,
+    workspace_id: domain::primitives::WorkspaceId,
+) -> Response {
+    let projects = state
+        .app
+        .projects()
+        .list_for_workspace(workspace_id)
+        .await
+        .unwrap_or_default();
+
+    let agents = state
+        .app
+        .agents()
+        .list_for_workspace(workspace_id)
+        .await
+        .unwrap_or_default();
+
+    let views: Vec<ProjectView> = projects
+        .iter()
+        .map(|p| {
+            let count = agents.iter().filter(|a| a.project_id == Some(p.id)).count();
+            project_to_view(p, count)
+        })
+        .collect();
+
+    ProjectListTemplate { projects: views }.into_response()
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -181,6 +181,45 @@ pub struct WorkspaceDetailTemplate {
     pub agent_id: String,
 }
 
+// ── Projects ────────────────────────────────────────────────────��────
+
+pub struct ProjectView {
+    pub id: String,
+    pub workspace_id: String,
+    pub name: String,
+    pub description: String,
+    pub status: String,
+    pub agent_count: usize,
+    pub created_at: String,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "project_list.html")]
+pub struct ProjectListTemplate {
+    pub projects: Vec<ProjectView>,
+}
+
+pub struct ProjectAgentView {
+    pub id: String,
+    pub name: String,
+    pub agent_type: String,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "project_detail.html")]
+pub struct ProjectDetailTemplate {
+    pub project: ProjectView,
+    pub unassigned_agents: Vec<ProjectAgentView>,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "project_agents_list.html")]
+pub struct ProjectAgentsListTemplate {
+    pub agents: Vec<ProjectAgentView>,
+    pub workspace_id: String,
+    pub project_id: String,
+}
+
 // ── Workspace Secrets ────────────────────────────────────────────────
 
 pub struct WorkspaceSecretView {

--- a/web/templates/project_agents_list.html
+++ b/web/templates/project_agents_list.html
@@ -1,0 +1,34 @@
+{% if agents.is_empty() %}
+<p><small>No agents assigned to this project yet.</small></p>
+{% else %}
+<figure>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Type</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for a in agents %}
+      <tr>
+        <td><strong>{{ a.name }}</strong></td>
+        <td>{{ a.agent_type }}</td>
+        <td>
+          <button
+            hx-post="/workspaces/{{ workspace_id }}/projects/{{ project_id }}/unassign/{{ a.id }}"
+            hx-target="#project-agents-list"
+            hx-swap="innerHTML"
+            class="secondary outline"
+            style="padding: 0.25rem 0.5rem; margin: 0; font-size: 0.85em;"
+          >
+            Unassign
+          </button>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</figure>
+{% endif %}

--- a/web/templates/project_detail.html
+++ b/web/templates/project_detail.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+
+{% block title %}{{ project.name }} — Project — Galoy Agents{% endblock %}
+
+{% block nav_workspaces %}class="active"{% endblock %}
+
+{% block content %}
+<h2>Edit Project</h2>
+
+<form method="post" action="/workspaces/{{ project.workspace_id }}/projects/{{ project.id }}">
+  <label>
+    Name
+    <input type="text" name="name" required value="{{ project.name }}">
+  </label>
+  <label>
+    Description
+    <textarea name="description" rows="3">{{ project.description }}</textarea>
+  </label>
+  <label>
+    Status
+    <select name="status">
+      <option value="active" {% if project.status == "active" %}selected{% endif %}>Active</option>
+      <option value="completed" {% if project.status == "completed" %}selected{% endif %}>Completed</option>
+    </select>
+  </label>
+  <div style="display: flex; gap: 1rem;">
+    <button type="submit">Save Changes</button>
+    <a href="/workspaces/{{ project.workspace_id }}" role="button" class="outline">Back to Workspace</a>
+  </div>
+</form>
+
+<hr>
+
+<h3>Agents in Project</h3>
+<div id="project-agents-list"
+     hx-get="/workspaces/{{ project.workspace_id }}/projects/{{ project.id }}/agents"
+     hx-trigger="load"
+     hx-swap="innerHTML">
+  <p aria-busy="true">Loading agents...</p>
+</div>
+
+<hr>
+<h3>Assign Agent</h3>
+{% if unassigned_agents.is_empty() %}
+<p><small>No unassigned agents available in this workspace.</small></p>
+{% else %}
+<form hx-post="/workspaces/{{ project.workspace_id }}/projects/{{ project.id }}/assign"
+      hx-target="#project-agents-list"
+      hx-swap="innerHTML">
+  <div style="display: flex; gap: 0.5rem; align-items: end;">
+    <label style="flex: 1;">
+      Agent
+      <select name="agent_id" required>
+        {% for a in unassigned_agents %}
+        <option value="{{ a.id }}">{{ a.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+    <button type="submit" style="width: auto;">Assign</button>
+  </div>
+</form>
+{% endif %}
+
+<hr>
+<details>
+  <summary>Danger Zone</summary>
+  <p>Archiving a project will unassign all its agents.</p>
+  <button
+    hx-post="/workspaces/{{ project.workspace_id }}/projects/{{ project.id }}/archive"
+    hx-confirm="Archive this project? All agents will be unassigned."
+    class="secondary outline"
+    style="color: var(--pico-color-red-500, #c62828);"
+  >
+    Archive Project
+  </button>
+</details>
+
+<footer>
+  <small>Created: {{ project.created_at }} | ID: <code>{{ project.id }}</code></small>
+</footer>
+{% endblock %}

--- a/web/templates/project_list.html
+++ b/web/templates/project_list.html
@@ -1,0 +1,48 @@
+{% if projects.is_empty() %}
+<p>No projects yet. Create one to organize your agents.</p>
+{% else %}
+<figure>
+  <table>
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Description</th>
+        <th>Status</th>
+        <th>Agents</th>
+        <th></th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for p in projects %}
+      <tr>
+        <td><strong>{{ p.name }}</strong></td>
+        <td>{{ p.description }}</td>
+        <td>
+          {% if p.status == "active" %}
+          <span class="badge-active">Active</span>
+          {% elif p.status == "completed" %}
+          <span style="color: var(--pico-muted-color);">Completed</span>
+          {% else %}
+          <span class="badge-revoked">Archived</span>
+          {% endif %}
+        </td>
+        <td>{{ p.agent_count }}</td>
+        <td style="display: flex; gap: 0.5rem;">
+          <a href="/workspaces/{{ p.workspace_id }}/projects/{{ p.id }}">Edit</a>
+          <button
+            hx-post="/workspaces/{{ p.workspace_id }}/projects/{{ p.id }}/archive"
+            hx-confirm="Archive this project? Agents will be unassigned."
+            hx-target="#project-list"
+            hx-swap="innerHTML"
+            class="secondary outline"
+            style="padding: 0.25rem 0.5rem; margin: 0; font-size: 0.85em;"
+          >
+            Archive
+          </button>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</figure>
+{% endif %}

--- a/web/templates/workspace_detail.html
+++ b/web/templates/workspace_detail.html
@@ -25,6 +25,36 @@
 
 <hr>
 
+<h3>Projects</h3>
+<p><small>Projects group related agents together within a workspace.</small></p>
+
+<div id="project-list"
+     hx-get="/workspaces/{{ workspace.id }}/projects/list"
+     hx-trigger="load"
+     hx-swap="innerHTML">
+  <p aria-busy="true">Loading projects...</p>
+</div>
+
+<details>
+  <summary>Create Project</summary>
+  <form hx-post="/workspaces/{{ workspace.id }}/projects"
+        hx-target="#project-list"
+        hx-swap="innerHTML"
+        hx-on::after-request="if(event.detail.successful) this.reset()">
+    <label>
+      Name
+      <input type="text" name="name" required placeholder="e.g. backend-api">
+    </label>
+    <label>
+      Description
+      <textarea name="description" rows="2" placeholder="What is this project for?"></textarea>
+    </label>
+    <button type="submit">Create Project</button>
+  </form>
+</details>
+
+<hr>
+
 <h3>Secrets</h3>
 <p><small>Secrets are injected into the agent sandbox as environment variables or files. Values are never displayed after creation.</small></p>
 


### PR DESCRIPTION
## Summary
- Add event-sourced `Project` entity (Initialized, Updated, StatusChanged events) following existing workspace/agent patterns
- Projects live under workspaces and group related agents together
- Agent-project association via `AgentEvent::ProjectChanged` and `Agent.project_id` field
- SQL migration adds `projects`/`project_events` tables and `project_id` FK on `agents`
- Dashboard UI with project list, create form, detail page, and agent assign/unassign

## Test plan
- [x] All 173 existing tests pass (no regressions)
- [x] New unit tests for Project entity hydration, update, status change, and idempotency
- [x] New unit tests for Agent `change_project` command and idempotency
- [x] `cargo clippy --all-targets -- -D warnings` passes clean
- [x] `cargo fmt` passes clean
- [x] All nix flake checks pass (fmt, clippy, nextest)
- [ ] Manual: create workspace → create project → assign agent → unassign → archive project

🤖 Generated with [Claude Code](https://claude.com/claude-code)