### PR TITLE
feat(web): workspace hub layout with sidebar selector

### DIFF
--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -542,11 +542,21 @@ fn workspace_to_view(ws: &domain::workspace::Workspace) -> WorkspaceView {
 }
 
 #[instrument(name = "web.workspaces_page", skip_all)]
-async fn workspaces_page(session: Session) -> Response {
+async fn workspaces_page(State(state): State<AppState>, session: Session) -> Response {
     if extract_user_id(&session).await.is_none() {
         return Redirect::to("/").into_response();
     }
-    WorkspacesTemplate {}.into_response()
+
+    let workspaces = state.app.workspaces().list_all().await.unwrap_or_default();
+
+    WorkspaceHubTemplate {
+        workspaces: workspaces.iter().map(workspace_to_view).collect(),
+        selected_workspace: None,
+        selected_workspace_id: String::new(),
+        agents: vec![],
+        selected_agent_id: String::new(),
+    }
+    .into_response()
 }
 
 #[instrument(name = "web.workspace_list", skip_all)]
@@ -817,11 +827,17 @@ async fn workspace_secret_delete(
 // Workspace Chat
 // ---------------------------------------------------------------------------
 
+#[derive(Debug, Deserialize, Default)]
+pub struct ChatQuery {
+    agent: Option<uuid::Uuid>,
+}
+
 #[instrument(name = "web.workspace_chat", skip_all)]
 async fn workspace_chat(
     State(state): State<AppState>,
     session: Session,
     Path(id): Path<uuid::Uuid>,
+    Query(query): Query<ChatQuery>,
 ) -> Response {
     if extract_user_id(&session).await.is_none() {
         return Redirect::to("/").into_response();
@@ -833,6 +849,8 @@ async fn workspace_chat(
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
+    let all_workspaces = state.app.workspaces().list_all().await.unwrap_or_default();
+
     let agents = state
         .app
         .agents()
@@ -840,18 +858,32 @@ async fn workspace_chat(
         .await
         .unwrap_or_default();
 
-    let lead = agents
-        .iter()
-        .find(|a| a.agent_role == domain::agent::AgentRole::WorkspaceLead);
-
-    let agent_id = match lead {
-        Some(a) => a.id.to_string(),
-        None => return Redirect::to("/workspaces").into_response(),
+    let selected_agent = match query.agent {
+        Some(agent_uuid) => {
+            let target = AgentId::from(agent_uuid);
+            agents.iter().find(|a| a.id == target)
+        }
+        None => agents
+            .iter()
+            .find(|a| a.agent_role == domain::agent::AgentRole::WorkspaceLead),
     };
 
-    WorkspaceChatTemplate {
-        workspace: workspace_to_view(&ws),
-        agent_id,
+    let selected_agent_id = selected_agent.map(|a| a.id.to_string()).unwrap_or_default();
+
+    let agent_views: Vec<AgentView> = agents
+        .iter()
+        .map(|a| AgentView {
+            id: a.id.to_string(),
+            name: a.name.clone(),
+        })
+        .collect();
+
+    WorkspaceHubTemplate {
+        workspaces: all_workspaces.iter().map(workspace_to_view).collect(),
+        selected_workspace_id: workspace_id.to_string(),
+        selected_workspace: Some(workspace_to_view(&ws)),
+        agents: agent_views,
+        selected_agent_id,
     }
     .into_response()
 }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -603,17 +603,18 @@ async fn workspace_create(
     };
 
     let description = form.description.filter(|d| !d.is_empty());
-    if let Err(e) = state
+    match state
         .app
         .workspaces()
         .create(user_id, &form.name, description)
         .await
     {
-        tracing::error!(error = %e, "Failed to create workspace");
-        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        Ok(ws) => Redirect::to(&format!("/workspaces/{}/chat", ws.id)).into_response(),
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to create workspace");
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
     }
-
-    Redirect::to("/workspaces").into_response()
 }
 
 #[instrument(name = "web.workspace_detail", skip_all)]

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -48,7 +48,7 @@ pub fn router() -> Router<AppState> {
         .route("/workspaces/{id}/chat", get(workspace_chat))
         .route("/workspaces", get(workspaces_page))
         .route("/workspaces/new", get(workspace_new))
-        .route("/workspaces/list", get(workspace_list))
+        .route("/workspaces/sidebar", get(workspace_sidebar_list))
         .route("/workspaces", post(workspace_create))
         .route("/workspaces/{id}", get(workspace_detail))
         .route("/workspaces/{id}", post(workspace_update))
@@ -559,19 +559,19 @@ async fn workspaces_page(State(state): State<AppState>, session: Session) -> Res
     .into_response()
 }
 
-#[instrument(name = "web.workspace_list", skip_all)]
-async fn workspace_list(State(state): State<AppState>, session: Session) -> Response {
+#[instrument(name = "web.workspace_sidebar_list", skip_all)]
+async fn workspace_sidebar_list(State(state): State<AppState>, session: Session) -> Response {
     if extract_user_id(&session).await.is_none() {
         return axum::http::StatusCode::UNAUTHORIZED.into_response();
     }
 
     match state.app.workspaces().list_all().await {
-        Ok(workspaces) => WorkspaceListTemplate {
+        Ok(workspaces) => WorkspaceSidebarListTemplate {
             workspaces: workspaces.iter().map(workspace_to_view).collect(),
         }
         .into_response(),
         Err(e) => {
-            tracing::error!(error = %e, "Failed to list workspaces");
+            tracing::error!(error = %e, "Failed to list workspaces for sidebar");
             axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
     }
@@ -632,8 +632,24 @@ async fn workspace_detail(
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
+    let agents = state
+        .app
+        .agents()
+        .list_for_workspace(workspace_id)
+        .await
+        .unwrap_or_default();
+
+    let agent_views: Vec<AgentView> = agents
+        .iter()
+        .map(|a| AgentView {
+            id: a.id.to_string(),
+            name: a.name.clone(),
+        })
+        .collect();
+
     WorkspaceDetailTemplate {
         workspace: workspace_to_view(&ws),
+        agents: agent_views,
     }
     .into_response()
 }
@@ -657,7 +673,7 @@ async fn workspace_update(
         .update(workspace_id, &form.name, description)
         .await
     {
-        Ok(_) => Redirect::to("/workspaces").into_response(),
+        Ok(_) => Redirect::to(&format!("/workspaces/{id}")).into_response(),
         Err(e) => {
             tracing::error!(error = %e, "Failed to update workspace");
             axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -113,16 +113,6 @@ pub struct WorkspaceView {
 }
 
 #[derive(Template, WebTemplate)]
-#[template(path = "workspaces.html")]
-pub struct WorkspacesTemplate {}
-
-#[derive(Template, WebTemplate)]
-#[template(path = "workspace_list.html")]
-pub struct WorkspaceListTemplate {
-    pub workspaces: Vec<WorkspaceView>,
-}
-
-#[derive(Template, WebTemplate)]
 #[template(path = "workspace_new.html")]
 pub struct WorkspaceNewTemplate {}
 
@@ -130,6 +120,7 @@ pub struct WorkspaceNewTemplate {}
 #[template(path = "workspace_detail.html")]
 pub struct WorkspaceDetailTemplate {
     pub workspace: WorkspaceView,
+    pub agents: Vec<AgentView>,
 }
 
 // ── Workspace Secrets ────────────────────────────────────────────────
@@ -146,6 +137,12 @@ pub struct WorkspaceSecretView {
 #[template(path = "workspace_secrets_list.html")]
 pub struct WorkspaceSecretsListTemplate {
     pub secrets: Vec<WorkspaceSecretView>,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "workspace_sidebar_list.html")]
+pub struct WorkspaceSidebarListTemplate {
+    pub workspaces: Vec<WorkspaceView>,
 }
 
 pub struct AgentView {

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -148,6 +148,22 @@ pub struct WorkspaceSecretsListTemplate {
     pub secrets: Vec<WorkspaceSecretView>,
 }
 
+pub struct AgentView {
+    pub id: String,
+    pub name: String,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "workspace_hub.html")]
+pub struct WorkspaceHubTemplate {
+    pub workspaces: Vec<WorkspaceView>,
+    pub selected_workspace: Option<WorkspaceView>,
+    /// Flat ID string for dropdown comparison (avoids Askama ref issues).
+    pub selected_workspace_id: String,
+    pub agents: Vec<AgentView>,
+    pub selected_agent_id: String,
+}
+
 #[derive(Template, WebTemplate)]
 #[template(path = "workspace_chat.html")]
 pub struct WorkspaceChatTemplate {

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -86,6 +86,7 @@
 </head>
 <body>
   <aside class="sidebar">
+    {% block sidebar_content %}
     <h4>Galoy Agents</h4>
     <nav>
       <ul>
@@ -101,6 +102,7 @@
     <div class="sidebar-bottom">
       <a href="/auth/logout">Logout</a>
     </div>
+    {% endblock %}
   </aside>
   <div class="content-area">
     {% block content %}{% endblock %}

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -88,9 +88,17 @@
   <aside class="sidebar">
     {% block sidebar_content %}
     <h4>Galoy Agents</h4>
+
+    <div class="section-label">Workspaces</div>
+    <div id="sidebar-ws-list"
+         hx-get="/workspaces/sidebar"
+         hx-trigger="load"
+         hx-swap="innerHTML">
+    </div>
+
+    <hr style="margin: 0.75rem 0;">
     <nav>
       <ul>
-        <li><a href="/workspaces" {% block nav_workspaces %}{% endblock %}>Workspaces</a></li>
         <li><a href="/dashboard" {% block nav_dashboard %}{% endblock %}>MCP Credentials</a></li>
         <li><a href="/code-assistant" {% block nav_code_assistant %}{% endblock %}>Code Assistant</a></li>
       </ul>

--- a/web/templates/workspace_detail.html
+++ b/web/templates/workspace_detail.html
@@ -1,11 +1,89 @@
 {% extends "base.html" %}
 
-{% block title %}{{ workspace.name }} — Galoy Agents{% endblock %}
+{% block title %}{{ workspace.name }} — Settings — Galoy Agents{% endblock %}
 
-{% block nav_workspaces %}class="active"{% endblock %}
+{% block head %}
+<style>
+  .ws-back {
+    display: block;
+    font-size: 0.8rem;
+    text-decoration: none;
+    color: var(--pico-muted-color);
+    margin-bottom: 0.25rem;
+  }
+  .ws-back:hover { color: var(--pico-primary); }
+  .ws-mode-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+  .ws-mode-header h4 { margin: 0; font-size: 1rem; }
+  .ws-settings-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    margin: 0;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    background: none;
+    text-decoration: none;
+    color: var(--pico-muted-color);
+    font-size: 0.9rem;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .ws-settings-btn.active {
+    background: var(--pico-primary-background);
+    color: var(--pico-primary-inverse);
+  }
+  .agent-item {
+    display: block;
+    padding: 0.4rem 0.75rem;
+    border-radius: var(--pico-border-radius);
+    text-decoration: none;
+    color: var(--pico-color);
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .agent-item:hover {
+    background: var(--pico-primary-background);
+    color: var(--pico-primary-inverse);
+  }
+</style>
+{% endblock %}
+
+{% block sidebar_content %}
+<a href="/workspaces" class="ws-back">&larr; Workspaces</a>
+<div class="ws-mode-header">
+  <h4>{{ workspace.name }}</h4>
+  <a href="/workspaces/{{ workspace.id }}" class="ws-settings-btn active" title="Workspace settings">&#9881;</a>
+</div>
+
+{% if !agents.is_empty() %}
+<div class="section-label">Agents</div>
+{% for agent in agents %}
+<a href="/workspaces/{{ workspace.id }}/chat?agent={{ agent.id }}" class="agent-item">
+  {{ agent.name }}
+</a>
+{% endfor %}
+{% else %}
+<div class="section-label">Agents</div>
+<small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
+{% endif %}
+
+<div class="sidebar-bottom">
+  <a href="/auth/logout">Logout</a>
+</div>
+{% endblock %}
 
 {% block content %}
-<h2>Edit Workspace</h2>
+<h2>Workspace Settings</h2>
 
 <form method="post" action="/workspaces/{{ workspace.id }}">
   <label>
@@ -18,8 +96,7 @@
   </label>
   <div style="display: flex; gap: 1rem;">
     <button type="submit">Save Changes</button>
-    <a href="/workspaces" role="button" class="outline">Cancel</a>
-    <a href="/workspaces/{{ workspace.id }}/chat" role="button" class="secondary">Chat with Agent</a>
+    <a href="/workspaces/{{ workspace.id }}/chat" role="button" class="outline">Back to Chat</a>
   </div>
 </form>
 

--- a/web/templates/workspace_hub.html
+++ b/web/templates/workspace_hub.html
@@ -1,0 +1,317 @@
+{% extends "base.html" %}
+
+{% block title %}Workspaces — Galoy Agents{% endblock %}
+
+{% block head %}
+<style>
+  /* Sidebar: workspace selector */
+  .ws-selector {
+    display: flex;
+    gap: 0.25rem;
+    align-items: center;
+    margin-bottom: 0.75rem;
+  }
+  .ws-selector select {
+    flex: 1;
+    margin: 0;
+    padding: 0.35rem 0.5rem;
+    font-size: 0.85rem;
+  }
+  .ws-selector .ws-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    padding: 0;
+    margin: 0;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    background: none;
+    text-decoration: none;
+    color: var(--pico-color);
+    font-size: 1rem;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .ws-selector .ws-btn:hover {
+    background: var(--pico-primary-background);
+    color: var(--pico-primary-inverse);
+  }
+
+  /* Sidebar: agent list */
+  .agent-list {
+    margin-bottom: 0.75rem;
+  }
+  .agent-list .section-label {
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--pico-muted-color);
+    padding: 0.25rem 0.75rem;
+    margin-bottom: 0.25rem;
+  }
+  .agent-item {
+    display: block;
+    padding: 0.4rem 0.75rem;
+    border-radius: var(--pico-border-radius);
+    text-decoration: none;
+    color: var(--pico-color);
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .agent-item:hover,
+  .agent-item.active {
+    background: var(--pico-primary-background);
+    color: var(--pico-primary-inverse);
+  }
+  .agent-item .agent-role {
+    font-size: 0.7rem;
+    color: var(--pico-muted-color);
+    margin-left: 0.25rem;
+  }
+  .agent-item.active .agent-role {
+    color: var(--pico-primary-inverse);
+    opacity: 0.7;
+  }
+
+  /* Main: chat layout */
+  .chat-layout {
+    display: flex;
+    flex-direction: column;
+    height: calc(100vh - 4rem);
+  }
+  .chat-header {
+    margin-bottom: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .chat-header h3 {
+    margin: 0;
+    font-size: 1.1rem;
+  }
+  .chat-header small {
+    color: var(--pico-muted-color);
+  }
+  .messages {
+    flex: 1;
+    overflow-y: auto;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    padding: 1rem;
+    margin-bottom: 0.75rem;
+    font-family: monospace;
+    font-size: 0.85rem;
+    background: var(--pico-code-background-color);
+  }
+  .messages .msg { margin-bottom: 0.5rem; white-space: pre-wrap; word-break: break-word; }
+  .messages .msg-system { color: var(--pico-muted-color); }
+  .messages .msg-assistant { color: var(--pico-color); }
+  .messages .msg-error { color: var(--pico-del-color); }
+  .messages .msg-result { color: var(--pico-ins-color); }
+  .chat-input { display: flex; gap: 0.5rem; }
+  .chat-input textarea { flex: 1; resize: none; margin: 0; }
+  .chat-input button { width: auto; align-self: end; margin: 0; }
+
+  /* Welcome state */
+  .hub-welcome {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: calc(100vh - 6rem);
+    text-align: center;
+    color: var(--pico-muted-color);
+  }
+  .hub-welcome h2 { margin-bottom: 0.5rem; }
+</style>
+{% endblock %}
+
+{% block sidebar_content %}
+<h4><a href="/workspaces" style="text-decoration: none; color: inherit;">Galoy Agents</a></h4>
+
+<div class="ws-selector">
+  <select id="workspace-select" onchange="switchWorkspace(this.value)">
+    <option value="">Select workspace...</option>
+    {% for ws in workspaces %}
+    <option value="{{ ws.id }}"{% if selected_workspace_id == ws.id %} selected{% endif %}>{{ ws.name }}</option>
+    {% endfor %}
+  </select>
+  {% if !selected_workspace_id.is_empty() %}
+  <a href="/workspaces/{{ selected_workspace_id }}" class="ws-btn" title="Workspace settings">&#9881;</a>
+  {% endif %}
+  <a href="/workspaces/new" class="ws-btn" title="New workspace">+</a>
+</div>
+
+{% if !agents.is_empty() %}
+<div class="agent-list">
+  <div class="section-label">Agents</div>
+  {% for agent in agents %}
+  <a href="/workspaces/{{ selected_workspace_id }}/chat?agent={{ agent.id }}"
+     class="agent-item{% if selected_agent_id == agent.id %} active{% endif %}"
+  >
+    {{ agent.name }}
+  </a>
+  {% endfor %}
+</div>
+{% endif %}
+
+<hr style="margin: 0.5rem 0;">
+<nav>
+  <ul>
+    <li><a href="/dashboard">MCP Credentials</a></li>
+    <li><a href="/code-assistant">Code Assistant</a></li>
+  </ul>
+  <div class="section-label">Administration</div>
+  <ul>
+    <li><a href="/audit">Audit Log</a></li>
+  </ul>
+</nav>
+<div class="sidebar-bottom">
+  <a href="/auth/logout">Logout</a>
+</div>
+{% endblock %}
+
+{% block content %}
+{% match selected_workspace %}
+  {% when Some(sel) %}
+    {% if !selected_agent_id.is_empty() %}
+      <div class="chat-layout">
+        <div class="chat-header">
+          <div>
+            <h3>{{ sel.name }}</h3>
+            <small>Agent chat</small>
+          </div>
+        </div>
+        <div class="messages" id="messages"></div>
+        <div class="chat-input">
+          <textarea id="prompt" rows="3" placeholder="Type a message..."></textarea>
+          <button id="send-btn" onclick="sendMessage()">Send</button>
+        </div>
+      </div>
+
+      <script>
+      const agentId = '{{ selected_agent_id }}';
+
+      function appendMsg(cls, text) {
+        const el = document.createElement('div');
+        el.className = 'msg ' + cls;
+        el.textContent = text;
+        const container = document.getElementById('messages');
+        container.appendChild(el);
+        container.scrollTop = container.scrollHeight;
+      }
+
+      async function sendMessage() {
+        const textarea = document.getElementById('prompt');
+        const prompt = textarea.value.trim();
+        if (!prompt) return;
+
+        textarea.value = '';
+        document.getElementById('send-btn').disabled = true;
+        appendMsg('msg-system', '> ' + prompt);
+
+        try {
+          const resp = await fetch('/api/v1/agents/' + agentId + '/message', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ prompt }),
+          });
+
+          if (!resp.ok) {
+            try {
+              const err = await resp.json();
+              appendMsg('msg-error', err.error || ('Error: ' + resp.status));
+            } catch {
+              appendMsg('msg-error', 'Error: ' + resp.status);
+            }
+            return;
+          }
+
+          const reader = resp.body.getReader();
+          const decoder = new TextDecoder();
+          let buffer = '';
+
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+
+            buffer += decoder.decode(value, { stream: true });
+            const lines = buffer.split('\n');
+            buffer = lines.pop() || '';
+
+            for (const line of lines) {
+              if (line.startsWith('data:')) {
+                const data = line.slice(5).trim();
+                if (!data) continue;
+                try {
+                  const parsed = JSON.parse(data);
+                  if (parsed.type === 'assistant_text') {
+                    appendMsg('msg-assistant', parsed.text);
+                  } else if (parsed.type === 'thinking') {
+                    appendMsg('msg-system', '(thinking) ' + parsed.text);
+                  } else if (parsed.type === 'user_message') {
+                    // Already rendered locally
+                  } else if (parsed.type === 'tool_call') {
+                    const args = parsed.arguments ? ' ' + JSON.stringify(parsed.arguments) : '';
+                    appendMsg('msg-system', 'tool: ' + parsed.name + args);
+                  } else if (parsed.type === 'tool_result') {
+                    appendMsg('msg-system', (parsed.is_error ? 'error: ' : 'ok: ') + parsed.name);
+                  } else if (parsed.type === 'done') {
+                    const tokens = (parsed.input_tokens || 0) + (parsed.output_tokens || 0);
+                    const parts = [(parsed.turns || 0) + ' turns', tokens + ' tokens'];
+                    if (parsed.duration_ms) parts.push((parsed.duration_ms / 1000).toFixed(1) + 's');
+                    if (parsed.cost_usd) parts.push('$' + parsed.cost_usd.toFixed(4));
+                    appendMsg('msg-result', 'Done — ' + parts.join(', '));
+                  } else if (parsed.type === 'error') {
+                    appendMsg('msg-error', parsed.message || JSON.stringify(parsed));
+                  } else if (parsed.type === 'service') {
+                    appendMsg('msg-system', parsed.message);
+                  }
+                } catch {
+                  appendMsg('msg-assistant', data);
+                }
+              }
+            }
+          }
+        } catch (e) {
+          appendMsg('msg-error', 'Network error: ' + e.message);
+        } finally {
+          document.getElementById('send-btn').disabled = false;
+          textarea.focus();
+        }
+      }
+
+      document.getElementById('prompt').addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          sendMessage();
+        }
+      });
+      </script>
+    {% else %}
+      <div class="hub-welcome">
+        <h2>No agents found</h2>
+        <p>This workspace doesn't have any agents yet.</p>
+      </div>
+    {% endif %}
+  {% when None %}
+  <div class="hub-welcome">
+    <h2>Welcome</h2>
+    <p>Select a workspace from the sidebar to get started,<br>or <a href="/workspaces/new">create a new one</a>.</p>
+  </div>
+{% endmatch %}
+
+<script>
+function switchWorkspace(id) {
+  if (id) {
+    window.location.href = '/workspaces/' + id + '/chat';
+  } else {
+    window.location.href = '/workspaces';
+  }
+}
+</script>
+{% endblock %}

--- a/web/templates/workspace_hub.html
+++ b/web/templates/workspace_hub.html
@@ -4,53 +4,70 @@
 
 {% block head %}
 <style>
-  /* Sidebar: workspace selector */
-  .ws-selector {
-    display: flex;
-    gap: 0.25rem;
-    align-items: center;
-    margin-bottom: 0.75rem;
+  /* ── Sidebar: top-level workspace list ─────────────────── */
+  .ws-list-item {
+    display: block;
+    padding: 0.4rem 0.75rem;
+    border-radius: var(--pico-border-radius);
+    text-decoration: none;
+    color: var(--pico-color);
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
-  .ws-selector select {
-    flex: 1;
-    margin: 0;
-    padding: 0.35rem 0.5rem;
+  .ws-list-item:hover {
+    background: var(--pico-primary-background);
+    color: var(--pico-primary-inverse);
+  }
+  .ws-new-link {
+    display: block;
+    padding: 0.4rem 0.75rem;
     font-size: 0.85rem;
+    color: var(--pico-muted-color);
+    text-decoration: none;
   }
-  .ws-selector .ws-btn {
+  .ws-new-link:hover { color: var(--pico-primary); }
+
+  /* ── Sidebar: workspace-mode header ────────────────────── */
+  .ws-back {
+    display: block;
+    font-size: 0.8rem;
+    text-decoration: none;
+    color: var(--pico-muted-color);
+    margin-bottom: 0.25rem;
+  }
+  .ws-back:hover { color: var(--pico-primary); }
+  .ws-mode-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+  .ws-mode-header h4 { margin: 0; font-size: 1rem; }
+  .ws-mode-header .ws-settings-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: 2rem;
-    height: 2rem;
+    width: 1.75rem;
+    height: 1.75rem;
     padding: 0;
     margin: 0;
     border: 1px solid var(--pico-muted-border-color);
     border-radius: var(--pico-border-radius);
     background: none;
     text-decoration: none;
-    color: var(--pico-color);
-    font-size: 1rem;
+    color: var(--pico-muted-color);
+    font-size: 0.9rem;
     cursor: pointer;
     flex-shrink: 0;
   }
-  .ws-selector .ws-btn:hover {
+  .ws-mode-header .ws-settings-btn:hover {
     background: var(--pico-primary-background);
     color: var(--pico-primary-inverse);
   }
 
-  /* Sidebar: agent list */
-  .agent-list {
-    margin-bottom: 0.75rem;
-  }
-  .agent-list .section-label {
-    font-size: 0.7rem;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--pico-muted-color);
-    padding: 0.25rem 0.75rem;
-    margin-bottom: 0.25rem;
-  }
+  /* ── Sidebar: agent list ───────────────────────────────── */
   .agent-item {
     display: block;
     padding: 0.4rem 0.75rem;
@@ -67,17 +84,8 @@
     background: var(--pico-primary-background);
     color: var(--pico-primary-inverse);
   }
-  .agent-item .agent-role {
-    font-size: 0.7rem;
-    color: var(--pico-muted-color);
-    margin-left: 0.25rem;
-  }
-  .agent-item.active .agent-role {
-    color: var(--pico-primary-inverse);
-    opacity: 0.7;
-  }
 
-  /* Main: chat layout */
+  /* ── Main: chat layout ─────────────────────────────────── */
   .chat-layout {
     display: flex;
     flex-direction: column;
@@ -89,13 +97,8 @@
     align-items: center;
     justify-content: space-between;
   }
-  .chat-header h3 {
-    margin: 0;
-    font-size: 1.1rem;
-  }
-  .chat-header small {
-    color: var(--pico-muted-color);
-  }
+  .chat-header h3 { margin: 0; font-size: 1.1rem; }
+  .chat-header small { color: var(--pico-muted-color); }
   .messages {
     flex: 1;
     overflow-y: auto;
@@ -116,7 +119,7 @@
   .chat-input textarea { flex: 1; resize: none; margin: 0; }
   .chat-input button { width: auto; align-self: end; margin: 0; }
 
-  /* Welcome state */
+  /* ── Main: welcome state ───────────────────────────────── */
   .hub-welcome {
     display: flex;
     flex-direction: column;
@@ -131,35 +134,39 @@
 {% endblock %}
 
 {% block sidebar_content %}
-<h4><a href="/workspaces" style="text-decoration: none; color: inherit;">Galoy Agents</a></h4>
-
-<div class="ws-selector">
-  <select id="workspace-select" onchange="switchWorkspace(this.value)">
-    <option value="">Select workspace...</option>
-    {% for ws in workspaces %}
-    <option value="{{ ws.id }}"{% if selected_workspace_id == ws.id %} selected{% endif %}>{{ ws.name }}</option>
-    {% endfor %}
-  </select>
-  {% if !selected_workspace_id.is_empty() %}
-  <a href="/workspaces/{{ selected_workspace_id }}" class="ws-btn" title="Workspace settings">&#9881;</a>
-  {% endif %}
-  <a href="/workspaces/new" class="ws-btn" title="New workspace">+</a>
+{% if !selected_workspace_id.is_empty() %}
+{# ── Workspace mode: zoomed-in sidebar ──────────────────── #}
+<a href="/workspaces" class="ws-back">&larr; Workspaces</a>
+<div class="ws-mode-header">
+  {% match selected_workspace %}{% when Some(sel) %}<h4>{{ sel.name }}</h4>{% when None %}<h4>Workspace</h4>{% endmatch %}
+  <a href="/workspaces/{{ selected_workspace_id }}" class="ws-settings-btn" title="Workspace settings">&#9881;</a>
 </div>
 
 {% if !agents.is_empty() %}
-<div class="agent-list">
-  <div class="section-label">Agents</div>
-  {% for agent in agents %}
-  <a href="/workspaces/{{ selected_workspace_id }}/chat?agent={{ agent.id }}"
-     class="agent-item{% if selected_agent_id == agent.id %} active{% endif %}"
-  >
-    {{ agent.name }}
-  </a>
-  {% endfor %}
-</div>
+<div class="section-label">Agents</div>
+{% for agent in agents %}
+<a href="/workspaces/{{ selected_workspace_id }}/chat?agent={{ agent.id }}"
+   class="agent-item{% if selected_agent_id == agent.id %} active{% endif %}"
+>
+  {{ agent.name }}
+</a>
+{% endfor %}
+{% else %}
+<div class="section-label">Agents</div>
+<small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
 
-<hr style="margin: 0.5rem 0;">
+{% else %}
+{# ── Top-level mode: nav + workspace list ───────────────── #}
+<h4>Galoy Agents</h4>
+
+<div class="section-label">Workspaces</div>
+{% for ws in workspaces %}
+<a href="/workspaces/{{ ws.id }}/chat" class="ws-list-item">{{ ws.name }}</a>
+{% endfor %}
+<a href="/workspaces/new" class="ws-new-link">+ New Workspace</a>
+
+<hr style="margin: 0.75rem 0;">
 <nav>
   <ul>
     <li><a href="/dashboard">MCP Credentials</a></li>
@@ -170,6 +177,8 @@
     <li><a href="/audit">Audit Log</a></li>
   </ul>
 </nav>
+{% endif %}
+
 <div class="sidebar-bottom">
   <a href="/auth/logout">Logout</a>
 </div>
@@ -300,18 +309,8 @@
     {% endif %}
   {% when None %}
   <div class="hub-welcome">
-    <h2>Welcome</h2>
+    <h2>Workspaces</h2>
     <p>Select a workspace from the sidebar to get started,<br>or <a href="/workspaces/new">create a new one</a>.</p>
   </div>
 {% endmatch %}
-
-<script>
-function switchWorkspace(id) {
-  if (id) {
-    window.location.href = '/workspaces/' + id + '/chat';
-  } else {
-    window.location.href = '/workspaces';
-  }
-}
-</script>
 {% endblock %}

--- a/web/templates/workspace_new.html
+++ b/web/templates/workspace_new.html
@@ -2,18 +2,6 @@
 
 {% block title %}New Workspace — Galoy Agents{% endblock %}
 
-{% block head %}
-<style>
-  details.config-section { margin-bottom: 1rem; }
-  details.config-section summary {
-    cursor: pointer; font-weight: 600; font-size: 0.95rem;
-    padding: 0.5rem 0; color: var(--pico-muted-color);
-  }
-  details.config-section summary:hover { color: var(--pico-color); }
-  details.config-section .config-fields { padding-top: 0.5rem; }
-</style>
-{% endblock %}
-
 {% block content %}
 <h2>New Workspace</h2>
 
@@ -26,58 +14,6 @@
     Description
     <textarea name="description" rows="3" placeholder="What is this workspace for?"></textarea>
   </label>
-
-  <details class="config-section">
-    <summary>Sandbox Resources</summary>
-    <div class="config-fields">
-      <label>
-        PVC Size
-        <input type="text" name="pvc_size" value="10Gi" placeholder="e.g. 10Gi">
-      </label>
-      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem;">
-        <label>
-          CPU
-          <select name="resource_cpu">
-            <option value="500m" selected>0.5 CPU</option>
-            <option value="1">1 CPU</option>
-            <option value="2">2 CPU</option>
-          </select>
-        </label>
-        <label>
-          RAM
-          <select name="resource_mem">
-            <option value="512Mi" selected>512 Mi</option>
-            <option value="1Gi">1 Gi</option>
-            <option value="2Gi">2 Gi</option>
-          </select>
-        </label>
-      </div>
-    </div>
-  </details>
-
-  <details class="config-section">
-    <summary>Model Configuration</summary>
-    <div class="config-fields">
-      <label>
-        Model
-        <select name="model">
-          <option value="claude-haiku-4-5-20251001" selected>Claude Haiku 4.5</option>
-          <option value="claude-sonnet-4-6-20250514">Claude Sonnet 4.6</option>
-          <option value="claude-opus-4-6-20250514">Claude Opus 4.6</option>
-        </select>
-      </label>
-      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 0.5rem;">
-        <label>
-          Max tokens
-          <input type="number" name="max_tokens" min="256" max="65536" value="4096">
-        </label>
-        <label>
-          Max turns
-          <input type="number" name="max_turns" min="1" max="200" value="25">
-        </label>
-      </div>
-    </div>
-  </details>
 
   <div style="display: flex; gap: 1rem;">
     <button type="submit">Create Workspace</button>

--- a/web/templates/workspace_new.html
+++ b/web/templates/workspace_new.html
@@ -2,8 +2,6 @@
 
 {% block title %}New Workspace — Galoy Agents{% endblock %}
 
-{% block nav_workspaces %}class="active"{% endblock %}
-
 {% block head %}
 <style>
   details.config-section { margin-bottom: 1rem; }

--- a/web/templates/workspace_sidebar_list.html
+++ b/web/templates/workspace_sidebar_list.html
@@ -1,0 +1,13 @@
+{% for ws in workspaces %}
+<a href="/workspaces/{{ ws.id }}/chat"
+   style="display:block; padding:0.4rem 0.75rem; border-radius:var(--pico-border-radius); text-decoration:none; color:var(--pico-color); font-size:0.9rem; white-space:nowrap; overflow:hidden; text-overflow:ellipsis;"
+   onmouseover="this.style.background='var(--pico-primary-background)';this.style.color='var(--pico-primary-inverse)'"
+   onmouseout="this.style.background='';this.style.color='var(--pico-color)'"
+>{{ ws.name }}</a>
+{% endfor %}
+{% if workspaces.is_empty() %}
+<small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No workspaces yet</small>
+{% endif %}
+<a href="/workspaces/new"
+   style="display:block; padding:0.4rem 0.75rem; font-size:0.85rem; color:var(--pico-muted-color); text-decoration:none;"
+>+ New Workspace</a>


### PR DESCRIPTION
## Summary
- Restructures the workspace UI from a table-list page to a Slack-like hub layout
- Left sidebar now has a workspace dropdown selector, agent list, and settings/new buttons
- Selecting a workspace loads agents in the sidebar and opens the lead agent chat in the main area
- Agent selection supported via `?agent=` query param for multi-agent workspaces
- Adds `sidebar_content` block to `base.html` so hub pages can override the sidebar without affecting other pages (dashboard, audit, code-assistant)

## Test plan
- [ ] Navigate to `/workspaces` — see welcome state with workspace dropdown
- [ ] Select a workspace from dropdown — navigates to `/workspaces/{id}/chat` with agent list and chat loaded
- [ ] Send a message in the chat — SSE streaming works as before
- [ ] Click gear icon next to dropdown — goes to workspace settings/edit page
- [ ] Click `+` button — goes to new workspace form
- [ ] Verify dashboard, audit, and code-assistant pages render unchanged
- [ ] Create/delete workspace flows still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)