### PR TITLE
refactor(auth): remove WorkspaceId from Agent auth variants

### DIFF
--- a/core/src/agent/entity.rs
+++ b/core/src/agent/entity.rs
@@ -89,7 +89,7 @@ impl Agent {
     /// Same as [`Self::auth_subject`] but tagged with the user that triggered
     /// the agent's work, so downstream actions can be attributed back to them.
     pub fn auth_subject_for_user(&self, user_id: UserId) -> AuthSubject {
-        AuthSubject::AgentOnBehalfOfUser(user_id, self.id, self.scopes_vec())
+        AuthSubject::AgentOnBehalfOfUser(self.id, user_id, self.scopes_vec())
     }
 
     /// Apply a batch of scope additions/removals as a single

--- a/core/src/agent/entity.rs
+++ b/core/src/agent/entity.rs
@@ -83,13 +83,13 @@ impl Agent {
     /// workspace + id, carrying the scopes persisted on the `Initialized`
     /// event. Use when no originating user can be attributed.
     pub fn auth_subject(&self) -> AuthSubject {
-        AuthSubject::Agent(self.workspace_id, self.id, self.scopes_vec())
+        AuthSubject::Agent(self.id, self.scopes_vec())
     }
 
     /// Same as [`Self::auth_subject`] but tagged with the user that triggered
     /// the agent's work, so downstream actions can be attributed back to them.
     pub fn auth_subject_for_user(&self, user_id: UserId) -> AuthSubject {
-        AuthSubject::AgentOnBehalfOfUser(user_id, self.workspace_id, self.id, self.scopes_vec())
+        AuthSubject::AgentOnBehalfOfUser(user_id, self.id, self.scopes_vec())
     }
 
     /// Apply a batch of scope additions/removals as a single

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -303,8 +303,7 @@ impl Agents {
         // rejected.
         match &subject {
             AuthSubject::User(_) | AuthSubject::ExportedAgent(_, _, _) => {}
-            AuthSubject::Agent(ws, _, _) | AuthSubject::AgentOnBehalfOfUser(_, ws, _, _)
-                if *ws == agent.workspace_id => {}
+            _ if subject.workspace_id() == Some(agent.workspace_id) => {}
             _ => return Err(AgentError::Unauthorized),
         }
 

--- a/core/src/audit/mod.rs
+++ b/core/src/audit/mod.rs
@@ -40,13 +40,13 @@ impl Audit {
             AuthSubject::ExportedAgent(user_id, _, _) => {
                 ctx.acting_user_id = Some(*user_id);
             }
-            AuthSubject::Agent(workspace_id, agent_id, _) => {
-                ctx.workspace_id = Some(*workspace_id);
+            AuthSubject::Agent(agent_id, _) => {
+                ctx.workspace_id = auth.workspace_id();
                 ctx.acting_agent_id = Some(*agent_id);
             }
-            AuthSubject::AgentOnBehalfOfUser(user_id, workspace_id, agent_id, _) => {
+            AuthSubject::AgentOnBehalfOfUser(user_id, agent_id, _) => {
                 ctx.acting_agent_id = Some(*agent_id);
-                ctx.workspace_id = Some(*workspace_id);
+                ctx.workspace_id = auth.workspace_id();
                 ctx.on_behalf_of_user_id = Some(*user_id);
             }
             AuthSubject::Anonymous => {}

--- a/core/src/audit/mod.rs
+++ b/core/src/audit/mod.rs
@@ -44,7 +44,7 @@ impl Audit {
                 ctx.workspace_id = auth.workspace_id();
                 ctx.acting_agent_id = Some(*agent_id);
             }
-            AuthSubject::AgentOnBehalfOfUser(user_id, agent_id, _) => {
+            AuthSubject::AgentOnBehalfOfUser(agent_id, user_id, _) => {
                 ctx.acting_agent_id = Some(*agent_id);
                 ctx.workspace_id = auth.workspace_id();
                 ctx.on_behalf_of_user_id = Some(*user_id);

--- a/core/src/primitives/auth_subject.rs
+++ b/core/src/primitives/auth_subject.rs
@@ -16,7 +16,7 @@ pub enum AuthSubject {
     /// originated from a `User` or `ExportedAgent`. Carries enough context
     /// to attribute downstream actions back to the originating user.
     /// The workspace is recoverable from scopes via [`Self::workspace_id`].
-    AgentOnBehalfOfUser(UserId, AgentId, Vec<AuthScope>),
+    AgentOnBehalfOfUser(AgentId, UserId, Vec<AuthScope>),
     /// No authentication provided.
     Anonymous,
 }
@@ -39,7 +39,7 @@ impl AuthSubject {
         match self {
             AuthSubject::User(user_id) => Some(*user_id),
             AuthSubject::ExportedAgent(user_id, _, _) => Some(*user_id),
-            AuthSubject::AgentOnBehalfOfUser(user_id, _, _) => Some(*user_id),
+            AuthSubject::AgentOnBehalfOfUser(_, user_id, _) => Some(*user_id),
             AuthSubject::Agent(_, _) | AuthSubject::Anonymous => None,
         }
     }
@@ -59,7 +59,7 @@ impl AuthSubject {
     pub fn acting_agent_id(&self) -> Option<AgentId> {
         match self {
             AuthSubject::Agent(agent_id, _) => Some(*agent_id),
-            AuthSubject::AgentOnBehalfOfUser(_, agent_id, _) => Some(*agent_id),
+            AuthSubject::AgentOnBehalfOfUser(agent_id, _, _) => Some(*agent_id),
             _ => None,
         }
     }
@@ -139,7 +139,7 @@ impl AuthSubject {
                 user_id: *user_id,
                 creds_id: *creds_id,
             },
-            AuthSubject::Agent(agent_id, _) | AuthSubject::AgentOnBehalfOfUser(_, agent_id, _) => {
+            AuthSubject::Agent(agent_id, _) | AuthSubject::AgentOnBehalfOfUser(agent_id, _, _) => {
                 UserMessageSource::Agent {
                     agent_id: *agent_id,
                 }

--- a/core/src/primitives/auth_subject.rs
+++ b/core/src/primitives/auth_subject.rs
@@ -8,12 +8,15 @@ pub enum AuthSubject {
     /// Authenticated via bearer token issued to a user (exported agent credential).
     ExportedAgent(UserId, McpCredsId, Vec<AuthScope>),
     /// Agent acting within its workspace without user attribution.
-    Agent(WorkspaceId, AgentId, Vec<AuthScope>),
+    /// The workspace is recoverable from the `WorkspaceRead`/`WorkspaceWrite`
+    /// scopes via [`Self::workspace_id`].
+    Agent(AgentId, Vec<AuthScope>),
     /// Agent acting within its workspace on behalf of a known user — used
     /// when the agent's tool calls are triggered by a request that itself
     /// originated from a `User` or `ExportedAgent`. Carries enough context
     /// to attribute downstream actions back to the originating user.
-    AgentOnBehalfOfUser(UserId, WorkspaceId, AgentId, Vec<AuthScope>),
+    /// The workspace is recoverable from scopes via [`Self::workspace_id`].
+    AgentOnBehalfOfUser(UserId, AgentId, Vec<AuthScope>),
     /// No authentication provided.
     Anonymous,
 }
@@ -23,8 +26,8 @@ impl AuthSubject {
         match self {
             AuthSubject::User(user_id) => Ok(*user_id),
             AuthSubject::ExportedAgent(_, _, _) => Err("ExportedAgent auth not allowed here"),
-            AuthSubject::Agent(_, _, _) => Err("Agent auth not allowed here"),
-            AuthSubject::AgentOnBehalfOfUser(_, _, _, _) => Err("Agent auth not allowed here"),
+            AuthSubject::Agent(_, _) => Err("Agent auth not allowed here"),
+            AuthSubject::AgentOnBehalfOfUser(_, _, _) => Err("Agent auth not allowed here"),
             AuthSubject::Anonymous => Err("Authentication required"),
         }
     }
@@ -36,25 +39,27 @@ impl AuthSubject {
         match self {
             AuthSubject::User(user_id) => Some(*user_id),
             AuthSubject::ExportedAgent(user_id, _, _) => Some(*user_id),
-            AuthSubject::AgentOnBehalfOfUser(user_id, _, _, _) => Some(*user_id),
-            AuthSubject::Agent(_, _, _) | AuthSubject::Anonymous => None,
+            AuthSubject::AgentOnBehalfOfUser(user_id, _, _) => Some(*user_id),
+            AuthSubject::Agent(_, _) | AuthSubject::Anonymous => None,
         }
     }
 
     /// Return the workspace this subject is acting within, if any.
+    /// For `Agent` and `AgentOnBehalfOfUser`, the workspace is recovered
+    /// from the `WorkspaceRead`/`WorkspaceWrite` scopes (always present
+    /// since agents receive these at creation time).
     pub fn workspace_id(&self) -> Option<WorkspaceId> {
-        match self {
-            AuthSubject::Agent(workspace_id, _, _) => Some(*workspace_id),
-            AuthSubject::AgentOnBehalfOfUser(_, workspace_id, _, _) => Some(*workspace_id),
+        self.scopes().iter().find_map(|s| match s {
+            AuthScope::WorkspaceRead(ws) | AuthScope::WorkspaceWrite(ws) => Some(*ws),
             _ => None,
-        }
+        })
     }
 
     /// Return the agent that is acting, if any.
     pub fn acting_agent_id(&self) -> Option<AgentId> {
         match self {
-            AuthSubject::Agent(_, agent_id, _) => Some(*agent_id),
-            AuthSubject::AgentOnBehalfOfUser(_, _, agent_id, _) => Some(*agent_id),
+            AuthSubject::Agent(agent_id, _) => Some(*agent_id),
+            AuthSubject::AgentOnBehalfOfUser(_, agent_id, _) => Some(*agent_id),
             _ => None,
         }
     }
@@ -63,8 +68,8 @@ impl AuthSubject {
     pub fn scopes(&self) -> &[AuthScope] {
         match self {
             AuthSubject::ExportedAgent(_, _, scopes)
-            | AuthSubject::Agent(_, _, scopes)
-            | AuthSubject::AgentOnBehalfOfUser(_, _, _, scopes) => scopes,
+            | AuthSubject::Agent(_, scopes)
+            | AuthSubject::AgentOnBehalfOfUser(_, _, scopes) => scopes,
             _ => &[],
         }
     }
@@ -92,8 +97,8 @@ impl AuthSubject {
         match self {
             AuthSubject::User(_) => true,
             AuthSubject::ExportedAgent(_, _, scopes)
-            | AuthSubject::Agent(_, _, scopes)
-            | AuthSubject::AgentOnBehalfOfUser(_, _, _, scopes) => scopes.contains(scope),
+            | AuthSubject::Agent(_, scopes)
+            | AuthSubject::AgentOnBehalfOfUser(_, _, scopes) => scopes.contains(scope),
             AuthSubject::Anonymous => false,
         }
     }
@@ -110,7 +115,7 @@ impl AuthSubject {
     pub fn is_agent(&self) -> bool {
         matches!(
             self,
-            AuthSubject::Agent(_, _, _) | AuthSubject::AgentOnBehalfOfUser(_, _, _, _)
+            AuthSubject::Agent(_, _) | AuthSubject::AgentOnBehalfOfUser(_, _, _)
         )
     }
 
@@ -134,10 +139,11 @@ impl AuthSubject {
                 user_id: *user_id,
                 creds_id: *creds_id,
             },
-            AuthSubject::Agent(_, agent_id, _)
-            | AuthSubject::AgentOnBehalfOfUser(_, _, agent_id, _) => UserMessageSource::Agent {
-                agent_id: *agent_id,
-            },
+            AuthSubject::Agent(agent_id, _) | AuthSubject::AgentOnBehalfOfUser(_, agent_id, _) => {
+                UserMessageSource::Agent {
+                    agent_id: *agent_id,
+                }
+            }
             AuthSubject::Anonymous => panic!("Anonymous subject has no message source"),
         }
     }

--- a/mcp-gateway/src/lib.rs
+++ b/mcp-gateway/src/lib.rs
@@ -56,7 +56,7 @@ impl McpGateway {
             .and_then(|parts| parts.extensions.get::<AuthSubject>());
         match auth {
             Some(auth @ AuthSubject::ExportedAgent(_, _, _))
-            | Some(auth @ AuthSubject::Agent(_, _, _)) => Ok(auth),
+            | Some(auth @ AuthSubject::Agent(_, _)) => Ok(auth),
             _ => Err(ErrorData::new(
                 ErrorCode::INVALID_REQUEST,
                 "Authentication required: provide a valid Bearer token",

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -1761,7 +1761,12 @@ async fn api_agent_secrets(
 ) -> Response {
     // Only allow Agent auth (SA token from sandbox pods)
     let (workspace_id, jwt_agent_id) = match &auth {
-        AuthSubject::Agent(workspace_id, agent_id, _) => (*workspace_id, *agent_id),
+        AuthSubject::Agent(agent_id, _) => {
+            let workspace_id = auth
+                .workspace_id()
+                .expect("Agent always has workspace scope");
+            (workspace_id, *agent_id)
+        }
         _ => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
     };
 


### PR DESCRIPTION
## Summary
- Remove redundant `WorkspaceId` field from `AuthSubject::Agent` and `AuthSubject::AgentOnBehalfOfUser` — agents always carry `WorkspaceRead`/`WorkspaceWrite` scopes, so the workspace is recoverable via `workspace_id()` scanning scopes
- Reorder both variants to put `AgentId` first as the primary identity: `Agent(AgentId, …)`, `AgentOnBehalfOfUser(AgentId, UserId, …)`
- Update all 8 files across 3 crates (core, web, mcp-gateway) that construct or pattern-match these variants

## Test plan
- [x] `nix flake check` passes (fmt, clippy, nextest)
- [ ] Verify agent ↔ agent messaging still resolves workspace correctly
- [ ] Verify audit entries record workspace_id for agent subjects
- [ ] Verify MCP gateway and sandbox bash tool authz unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)