### PR TITLE
feat(agent): create agents from the UI, attach/detach sandboxes

### DIFF
--- a/.sqlx/query-10320dfefa193135772b80a418c95ad3292601ba85c3ead24b522fc905afcc5c.json
+++ b/.sqlx/query-10320dfefa193135772b80a418c95ad3292601ba85c3ead24b522fc905afcc5c.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n                id AS \"id: AuditEntryId\",\n                acting_user_id AS \"acting_user_id: UserId\",\n                workspace_id AS \"workspace_id: WorkspaceId\",\n                acting_agent_id AS \"acting_agent_id: AgentId\",\n                on_behalf_of_user_id AS \"on_behalf_of_user_id: UserId\",\n                interaction_type,\n                action,\n                metadata AS \"metadata: serde_json::Value\",\n                outcome,\n                error,\n                duration_ms,\n                tokens_returned,\n                recorded_at\n            FROM audit_entries\n            ORDER BY id DESC\n            LIMIT $1",
+  "query": "SELECT\n                id AS \"id: AuditEntryId\",\n                acting_user_id AS \"acting_user_id: UserId\",\n                workspace_id AS \"workspace_id: WorkspaceId\",\n                acting_agent_id AS \"acting_agent_id: AgentId\",\n                on_behalf_of_user_id AS \"on_behalf_of_user_id: UserId\",\n                sandbox_id AS \"sandbox_id: SandboxId\",\n                interaction_type,\n                action,\n                metadata AS \"metadata: serde_json::Value\",\n                outcome,\n                error,\n                duration_ms,\n                tokens_returned,\n                recorded_at\n            FROM audit_entries\n            ORDER BY id DESC\n            LIMIT $1",
   "describe": {
     "columns": [
       {
@@ -30,41 +30,46 @@
       },
       {
         "ordinal": 5,
+        "name": "sandbox_id: SandboxId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
         "name": "interaction_type",
         "type_info": "Varchar"
       },
       {
-        "ordinal": 6,
+        "ordinal": 7,
         "name": "action",
         "type_info": "Varchar"
       },
       {
-        "ordinal": 7,
+        "ordinal": 8,
         "name": "metadata: serde_json::Value",
         "type_info": "Jsonb"
       },
       {
-        "ordinal": 8,
+        "ordinal": 9,
         "name": "outcome",
         "type_info": "Varchar"
       },
       {
-        "ordinal": 9,
+        "ordinal": 10,
         "name": "error",
         "type_info": "Bool"
       },
       {
-        "ordinal": 10,
+        "ordinal": 11,
         "name": "duration_ms",
         "type_info": "Int8"
       },
       {
-        "ordinal": 11,
+        "ordinal": 12,
         "name": "tokens_returned",
         "type_info": "Int8"
       },
       {
-        "ordinal": 12,
+        "ordinal": 13,
         "name": "recorded_at",
         "type_info": "Timestamptz"
       }
@@ -80,6 +85,7 @@
       true,
       true,
       true,
+      true,
       false,
       false,
       false,
@@ -90,5 +96,5 @@
       false
     ]
   },
-  "hash": "164decd0a7f7de260277f33df97bbee9d6c0cd921cb3fab9884105cbfac89c48"
+  "hash": "10320dfefa193135772b80a418c95ad3292601ba85c3ead24b522fc905afcc5c"
 }

--- a/.sqlx/query-1481e0304309bac7685b3b3fad0fbb0a002314c4cc6e277827854275d6cc9c0e.json
+++ b/.sqlx/query-1481e0304309bac7685b3b3fad0fbb0a002314c4cc6e277827854275d6cc9c0e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n                id AS \"id: AuditEntryId\",\n                acting_user_id AS \"acting_user_id: UserId\",\n                workspace_id AS \"workspace_id: WorkspaceId\",\n                acting_agent_id AS \"acting_agent_id: AgentId\",\n                on_behalf_of_user_id AS \"on_behalf_of_user_id: UserId\",\n                interaction_type,\n                action,\n                metadata AS \"metadata: serde_json::Value\",\n                outcome,\n                error,\n                duration_ms,\n                tokens_returned,\n                recorded_at\n            FROM audit_entries\n            WHERE ($1::uuid IS NULL OR workspace_id = $1)\n              AND ($2::uuid IS NULL OR acting_user_id = $2)\n              AND ($3::uuid IS NULL OR acting_agent_id = $3)\n              AND ($4::uuid IS NULL OR acting_agent_id IS NULL OR acting_agent_id != $4)\n              AND ($5::text IS NULL OR action ILIKE $5)\n              AND ($6::text IS NULL OR outcome ILIKE $6)\n              AND ($7::bool IS NULL OR error = $7)\n            ORDER BY id DESC\n            LIMIT $8",
+  "query": "SELECT\n                id AS \"id: AuditEntryId\",\n                acting_user_id AS \"acting_user_id: UserId\",\n                workspace_id AS \"workspace_id: WorkspaceId\",\n                acting_agent_id AS \"acting_agent_id: AgentId\",\n                on_behalf_of_user_id AS \"on_behalf_of_user_id: UserId\",\n                sandbox_id AS \"sandbox_id: SandboxId\",\n                interaction_type,\n                action,\n                metadata AS \"metadata: serde_json::Value\",\n                outcome,\n                error,\n                duration_ms,\n                tokens_returned,\n                recorded_at\n            FROM audit_entries\n            WHERE ($1::uuid IS NULL OR workspace_id = $1)\n              AND ($2::uuid IS NULL OR acting_user_id = $2)\n              AND ($3::uuid IS NULL OR acting_agent_id = $3)\n              AND ($4::uuid IS NULL OR acting_agent_id IS NULL OR acting_agent_id != $4)\n              AND ($5::uuid IS NULL OR sandbox_id = $5)\n              AND ($6::text IS NULL OR action ILIKE $6)\n              AND ($7::text IS NULL OR outcome ILIKE $7)\n              AND ($8::bool IS NULL OR error = $8)\n            ORDER BY id DESC\n            LIMIT $9",
   "describe": {
     "columns": [
       {
@@ -30,47 +30,53 @@
       },
       {
         "ordinal": 5,
+        "name": "sandbox_id: SandboxId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
         "name": "interaction_type",
         "type_info": "Varchar"
       },
       {
-        "ordinal": 6,
+        "ordinal": 7,
         "name": "action",
         "type_info": "Varchar"
       },
       {
-        "ordinal": 7,
+        "ordinal": 8,
         "name": "metadata: serde_json::Value",
         "type_info": "Jsonb"
       },
       {
-        "ordinal": 8,
+        "ordinal": 9,
         "name": "outcome",
         "type_info": "Varchar"
       },
       {
-        "ordinal": 9,
+        "ordinal": 10,
         "name": "error",
         "type_info": "Bool"
       },
       {
-        "ordinal": 10,
+        "ordinal": 11,
         "name": "duration_ms",
         "type_info": "Int8"
       },
       {
-        "ordinal": 11,
+        "ordinal": 12,
         "name": "tokens_returned",
         "type_info": "Int8"
       },
       {
-        "ordinal": 12,
+        "ordinal": 13,
         "name": "recorded_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
+        "Uuid",
         "Uuid",
         "Uuid",
         "Uuid",
@@ -87,6 +93,7 @@
       true,
       true,
       true,
+      true,
       false,
       false,
       false,
@@ -97,5 +104,5 @@
       false
     ]
   },
-  "hash": "a1a5055a7fc6b0b964aa949b05c4a715fa95f2fd9eacd8967ddaff71315ed23b"
+  "hash": "1481e0304309bac7685b3b3fad0fbb0a002314c4cc6e277827854275d6cc9c0e"
 }

--- a/.sqlx/query-e2217770a01bdb6925180b1e084baac0cc0b9b60ec8edc2a948220ace89d33e8.json
+++ b/.sqlx/query-e2217770a01bdb6925180b1e084baac0cc0b9b60ec8edc2a948220ace89d33e8.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "INSERT INTO audit_entries\n                (acting_user_id, workspace_id, acting_agent_id, on_behalf_of_user_id,\n                 interaction_type, action, metadata, outcome, error, duration_ms, tokens_returned)\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)\n            RETURNING\n                id AS \"id: AuditEntryId\",\n                acting_user_id AS \"acting_user_id: UserId\",\n                workspace_id AS \"workspace_id: WorkspaceId\",\n                acting_agent_id AS \"acting_agent_id: AgentId\",\n                on_behalf_of_user_id AS \"on_behalf_of_user_id: UserId\",\n                interaction_type,\n                action,\n                metadata AS \"metadata: serde_json::Value\",\n                outcome,\n                error,\n                duration_ms,\n                tokens_returned,\n                recorded_at",
+  "query": "INSERT INTO audit_entries\n                (acting_user_id, workspace_id, acting_agent_id, on_behalf_of_user_id,\n                 sandbox_id, interaction_type, action, metadata, outcome, error,\n                 duration_ms, tokens_returned)\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)\n            RETURNING\n                id AS \"id: AuditEntryId\",\n                acting_user_id AS \"acting_user_id: UserId\",\n                workspace_id AS \"workspace_id: WorkspaceId\",\n                acting_agent_id AS \"acting_agent_id: AgentId\",\n                on_behalf_of_user_id AS \"on_behalf_of_user_id: UserId\",\n                sandbox_id AS \"sandbox_id: SandboxId\",\n                interaction_type,\n                action,\n                metadata AS \"metadata: serde_json::Value\",\n                outcome,\n                error,\n                duration_ms,\n                tokens_returned,\n                recorded_at",
   "describe": {
     "columns": [
       {
@@ -30,47 +30,53 @@
       },
       {
         "ordinal": 5,
+        "name": "sandbox_id: SandboxId",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 6,
         "name": "interaction_type",
         "type_info": "Varchar"
       },
       {
-        "ordinal": 6,
+        "ordinal": 7,
         "name": "action",
         "type_info": "Varchar"
       },
       {
-        "ordinal": 7,
+        "ordinal": 8,
         "name": "metadata: serde_json::Value",
         "type_info": "Jsonb"
       },
       {
-        "ordinal": 8,
+        "ordinal": 9,
         "name": "outcome",
         "type_info": "Varchar"
       },
       {
-        "ordinal": 9,
+        "ordinal": 10,
         "name": "error",
         "type_info": "Bool"
       },
       {
-        "ordinal": 10,
+        "ordinal": 11,
         "name": "duration_ms",
         "type_info": "Int8"
       },
       {
-        "ordinal": 11,
+        "ordinal": 12,
         "name": "tokens_returned",
         "type_info": "Int8"
       },
       {
-        "ordinal": 12,
+        "ordinal": 13,
         "name": "recorded_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
+        "Uuid",
         "Uuid",
         "Uuid",
         "Uuid",
@@ -90,6 +96,7 @@
       true,
       true,
       true,
+      true,
       false,
       false,
       false,
@@ -100,5 +107,5 @@
       false
     ]
   },
-  "hash": "f366c5cee2aef8a45b34d814b3a46f404d42ead311bd5b93cb3e81b368ec9608"
+  "hash": "e2217770a01bdb6925180b1e084baac0cc0b9b60ec8edc2a948220ace89d33e8"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1638,6 +1638,7 @@ dependencies = [
  "tower-sessions",
  "tracing",
  "tracing-opentelemetry",
+ "url",
  "uuid",
 ]
 

--- a/charts/galoy-agents/templates/configmap.yaml
+++ b/charts/galoy-agents/templates/configmap.yaml
@@ -31,6 +31,18 @@ data:
             - type: text
               text: |-
                 {{- .Values.galoyAgents.config.agents.workspaceLead.systemPrompt | nindent 16 }}
+        {{- with .Values.galoyAgents.config.agents.agent }}
+        agent:
+          model: {{ .model | quote }}
+          max_tokens: {{ .maxTokens }}
+          {{- with .resetTimeDeltaSeconds }}
+          reset_time_delta_seconds: {{ . }}
+          {{- end }}
+          system:
+            - type: text
+              text: |-
+                {{- .systemPrompt | nindent 16 }}
+        {{- end }}
     toolsets:
       code_assistant:
         db_path: {{ .Values.galoyAgents.config.codeAssistant.dbPath | quote }}

--- a/charts/galoy-agents/values.yaml
+++ b/charts/galoy-agents/values.yaml
@@ -33,12 +33,9 @@ galoyAgents:
       githubRedirectUri: ""
       githubAllowedTeams: []
     ## Per-role defaults applied when an agent with that role is created.
-    ## `workspaceLead` is REQUIRED — the binary refuses to start if
-    ## `agents.builtin_roles.workspace_lead` is missing.
-    ## `agent` is optional; when absent the generic `Agent` role falls
-    ## back to `workspaceLead`'s config, which means the agent ends up
-    ## introducing itself as the workspace lead. Provide a dedicated
-    ## `agent:` block below to avoid that.
+    ## Both `workspaceLead` and `agent` are REQUIRED — the binary refuses
+    ## to start if either `agents.builtin_roles.workspace_lead` or
+    ## `agents.builtin_roles.agent` is missing.
     agents:
       workspaceLead:
         model: "claude-haiku-4-5-20251001"

--- a/charts/galoy-agents/values.yaml
+++ b/charts/galoy-agents/values.yaml
@@ -33,8 +33,12 @@ galoyAgents:
       githubRedirectUri: ""
       githubAllowedTeams: []
     ## Per-role defaults applied when an agent with that role is created.
-    ## `workspaceLead` is the only role today and is REQUIRED — the binary
-    ## refuses to start if `agents.builtin_roles.workspace_lead` is missing.
+    ## `workspaceLead` is REQUIRED — the binary refuses to start if
+    ## `agents.builtin_roles.workspace_lead` is missing.
+    ## `agent` is optional; when absent the generic `Agent` role falls
+    ## back to `workspaceLead`'s config, which means the agent ends up
+    ## introducing itself as the workspace lead. Provide a dedicated
+    ## `agent:` block below to avoid that.
     agents:
       workspaceLead:
         model: "claude-haiku-4-5-20251001"
@@ -47,6 +51,15 @@ galoyAgents:
           You are the workspace lead agent. You coordinate tasks,
           answer questions, and use the available tools to help the
           user accomplish their goals. Be concise and action-oriented.
+      agent:
+        model: "claude-haiku-4-5-20251001"
+        maxTokens: 4096
+        resetTimeDeltaSeconds: 600
+        systemPrompt: |
+          You are an agent operating inside a Galoy Agents workspace.
+          You work on the tasks assigned to you and, when attached to
+          a sandbox, you run commands and edit files inside it. Be
+          concise and action-oriented.
     codeAssistant:
       dbPath: "/data/code-assistant/code-assistant.db"
     concourse:

--- a/core/migrations/20260415000001_audit_entries_sandbox_id.sql
+++ b/core/migrations/20260415000001_audit_entries_sandbox_id.sql
@@ -1,0 +1,2 @@
+ALTER TABLE audit_entries ADD COLUMN sandbox_id UUID;
+CREATE INDEX idx_audit_entries_sandbox ON audit_entries(sandbox_id);

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -11,7 +11,7 @@ use super::AgentRole;
 /// [`AgentsConfig::builtin_roles`] for the service to start. Add new
 /// variants to the enum AND to this list — the compiler won't help, but
 /// [`AgentsConfig::validate`] will fail fast at startup.
-const REQUIRED_ROLES: &[AgentRole] = &[AgentRole::WorkspaceLead];
+const REQUIRED_ROLES: &[AgentRole] = &[AgentRole::WorkspaceLead, AgentRole::Agent];
 
 /// Whole-second auto-reset threshold for an `AgentSession`. Wraps a
 /// `u32` count of seconds; the `#[serde(transparent)]` derive lets it

--- a/core/src/agent/entity.rs
+++ b/core/src/agent/entity.rs
@@ -1,7 +1,10 @@
+use std::collections::HashSet;
+
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use crate::primitives::{AgentId, AuthScope, AuthSubject, UserId, WorkspaceId};
+use crate::primitives::{AgentId, AuthScope, AuthSubject, SandboxId, UserId, WorkspaceId};
+use crate::sandbox::SandboxAgentMode;
 use es_entity::*;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, sqlx::Type)]
@@ -9,6 +12,10 @@ use es_entity::*;
 #[sqlx(type_name = "VARCHAR", rename_all = "snake_case")]
 pub enum AgentRole {
     WorkspaceLead,
+    /// Generic agent role created on demand (e.g. from the workspace UI).
+    /// Defaults to the same authz scopes as [`Self::WorkspaceLead`] and
+    /// reuses its `RoleConfig` when a dedicated `agent:` block is absent.
+    Agent,
 }
 
 #[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
@@ -22,6 +29,21 @@ pub enum AgentEvent {
         name: String,
         authz_scopes: Vec<AuthScope>,
     },
+    /// Single delta event for adds and removes — bundles both sides of an
+    /// attach/detach into one record. `added` and `removed` carry only the
+    /// effective delta (no-ops are filtered out before the event fires).
+    AuthScopesUpdated {
+        added: Vec<AuthScope>,
+        removed: Vec<AuthScope>,
+    },
+    /// The agent has been attached to `sandbox_id` in `mode`. Records both
+    /// first-time attachment and mode upgrade/downgrade on the same sandbox.
+    SandboxAttached {
+        sandbox_id: SandboxId,
+        mode: SandboxAgentMode,
+    },
+    /// The agent has been detached from `sandbox_id`.
+    SandboxDetached { sandbox_id: SandboxId },
 }
 
 #[derive(EsEntity, Builder)]
@@ -31,33 +53,157 @@ pub struct Agent {
     pub workspace_id: WorkspaceId,
     pub agent_role: AgentRole,
     pub name: String,
-    pub authz_scopes: Vec<AuthScope>,
+    /// Backed by a `HashSet` to enforce no-duplicates at the entity level.
+    /// Wire format (`Initialized.authz_scopes`, `AuthScopesUpdated.added/removed`)
+    /// stays as `Vec<AuthScope>` for backward-compatible JSON serialization.
+    pub authz_scopes: HashSet<AuthScope>,
+    /// Which sandbox this agent is currently attached to, if any. The entity
+    /// enforces **at most one** attached sandbox at a time via
+    /// [`Self::sandbox_attached`] — to switch sandboxes the caller must first
+    /// [`Self::sandbox_detached`] the existing one.
+    #[builder(default)]
+    pub attached_sandbox: Option<(SandboxId, SandboxAgentMode)>,
     events: EntityEvents<AgentEvent>,
 }
 
 impl Agent {
+    fn scopes_vec(&self) -> Vec<AuthScope> {
+        self.authz_scopes.iter().cloned().collect()
+    }
+
     /// The auth subject this agent acts as when invoking tools — its own
     /// workspace + id, carrying the scopes persisted on the `Initialized`
     /// event. Use when no originating user can be attributed.
     pub fn auth_subject(&self) -> AuthSubject {
-        AuthSubject::Agent(self.workspace_id, self.id, self.authz_scopes.clone())
+        AuthSubject::Agent(self.workspace_id, self.id, self.scopes_vec())
     }
 
     /// Same as [`Self::auth_subject`] but tagged with the user that triggered
     /// the agent's work, so downstream actions can be attributed back to them.
     pub fn auth_subject_for_user(&self, user_id: UserId) -> AuthSubject {
-        AuthSubject::AgentOnBehalfOfUser(
-            user_id,
-            self.workspace_id,
-            self.id,
-            self.authz_scopes.clone(),
-        )
+        AuthSubject::AgentOnBehalfOfUser(user_id, self.workspace_id, self.id, self.scopes_vec())
+    }
+
+    /// Apply a batch of scope additions/removals as a single
+    /// [`AgentEvent::AuthScopesUpdated`] event. Only entries that actually
+    /// change the set are recorded — passing scopes the agent already has
+    /// (or doesn't have) is a no-op for that entry. Returns
+    /// [`Idempotent::AlreadyApplied`] when the resulting delta is empty.
+    fn update_auth_scopes(&mut self, added: &[AuthScope], removed: &[AuthScope]) -> Idempotent<()> {
+        // `HashSet::insert` returns true iff the value wasn't already present;
+        // `HashSet::remove` returns true iff it was. Use those directly so the
+        // mutation and the "did it change?" check happen in one pass.
+        let mut effective_added: Vec<AuthScope> = Vec::new();
+        for scope in added {
+            if self.authz_scopes.insert(scope.clone()) {
+                effective_added.push(scope.clone());
+            }
+        }
+        let mut effective_removed: Vec<AuthScope> = Vec::new();
+        for scope in removed {
+            if self.authz_scopes.remove(scope) {
+                effective_removed.push(scope.clone());
+            }
+        }
+
+        if effective_added.is_empty() && effective_removed.is_empty() {
+            return Idempotent::AlreadyApplied;
+        }
+
+        self.events.push(AgentEvent::AuthScopesUpdated {
+            added: effective_added,
+            removed: effective_removed,
+        });
+        Idempotent::Executed(())
+    }
+
+    /// Record that this agent is now attached to `sandbox_id` in `mode`.
+    ///
+    /// **Invariant:** an agent can hold at most one sandbox attachment at a
+    /// time. Attaching to a sandbox other than the one already attached
+    /// returns [`super::error::AgentError::AlreadyAttachedToSandbox`] —
+    /// callers must [`Self::sandbox_detached`] the existing sandbox first.
+    ///
+    /// Re-attaching the same sandbox with the same mode is idempotent; the
+    /// same sandbox with a different mode is an in-place upgrade/downgrade
+    /// (the mode switches and scopes are updated). **Write always implies
+    /// Read**, so attaching as Write grants both; downgrading to Read
+    /// removes the Write scope.
+    pub(super) fn sandbox_attached(
+        &mut self,
+        sandbox_id: SandboxId,
+        mode: SandboxAgentMode,
+    ) -> Result<Idempotent<()>, super::error::AgentError> {
+        if let Some((existing_id, existing_mode)) = self.attached_sandbox {
+            if existing_id != sandbox_id {
+                return Err(super::error::AgentError::AlreadyAttachedToSandbox {
+                    current: existing_id,
+                });
+            }
+            if existing_mode == mode {
+                return Ok(Idempotent::AlreadyApplied);
+            }
+        }
+
+        self.attached_sandbox = Some((sandbox_id, mode));
+        self.apply_sandbox_scopes(sandbox_id, mode);
+        self.events
+            .push(AgentEvent::SandboxAttached { sandbox_id, mode });
+        Ok(Idempotent::Executed(()))
+    }
+
+    /// Record that this agent has been detached from `sandbox_id` — clears
+    /// the tracked attachment and drops both `SandboxRead` and
+    /// `SandboxWrite` scopes for that id. Idempotent: no-op when the agent
+    /// isn't attached to that sandbox.
+    pub(super) fn sandbox_detached(&mut self, sandbox_id: SandboxId) -> Idempotent<()> {
+        let is_attached = matches!(self.attached_sandbox, Some((id, _)) if id == sandbox_id);
+        if !is_attached {
+            return Idempotent::AlreadyApplied;
+        }
+
+        self.attached_sandbox = None;
+        self.update_auth_scopes(
+            &[],
+            &[
+                AuthScope::SandboxRead(sandbox_id),
+                AuthScope::SandboxWrite(sandbox_id),
+            ],
+        );
+        self.events.push(AgentEvent::SandboxDetached { sandbox_id });
+        Idempotent::Executed(())
+    }
+
+    /// Apply the correct scope delta for an attachment `mode`: downgrade to
+    /// Read removes the Write scope; upgrade to Write adds both. Shared by
+    /// [`Self::sandbox_attached`].
+    fn apply_sandbox_scopes(
+        &mut self,
+        sandbox_id: SandboxId,
+        mode: SandboxAgentMode,
+    ) -> Idempotent<()> {
+        let (added, removed) = match mode {
+            SandboxAgentMode::Read => (
+                vec![AuthScope::SandboxRead(sandbox_id)],
+                vec![AuthScope::SandboxWrite(sandbox_id)],
+            ),
+            SandboxAgentMode::Write => (
+                vec![
+                    AuthScope::SandboxRead(sandbox_id),
+                    AuthScope::SandboxWrite(sandbox_id),
+                ],
+                vec![],
+            ),
+        };
+        self.update_auth_scopes(&added, &removed)
     }
 }
 
 impl TryFromEvents<AgentEvent> for Agent {
     fn try_from_events(events: EntityEvents<AgentEvent>) -> Result<Self, EntityHydrationError> {
         let mut builder = AgentBuilder::default();
+        let mut scopes: HashSet<AuthScope> = HashSet::new();
+        let mut attached_sandbox: Option<(SandboxId, SandboxAgentMode)> = None;
 
         for event in events.iter_all() {
             match event {
@@ -72,13 +218,33 @@ impl TryFromEvents<AgentEvent> for Agent {
                         .id(*id)
                         .workspace_id(*workspace_id)
                         .agent_role(*agent_role)
-                        .name(name.clone())
-                        .authz_scopes(authz_scopes.clone());
+                        .name(name.clone());
+                    scopes = authz_scopes.iter().cloned().collect();
+                }
+                AgentEvent::AuthScopesUpdated { added, removed } => {
+                    for s in added {
+                        scopes.insert(s.clone());
+                    }
+                    for s in removed {
+                        scopes.remove(s);
+                    }
+                }
+                AgentEvent::SandboxAttached { sandbox_id, mode } => {
+                    attached_sandbox = Some((*sandbox_id, *mode));
+                }
+                AgentEvent::SandboxDetached { sandbox_id } => {
+                    if matches!(attached_sandbox, Some((id, _)) if id == *sandbox_id) {
+                        attached_sandbox = None;
+                    }
                 }
             }
         }
 
-        builder.events(events).build()
+        builder
+            .authz_scopes(scopes)
+            .attached_sandbox(attached_sandbox)
+            .events(events)
+            .build()
     }
 }
 

--- a/core/src/agent/entity.rs
+++ b/core/src/agent/entity.rs
@@ -152,7 +152,10 @@ impl Agent {
         }
 
         self.attached_sandbox = Some((sandbox_id, mode));
-        self.apply_sandbox_scopes(sandbox_id, mode);
+        // Scope delta may be AlreadyApplied (e.g. on an upgrade that only
+        // adds an already-held scope); we still record the attachment
+        // event below.
+        let _ = self.apply_sandbox_scopes(sandbox_id, mode);
         self.events
             .push(AgentEvent::SandboxAttached { sandbox_id, mode });
         Ok(Idempotent::Executed(()))
@@ -169,7 +172,9 @@ impl Agent {
         }
 
         self.attached_sandbox = None;
-        self.update_auth_scopes(
+        // Scope removal may be AlreadyApplied if the agent somehow didn't
+        // have the scopes (defensive); the detach event still fires.
+        let _ = self.update_auth_scopes(
             &[],
             &[
                 AuthScope::SandboxRead(sandbox_id),

--- a/core/src/agent/entity.rs
+++ b/core/src/agent/entity.rs
@@ -134,6 +134,12 @@ impl Agent {
         sandbox_id: SandboxId,
         mode: SandboxAgentMode,
     ) -> Result<Idempotent<()>, super::error::AgentError> {
+        // Leads orchestrate other agents — they never run inside a sandbox
+        // themselves.
+        if matches!(self.agent_role, AgentRole::WorkspaceLead) {
+            return Err(super::error::AgentError::LeadCannotAttachSandbox);
+        }
+
         if let Some((existing_id, existing_mode)) = self.attached_sandbox {
             if existing_id != sandbox_id {
                 return Err(super::error::AgentError::AlreadyAttachedToSandbox {

--- a/core/src/agent/error.rs
+++ b/core/src/agent/error.rs
@@ -1,5 +1,8 @@
 use thiserror::Error;
 
+use crate::primitives::SandboxId;
+use crate::sandbox::error::SandboxError;
+
 use super::repo::{AgentCreateError, AgentFindError, AgentModifyError, AgentQueryError};
 use super::session::error::AgentSessionError;
 
@@ -17,10 +20,16 @@ pub enum AgentError {
     Query(#[from] AgentQueryError),
     #[error("AgentError - Session: {0}")]
     Session(#[from] AgentSessionError),
+    #[error("AgentError - Sandbox: {0}")]
+    Sandbox(#[from] SandboxError),
     #[error("AgentError - prompt request channel closed")]
     PromptRequestChannelClosed,
     #[error("AgentError - role not configured: {0:?}")]
     RoleNotConfigured(super::entity::AgentRole),
     #[error("AgentError - unauthorized")]
     Unauthorized,
+    #[error(
+        "AgentError - agent is already attached to sandbox {current}; detach it before attaching another"
+    )]
+    AlreadyAttachedToSandbox { current: SandboxId },
 }

--- a/core/src/agent/error.rs
+++ b/core/src/agent/error.rs
@@ -32,4 +32,6 @@ pub enum AgentError {
         "AgentError - agent is already attached to sandbox {current}; detach it before attaching another"
     )]
     AlreadyAttachedToSandbox { current: SandboxId },
+    #[error("AgentError - workspace lead cannot attach a sandbox")]
+    LeadCannotAttachSandbox,
 }

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -93,14 +93,10 @@ impl Agents {
         name: impl Into<String> + std::fmt::Debug,
         attach_sandbox: Option<(SandboxId, SandboxAgentMode)>,
     ) -> Result<Agent, AgentError> {
-        // Fall back to the WorkspaceLead config for the generic `Agent`
-        // role when no dedicated block exists, so deployments don't need
-        // duplicate config to use the new role.
         let role_config = self
             .config
             .builtin_roles
             .get(&agent_role)
-            .or_else(|| self.config.builtin_roles.get(&AgentRole::WorkspaceLead))
             .ok_or(AgentError::RoleNotConfigured(agent_role))?
             .clone();
 

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -11,10 +11,10 @@ use crate::toolset::ToolSets;
 
 /// Default authorization scopes granted to an agent when it's created.
 /// Eventually this will move into role-config, but for now it's hard-wired:
-/// `WorkspaceLead` gets read+write on its own workspace.
+/// both built-in roles get read+write on their own workspace.
 fn default_authz_scopes(role: AgentRole, workspace_id: WorkspaceId) -> Vec<AuthScope> {
     match role {
-        AgentRole::WorkspaceLead => vec![
+        AgentRole::WorkspaceLead | AgentRole::Agent => vec![
             AuthScope::WorkspaceRead(workspace_id),
             AuthScope::WorkspaceWrite(workspace_id),
         ],
@@ -23,7 +23,8 @@ fn default_authz_scopes(role: AgentRole, workspace_id: WorkspaceId) -> Vec<AuthS
 
 use tracing::instrument;
 
-use crate::primitives::{AgentId, AuthScope, AuthSubject, ChatOutputEvent, WorkspaceId};
+use crate::primitives::{AgentId, AuthScope, AuthSubject, ChatOutputEvent, SandboxId, WorkspaceId};
+use crate::sandbox::{SandboxAgentMode, Sandboxes};
 pub use config::{AgentsConfig, ResetTimeDeltaSeconds, RoleConfig};
 pub use entity::*;
 pub use error::AgentError;
@@ -34,6 +35,7 @@ use session::Sessions;
 pub struct Agents {
     repo: AgentRepo,
     sessions: Sessions,
+    sandboxes: Sandboxes,
     config: AgentsConfig,
     toolsets: Arc<ToolSets>,
     prompt_requests: llm::PromptRequestChannel,
@@ -45,10 +47,12 @@ impl Agents {
         config: AgentsConfig,
         toolsets: Arc<ToolSets>,
         prompt_requests: llm::PromptRequestChannel,
+        sandboxes: Sandboxes,
     ) -> Self {
         Self {
             repo: AgentRepo::new(pool),
             sessions: Sessions::new(pool),
+            sandboxes,
             config,
             toolsets,
             prompt_requests,
@@ -61,15 +65,25 @@ impl Agents {
         workspace_id: WorkspaceId,
         agent_role: AgentRole,
         name: impl Into<String> + std::fmt::Debug,
+        attach_sandbox: Option<(SandboxId, SandboxAgentMode)>,
     ) -> Result<Agent, AgentError> {
         let mut op = self.repo.begin_op().await?;
         let agent = self
-            .create_in_op(&mut op, workspace_id, agent_role, name)
+            .create_in_op(&mut op, workspace_id, agent_role, name, attach_sandbox)
             .await?;
         op.commit().await?;
         Ok(agent)
     }
 
+    /// Composable variant of [`Self::create`]. When `attach_sandbox` is
+    /// `Some((sandbox_id, mode))`, the agent is attached to the sandbox as
+    /// part of the same op — the entity-level invariants (workspace match,
+    /// single-writer) are enforced by
+    /// [`crate::sandbox::Sandboxes::attach_to_agent_in_op`] and the
+    /// matching `SandboxRead`/`SandboxWrite` scopes are written via
+    /// [`Agent::sandbox_attached`]. Bypasses the subject-based authz check
+    /// that [`Self::attach_sandbox`] performs — callers of `create_in_op`
+    /// are trusted to have authorized the action upstream.
     #[instrument(name = "domain.agent.create_in_op", skip(self, op))]
     pub async fn create_in_op(
         &self,
@@ -77,11 +91,16 @@ impl Agents {
         workspace_id: WorkspaceId,
         agent_role: AgentRole,
         name: impl Into<String> + std::fmt::Debug,
+        attach_sandbox: Option<(SandboxId, SandboxAgentMode)>,
     ) -> Result<Agent, AgentError> {
+        // Fall back to the WorkspaceLead config for the generic `Agent`
+        // role when no dedicated block exists, so deployments don't need
+        // duplicate config to use the new role.
         let role_config = self
             .config
             .builtin_roles
             .get(&agent_role)
+            .or_else(|| self.config.builtin_roles.get(&AgentRole::WorkspaceLead))
             .ok_or(AgentError::RoleNotConfigured(agent_role))?
             .clone();
 
@@ -95,7 +114,7 @@ impl Agents {
             .build()
             .expect("NewAgent build");
 
-        let agent = self.repo.create_in_op(op, new_agent).await?;
+        let mut agent = self.repo.create_in_op(op, new_agent).await?;
 
         // Build the prompt's `tools` array from the registry as if the
         // agent were calling them — it will, with these same scopes, once
@@ -118,6 +137,16 @@ impl Agents {
                 role_config.reset_time_delta_seconds,
             )
             .await?;
+
+        if let Some((sandbox_id, mode)) = attach_sandbox {
+            self.sandboxes
+                .attach_to_agent_in_op(op, workspace_id, sandbox_id, agent.id, mode)
+                .await?;
+            if agent.sandbox_attached(sandbox_id, mode)?.did_execute() {
+                self.repo.update_in_op(op, &mut agent).await?;
+            }
+        }
+
         Ok(agent)
     }
 
@@ -162,6 +191,73 @@ impl Agents {
         self.sessions.delete_for_agent_in_op(op, id).await?;
         self.repo.delete_in_op(op, agent).await?;
         Ok(())
+    }
+
+    /// Attach a sandbox to an agent in `mode` (Read or Write). The subject
+    /// must hold [`AuthScope::WorkspaceWrite`] on the agent's workspace.
+    /// Re-attach with a different mode is allowed (downgrade unconditional;
+    /// upgrade to Write succeeds only if no other agent currently holds
+    /// Write — see [`crate::sandbox::Sandbox::attach_agent`]). After the
+    /// entity-level attach, the matching `SandboxRead`/`SandboxWrite`
+    /// scope is added to the agent (and any stale opposite-mode scope for
+    /// the same sandbox is removed).
+    #[instrument(name = "domain.agent.attach_sandbox", skip(self, subject))]
+    pub async fn attach_sandbox(
+        &self,
+        subject: &AuthSubject,
+        agent_id: AgentId,
+        sandbox_id: SandboxId,
+        mode: SandboxAgentMode,
+    ) -> Result<Agent, AgentError> {
+        let agent = self.repo.find_by_id(agent_id).await?;
+        let workspace_id = agent.workspace_id;
+
+        if !subject.has_any(&[AuthScope::Admin, AuthScope::WorkspaceWrite(workspace_id)]) {
+            return Err(AgentError::Unauthorized);
+        }
+
+        let mut op = self.repo.begin_op().await?;
+        self.sandboxes
+            .attach_to_agent_in_op(&mut op, workspace_id, sandbox_id, agent_id, mode)
+            .await?;
+
+        // Refetch so we update the most recent version of the agent.
+        let mut agent = self.repo.find_by_id(agent_id).await?;
+        if agent.sandbox_attached(sandbox_id, mode)?.did_execute() {
+            self.repo.update_in_op(&mut op, &mut agent).await?;
+        }
+        op.commit().await?;
+        Ok(agent)
+    }
+
+    /// Detach a sandbox from an agent. Authz mirrors `attach_sandbox`.
+    /// Idempotent at both layers — entity attach list and agent scope.
+    #[instrument(name = "domain.agent.detach_sandbox", skip(self, subject))]
+    pub async fn detach_sandbox(
+        &self,
+        subject: &AuthSubject,
+        agent_id: AgentId,
+        sandbox_id: SandboxId,
+    ) -> Result<Agent, AgentError> {
+        let agent = self.repo.find_by_id(agent_id).await?;
+        if !subject.has_any(&[
+            AuthScope::Admin,
+            AuthScope::WorkspaceWrite(agent.workspace_id),
+        ]) {
+            return Err(AgentError::Unauthorized);
+        }
+
+        let mut op = self.repo.begin_op().await?;
+        self.sandboxes
+            .detach_from_agent_in_op(&mut op, sandbox_id, agent_id)
+            .await?;
+
+        let mut agent = self.repo.find_by_id(agent_id).await?;
+        if agent.sandbox_detached(sandbox_id).did_execute() {
+            self.repo.update_in_op(&mut op, &mut agent).await?;
+        }
+        op.commit().await?;
+        Ok(agent)
     }
 
     #[instrument(name = "domain.agent.send_message", skip(self, prompt))]

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -139,12 +139,14 @@ impl Agents {
             .await?;
 
         if let Some((sandbox_id, mode)) = attach_sandbox {
-            self.sandboxes
-                .attach_to_agent_in_op(op, workspace_id, sandbox_id, agent.id, mode)
-                .await?;
+            // Agent side first — `sandbox_attached` rejects a WorkspaceLead
+            // role before we touch the sandbox side.
             if agent.sandbox_attached(sandbox_id, mode)?.did_execute() {
                 self.repo.update_in_op(op, &mut agent).await?;
             }
+            self.sandboxes
+                .attach_to_agent_in_op(op, workspace_id, sandbox_id, agent.id, mode)
+                .await?;
         }
 
         Ok(agent)
@@ -217,15 +219,20 @@ impl Agents {
         }
 
         let mut op = self.repo.begin_op().await?;
-        self.sandboxes
-            .attach_to_agent_in_op(&mut op, workspace_id, sandbox_id, agent_id, mode)
-            .await?;
 
-        // Refetch so we update the most recent version of the agent.
+        // Agent side first: `sandbox_attached` enforces the entity-level
+        // invariants (lead can't attach; at most one sandbox per agent).
+        // Failing here short-circuits before the sandbox-side round-trip.
         let mut agent = self.repo.find_by_id(agent_id).await?;
         if agent.sandbox_attached(sandbox_id, mode)?.did_execute() {
             self.repo.update_in_op(&mut op, &mut agent).await?;
         }
+
+        // Then sandbox side (enforces workspace match and single-writer).
+        self.sandboxes
+            .attach_to_agent_in_op(&mut op, workspace_id, sandbox_id, agent_id, mode)
+            .await?;
+
         op.commit().await?;
         Ok(agent)
     }
@@ -248,14 +255,17 @@ impl Agents {
         }
 
         let mut op = self.repo.begin_op().await?;
-        self.sandboxes
-            .detach_from_agent_in_op(&mut op, sandbox_id, agent_id)
-            .await?;
 
+        // Symmetric with attach: agent side first, then sandbox side.
         let mut agent = self.repo.find_by_id(agent_id).await?;
         if agent.sandbox_detached(sandbox_id).did_execute() {
             self.repo.update_in_op(&mut op, &mut agent).await?;
         }
+
+        self.sandboxes
+            .detach_from_agent_in_op(&mut op, sandbox_id, agent_id)
+            .await?;
+
         op.commit().await?;
         Ok(agent)
     }

--- a/core/src/audit/mod.rs
+++ b/core/src/audit/mod.rs
@@ -58,6 +58,11 @@ impl Audit {
         Self::update_context(|ctx| ctx.workspace_id = Some(workspace_id));
     }
 
+    /// Record the sandbox targeted by this interaction.
+    pub fn record_sandbox_id(sandbox_id: SandboxId) {
+        Self::update_context(|ctx| ctx.sandbox_id = Some(sandbox_id));
+    }
+
     /// Record the interaction type (API call, MCP call, …).
     pub fn record_interaction_type(itype: InteractionType) {
         Self::update_context(|ctx| ctx.interaction_type = Some(itype));
@@ -164,6 +169,7 @@ impl Audit {
                 workspace_id AS "workspace_id: WorkspaceId",
                 acting_agent_id AS "acting_agent_id: AgentId",
                 on_behalf_of_user_id AS "on_behalf_of_user_id: UserId",
+                sandbox_id AS "sandbox_id: SandboxId",
                 interaction_type,
                 action,
                 metadata AS "metadata: serde_json::Value",
@@ -192,6 +198,7 @@ impl Audit {
         let acting_user_id = query.acting_user_id.map(uuid::Uuid::from);
         let acting_agent_id = query.acting_agent_id.map(uuid::Uuid::from);
         let exclude_agent_id = query.exclude_agent_id.map(uuid::Uuid::from);
+        let sandbox_id = query.sandbox_id.map(uuid::Uuid::from);
         let action = query.action.as_deref();
         let outcome = query.outcome.as_deref();
         let error = query.error;
@@ -205,6 +212,7 @@ impl Audit {
                 workspace_id AS "workspace_id: WorkspaceId",
                 acting_agent_id AS "acting_agent_id: AgentId",
                 on_behalf_of_user_id AS "on_behalf_of_user_id: UserId",
+                sandbox_id AS "sandbox_id: SandboxId",
                 interaction_type,
                 action,
                 metadata AS "metadata: serde_json::Value",
@@ -218,15 +226,17 @@ impl Audit {
               AND ($2::uuid IS NULL OR acting_user_id = $2)
               AND ($3::uuid IS NULL OR acting_agent_id = $3)
               AND ($4::uuid IS NULL OR acting_agent_id IS NULL OR acting_agent_id != $4)
-              AND ($5::text IS NULL OR action ILIKE $5)
-              AND ($6::text IS NULL OR outcome ILIKE $6)
-              AND ($7::bool IS NULL OR error = $7)
+              AND ($5::uuid IS NULL OR sandbox_id = $5)
+              AND ($6::text IS NULL OR action ILIKE $6)
+              AND ($7::text IS NULL OR outcome ILIKE $7)
+              AND ($8::bool IS NULL OR error = $8)
             ORDER BY id DESC
-            LIMIT $8"#,
+            LIMIT $9"#,
             workspace_id,
             acting_user_id,
             acting_agent_id,
             exclude_agent_id,
+            sandbox_id,
             action,
             outcome,
             error,
@@ -242,6 +252,7 @@ impl Audit {
         let workspace_id = ctx.workspace_id.map(uuid::Uuid::from);
         let acting_agent_id = ctx.acting_agent_id.map(uuid::Uuid::from);
         let on_behalf_of = ctx.on_behalf_of_user_id.map(uuid::Uuid::from);
+        let sandbox_id = ctx.sandbox_id.map(uuid::Uuid::from);
         let itype = ctx
             .interaction_type
             .as_ref()
@@ -259,14 +270,16 @@ impl Audit {
             AuditEntry,
             r#"INSERT INTO audit_entries
                 (acting_user_id, workspace_id, acting_agent_id, on_behalf_of_user_id,
-                 interaction_type, action, metadata, outcome, error, duration_ms, tokens_returned)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+                 sandbox_id, interaction_type, action, metadata, outcome, error,
+                 duration_ms, tokens_returned)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
             RETURNING
                 id AS "id: AuditEntryId",
                 acting_user_id AS "acting_user_id: UserId",
                 workspace_id AS "workspace_id: WorkspaceId",
                 acting_agent_id AS "acting_agent_id: AgentId",
                 on_behalf_of_user_id AS "on_behalf_of_user_id: UserId",
+                sandbox_id AS "sandbox_id: SandboxId",
                 interaction_type,
                 action,
                 metadata AS "metadata: serde_json::Value",
@@ -279,6 +292,7 @@ impl Audit {
             workspace_id,
             acting_agent_id,
             on_behalf_of,
+            sandbox_id,
             itype,
             action,
             metadata,

--- a/core/src/audit/primitives.rs
+++ b/core/src/audit/primitives.rs
@@ -59,6 +59,10 @@ pub struct AuditContextData {
     pub acting_agent_id: Option<AgentId>,
     pub on_behalf_of_user_id: Option<UserId>,
     pub interaction_type: Option<InteractionType>,
+    /// Sandbox targeted by this interaction. Set by sandbox-service
+    /// methods via [`crate::audit::Audit::record_sandbox_id`] so audit
+    /// log queries can filter by sandbox.
+    pub sandbox_id: Option<SandboxId>,
     pub action: Option<String>,
     pub outcome: Option<InteractionOutcome>,
     pub duration_ms: Option<u64>,
@@ -80,6 +84,8 @@ pub struct AuditLogQuery {
     pub acting_agent_id: Option<AgentId>,
     /// Exclude entries by this agent (e.g. to hide the caller's own logs).
     pub exclude_agent_id: Option<AgentId>,
+    /// Only entries for this sandbox.
+    pub sandbox_id: Option<SandboxId>,
     /// Substring match on the `action` column.
     pub action: Option<String>,
     /// Substring match on the `outcome` column (e.g. "success", "error").
@@ -98,6 +104,7 @@ pub struct AuditEntry {
     pub workspace_id: Option<WorkspaceId>,
     pub acting_agent_id: Option<AgentId>,
     pub on_behalf_of_user_id: Option<UserId>,
+    pub sandbox_id: Option<SandboxId>,
     pub interaction_type: String,
     pub action: String,
     pub metadata: serde_json::Value,

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -112,13 +112,6 @@ impl App {
 
         let mcp_creds = McpCredentials::new(pool);
         let slash_commands = Arc::new(slash_command::default_registry());
-        let agents = Arc::new(Agents::new(
-            pool,
-            config.agents,
-            Arc::clone(&toolsets),
-            prompt_tx,
-        ));
-        let workspaces = Workspaces::new(pool, Arc::clone(&agents));
 
         let encryption_key = config.encryption.encryption_key();
         let workspace_secrets = WorkspaceSecrets::new(pool, encryption_key);
@@ -148,6 +141,15 @@ impl App {
         };
 
         let sandboxes = Sandboxes::init(pool, config.sandbox, github_app.clone()).await?;
+
+        let agents = Arc::new(Agents::new(
+            pool,
+            config.agents,
+            Arc::clone(&toolsets),
+            prompt_tx,
+            sandboxes.clone(),
+        ));
+        let workspaces = Workspaces::new(pool, Arc::clone(&agents));
 
         Ok(Self {
             users: Users::new(pool),

--- a/core/src/primitives/auth_scope.rs
+++ b/core/src/primitives/auth_scope.rs
@@ -2,7 +2,7 @@ use std::{fmt, str::FromStr};
 
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
-use super::WorkspaceId;
+use super::{SandboxId, WorkspaceId};
 
 /// A typed authorization scope carried by [`super::AuthSubject`] variants.
 ///
@@ -17,6 +17,10 @@ pub enum AuthScope {
     WorkspaceRead(WorkspaceId),
     /// Write access scoped to a specific workspace.
     WorkspaceWrite(WorkspaceId),
+    /// Read access scoped to a specific sandbox (granted via attach).
+    SandboxRead(SandboxId),
+    /// Write access scoped to a specific sandbox (granted via attach as writer).
+    SandboxWrite(SandboxId),
     /// Catch-all for scope strings that don't (yet) have a dedicated variant.
     Raw(String),
 }
@@ -31,6 +35,8 @@ impl fmt::Display for AuthScope {
             AuthScope::Admin => f.write_str("admin"),
             AuthScope::WorkspaceRead(id) => write!(f, "ws:{id}:read"),
             AuthScope::WorkspaceWrite(id) => write!(f, "ws:{id}:write"),
+            AuthScope::SandboxRead(id) => write!(f, "sandbox:{id}:read"),
+            AuthScope::SandboxWrite(id) => write!(f, "sandbox:{id}:write"),
             AuthScope::Raw(s) => f.write_str(s),
         }
     }
@@ -53,6 +59,19 @@ impl FromStr for AuthScope {
             } else if let Some(uuid_str) = rest.strip_suffix(":write") {
                 if let Ok(uuid) = uuid_str.parse::<uuid::Uuid>() {
                     return Ok(AuthScope::WorkspaceWrite(WorkspaceId::from(uuid)));
+                }
+            }
+        }
+
+        // Parse "sandbox:{uuid}:read" / "sandbox:{uuid}:write"
+        if let Some(rest) = s.strip_prefix("sandbox:") {
+            if let Some(uuid_str) = rest.strip_suffix(":read") {
+                if let Ok(uuid) = uuid_str.parse::<uuid::Uuid>() {
+                    return Ok(AuthScope::SandboxRead(SandboxId::from(uuid)));
+                }
+            } else if let Some(uuid_str) = rest.strip_suffix(":write") {
+                if let Ok(uuid) = uuid_str.parse::<uuid::Uuid>() {
+                    return Ok(AuthScope::SandboxWrite(SandboxId::from(uuid)));
                 }
             }
         }
@@ -103,16 +122,23 @@ mod tests {
         WorkspaceId::from(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8").unwrap())
     }
 
+    fn test_sandbox_id() -> SandboxId {
+        SandboxId::from(uuid::Uuid::parse_str("e1e2e3e4-f1f2-1112-2122-313233343536").unwrap())
+    }
+
     /// Round-trip: every variant must survive `Display` → `FromStr`.
     /// When adding a new variant, add it to this list so CI catches any
     /// mismatch immediately.
     #[test]
     fn round_trip_all_variants() {
         let ws_id = test_workspace_id();
+        let sb_id = test_sandbox_id();
         let variants = vec![
             AuthScope::Admin,
             AuthScope::WorkspaceRead(ws_id),
             AuthScope::WorkspaceWrite(ws_id),
+            AuthScope::SandboxRead(sb_id),
+            AuthScope::SandboxWrite(sb_id),
             AuthScope::Raw("custom:thing".to_owned()),
         ];
 
@@ -121,6 +147,33 @@ mod tests {
             let parsed: AuthScope = serialized.parse().unwrap();
             assert_eq!(scope, parsed);
         }
+    }
+
+    #[test]
+    fn display_sandbox_scopes() {
+        let sb_id = test_sandbox_id();
+        assert_eq!(
+            AuthScope::SandboxRead(sb_id).to_string(),
+            "sandbox:e1e2e3e4-f1f2-1112-2122-313233343536:read"
+        );
+        assert_eq!(
+            AuthScope::SandboxWrite(sb_id).to_string(),
+            "sandbox:e1e2e3e4-f1f2-1112-2122-313233343536:write"
+        );
+    }
+
+    #[test]
+    fn from_str_sandbox() {
+        let sb_id = test_sandbox_id();
+        let read: AuthScope = "sandbox:e1e2e3e4-f1f2-1112-2122-313233343536:read"
+            .parse()
+            .unwrap();
+        assert_eq!(read, AuthScope::SandboxRead(sb_id));
+
+        let write: AuthScope = "sandbox:e1e2e3e4-f1f2-1112-2122-313233343536:write"
+            .parse()
+            .unwrap();
+        assert_eq!(write, AuthScope::SandboxWrite(sb_id));
     }
 
     #[test]

--- a/core/src/primitives/auth_subject.rs
+++ b/core/src/primitives/auth_subject.rs
@@ -81,6 +81,12 @@ impl AuthSubject {
         }
     }
 
+    /// True if the subject carries any of the supplied scopes. Useful for
+    /// checks like "Admin OR WorkspaceWrite(ws)".
+    pub fn has_any(&self, scopes: &[AuthScope]) -> bool {
+        scopes.iter().any(|s| self.has_scope(s))
+    }
+
     /// Convert the subject into the principal that should be recorded as the
     /// originator of a message. Panics for `Anonymous` (callers must
     /// authenticate before sending messages).

--- a/core/src/sandbox/entity.rs
+++ b/core/src/sandbox/entity.rs
@@ -7,6 +7,18 @@ use sandbox::{SandboxMode, SandboxSpecs};
 
 use crate::primitives::*;
 
+/// How an agent is attached to a sandbox.
+///
+/// Multiple agents may attach in [`SandboxAgentMode::Read`]; at most one
+/// agent may attach in [`SandboxAgentMode::Write`] at a time. The entity
+/// enforces this invariant in [`Sandbox::attach_agent`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SandboxAgentMode {
+    Read,
+    Write,
+}
+
 /// Tracked lifecycle state of the remote sandbox (k8s pod or local process).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -73,6 +85,17 @@ pub enum SandboxEvent {
         step: String,
         reason: String,
     },
+    /// An agent is now attached to this sandbox in `mode`. If the agent was
+    /// previously attached in a different mode, this event captures the new
+    /// state (upgrade/downgrade).
+    AgentAttached {
+        agent_id: AgentId,
+        mode: SandboxAgentMode,
+    },
+    /// An agent that was previously attached has been detached.
+    AgentDetached {
+        agent_id: AgentId,
+    },
 }
 
 #[derive(EsEntity, Builder)]
@@ -95,6 +118,10 @@ pub struct Sandbox {
     pub exported_system_prompt: Option<ExportedFile>,
     #[builder(default)]
     pub exported_skills: Vec<ExportedSkill>,
+    /// Agents currently attached to this sandbox. At most one entry may
+    /// have [`SandboxAgentMode::Write`] (enforced by [`Self::attach_agent`]).
+    #[builder(default)]
+    pub attached_agents: Vec<(AgentId, SandboxAgentMode)>,
     events: EntityEvents<SandboxEvent>,
 }
 
@@ -202,6 +229,78 @@ impl Sandbox {
             Idempotent::AlreadyApplied
         }
     }
+
+    /// Attach `agent_id` in `mode`, enforcing the workspace and
+    /// single-writer invariants.
+    ///
+    /// - The supplied `workspace_id` must match the sandbox's own
+    ///   workspace — else returns
+    ///   [`super::error::SandboxError::WrongWorkspace`].
+    /// - Same agent already attached in the same mode → [`Idempotent::AlreadyApplied`].
+    /// - Same agent already attached in a different mode → upgrade or downgrade
+    ///   (a downgrade to Read always succeeds; an upgrade to Write only succeeds
+    ///   when no other agent currently holds Write).
+    /// - Attaching as Write while another agent already holds Write returns
+    ///   [`super::error::SandboxError::WriteSlotTaken`].
+    pub(super) fn attach_agent(
+        &mut self,
+        agent_id: AgentId,
+        workspace_id: WorkspaceId,
+        mode: SandboxAgentMode,
+    ) -> Result<Idempotent<()>, super::error::SandboxError> {
+        if self.workspace_id != workspace_id {
+            return Err(super::error::SandboxError::WrongWorkspace {
+                expected: workspace_id,
+                actual: self.workspace_id,
+            });
+        }
+
+        let current_mode = self
+            .attached_agents
+            .iter()
+            .find(|(id, _)| *id == agent_id)
+            .map(|(_, m)| *m);
+
+        if current_mode == Some(mode) {
+            return Ok(Idempotent::AlreadyApplied);
+        }
+
+        if mode == SandboxAgentMode::Write {
+            if let Some((other, _)) = self
+                .attached_agents
+                .iter()
+                .find(|(id, m)| *id != agent_id && *m == SandboxAgentMode::Write)
+            {
+                return Err(super::error::SandboxError::WriteSlotTaken {
+                    current_writer: *other,
+                });
+            }
+        }
+
+        if let Some(entry) = self
+            .attached_agents
+            .iter_mut()
+            .find(|(id, _)| *id == agent_id)
+        {
+            entry.1 = mode;
+        } else {
+            self.attached_agents.push((agent_id, mode));
+        }
+        self.events
+            .push(SandboxEvent::AgentAttached { agent_id, mode });
+        Ok(Idempotent::Executed(()))
+    }
+
+    /// Detach `agent_id`. Idempotent: no-op if the agent isn't attached.
+    pub(super) fn detach_agent(&mut self, agent_id: AgentId) -> Idempotent<()> {
+        let len_before = self.attached_agents.len();
+        self.attached_agents.retain(|(id, _)| *id != agent_id);
+        if self.attached_agents.len() == len_before {
+            return Idempotent::AlreadyApplied;
+        }
+        self.events.push(SandboxEvent::AgentDetached { agent_id });
+        Idempotent::Executed(())
+    }
 }
 
 impl core::fmt::Display for Sandbox {
@@ -217,6 +316,7 @@ impl core::fmt::Display for Sandbox {
 impl TryFromEvents<SandboxEvent> for Sandbox {
     fn try_from_events(events: EntityEvents<SandboxEvent>) -> Result<Self, EntityHydrationError> {
         let mut builder = SandboxBuilder::default();
+        let mut attached_agents: Vec<(AgentId, SandboxAgentMode)> = Vec::new();
 
         // We accumulate `last_error` as we walk the events: a
         // `ProvisioningFailed` sets it; any subsequent successful
@@ -258,8 +358,22 @@ impl TryFromEvents<SandboxEvent> for Sandbox {
                 SandboxEvent::ProvisioningFailed { reason, .. } => {
                     last_error = Some(reason.clone());
                 }
+                SandboxEvent::AgentAttached { agent_id, mode } => {
+                    if let Some(entry) = attached_agents
+                        .iter_mut()
+                        .find(|(id, _): &&mut (AgentId, SandboxAgentMode)| *id == *agent_id)
+                    {
+                        entry.1 = *mode;
+                    } else {
+                        attached_agents.push((*agent_id, *mode));
+                    }
+                }
+                SandboxEvent::AgentDetached { agent_id } => {
+                    attached_agents.retain(|(id, _)| *id != *agent_id);
+                }
             }
         }
+        builder = builder.attached_agents(attached_agents);
 
         builder.last_error(last_error).events(events).build()
     }
@@ -315,9 +429,13 @@ mod tests {
     }
 
     fn new_sandbox() -> Sandbox {
+        sandbox_in_workspace(WorkspaceId::new())
+    }
+
+    fn sandbox_in_workspace(workspace_id: WorkspaceId) -> Sandbox {
         let new = NewSandbox::builder()
             .id(SandboxId::new())
-            .workspace_id(WorkspaceId::new())
+            .workspace_id(workspace_id)
             .name("test-sandbox")
             .specs(test_specs())
             .mode(SandboxMode::Scratch)
@@ -365,6 +483,171 @@ mod tests {
         assert!(!res.did_execute());
     }
 
+    // ── attach_agent / detach_agent ────────────────────────────────
+
+    #[test]
+    fn attach_agent_records_new_reader() {
+        let mut sb = new_sandbox();
+        let ws = sb.workspace_id;
+        let agent = AgentId::new();
+
+        let res = sb
+            .attach_agent(agent, ws, SandboxAgentMode::Read)
+            .expect("attach");
+        assert!(res.did_execute());
+        assert_eq!(sb.attached_agents, vec![(agent, SandboxAgentMode::Read)]);
+    }
+
+    #[test]
+    fn attach_agent_records_new_writer() {
+        let mut sb = new_sandbox();
+        let ws = sb.workspace_id;
+        let agent = AgentId::new();
+
+        let res = sb
+            .attach_agent(agent, ws, SandboxAgentMode::Write)
+            .expect("attach");
+        assert!(res.did_execute());
+        assert_eq!(sb.attached_agents, vec![(agent, SandboxAgentMode::Write)]);
+    }
+
+    #[test]
+    fn attach_agent_same_mode_is_idempotent() {
+        let mut sb = new_sandbox();
+        let ws = sb.workspace_id;
+        let agent = AgentId::new();
+
+        sb.attach_agent(agent, ws, SandboxAgentMode::Read).unwrap();
+        let res = sb
+            .attach_agent(agent, ws, SandboxAgentMode::Read)
+            .expect("re-attach");
+        assert!(!res.did_execute(), "second attach must be AlreadyApplied");
+    }
+
+    #[test]
+    fn attach_agent_upgrades_read_to_write_when_slot_free() {
+        let mut sb = new_sandbox();
+        let ws = sb.workspace_id;
+        let agent = AgentId::new();
+
+        sb.attach_agent(agent, ws, SandboxAgentMode::Read).unwrap();
+        let res = sb
+            .attach_agent(agent, ws, SandboxAgentMode::Write)
+            .expect("upgrade");
+        assert!(res.did_execute());
+        assert_eq!(sb.attached_agents, vec![(agent, SandboxAgentMode::Write)]);
+    }
+
+    #[test]
+    fn attach_agent_downgrades_write_to_read() {
+        let mut sb = new_sandbox();
+        let ws = sb.workspace_id;
+        let agent = AgentId::new();
+
+        sb.attach_agent(agent, ws, SandboxAgentMode::Write).unwrap();
+        let res = sb
+            .attach_agent(agent, ws, SandboxAgentMode::Read)
+            .expect("downgrade");
+        assert!(res.did_execute());
+        assert_eq!(sb.attached_agents, vec![(agent, SandboxAgentMode::Read)]);
+    }
+
+    #[test]
+    fn attach_agent_allows_multiple_readers() {
+        let mut sb = new_sandbox();
+        let ws = sb.workspace_id;
+        let a = AgentId::new();
+        let b = AgentId::new();
+        let c = AgentId::new();
+
+        sb.attach_agent(a, ws, SandboxAgentMode::Read).unwrap();
+        sb.attach_agent(b, ws, SandboxAgentMode::Read).unwrap();
+        sb.attach_agent(c, ws, SandboxAgentMode::Read).unwrap();
+        assert_eq!(sb.attached_agents.len(), 3);
+        assert!(sb
+            .attached_agents
+            .iter()
+            .all(|(_, m)| *m == SandboxAgentMode::Read));
+    }
+
+    #[test]
+    fn attach_agent_rejects_second_writer() {
+        let mut sb = new_sandbox();
+        let ws = sb.workspace_id;
+        let writer_a = AgentId::new();
+        let writer_b = AgentId::new();
+
+        sb.attach_agent(writer_a, ws, SandboxAgentMode::Write)
+            .unwrap();
+        let err = sb
+            .attach_agent(writer_b, ws, SandboxAgentMode::Write)
+            .expect_err("second writer must be rejected");
+        match err {
+            super::super::error::SandboxError::WriteSlotTaken { current_writer } => {
+                assert_eq!(current_writer, writer_a);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+        // The attach list is unchanged.
+        assert_eq!(
+            sb.attached_agents,
+            vec![(writer_a, SandboxAgentMode::Write)]
+        );
+    }
+
+    #[test]
+    fn attach_agent_allows_writer_with_existing_readers() {
+        let mut sb = new_sandbox();
+        let ws = sb.workspace_id;
+        let r1 = AgentId::new();
+        let r2 = AgentId::new();
+        let w = AgentId::new();
+
+        sb.attach_agent(r1, ws, SandboxAgentMode::Read).unwrap();
+        sb.attach_agent(r2, ws, SandboxAgentMode::Read).unwrap();
+        let res = sb
+            .attach_agent(w, ws, SandboxAgentMode::Write)
+            .expect("writer ok with existing readers");
+        assert!(res.did_execute());
+    }
+
+    #[test]
+    fn attach_agent_rejects_wrong_workspace() {
+        let owning_ws = WorkspaceId::new();
+        let other_ws = WorkspaceId::new();
+        let mut sb = sandbox_in_workspace(owning_ws);
+
+        let err = sb
+            .attach_agent(AgentId::new(), other_ws, SandboxAgentMode::Read)
+            .expect_err("wrong workspace");
+        match err {
+            super::super::error::SandboxError::WrongWorkspace { expected, actual } => {
+                assert_eq!(expected, other_ws);
+                assert_eq!(actual, owning_ws);
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detach_agent_removes_attachment() {
+        let mut sb = new_sandbox();
+        let ws = sb.workspace_id;
+        let agent = AgentId::new();
+        sb.attach_agent(agent, ws, SandboxAgentMode::Write).unwrap();
+
+        let res = sb.detach_agent(agent);
+        assert!(res.did_execute());
+        assert!(sb.attached_agents.is_empty());
+    }
+
+    #[test]
+    fn detach_unknown_agent_is_idempotent() {
+        let mut sb = new_sandbox();
+        let res = sb.detach_agent(AgentId::new());
+        assert!(!res.did_execute());
+    }
+
     #[test]
     fn provisioning_after_errored_clears_last_error() {
         let mut sb = new_sandbox();
@@ -372,5 +655,62 @@ mod tests {
         let _ = sb.provisioning();
         assert_eq!(sb.state, SandboxState::Provisioning);
         assert!(sb.last_error.is_none());
+    }
+
+    #[test]
+    fn hydration_replays_attach_detach_history() {
+        // Synthesize a stream of events and verify try_from_events folds
+        // them into the expected attached_agents state. Each AgentAttached
+        // upserts the (agent_id, mode); AgentDetached removes the entry.
+        let sandbox_id = SandboxId::new();
+        let workspace_id = WorkspaceId::new();
+        let a = AgentId::new();
+        let b = AgentId::new();
+
+        let events = EntityEvents::init(
+            sandbox_id,
+            [
+                SandboxEvent::Initialized {
+                    id: sandbox_id,
+                    workspace_id,
+                    name: "test-sandbox".into(),
+                    specs: test_specs(),
+                    mode: SandboxMode::Scratch,
+                },
+                SandboxEvent::AgentAttached {
+                    agent_id: a,
+                    mode: SandboxAgentMode::Read,
+                },
+                SandboxEvent::AgentAttached {
+                    agent_id: b,
+                    mode: SandboxAgentMode::Write,
+                },
+                // b is detached; the writer slot is free again.
+                SandboxEvent::AgentDetached { agent_id: b },
+                // Now a upgrades to Write.
+                SandboxEvent::AgentAttached {
+                    agent_id: a,
+                    mode: SandboxAgentMode::Write,
+                },
+            ],
+        );
+
+        let sb = Sandbox::try_from_events(events).unwrap();
+        assert_eq!(sb.attached_agents, vec![(a, SandboxAgentMode::Write)]);
+    }
+
+    #[test]
+    fn attach_agent_after_detach_can_reuse_writer_slot() {
+        let mut sb = new_sandbox();
+        let ws = sb.workspace_id;
+        let a = AgentId::new();
+        let b = AgentId::new();
+
+        sb.attach_agent(a, ws, SandboxAgentMode::Write).unwrap();
+        sb.detach_agent(a);
+        let res = sb
+            .attach_agent(b, ws, SandboxAgentMode::Write)
+            .expect("writer slot should be free after detach");
+        assert!(res.did_execute());
     }
 }

--- a/core/src/sandbox/entity.rs
+++ b/core/src/sandbox/entity.rs
@@ -517,7 +517,7 @@ mod tests {
         let ws = sb.workspace_id;
         let agent = AgentId::new();
 
-        sb.attach_agent(agent, ws, SandboxAgentMode::Read).unwrap();
+        let _ = sb.attach_agent(agent, ws, SandboxAgentMode::Read).unwrap();
         let res = sb
             .attach_agent(agent, ws, SandboxAgentMode::Read)
             .expect("re-attach");
@@ -530,7 +530,7 @@ mod tests {
         let ws = sb.workspace_id;
         let agent = AgentId::new();
 
-        sb.attach_agent(agent, ws, SandboxAgentMode::Read).unwrap();
+        let _ = sb.attach_agent(agent, ws, SandboxAgentMode::Read).unwrap();
         let res = sb
             .attach_agent(agent, ws, SandboxAgentMode::Write)
             .expect("upgrade");
@@ -544,7 +544,7 @@ mod tests {
         let ws = sb.workspace_id;
         let agent = AgentId::new();
 
-        sb.attach_agent(agent, ws, SandboxAgentMode::Write).unwrap();
+        let _ = sb.attach_agent(agent, ws, SandboxAgentMode::Write).unwrap();
         let res = sb
             .attach_agent(agent, ws, SandboxAgentMode::Read)
             .expect("downgrade");
@@ -560,9 +560,9 @@ mod tests {
         let b = AgentId::new();
         let c = AgentId::new();
 
-        sb.attach_agent(a, ws, SandboxAgentMode::Read).unwrap();
-        sb.attach_agent(b, ws, SandboxAgentMode::Read).unwrap();
-        sb.attach_agent(c, ws, SandboxAgentMode::Read).unwrap();
+        let _ = sb.attach_agent(a, ws, SandboxAgentMode::Read).unwrap();
+        let _ = sb.attach_agent(b, ws, SandboxAgentMode::Read).unwrap();
+        let _ = sb.attach_agent(c, ws, SandboxAgentMode::Read).unwrap();
         assert_eq!(sb.attached_agents.len(), 3);
         assert!(sb
             .attached_agents
@@ -577,10 +577,14 @@ mod tests {
         let writer_a = AgentId::new();
         let writer_b = AgentId::new();
 
-        sb.attach_agent(writer_a, ws, SandboxAgentMode::Write)
+        let _ = sb
+            .attach_agent(writer_a, ws, SandboxAgentMode::Write)
             .unwrap();
+        // Map Ok to () so we can rely on the Debug impl for expect_err —
+        // `Idempotent` doesn't derive Debug.
         let err = sb
             .attach_agent(writer_b, ws, SandboxAgentMode::Write)
+            .map(|_| ())
             .expect_err("second writer must be rejected");
         match err {
             super::super::error::SandboxError::WriteSlotTaken { current_writer } => {
@@ -603,8 +607,8 @@ mod tests {
         let r2 = AgentId::new();
         let w = AgentId::new();
 
-        sb.attach_agent(r1, ws, SandboxAgentMode::Read).unwrap();
-        sb.attach_agent(r2, ws, SandboxAgentMode::Read).unwrap();
+        let _ = sb.attach_agent(r1, ws, SandboxAgentMode::Read).unwrap();
+        let _ = sb.attach_agent(r2, ws, SandboxAgentMode::Read).unwrap();
         let res = sb
             .attach_agent(w, ws, SandboxAgentMode::Write)
             .expect("writer ok with existing readers");
@@ -619,6 +623,7 @@ mod tests {
 
         let err = sb
             .attach_agent(AgentId::new(), other_ws, SandboxAgentMode::Read)
+            .map(|_| ())
             .expect_err("wrong workspace");
         match err {
             super::super::error::SandboxError::WrongWorkspace { expected, actual } => {
@@ -634,7 +639,7 @@ mod tests {
         let mut sb = new_sandbox();
         let ws = sb.workspace_id;
         let agent = AgentId::new();
-        sb.attach_agent(agent, ws, SandboxAgentMode::Write).unwrap();
+        let _ = sb.attach_agent(agent, ws, SandboxAgentMode::Write).unwrap();
 
         let res = sb.detach_agent(agent);
         assert!(res.did_execute());
@@ -706,8 +711,8 @@ mod tests {
         let a = AgentId::new();
         let b = AgentId::new();
 
-        sb.attach_agent(a, ws, SandboxAgentMode::Write).unwrap();
-        sb.detach_agent(a);
+        let _ = sb.attach_agent(a, ws, SandboxAgentMode::Write).unwrap();
+        let _ = sb.detach_agent(a);
         let res = sb
             .attach_agent(b, ws, SandboxAgentMode::Write)
             .expect("writer slot should be free after detach");

--- a/core/src/sandbox/error.rs
+++ b/core/src/sandbox/error.rs
@@ -2,6 +2,8 @@ use thiserror::Error;
 
 use sandbox::AdminError;
 
+use crate::primitives::{AgentId, WorkspaceId};
+
 use super::repo::{SandboxCreateError, SandboxFindError, SandboxModifyError, SandboxQueryError};
 
 #[derive(Error, Debug)]
@@ -20,4 +22,11 @@ pub enum SandboxError {
     Admin(#[from] AdminError),
     #[error("SandboxError - Hydration: {0}")]
     Hydration(#[from] es_entity::EntityHydrationError),
+    #[error("SandboxError - sandbox does not belong to workspace {expected} (actual: {actual})")]
+    WrongWorkspace {
+        expected: WorkspaceId,
+        actual: WorkspaceId,
+    },
+    #[error("SandboxError - write slot already taken by agent {current_writer}")]
+    WriteSlotTaken { current_writer: AgentId },
 }

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -20,7 +20,7 @@ use crate::github_app::GitHubAppTokenProvider;
 const PROVISION_TIMEOUT: Duration = Duration::from_secs(120);
 
 pub use config::{SandboxBackendConfig, SandboxConfig};
-pub use entity::{NewSandbox, Sandbox, SandboxEvent, SandboxState};
+pub use entity::{NewSandbox, Sandbox, SandboxAgentMode, SandboxEvent, SandboxState};
 pub use error::*;
 use repo::*;
 
@@ -345,6 +345,53 @@ impl Sandboxes {
         // Re-use the same background lifecycle the initial create goes
         // through — admin.create_sandbox → wait_ready → /initialize → Ready.
         self.spawn_sandbox_creation(id);
+        Ok(sandbox)
+    }
+
+    /// Attach `agent_id` to the sandbox in `mode`. Verifies the sandbox
+    /// belongs to `workspace_id` (else returns
+    /// [`SandboxError::WrongWorkspace`]) and delegates to
+    /// [`Sandbox::attach_agent`] which enforces single-writer.
+    #[instrument(
+        name = "domain.sandbox.attach_to_agent_in_op",
+        skip(self, op),
+        fields(%workspace_id, %sandbox_id, %agent_id, ?mode)
+    )]
+    pub async fn attach_to_agent_in_op(
+        &self,
+        op: &mut DbOp<'_>,
+        workspace_id: WorkspaceId,
+        sandbox_id: SandboxId,
+        agent_id: AgentId,
+        mode: SandboxAgentMode,
+    ) -> Result<Sandbox, SandboxError> {
+        let mut sandbox = self.repo.find_by_id(sandbox_id).await?;
+        if sandbox
+            .attach_agent(agent_id, workspace_id, mode)?
+            .did_execute()
+        {
+            self.repo.update_in_op(op, &mut sandbox).await?;
+        }
+        Ok(sandbox)
+    }
+
+    /// Detach `agent_id` from the sandbox. Idempotent at the entity level
+    /// (no-op if not attached).
+    #[instrument(
+        name = "domain.sandbox.detach_from_agent_in_op",
+        skip(self, op),
+        fields(%sandbox_id, %agent_id)
+    )]
+    pub async fn detach_from_agent_in_op(
+        &self,
+        op: &mut DbOp<'_>,
+        sandbox_id: SandboxId,
+        agent_id: AgentId,
+    ) -> Result<Sandbox, SandboxError> {
+        let mut sandbox = self.repo.find_by_id(sandbox_id).await?;
+        if sandbox.detach_agent(agent_id).did_execute() {
+            self.repo.update_in_op(op, &mut sandbox).await?;
+        }
         Ok(sandbox)
     }
 

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -13,6 +13,7 @@ use sandbox::admin_client::{AdminClient, K8sAdminClient, LocalAdminClient, Local
 use sandbox::instance_client::{InitializeRequest, InitializeResponse, InstanceClient};
 pub use sandbox::{SandboxMode, SandboxSpecs};
 
+use crate::audit::Audit;
 use crate::github_app::GitHubAppTokenProvider;
 
 /// How long [`Sandboxes::spawn_sandbox_creation`] waits for the admin
@@ -104,6 +105,7 @@ impl Sandboxes {
             .expect("could not build new sandbox");
 
         let sandbox = self.repo.create_in_op(op, new_sandbox).await?;
+        Audit::record_sandbox_id(sandbox.id);
         Ok(sandbox)
     }
 
@@ -336,6 +338,7 @@ impl Sandboxes {
         id: impl Into<SandboxId> + std::fmt::Debug,
     ) -> Result<Sandbox, SandboxError> {
         let id = id.into();
+        Audit::record_sandbox_id(id);
         let mut op = self.repo.begin_op().await?;
         let mut sandbox = self.repo.find_by_id(id).await?;
         if sandbox.provisioning().did_execute() {
@@ -365,6 +368,7 @@ impl Sandboxes {
         agent_id: AgentId,
         mode: SandboxAgentMode,
     ) -> Result<Sandbox, SandboxError> {
+        Audit::record_sandbox_id(sandbox_id);
         let mut sandbox = self.repo.find_by_id(sandbox_id).await?;
         if sandbox
             .attach_agent(agent_id, workspace_id, mode)?
@@ -388,6 +392,7 @@ impl Sandboxes {
         sandbox_id: SandboxId,
         agent_id: AgentId,
     ) -> Result<Sandbox, SandboxError> {
+        Audit::record_sandbox_id(sandbox_id);
         let mut sandbox = self.repo.find_by_id(sandbox_id).await?;
         if sandbox.detach_agent(agent_id).did_execute() {
             self.repo.update_in_op(op, &mut sandbox).await?;
@@ -419,6 +424,7 @@ impl Sandboxes {
         id: impl Into<SandboxId> + std::fmt::Debug,
     ) -> Result<Sandbox, SandboxError> {
         let id = id.into();
+        Audit::record_sandbox_id(id);
         let mut sandbox = self.repo.find_by_id(id).await?;
 
         let resource_name = sandbox.resource_name();

--- a/core/src/toolset/top_level/log.rs
+++ b/core/src/toolset/top_level/log.rs
@@ -203,6 +203,7 @@ fn parse_query(arguments: &Option<JsonObject>) -> AuditLogQuery {
 
     let acting_user_id = parse_uuid_field(args, "user_id");
     let acting_agent_id = parse_uuid_field(args, "agent_id");
+    let sandbox_id = parse_uuid_field(args, "sandbox_id");
 
     let error = args
         .and_then(|a| a.get("errors_only"))
@@ -215,6 +216,7 @@ fn parse_query(arguments: &Option<JsonObject>) -> AuditLogQuery {
         outcome,
         acting_user_id: acting_user_id.map(crate::primitives::UserId::from),
         acting_agent_id: acting_agent_id.map(crate::primitives::AgentId::from),
+        sandbox_id: sandbox_id.map(crate::primitives::SandboxId::from),
         error,
         ..Default::default()
     }
@@ -259,6 +261,11 @@ fn common_schema_properties() -> serde_json::Value {
             "type": "string",
             "format": "uuid",
             "description": "Filter by acting agent ID."
+        },
+        "sandbox_id": {
+            "type": "string",
+            "format": "uuid",
+            "description": "Filter by sandbox ID."
         },
         "limit": {
             "type": "integer",

--- a/core/src/workspace/mod.rs
+++ b/core/src/workspace/mod.rs
@@ -45,7 +45,8 @@ impl Workspaces {
                 &mut op,
                 workspace_id,
                 AgentRole::WorkspaceLead,
-                format!("{name}-lead"),
+                "lead",
+                None,
             )
             .await?;
 

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -45,7 +45,7 @@ async fn send_message_round_trip_via_prompt_channel() {
             .expect("init toolsets"),
     );
 
-    let sandboxes = Sandboxes::init(&pool, SandboxConfig::default())
+    let sandboxes = Sandboxes::init(&pool, SandboxConfig::default(), None)
         .await
         .expect("init sandboxes");
     let agents = Agents::new(&pool, config, toolsets, prompt_tx, sandboxes);
@@ -180,7 +180,7 @@ async fn send_message_dispatches_registered_tool_call() {
     toolsets.register_top_level(PingTool::new());
     let toolsets = Arc::new(toolsets);
 
-    let sandboxes = Sandboxes::init(&pool, SandboxConfig::default())
+    let sandboxes = Sandboxes::init(&pool, SandboxConfig::default(), None)
         .await
         .expect("init sandboxes");
     let agents = Agents::new(&pool, config, toolsets, prompt_tx, sandboxes);

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use galoy_agents_core::agent::{AgentRole, Agents, AgentsConfig, RoleConfig};
 use galoy_agents_core::primitives::{AuthSubject, ChatOutputEvent, UserId, WorkspaceId};
+use galoy_agents_core::sandbox::{SandboxConfig, Sandboxes};
 use galoy_agents_core::toolset::{ToolSets, ToolSetsConfig, ToolSetsError, TopLevelTool};
 use llm::prompt::AssistantBlock;
 use llm::{PromptRequest, PromptResponse, Usage};
@@ -44,10 +45,13 @@ async fn send_message_round_trip_via_prompt_channel() {
             .expect("init toolsets"),
     );
 
-    let agents = Agents::new(&pool, config, toolsets, prompt_tx);
+    let sandboxes = Sandboxes::init(&pool, SandboxConfig::default())
+        .await
+        .expect("init sandboxes");
+    let agents = Agents::new(&pool, config, toolsets, prompt_tx, sandboxes);
 
     let agent = agents
-        .create(WorkspaceId::new(), AgentRole::WorkspaceLead, "lead")
+        .create(WorkspaceId::new(), AgentRole::WorkspaceLead, "lead", None)
         .await
         .expect("create agent");
 
@@ -176,10 +180,13 @@ async fn send_message_dispatches_registered_tool_call() {
     toolsets.register_top_level(PingTool::new());
     let toolsets = Arc::new(toolsets);
 
-    let agents = Agents::new(&pool, config, toolsets, prompt_tx);
+    let sandboxes = Sandboxes::init(&pool, SandboxConfig::default())
+        .await
+        .expect("init sandboxes");
+    let agents = Agents::new(&pool, config, toolsets, prompt_tx, sandboxes);
 
     let agent = agents
-        .create(WorkspaceId::new(), AgentRole::WorkspaceLead, "lead")
+        .create(WorkspaceId::new(), AgentRole::WorkspaceLead, "lead", None)
         .await
         .expect("create agent");
 

--- a/galoy-agents.yml
+++ b/galoy-agents.yml
@@ -19,6 +19,17 @@ agents:
             You are the workspace lead agent. You coordinate tasks,
             answer questions, and use the available tools to help the
             user accomplish their goals. Be concise and action-oriented.
+    agent:
+      model: claude-haiku-4-5-20251001
+      max_tokens: 4096
+      reset_time_delta_seconds: 600
+      system:
+        - type: text
+          text: |
+            You are an agent operating inside a Galoy Agents workspace.
+            You work on the tasks assigned to you and, when attached to
+            a sandbox, you run commands and edit files inside it. Be
+            concise and action-oriented.
 sandbox:
   # Local mode spawns the sandbox tool server as a child process per sandbox.
   # Each sandbox lives in <local_repo_root>/.sandboxes/<name>/.

--- a/web/Cargo.toml
+++ b/web/Cargo.toml
@@ -34,4 +34,5 @@ opentelemetry = "0.31"
 opentelemetry-http = "0.31"
 tracing = "0.1"
 tracing-opentelemetry = "0.32"
+url = { workspace = true }
 uuid = { version = "1", features = ["v4"] }

--- a/web/src/auth/mod.rs
+++ b/web/src/auth/mod.rs
@@ -113,11 +113,7 @@ async fn resolve_auth_context(
                         id_str.parse::<uuid::Uuid>().expect("validated as UUID"),
                     );
                     if let Ok(agent) = state.app.agents().find_by_id(agent_id).await {
-                        return AuthSubject::Agent(
-                            agent.workspace_id,
-                            agent.id,
-                            agent.authz_scopes.clone(),
-                        );
+                        return agent.auth_subject();
                     }
                 }
             }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -539,6 +539,7 @@ async fn workspaces_page(State(state): State<AppState>, session: Session) -> Res
         lead_agent: None,
         agents: vec![],
         selected_agent_id: String::new(),
+        selected_agent: None,
     }
     .into_response()
 }
@@ -1605,7 +1606,14 @@ async fn workspace_chat(
             .find(|a| a.agent_role == domain::agent::AgentRole::WorkspaceLead),
     };
 
-    let selected_agent_id = selected_agent.map(|a| a.id.to_string()).unwrap_or_default();
+    let selected_agent_view = selected_agent.map(|a| AgentView {
+        id: a.id.to_string(),
+        name: a.name.clone(),
+    });
+    let selected_agent_id = selected_agent_view
+        .as_ref()
+        .map(|v| v.id.clone())
+        .unwrap_or_default();
 
     // Split lead out so the sidebar can render it above the "Agents" header.
     let mut lead_agent: Option<AgentView> = None;
@@ -1629,6 +1637,7 @@ async fn workspace_chat(
         lead_agent,
         agents: agent_views,
         selected_agent_id,
+        selected_agent: selected_agent_view,
     }
     .into_response()
 }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -616,23 +616,12 @@ async fn workspace_detail(
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let agents = state
-        .app
-        .agents()
-        .list_for_workspace(workspace_id)
-        .await
-        .unwrap_or_default();
-
-    let agent_views: Vec<AgentView> = agents
-        .iter()
-        .map(|a| AgentView {
-            id: a.id.to_string(),
-            name: a.name.clone(),
-        })
-        .collect();
+    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
 
     WorkspaceDetailTemplate {
         workspace: workspace_to_view(&ws),
+        lead_agent,
+        lead_agent,
         agents: agent_views,
     }
     .into_response()
@@ -854,20 +843,7 @@ async fn workspace_skills_page(
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let agents = state
-        .app
-        .agents()
-        .list_for_workspace(workspace_id)
-        .await
-        .unwrap_or_default();
-
-    let agent_views: Vec<AgentView> = agents
-        .iter()
-        .map(|a| AgentView {
-            id: a.id.to_string(),
-            name: a.name.clone(),
-        })
-        .collect();
+    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
 
     let skills = state
         .app
@@ -878,6 +854,8 @@ async fn workspace_skills_page(
 
     WorkspaceSkillsPageTemplate {
         workspace: workspace_to_view(&ws),
+        lead_agent,
+        lead_agent,
         agents: agent_views,
         skills: skills.iter().map(skill_to_view).collect(),
     }
@@ -900,23 +878,12 @@ async fn workspace_skill_new(
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let agents = state
-        .app
-        .agents()
-        .list_for_workspace(workspace_id)
-        .await
-        .unwrap_or_default();
-
-    let agent_views: Vec<AgentView> = agents
-        .iter()
-        .map(|a| AgentView {
-            id: a.id.to_string(),
-            name: a.name.clone(),
-        })
-        .collect();
+    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
 
     WorkspaceSkillNewTemplate {
         workspace: workspace_to_view(&ws),
+        lead_agent,
+        lead_agent,
         agents: agent_views,
     }
     .into_response()
@@ -979,23 +946,12 @@ async fn workspace_skill_edit(
         Err(_) => return Redirect::to(&format!("/workspaces/{id}/skills")).into_response(),
     };
 
-    let agents = state
-        .app
-        .agents()
-        .list_for_workspace(workspace_id)
-        .await
-        .unwrap_or_default();
-
-    let agent_views: Vec<AgentView> = agents
-        .iter()
-        .map(|a| AgentView {
-            id: a.id.to_string(),
-            name: a.name.clone(),
-        })
-        .collect();
+    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
 
     WorkspaceSkillEditTemplate {
         workspace: workspace_to_view(&ws),
+        lead_agent,
+        lead_agent,
         agents: agent_views,
         skill: skill_to_view(&skill),
     }
@@ -1109,23 +1065,35 @@ fn sandbox_to_view(s: &domain::sandbox::Sandbox) -> SandboxView {
     }
 }
 
+/// Returns `(lead_agent, other_agents)` for the workspace sidebar.
+/// The lead sits on its own above the `Agents` header; the rest form the
+/// list underneath. If there's no WorkspaceLead (shouldn't happen after
+/// workspace create, but handle gracefully), `lead_agent` is `None`.
 async fn workspace_sidebar_context(
     state: &AppState,
     workspace_id: domain::primitives::WorkspaceId,
-) -> Vec<AgentView> {
+) -> (Option<AgentView>, Vec<AgentView>) {
     let agents = state
         .app
         .agents()
         .list_for_workspace(workspace_id)
         .await
         .unwrap_or_default();
-    agents
-        .iter()
-        .map(|a| AgentView {
+
+    let mut lead: Option<AgentView> = None;
+    let mut others: Vec<AgentView> = Vec::with_capacity(agents.len());
+    for a in agents.iter() {
+        let view = AgentView {
             id: a.id.to_string(),
             name: a.name.clone(),
-        })
-        .collect()
+        };
+        if a.agent_role == domain::agent::AgentRole::WorkspaceLead && lead.is_none() {
+            lead = Some(view);
+        } else {
+            others.push(view);
+        }
+    }
+    (lead, others)
 }
 
 #[instrument(name = "web.workspace_sandboxes_page", skip_all)]
@@ -1144,7 +1112,7 @@ async fn workspace_sandboxes_page(
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let agent_views = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
 
     let sandboxes = state
         .app
@@ -1155,6 +1123,7 @@ async fn workspace_sandboxes_page(
 
     WorkspaceSandboxesPageTemplate {
         workspace: workspace_to_view(&ws),
+        lead_agent,
         agents: agent_views,
         sandboxes: sandboxes.iter().map(sandbox_to_view).collect(),
     }
@@ -1177,10 +1146,11 @@ async fn workspace_sandbox_new(
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let agent_views = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
 
     WorkspaceSandboxNewTemplate {
         workspace: workspace_to_view(&ws),
+        lead_agent,
         agents: agent_views,
     }
     .into_response()
@@ -1275,10 +1245,11 @@ async fn workspace_sandbox_detail(
         Err(_) => return Redirect::to(&format!("/workspaces/{id}/sandboxes")).into_response(),
     };
 
-    let agent_views = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
 
     WorkspaceSandboxDetailTemplate {
         workspace: workspace_to_view(&ws),
+        lead_agent,
         agents: agent_views,
         sandbox: sandbox_to_view(&sandbox),
     }
@@ -1343,7 +1314,7 @@ async fn workspace_agent_new(
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let agent_views = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
 
     let sandbox_options: Vec<SandboxOptionView> = state
         .app
@@ -1361,6 +1332,7 @@ async fn workspace_agent_new(
 
     WorkspaceAgentNewTemplate {
         workspace: workspace_to_view(&ws),
+        lead_agent,
         agents: agent_views,
         sandbox_options,
     }
@@ -1474,7 +1446,7 @@ async fn workspace_agent_detail(
         Err(_) => return Redirect::to(&format!("/workspaces/{id}")).into_response(),
     };
 
-    let agents = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agents) = workspace_sidebar_context(&state, workspace_id).await;
 
     let attached_view = attached_sandbox_view(&state, agent.attached_sandbox).await;
 
@@ -1499,12 +1471,14 @@ async fn workspace_agent_detail(
 
     WorkspaceAgentDetailTemplate {
         workspace: workspace_to_view(&ws),
+        lead_agent,
         agents,
         agent: AgentDetailView {
             id: agent.id.to_string(),
             workspace_id: agent.workspace_id.to_string(),
             name: agent.name.clone(),
             role: role_label(agent.agent_role).to_string(),
+            is_lead: matches!(agent.agent_role, domain::agent::AgentRole::WorkspaceLead),
             attached_sandbox: attached_view,
         },
         sandbox_options,
@@ -1636,18 +1610,26 @@ async fn workspace_chat(
 
     let selected_agent_id = selected_agent.map(|a| a.id.to_string()).unwrap_or_default();
 
-    let agent_views: Vec<AgentView> = agents
-        .iter()
-        .map(|a| AgentView {
+    // Split lead out so the sidebar can render it above the "Agents" header.
+    let mut lead_agent: Option<AgentView> = None;
+    let mut agent_views: Vec<AgentView> = Vec::with_capacity(agents.len());
+    for a in agents.iter() {
+        let view = AgentView {
             id: a.id.to_string(),
             name: a.name.clone(),
-        })
-        .collect();
+        };
+        if a.agent_role == domain::agent::AgentRole::WorkspaceLead && lead_agent.is_none() {
+            lead_agent = Some(view);
+        } else {
+            agent_views.push(view);
+        }
+    }
 
     WorkspaceHubTemplate {
         workspaces: all_workspaces.iter().map(workspace_to_view).collect(),
         selected_workspace_id: workspace_id.to_string(),
         selected_workspace: Some(workspace_to_view(&ws)),
+        lead_agent,
         agents: agent_views,
         selected_agent_id,
     }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -536,6 +536,7 @@ async fn workspaces_page(State(state): State<AppState>, session: Session) -> Res
         workspaces: workspaces.iter().map(workspace_to_view).collect(),
         selected_workspace: None,
         selected_workspace_id: String::new(),
+        lead_agent: None,
         agents: vec![],
         selected_agent_id: String::new(),
     }
@@ -620,7 +621,6 @@ async fn workspace_detail(
 
     WorkspaceDetailTemplate {
         workspace: workspace_to_view(&ws),
-        lead_agent,
         lead_agent,
         agents: agent_views,
     }
@@ -855,7 +855,6 @@ async fn workspace_skills_page(
     WorkspaceSkillsPageTemplate {
         workspace: workspace_to_view(&ws),
         lead_agent,
-        lead_agent,
         agents: agent_views,
         skills: skills.iter().map(skill_to_view).collect(),
     }
@@ -882,7 +881,6 @@ async fn workspace_skill_new(
 
     WorkspaceSkillNewTemplate {
         workspace: workspace_to_view(&ws),
-        lead_agent,
         lead_agent,
         agents: agent_views,
     }
@@ -950,7 +948,6 @@ async fn workspace_skill_edit(
 
     WorkspaceSkillEditTemplate {
         workspace: workspace_to_view(&ws),
-        lead_agent,
         lead_agent,
         agents: agent_views,
         skill: skill_to_view(&skill),
@@ -1371,12 +1368,12 @@ async fn workspace_agent_create(
         .filter(|s| !s.is_empty())
         .and_then(|sb| sb.parse::<uuid::Uuid>().ok())
         .map(SandboxId::from)
-        .and_then(|sb| {
+        .map(|sb| {
             let mode = match form.attach_mode.as_deref().unwrap_or("read") {
                 "write" => SandboxAgentMode::Write,
                 _ => SandboxAgentMode::Read,
             };
-            Some((sb, mode))
+            (sb, mode)
         });
 
     match state

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -20,7 +20,7 @@ use domain::auth::AuthSubject;
 use domain::mcp_creds::token::generate_token;
 use domain::mcp_creds::McpCreds;
 use domain::primitives::{AgentId, McpCredsId, SandboxId, SkillId, UserId, WorkspaceSecretId};
-use domain::sandbox::{SandboxMode, SandboxSpecs};
+use domain::sandbox::{SandboxAgentMode, SandboxMode, SandboxSpecs};
 
 use crate::templates::*;
 use crate::AppState;
@@ -89,6 +89,20 @@ pub fn router() -> Router<AppState> {
         .route(
             "/workspaces/{id}/sandboxes/{sandbox_id}/restart",
             post(workspace_sandbox_restart),
+        )
+        .route("/workspaces/{id}/agents/new", get(workspace_agent_new))
+        .route("/workspaces/{id}/agents", post(workspace_agent_create))
+        .route(
+            "/workspaces/{id}/agents/{agent_id}",
+            get(workspace_agent_detail),
+        )
+        .route(
+            "/workspaces/{id}/agents/{agent_id}/attach_sandbox",
+            post(workspace_agent_attach_sandbox),
+        )
+        .route(
+            "/workspaces/{id}/agents/{agent_id}/detach_sandbox",
+            post(workspace_agent_detach_sandbox),
         )
 }
 
@@ -1307,6 +1321,272 @@ async fn workspace_sandbox_restart(
     }
 
     Redirect::to(&format!("/workspaces/{id}/sandboxes/{sandbox_id}")).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Workspace Agents (create form)
+// ---------------------------------------------------------------------------
+
+#[instrument(name = "web.workspace_agent_new", skip_all)]
+async fn workspace_agent_new(
+    State(state): State<AppState>,
+    session: Session,
+    Path(id): Path<uuid::Uuid>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return Redirect::to("/").into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(id);
+    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+        Ok(ws) => ws,
+        Err(_) => return Redirect::to("/workspaces").into_response(),
+    };
+
+    let agent_views = workspace_sidebar_context(&state, workspace_id).await;
+
+    let sandbox_options: Vec<SandboxOptionView> = state
+        .app
+        .sandboxes()
+        .list_for_workspace(workspace_id)
+        .await
+        .unwrap_or_default()
+        .iter()
+        .map(|s| SandboxOptionView {
+            id: s.id.to_string(),
+            name: s.name.clone(),
+            state: s.state.to_string(),
+        })
+        .collect();
+
+    WorkspaceAgentNewTemplate {
+        workspace: workspace_to_view(&ws),
+        agents: agent_views,
+        sandbox_options,
+    }
+    .into_response()
+}
+
+#[derive(Deserialize)]
+struct CreateAgentForm {
+    name: String,
+    /// Empty string when no sandbox selected; parsed as UUID otherwise.
+    #[serde(default)]
+    sandbox_id: Option<String>,
+    #[serde(default)]
+    attach_mode: Option<String>,
+}
+
+#[instrument(name = "web.workspace_agent_create", skip_all)]
+async fn workspace_agent_create(
+    State(state): State<AppState>,
+    session: Session,
+    Path(id): Path<uuid::Uuid>,
+    Form(form): Form<CreateAgentForm>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return Redirect::to("/").into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(id);
+
+    // Pair sandbox_id + attach_mode into Some((id, mode)) only when both are
+    // present and valid; otherwise treat as "no attachment".
+    let attach = form
+        .sandbox_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .and_then(|sb| sb.parse::<uuid::Uuid>().ok())
+        .map(SandboxId::from)
+        .and_then(|sb| {
+            let mode = match form.attach_mode.as_deref().unwrap_or("read") {
+                "write" => SandboxAgentMode::Write,
+                _ => SandboxAgentMode::Read,
+            };
+            Some((sb, mode))
+        });
+
+    match state
+        .app
+        .agents()
+        .create(
+            workspace_id,
+            domain::agent::AgentRole::Agent,
+            form.name,
+            attach,
+        )
+        .await
+    {
+        Ok(agent) => {
+            Redirect::to(&format!("/workspaces/{id}/chat?agent={}", agent.id)).into_response()
+        }
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to create agent");
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+    }
+}
+
+fn role_label(role: domain::agent::AgentRole) -> &'static str {
+    match role {
+        domain::agent::AgentRole::WorkspaceLead => "Workspace Lead",
+        domain::agent::AgentRole::Agent => "Agent",
+    }
+}
+
+async fn attached_sandbox_view(
+    state: &AppState,
+    attached: Option<(SandboxId, SandboxAgentMode)>,
+) -> Option<AttachedSandboxView> {
+    let (sbx_id, mode) = attached?;
+    let sandbox = state.app.sandboxes().find_by_id(sbx_id).await.ok()?;
+    Some(AttachedSandboxView {
+        id: sandbox.id.to_string(),
+        name: sandbox.name.clone(),
+        mode: match mode {
+            SandboxAgentMode::Read => "read".to_string(),
+            SandboxAgentMode::Write => "write".to_string(),
+        },
+        state: sandbox.state.to_string(),
+    })
+}
+
+#[instrument(name = "web.workspace_agent_detail", skip_all)]
+async fn workspace_agent_detail(
+    State(state): State<AppState>,
+    session: Session,
+    Path((id, agent_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> Response {
+    if extract_user_id(&session).await.is_none() {
+        return Redirect::to("/").into_response();
+    }
+
+    let workspace_id = domain::primitives::WorkspaceId::from(id);
+    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+        Ok(ws) => ws,
+        Err(_) => return Redirect::to("/workspaces").into_response(),
+    };
+
+    let agent_id = AgentId::from(agent_id);
+    let agent = match state.app.agents().find_by_id(agent_id).await {
+        Ok(a) => a,
+        Err(_) => return Redirect::to(&format!("/workspaces/{id}")).into_response(),
+    };
+
+    let agents = workspace_sidebar_context(&state, workspace_id).await;
+
+    let attached_view = attached_sandbox_view(&state, agent.attached_sandbox).await;
+
+    // Dropdown options are only needed when no sandbox is currently attached.
+    let sandbox_options: Vec<SandboxOptionView> = if attached_view.is_some() {
+        Vec::new()
+    } else {
+        state
+            .app
+            .sandboxes()
+            .list_for_workspace(workspace_id)
+            .await
+            .unwrap_or_default()
+            .iter()
+            .map(|s| SandboxOptionView {
+                id: s.id.to_string(),
+                name: s.name.clone(),
+                state: s.state.to_string(),
+            })
+            .collect()
+    };
+
+    WorkspaceAgentDetailTemplate {
+        workspace: workspace_to_view(&ws),
+        agents,
+        agent: AgentDetailView {
+            id: agent.id.to_string(),
+            workspace_id: agent.workspace_id.to_string(),
+            name: agent.name.clone(),
+            role: role_label(agent.agent_role).to_string(),
+            attached_sandbox: attached_view,
+        },
+        sandbox_options,
+    }
+    .into_response()
+}
+
+#[derive(Deserialize)]
+struct AttachSandboxForm {
+    sandbox_id: String,
+    mode: String,
+}
+
+#[instrument(name = "web.workspace_agent_attach_sandbox", skip_all)]
+async fn workspace_agent_attach_sandbox(
+    State(state): State<AppState>,
+    session: Session,
+    Path((id, agent_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+    Form(form): Form<AttachSandboxForm>,
+) -> Response {
+    let Some(user_id) = extract_user_id(&session).await else {
+        return Redirect::to("/").into_response();
+    };
+    let subject = domain::primitives::AuthSubject::User(user_id);
+
+    let agent_id = AgentId::from(agent_id);
+    let Ok(sandbox_uuid) = form.sandbox_id.parse::<uuid::Uuid>() else {
+        tracing::warn!(raw = %form.sandbox_id, "invalid sandbox_id in attach form");
+        return Redirect::to(&format!("/workspaces/{id}/agents/{agent_id}")).into_response();
+    };
+    let sandbox_id = SandboxId::from(sandbox_uuid);
+    let mode = match form.mode.as_str() {
+        "write" => SandboxAgentMode::Write,
+        _ => SandboxAgentMode::Read,
+    };
+
+    if let Err(e) = state
+        .app
+        .agents()
+        .attach_sandbox(&subject, agent_id, sandbox_id, mode)
+        .await
+    {
+        tracing::error!(error = %e, "Failed to attach sandbox");
+        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    Redirect::to(&format!("/workspaces/{id}/agents/{agent_id}")).into_response()
+}
+
+#[instrument(name = "web.workspace_agent_detach_sandbox", skip_all)]
+async fn workspace_agent_detach_sandbox(
+    State(state): State<AppState>,
+    session: Session,
+    Path((id, agent_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+) -> Response {
+    let Some(user_id) = extract_user_id(&session).await else {
+        return Redirect::to("/").into_response();
+    };
+    let subject = domain::primitives::AuthSubject::User(user_id);
+
+    let agent_id = AgentId::from(agent_id);
+    // The handler needs the sandbox_id; fetch the agent to look it up.
+    let sandbox_id = match state.app.agents().find_by_id(agent_id).await {
+        Ok(a) => a.attached_sandbox.map(|(sbx, _)| sbx),
+        Err(_) => return Redirect::to(&format!("/workspaces/{id}")).into_response(),
+    };
+    let Some(sandbox_id) = sandbox_id else {
+        // Already detached; nothing to do.
+        return Redirect::to(&format!("/workspaces/{id}/agents/{agent_id}")).into_response();
+    };
+
+    if let Err(e) = state
+        .app
+        .agents()
+        .detach_sandbox(&subject, agent_id, sandbox_id)
+        .await
+    {
+        tracing::error!(error = %e, "Failed to detach sandbox");
+        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    Redirect::to(&format!("/workspaces/{id}/agents/{agent_id}")).into_response()
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -1422,11 +1422,18 @@ async fn attached_sandbox_view(
     })
 }
 
+#[derive(Debug, Deserialize, Default)]
+struct AgentDetailQuery {
+    #[serde(default)]
+    error: Option<String>,
+}
+
 #[instrument(name = "web.workspace_agent_detail", skip_all)]
 async fn workspace_agent_detail(
     State(state): State<AppState>,
     session: Session,
     Path((id, agent_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+    Query(query): Query<AgentDetailQuery>,
 ) -> Response {
     if extract_user_id(&session).await.is_none() {
         return Redirect::to("/").into_response();
@@ -1480,7 +1487,25 @@ async fn workspace_agent_detail(
             attached_sandbox: attached_view,
         },
         sandbox_options,
+        error: query.error,
     }
+    .into_response()
+}
+
+/// Build `/workspaces/{id}/agents/{agent_id}?error=<encoded>` so the
+/// detail page can render a flash banner explaining why the last
+/// attach/detach failed.
+fn agent_detail_redirect_with_error(
+    workspace_id: uuid::Uuid,
+    agent_id: AgentId,
+    msg: &str,
+) -> Response {
+    let query: String = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("error", msg)
+        .finish();
+    Redirect::to(&format!(
+        "/workspaces/{workspace_id}/agents/{agent_id}?{query}"
+    ))
     .into_response()
 }
 
@@ -1519,8 +1544,8 @@ async fn workspace_agent_attach_sandbox(
         .attach_sandbox(&subject, agent_id, sandbox_id, mode)
         .await
     {
-        tracing::error!(error = %e, "Failed to attach sandbox");
-        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        tracing::warn!(error = %e, "attach_sandbox failed");
+        return agent_detail_redirect_with_error(id, agent_id, &e.to_string());
     }
 
     Redirect::to(&format!("/workspaces/{id}/agents/{agent_id}")).into_response()
@@ -1554,8 +1579,8 @@ async fn workspace_agent_detach_sandbox(
         .detach_sandbox(&subject, agent_id, sandbox_id)
         .await
     {
-        tracing::error!(error = %e, "Failed to detach sandbox");
-        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        tracing::warn!(error = %e, "detach_sandbox failed");
+        return agent_detail_redirect_with_error(id, agent_id, &e.to_string());
     }
 
     Redirect::to(&format!("/workspaces/{id}/agents/{agent_id}")).into_response()

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -118,6 +118,7 @@ pub struct WorkspaceNewTemplate {}
 #[template(path = "workspace_detail.html")]
 pub struct WorkspaceDetailTemplate {
     pub workspace: WorkspaceView,
+    pub lead_agent: Option<AgentView>,
     pub agents: Vec<AgentView>,
 }
 
@@ -137,6 +138,7 @@ pub struct SkillView {
 #[template(path = "workspace_skills.html")]
 pub struct WorkspaceSkillsPageTemplate {
     pub workspace: WorkspaceView,
+    pub lead_agent: Option<AgentView>,
     pub agents: Vec<AgentView>,
     pub skills: Vec<SkillView>,
 }
@@ -145,6 +147,7 @@ pub struct WorkspaceSkillsPageTemplate {
 #[template(path = "workspace_skill_new.html")]
 pub struct WorkspaceSkillNewTemplate {
     pub workspace: WorkspaceView,
+    pub lead_agent: Option<AgentView>,
     pub agents: Vec<AgentView>,
 }
 
@@ -152,6 +155,7 @@ pub struct WorkspaceSkillNewTemplate {
 #[template(path = "workspace_skill_edit.html")]
 pub struct WorkspaceSkillEditTemplate {
     pub workspace: WorkspaceView,
+    pub lead_agent: Option<AgentView>,
     pub agents: Vec<AgentView>,
     pub skill: SkillView,
 }
@@ -197,6 +201,7 @@ pub struct SandboxView {
 #[template(path = "workspace_sandboxes.html")]
 pub struct WorkspaceSandboxesPageTemplate {
     pub workspace: WorkspaceView,
+    pub lead_agent: Option<AgentView>,
     pub agents: Vec<AgentView>,
     pub sandboxes: Vec<SandboxView>,
 }
@@ -205,6 +210,7 @@ pub struct WorkspaceSandboxesPageTemplate {
 #[template(path = "workspace_sandbox_new.html")]
 pub struct WorkspaceSandboxNewTemplate {
     pub workspace: WorkspaceView,
+    pub lead_agent: Option<AgentView>,
     pub agents: Vec<AgentView>,
 }
 
@@ -212,6 +218,7 @@ pub struct WorkspaceSandboxNewTemplate {
 #[template(path = "workspace_sandbox_detail.html")]
 pub struct WorkspaceSandboxDetailTemplate {
     pub workspace: WorkspaceView,
+    pub lead_agent: Option<AgentView>,
     pub agents: Vec<AgentView>,
     pub sandbox: SandboxView,
 }
@@ -231,6 +238,7 @@ pub struct SandboxOptionView {
 #[template(path = "workspace_agent_new.html")]
 pub struct WorkspaceAgentNewTemplate {
     pub workspace: WorkspaceView,
+    pub lead_agent: Option<AgentView>,
     pub agents: Vec<AgentView>,
     pub sandbox_options: Vec<SandboxOptionView>,
 }
@@ -249,6 +257,9 @@ pub struct AgentDetailView {
     pub workspace_id: String,
     pub name: String,
     pub role: String,
+    /// True when the agent is the workspace lead. The lead never runs in a
+    /// sandbox, so the attach form is hidden in the detail view.
+    pub is_lead: bool,
     pub attached_sandbox: Option<AttachedSandboxView>,
 }
 
@@ -256,6 +267,7 @@ pub struct AgentDetailView {
 #[template(path = "workspace_agent_detail.html")]
 pub struct WorkspaceAgentDetailTemplate {
     pub workspace: WorkspaceView,
+    pub lead_agent: Option<AgentView>,
     pub agents: Vec<AgentView>,
     pub agent: AgentDetailView,
     /// Used to populate the attach-sandbox dropdown when the agent has no
@@ -297,6 +309,7 @@ pub struct WorkspaceHubTemplate {
     pub selected_workspace: Option<WorkspaceView>,
     /// Flat ID string for dropdown comparison (avoids Askama ref issues).
     pub selected_workspace_id: String,
+    pub lead_agent: Option<AgentView>,
     pub agents: Vec<AgentView>,
     pub selected_agent_id: String,
 }

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -216,6 +216,53 @@ pub struct WorkspaceSandboxDetailTemplate {
     pub sandbox: SandboxView,
 }
 
+// ── Agents (workspace-context create form) ─────────────────────────────
+
+/// Minimal dropdown option for the sandbox attachment selector on the
+/// new-agent form. Only sandboxes that exist in the workspace are offered.
+#[allow(dead_code)]
+pub struct SandboxOptionView {
+    pub id: String,
+    pub name: String,
+    pub state: String,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "workspace_agent_new.html")]
+pub struct WorkspaceAgentNewTemplate {
+    pub workspace: WorkspaceView,
+    pub agents: Vec<AgentView>,
+    pub sandbox_options: Vec<SandboxOptionView>,
+}
+
+#[allow(dead_code)]
+pub struct AttachedSandboxView {
+    pub id: String,
+    pub name: String,
+    pub mode: String,
+    pub state: String,
+}
+
+#[allow(dead_code)]
+pub struct AgentDetailView {
+    pub id: String,
+    pub workspace_id: String,
+    pub name: String,
+    pub role: String,
+    pub attached_sandbox: Option<AttachedSandboxView>,
+}
+
+#[derive(Template, WebTemplate)]
+#[template(path = "workspace_agent_detail.html")]
+pub struct WorkspaceAgentDetailTemplate {
+    pub workspace: WorkspaceView,
+    pub agents: Vec<AgentView>,
+    pub agent: AgentDetailView,
+    /// Used to populate the attach-sandbox dropdown when the agent has no
+    /// current attachment. Empty when `agent.attached_sandbox` is `Some`.
+    pub sandbox_options: Vec<SandboxOptionView>,
+}
+
 // ── Workspace Secrets ────────────────────────────────────────────────
 
 pub struct WorkspaceSecretView {

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -273,6 +273,9 @@ pub struct WorkspaceAgentDetailTemplate {
     /// Used to populate the attach-sandbox dropdown when the agent has no
     /// current attachment. Empty when `agent.attached_sandbox` is `Some`.
     pub sandbox_options: Vec<SandboxOptionView>,
+    /// Flash message surfaced after a failed attach/detach (arrives via
+    /// `?error=...` on the redirect back to this page).
+    pub error: Option<String>,
 }
 
 // ── Workspace Secrets ────────────────────────────────────────────────

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -312,6 +312,10 @@ pub struct WorkspaceHubTemplate {
     pub lead_agent: Option<AgentView>,
     pub agents: Vec<AgentView>,
     pub selected_agent_id: String,
+    /// The agent the chat view is rendering for. Used to show that
+    /// agent's name in the chat header so it updates when the user
+    /// switches between agents (instead of showing the workspace name).
+    pub selected_agent: Option<AgentView>,
 }
 
 #[derive(Template, WebTemplate)]

--- a/web/templates/workspace_agent_detail.html
+++ b/web/templates/workspace_agent_detail.html
@@ -1,0 +1,164 @@
+{% extends "base.html" %}
+
+{% block title %}{{ agent.name }} — {{ workspace.name }} — Galoy Agents{% endblock %}
+
+{% block head %}
+<style>
+  .ws-back {
+    display: block;
+    font-size: 0.8rem;
+    text-decoration: none;
+    color: var(--pico-muted-color);
+    margin-bottom: 0.25rem;
+  }
+  .ws-back:hover { color: var(--pico-primary); }
+  .ws-mode-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: 1rem;
+  }
+  .ws-mode-header h4 { margin: 0; font-size: 1rem; }
+  .ws-settings-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    margin: 0;
+    border: 1px solid var(--pico-muted-border-color);
+    border-radius: var(--pico-border-radius);
+    background: none;
+    text-decoration: none;
+    color: var(--pico-muted-color);
+    font-size: 0.9rem;
+    cursor: pointer;
+    flex-shrink: 0;
+  }
+  .ws-settings-btn:hover {
+    background: var(--pico-primary-background);
+    color: var(--pico-primary-inverse);
+  }
+  .agent-item {
+    display: block;
+    padding: 0.4rem 0.75rem;
+    border-radius: var(--pico-border-radius);
+    text-decoration: none;
+    color: var(--pico-color);
+    font-size: 0.9rem;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+  .agent-item:hover,
+  .agent-item.active {
+    background: var(--pico-primary-background);
+    color: var(--pico-primary-inverse);
+  }
+  .agent-field {
+    display: grid;
+    grid-template-columns: 10rem 1fr;
+    padding: 0.4rem 0;
+    border-bottom: 1px solid var(--pico-muted-border-color);
+    gap: 1rem;
+  }
+  .agent-field:last-of-type { border-bottom: none; }
+  .agent-field dt { font-weight: 600; color: var(--pico-muted-color); }
+  .agent-field dd { margin: 0; }
+</style>
+{% endblock %}
+
+{% block sidebar_content %}
+<a href="/workspaces" class="ws-back">&larr; Workspaces</a>
+<div class="ws-mode-header">
+  <h4>{{ workspace.name }}</h4>
+  <a href="/workspaces/{{ workspace.id }}" class="ws-settings-btn" title="Workspace settings">&#9881;</a>
+</div>
+
+<div class="section-label">Agents</div>
+{% if !agents.is_empty() %}
+{% for a in agents %}
+<a href="/workspaces/{{ workspace.id }}/chat?agent={{ a.id }}" class="agent-item{% if a.id == agent.id %} active{% endif %}">
+  {{ a.name }}
+</a>
+{% endfor %}
+{% else %}
+<small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
+{% endif %}
+<a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>
+
+<hr style="margin: 0.75rem 0;">
+<nav>
+  <ul>
+    <li><a href="/workspaces/{{ workspace.id }}/skills" class="agent-item">Skills</a></li>
+    <li><a href="/workspaces/{{ workspace.id }}/sandboxes" class="agent-item">Sandboxes</a></li>
+  </ul>
+</nav>
+
+<div class="sidebar-bottom">
+  <a href="/auth/logout">Logout</a>
+</div>
+{% endblock %}
+
+{% block content %}
+<a href="/workspaces/{{ workspace.id }}/chat?agent={{ agent.id }}" style="font-size: 0.85rem; text-decoration: none; color: var(--pico-muted-color);">&larr; Back to chat</a>
+<h2>{{ agent.name }}</h2>
+
+<dl>
+  <div class="agent-field">
+    <dt>Role</dt>
+    <dd>{{ agent.role }}</dd>
+  </div>
+  <div class="agent-field">
+    <dt>ID</dt>
+    <dd><code>{{ agent.id }}</code></dd>
+  </div>
+</dl>
+
+<hr>
+<h3>Sandbox attachment</h3>
+
+{% match agent.attached_sandbox %}
+{% when Some(sb) %}
+<p>
+  Attached to
+  <a href="/workspaces/{{ workspace.id }}/sandboxes/{{ sb.id }}"><strong>{{ sb.name }}</strong></a>
+  in <code>{{ sb.mode }}</code> mode <small>(sandbox state: <code>{{ sb.state }}</code>)</small>.
+</p>
+<form method="post" action="/workspaces/{{ workspace.id }}/agents/{{ agent.id }}/detach_sandbox">
+  <button
+    type="submit"
+    onclick="return confirm('Detach this sandbox from the agent? The sandbox itself is not deleted.')"
+    class="secondary outline"
+  >
+    Detach Sandbox
+  </button>
+</form>
+
+{% when None %}
+{% if sandbox_options.is_empty() %}
+<p><em>No sandboxes in this workspace yet — <a href="/workspaces/{{ workspace.id }}/sandboxes/new">create one</a> first.</em></p>
+{% else %}
+<p><small>The agent can hold at most one sandbox at a time. Write mode is exclusive; Read mode is shared.</small></p>
+<form method="post" action="/workspaces/{{ workspace.id }}/agents/{{ agent.id }}/attach_sandbox">
+  <label>
+    Sandbox
+    <select name="sandbox_id" required>
+      {% for sb in sandbox_options %}
+      <option value="{{ sb.id }}">{{ sb.name }} ({{ sb.state }})</option>
+      {% endfor %}
+    </select>
+  </label>
+  <label>
+    Mode
+    <select name="mode" required>
+      <option value="read">Read — shared, multiple agents allowed</option>
+      <option value="write">Write — exclusive, one agent at a time</option>
+    </select>
+  </label>
+  <button type="submit">Attach Sandbox</button>
+</form>
+{% endif %}
+{% endmatch %}
+{% endblock %}

--- a/web/templates/workspace_agent_detail.html
+++ b/web/templates/workspace_agent_detail.html
@@ -76,6 +76,14 @@
   <a href="/workspaces/{{ workspace.id }}" class="ws-settings-btn" title="Workspace settings">&#9881;</a>
 </div>
 
+{% match lead_agent %}
+  {% when Some(lead) %}
+  <a href="/workspaces/{{ workspace.id }}/chat?agent={{ lead.id }}" class="agent-item{% if lead.id == agent.id %} active{% endif %}">
+    {{ lead.name }}
+  </a>
+  {% when None %}
+{% endmatch %}
+
 <div class="section-label">Agents</div>
 {% if !agents.is_empty() %}
 {% for a in agents %}
@@ -119,6 +127,9 @@
 <hr>
 <h3>Sandbox attachment</h3>
 
+{% if agent.is_lead %}
+<p><small>The workspace lead orchestrates other agents and never runs in a sandbox itself.</small></p>
+{% else %}
 {% match agent.attached_sandbox %}
 {% when Some(sb) %}
 <p>
@@ -161,4 +172,5 @@
 </form>
 {% endif %}
 {% endmatch %}
+{% endif %}
 {% endblock %}

--- a/web/templates/workspace_agent_detail.html
+++ b/web/templates/workspace_agent_detail.html
@@ -113,6 +113,15 @@
 <a href="/workspaces/{{ workspace.id }}/chat?agent={{ agent.id }}" style="font-size: 0.85rem; text-decoration: none; color: var(--pico-muted-color);">&larr; Back to chat</a>
 <h2>{{ agent.name }}</h2>
 
+{% match error %}
+  {% when Some(msg) %}
+  <article style="border-left: 4px solid var(--pico-color-red-500, #c62828); padding: 0.5rem 1rem; background: var(--pico-card-background-color);">
+    <strong>Could not attach/detach sandbox.</strong>
+    <pre style="margin-top: 0.5rem; white-space: pre-wrap; word-wrap: break-word;"><code>{{ msg }}</code></pre>
+  </article>
+  {% when None %}
+{% endmatch %}
+
 <dl>
   <div class="agent-field">
     <dt>Role</dt>

--- a/web/templates/workspace_agent_new.html
+++ b/web/templates/workspace_agent_new.html
@@ -70,6 +70,14 @@
   <a href="/workspaces/{{ workspace.id }}" class="ws-settings-btn" title="Workspace settings">&#9881;</a>
 </div>
 
+{% match lead_agent %}
+  {% when Some(lead) %}
+  <a href="/workspaces/{{ workspace.id }}/chat?agent={{ lead.id }}" class="agent-item">
+    {{ lead.name }}
+  </a>
+  {% when None %}
+{% endmatch %}
+
 <div class="section-label">Agents</div>
 {% if !agents.is_empty() %}
 {% for agent in agents %}

--- a/web/templates/workspace_agent_new.html
+++ b/web/templates/workspace_agent_new.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}New Sandbox — {{ workspace.name }} — Galoy Agents{% endblock %}
+{% block title %}New Agent — {{ workspace.name }} — Galoy Agents{% endblock %}
 
 {% block head %}
 <style>
@@ -56,6 +56,10 @@
     background: var(--pico-primary-background);
     color: var(--pico-primary-inverse);
   }
+  .agent-item-add {
+    color: var(--pico-muted-color);
+    font-style: italic;
+  }
 </style>
 {% endblock %}
 
@@ -66,24 +70,23 @@
   <a href="/workspaces/{{ workspace.id }}" class="ws-settings-btn" title="Workspace settings">&#9881;</a>
 </div>
 
-{% if !agents.is_empty() %}
 <div class="section-label">Agents</div>
+{% if !agents.is_empty() %}
 {% for agent in agents %}
 <a href="/workspaces/{{ workspace.id }}/chat?agent={{ agent.id }}" class="agent-item">
   {{ agent.name }}
 </a>
 {% endfor %}
 {% else %}
-<div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
-<a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>
+<a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item agent-item-add active">+ Add Agent</a>
 
 <hr style="margin: 0.75rem 0;">
 <nav>
   <ul>
     <li><a href="/workspaces/{{ workspace.id }}/skills" class="agent-item">Skills</a></li>
-    <li><a href="/workspaces/{{ workspace.id }}/sandboxes" class="agent-item active">Sandboxes</a></li>
+    <li><a href="/workspaces/{{ workspace.id }}/sandboxes" class="agent-item">Sandboxes</a></li>
   </ul>
 </nav>
 
@@ -93,46 +96,38 @@
 {% endblock %}
 
 {% block content %}
-<a href="/workspaces/{{ workspace.id }}/sandboxes" style="font-size: 0.85rem; text-decoration: none; color: var(--pico-muted-color);">&larr; Back to Sandboxes</a>
-<h2>New Sandbox</h2>
+<a href="/workspaces/{{ workspace.id }}" style="font-size: 0.85rem; text-decoration: none; color: var(--pico-muted-color);">&larr; Back to {{ workspace.name }}</a>
+<h2>New Agent</h2>
 
-<form method="post" action="/workspaces/{{ workspace.id }}/sandboxes">
+<form method="post" action="/workspaces/{{ workspace.id }}/agents">
   <label>
     Name
-    <input type="text" name="name" required placeholder="my-sandbox">
+    <input type="text" name="name" required placeholder="research">
   </label>
 
-  <label>
-    Mode
-    <select name="mode" required>
-      <option value="scratch">Scratch — empty workspace</option>
-      <option value="repo">Repo — clone a git repository</option>
-    </select>
-  </label>
-
-  <label>
-    Repo URL <small>(only used in repo mode)</small>
-    <input type="text" name="repo_url" placeholder="https://github.com/org/repo">
-  </label>
-
-  <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1rem;">
+  <fieldset>
+    <legend><small>Sandbox attachment (optional)</small></legend>
     <label>
-      CPU
-      <input type="text" name="cpu" required value="500m">
+      Attach sandbox
+      <select name="sandbox_id">
+        <option value="">— none —</option>
+        {% for sb in sandbox_options %}
+        <option value="{{ sb.id }}">{{ sb.name }} ({{ sb.state }})</option>
+        {% endfor %}
+      </select>
     </label>
     <label>
-      Memory
-      <input type="text" name="memory" required value="512Mi">
+      Mode <small>(only used when a sandbox is selected)</small>
+      <select name="attach_mode">
+        <option value="read">Read — shared, multiple agents allowed</option>
+        <option value="write">Write — exclusive, one agent at a time</option>
+      </select>
     </label>
-    <label>
-      Disk Size
-      <input type="text" name="disk_size" required value="10Gi">
-    </label>
-  </div>
+  </fieldset>
 
   <div style="display: flex; gap: 1rem;">
-    <button type="submit">Create Sandbox</button>
-    <a href="/workspaces/{{ workspace.id }}/sandboxes" role="button" class="outline">Cancel</a>
+    <button type="submit">Create Agent</button>
+    <a href="/workspaces/{{ workspace.id }}" role="button" class="outline">Cancel</a>
   </div>
 </form>
 {% endblock %}

--- a/web/templates/workspace_detail.html
+++ b/web/templates/workspace_detail.html
@@ -65,15 +65,22 @@
   <a href="/workspaces/{{ workspace.id }}" class="ws-settings-btn active" title="Workspace settings">&#9881;</a>
 </div>
 
-{% if !agents.is_empty() %}
+{% match lead_agent %}
+  {% when Some(lead) %}
+  <a href="/workspaces/{{ workspace.id }}/chat?agent={{ lead.id }}" class="agent-item">
+    {{ lead.name }}
+  </a>
+  {% when None %}
+{% endmatch %}
+
 <div class="section-label">Agents</div>
+{% if !agents.is_empty() %}
 {% for agent in agents %}
 <a href="/workspaces/{{ workspace.id }}/chat?agent={{ agent.id }}" class="agent-item">
   {{ agent.name }}
 </a>
 {% endfor %}
 {% else %}
-<div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
 <a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>

--- a/web/templates/workspace_detail.html
+++ b/web/templates/workspace_detail.html
@@ -76,6 +76,7 @@
 <div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
+<a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>
 
 <hr style="margin: 0.75rem 0;">
 <nav>

--- a/web/templates/workspace_hub.html
+++ b/web/templates/workspace_hub.html
@@ -208,7 +208,10 @@
       <div class="chat-layout">
         <div class="chat-header">
           <div>
-            <h3>{{ sel.name }}</h3>
+            {% match selected_agent %}
+              {% when Some(sa) %}<h3>{{ sa.name }}</h3>
+              {% when None %}<h3>{{ sel.name }}</h3>
+            {% endmatch %}
             <small>Agent chat</small>
           </div>
           <a href="/workspaces/{{ selected_workspace_id }}/agents/{{ selected_agent_id }}"

--- a/web/templates/workspace_hub.html
+++ b/web/templates/workspace_hub.html
@@ -142,8 +142,17 @@
   <a href="/workspaces/{{ selected_workspace_id }}" class="ws-settings-btn" title="Workspace settings">&#9881;</a>
 </div>
 
-{% if !agents.is_empty() %}
+{% match lead_agent %}
+  {% when Some(lead) %}
+  <a href="/workspaces/{{ selected_workspace_id }}/chat?agent={{ lead.id }}"
+     class="agent-item{% if selected_agent_id == lead.id %} active{% endif %}">
+    {{ lead.name }}
+  </a>
+  {% when None %}
+{% endmatch %}
+
 <div class="section-label">Agents</div>
+{% if !agents.is_empty() %}
 {% for agent in agents %}
 <a href="/workspaces/{{ selected_workspace_id }}/chat?agent={{ agent.id }}"
    class="agent-item{% if selected_agent_id == agent.id %} active{% endif %}"
@@ -152,7 +161,6 @@
 </a>
 {% endfor %}
 {% else %}
-<div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
 <a href="/workspaces/{{ selected_workspace_id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>

--- a/web/templates/workspace_hub.html
+++ b/web/templates/workspace_hub.html
@@ -45,7 +45,7 @@
     margin-bottom: 1rem;
   }
   .ws-mode-header h4 { margin: 0; font-size: 1rem; }
-  .ws-mode-header .ws-settings-btn {
+  .ws-settings-btn {
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -62,7 +62,7 @@
     cursor: pointer;
     flex-shrink: 0;
   }
-  .ws-mode-header .ws-settings-btn:hover {
+  .ws-settings-btn:hover {
     background: var(--pico-primary-background);
     color: var(--pico-primary-inverse);
   }
@@ -155,6 +155,7 @@
 <div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
+<a href="/workspaces/{{ selected_workspace_id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>
 
 <hr style="margin: 0.75rem 0;">
 <nav>
@@ -202,6 +203,8 @@
             <h3>{{ sel.name }}</h3>
             <small>Agent chat</small>
           </div>
+          <a href="/workspaces/{{ selected_workspace_id }}/agents/{{ selected_agent_id }}"
+             class="ws-settings-btn" title="Agent settings">&#9881;</a>
         </div>
         <div class="messages" id="messages"></div>
         <div class="chat-input">

--- a/web/templates/workspace_sandbox_detail.html
+++ b/web/templates/workspace_sandbox_detail.html
@@ -92,15 +92,22 @@
   <a href="/workspaces/{{ workspace.id }}" class="ws-settings-btn" title="Workspace settings">&#9881;</a>
 </div>
 
-{% if !agents.is_empty() %}
+{% match lead_agent %}
+  {% when Some(lead) %}
+  <a href="/workspaces/{{ workspace.id }}/chat?agent={{ lead.id }}" class="agent-item">
+    {{ lead.name }}
+  </a>
+  {% when None %}
+{% endmatch %}
+
 <div class="section-label">Agents</div>
+{% if !agents.is_empty() %}
 {% for agent in agents %}
 <a href="/workspaces/{{ workspace.id }}/chat?agent={{ agent.id }}" class="agent-item">
   {{ agent.name }}
 </a>
 {% endfor %}
 {% else %}
-<div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
 <a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>

--- a/web/templates/workspace_sandbox_detail.html
+++ b/web/templates/workspace_sandbox_detail.html
@@ -103,6 +103,7 @@
 <div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
+<a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>
 
 <hr style="margin: 0.75rem 0;">
 <nav>

--- a/web/templates/workspace_sandbox_new.html
+++ b/web/templates/workspace_sandbox_new.html
@@ -66,15 +66,22 @@
   <a href="/workspaces/{{ workspace.id }}" class="ws-settings-btn" title="Workspace settings">&#9881;</a>
 </div>
 
-{% if !agents.is_empty() %}
+{% match lead_agent %}
+  {% when Some(lead) %}
+  <a href="/workspaces/{{ workspace.id }}/chat?agent={{ lead.id }}" class="agent-item">
+    {{ lead.name }}
+  </a>
+  {% when None %}
+{% endmatch %}
+
 <div class="section-label">Agents</div>
+{% if !agents.is_empty() %}
 {% for agent in agents %}
 <a href="/workspaces/{{ workspace.id }}/chat?agent={{ agent.id }}" class="agent-item">
   {{ agent.name }}
 </a>
 {% endfor %}
 {% else %}
-<div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
 <a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>

--- a/web/templates/workspace_sandboxes.html
+++ b/web/templates/workspace_sandboxes.html
@@ -66,15 +66,22 @@
   <a href="/workspaces/{{ workspace.id }}" class="ws-settings-btn" title="Workspace settings">&#9881;</a>
 </div>
 
-{% if !agents.is_empty() %}
+{% match lead_agent %}
+  {% when Some(lead) %}
+  <a href="/workspaces/{{ workspace.id }}/chat?agent={{ lead.id }}" class="agent-item">
+    {{ lead.name }}
+  </a>
+  {% when None %}
+{% endmatch %}
+
 <div class="section-label">Agents</div>
+{% if !agents.is_empty() %}
 {% for agent in agents %}
 <a href="/workspaces/{{ workspace.id }}/chat?agent={{ agent.id }}" class="agent-item">
   {{ agent.name }}
 </a>
 {% endfor %}
 {% else %}
-<div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
 <a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>

--- a/web/templates/workspace_sandboxes.html
+++ b/web/templates/workspace_sandboxes.html
@@ -77,6 +77,7 @@
 <div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
+<a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>
 
 <hr style="margin: 0.75rem 0;">
 <nav>

--- a/web/templates/workspace_skill_edit.html
+++ b/web/templates/workspace_skill_edit.html
@@ -66,15 +66,22 @@
   <a href="/workspaces/{{ workspace.id }}" class="ws-settings-btn" title="Workspace settings">&#9881;</a>
 </div>
 
-{% if !agents.is_empty() %}
+{% match lead_agent %}
+  {% when Some(lead) %}
+  <a href="/workspaces/{{ workspace.id }}/chat?agent={{ lead.id }}" class="agent-item">
+    {{ lead.name }}
+  </a>
+  {% when None %}
+{% endmatch %}
+
 <div class="section-label">Agents</div>
+{% if !agents.is_empty() %}
 {% for agent in agents %}
 <a href="/workspaces/{{ workspace.id }}/chat?agent={{ agent.id }}" class="agent-item">
   {{ agent.name }}
 </a>
 {% endfor %}
 {% else %}
-<div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
 <a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>

--- a/web/templates/workspace_skill_edit.html
+++ b/web/templates/workspace_skill_edit.html
@@ -77,6 +77,7 @@
 <div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
+<a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>
 
 <hr style="margin: 0.75rem 0;">
 <nav>

--- a/web/templates/workspace_skill_new.html
+++ b/web/templates/workspace_skill_new.html
@@ -66,15 +66,22 @@
   <a href="/workspaces/{{ workspace.id }}" class="ws-settings-btn" title="Workspace settings">&#9881;</a>
 </div>
 
-{% if !agents.is_empty() %}
+{% match lead_agent %}
+  {% when Some(lead) %}
+  <a href="/workspaces/{{ workspace.id }}/chat?agent={{ lead.id }}" class="agent-item">
+    {{ lead.name }}
+  </a>
+  {% when None %}
+{% endmatch %}
+
 <div class="section-label">Agents</div>
+{% if !agents.is_empty() %}
 {% for agent in agents %}
 <a href="/workspaces/{{ workspace.id }}/chat?agent={{ agent.id }}" class="agent-item">
   {{ agent.name }}
 </a>
 {% endfor %}
 {% else %}
-<div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
 <a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>

--- a/web/templates/workspace_skill_new.html
+++ b/web/templates/workspace_skill_new.html
@@ -77,6 +77,7 @@
 <div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
+<a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>
 
 <hr style="margin: 0.75rem 0;">
 <nav>

--- a/web/templates/workspace_skills.html
+++ b/web/templates/workspace_skills.html
@@ -66,15 +66,22 @@
   <a href="/workspaces/{{ workspace.id }}" class="ws-settings-btn" title="Workspace settings">&#9881;</a>
 </div>
 
-{% if !agents.is_empty() %}
+{% match lead_agent %}
+  {% when Some(lead) %}
+  <a href="/workspaces/{{ workspace.id }}/chat?agent={{ lead.id }}" class="agent-item">
+    {{ lead.name }}
+  </a>
+  {% when None %}
+{% endmatch %}
+
 <div class="section-label">Agents</div>
+{% if !agents.is_empty() %}
 {% for agent in agents %}
 <a href="/workspaces/{{ workspace.id }}/chat?agent={{ agent.id }}" class="agent-item">
   {{ agent.name }}
 </a>
 {% endfor %}
 {% else %}
-<div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
 <a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>

--- a/web/templates/workspace_skills.html
+++ b/web/templates/workspace_skills.html
@@ -77,6 +77,7 @@
 <div class="section-label">Agents</div>
 <small style="padding: 0.25rem 0.75rem; color: var(--pico-muted-color);">No agents yet</small>
 {% endif %}
+<a href="/workspaces/{{ workspace.id }}/agents/new" class="agent-item" style="color: var(--pico-muted-color); font-style: italic;">+ Add Agent</a>
 
 <hr style="margin: 0.75rem 0;">
 <nav>


### PR DESCRIPTION
## Summary
- Exposes agent creation in the workspace UI (new \`+ Add Agent\` link in every workspace-context sidebar).
- Introduces an \`Agent\` role alongside \`WorkspaceLead\`, each with its own required \`agents.builtin_roles.*\` config block so non-lead agents stop inheriting the lead's system prompt.
- Adds sandbox attachment lifecycle: an agent holds at most one sandbox at a time; the sandbox tracks a single writer. The lead cannot attach. Scope (\`SandboxRead\` / \`SandboxWrite\`) is granted/revoked in lockstep via a new \`AuthScopesUpdated\` delta event.
- Adds an agent detail page (\`/workspaces/{id}/agents/{agent_id}\`) with attach/detach forms and a flash banner when the service rejects a request (e.g. \"write slot already taken\").
- Rearranges the workspace sidebar: the lead sits above the \`Agents\` header, non-lead agents sit under it.

## Domain
- \`AgentRole::Agent\` added; both roles are REQUIRED in \`AgentsConfig::validate\` (no silent fallback to lead).
- \`Agent\` entity: \`attached_sandbox: Option<(SandboxId, SandboxAgentMode)>\`, \`authz_scopes: HashSet<AuthScope>\`, new events \`AuthScopesUpdated\` / \`SandboxAttached\` / \`SandboxDetached\`, \`sandbox_attached\` returns \`Result<Idempotent<()>, AgentError>\` and rejects \`WorkspaceLead\` + different-sandbox attachments with dedicated errors (\`LeadCannotAttachSandbox\`, \`AlreadyAttachedToSandbox\`).
- \`Sandbox\` entity: \`attached_agents: Vec<(AgentId, SandboxAgentMode)>\`, \`attach_agent\` enforces workspace match + single-writer (\`WriteSlotTaken\`, \`WrongWorkspace\`).
- \`AuthScope\`: \`SandboxRead(SandboxId)\` / \`SandboxWrite(SandboxId)\` string round-trip (\`sandbox:<uuid>:read\` / \`:write\`).
- \`AuthSubject::has_any(&[scopes])\` helper.
- \`Agents::create\` / \`create_in_op\` take \`attach_sandbox: Option<(SandboxId, SandboxAgentMode)>\` for create-time attach.
- \`Agents::attach_sandbox\` / \`detach_sandbox\` use cases with \`Admin OR WorkspaceWrite\` authz; update the agent before the sandbox so entity rejections short-circuit the sandbox-side round trip.

## UI
- \`+ Add Agent\` link across all 8 workspace sidebars; dedicated lead row pinned above the Agents section.
- New \`/workspaces/{id}/agents/new\` form (name, optional sandbox + mode).
- New \`/workspaces/{id}/agents/{agent_id}\` detail page with attach/detach; hidden for the lead with an explanation; flash banner on failure.
- Chat header in the hub now shows the selected agent's name (was showing the workspace name).
- ⚙ gear in the chat header links to agent detail.

## Test plan
- [ ] Create a workspace — lead is named \"lead\" and pinned above the Agents header
- [ ] Click \"+ Add Agent\", create \`test\` with no sandbox → the agent's chat replies as an Agent (not the lead)
- [ ] Create a second agent, attach the same sandbox to both in Write mode → second attach surfaces a red banner explaining WriteSlotTaken
- [ ] Open the lead's settings → Sandbox attachment section is replaced with the explanation, no form
- [ ] Detach a sandbox, re-attach in Read mode → scopes update without error
- [ ] Restart server with \`agents.builtin_roles.agent\` removed from config → \`App::init\` fails fast