### PR TITLE
refactor(core): wrap all services in Arc to avoid cloning

### DIFF
--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -50,8 +50,8 @@ use session::Sessions;
 pub struct Agents {
     repo: AgentRepo,
     sessions: Sessions,
-    sandboxes: Sandboxes,
-    skills: Skills,
+    sandboxes: Arc<Sandboxes>,
+    skills: Arc<Skills>,
     config: AgentsConfig,
     toolsets: Arc<ToolSets>,
     prompt_requests: llm::PromptRequestChannel,
@@ -63,8 +63,8 @@ impl Agents {
         config: AgentsConfig,
         toolsets: Arc<ToolSets>,
         prompt_requests: llm::PromptRequestChannel,
-        sandboxes: Sandboxes,
-        skills: Skills,
+        sandboxes: Arc<Sandboxes>,
+        skills: Arc<Skills>,
     ) -> Self {
         Self {
             repo: AgentRepo::new(pool),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -41,17 +41,17 @@ use workspace_secret::WorkspaceSecrets;
 
 #[derive(Clone)]
 pub struct App {
-    users: Users,
-    mcp_creds: McpCredentials,
+    users: Arc<Users>,
+    mcp_creds: Arc<McpCredentials>,
     agents: Arc<Agents>,
     audit: Arc<Audit>,
     code_assistant: Option<Arc<CodeAssistant>>,
     toolsets: Arc<ToolSets>,
-    workspaces: Workspaces,
-    workspace_secrets: WorkspaceSecrets,
-    skills: Skills,
-    sandboxes: Sandboxes,
-    github_app: Option<GitHubAppTokenProvider>,
+    workspaces: Arc<Workspaces>,
+    workspace_secrets: Arc<WorkspaceSecrets>,
+    skills: Arc<Skills>,
+    sandboxes: Arc<Sandboxes>,
+    github_app: Option<Arc<GitHubAppTokenProvider>>,
     /// Held so the executor's worker task stays alive for the lifetime of
     /// `App`; dropped on shutdown which aborts the task.
     _prompt_executor: Arc<PromptExecutor>,
@@ -133,7 +133,7 @@ impl App {
                     .await
                     .map_err(|e| AppError::GitHubApp(format!("startup token check failed: {e}")))?;
                 tracing::info!("GitHub App token provider initialized and verified");
-                Some(provider)
+                Some(Arc::new(provider))
             }
             None => {
                 tracing::info!("GitHub App not configured — token auto-provisioning disabled");
@@ -141,19 +141,19 @@ impl App {
             }
         };
 
-        let sandboxes = Sandboxes::init(pool, config.sandbox, github_app.clone()).await?;
-        let skills = Skills::new(pool, sandboxes.clone());
+        let sandboxes = Arc::new(Sandboxes::init(pool, config.sandbox, github_app.clone()).await?);
+        let skills = Arc::new(Skills::new(pool, Arc::clone(&sandboxes)));
 
         // Sandbox-backed tools (Bash, TextEditor) need the sandboxes
         // service to resolve the running pod for an attached agent —
         // register them after sandboxes is up but before we wrap the
         // toolsets in Arc.
-        toolsets.register_top_level(Bash::new(sandboxes.clone()));
-        toolsets.register_top_level(TextEditor::new(sandboxes.clone()));
-        toolsets.register_top_level(Grep::new(sandboxes.clone()));
-        toolsets.register_top_level(GlobTool::new(sandboxes.clone()));
-        toolsets.register_top_level(Read::new(sandboxes.clone()));
-        toolsets.register_top_level(Ls::new(sandboxes.clone()));
+        toolsets.register_top_level(Bash::new(Arc::clone(&sandboxes)));
+        toolsets.register_top_level(TextEditor::new(Arc::clone(&sandboxes)));
+        toolsets.register_top_level(Grep::new(Arc::clone(&sandboxes)));
+        toolsets.register_top_level(GlobTool::new(Arc::clone(&sandboxes)));
+        toolsets.register_top_level(Read::new(Arc::clone(&sandboxes)));
+        toolsets.register_top_level(Ls::new(Arc::clone(&sandboxes)));
         let toolsets = Arc::new(toolsets);
 
         let agents = Arc::new(Agents::new(
@@ -161,8 +161,8 @@ impl App {
             config.agents,
             Arc::clone(&toolsets),
             prompt_tx,
-            sandboxes.clone(),
-            skills.clone(),
+            Arc::clone(&sandboxes),
+            Arc::clone(&skills),
         ));
 
         // Register agent & sandbox management tools now that both services
@@ -172,38 +172,38 @@ impl App {
         toolsets.register_top_level(AdminAgentCreate::new(Arc::clone(&agents)));
         toolsets.register_top_level(WorkspaceAgentAttachSandbox::new(
             Arc::clone(&agents),
-            sandboxes.clone(),
+            Arc::clone(&sandboxes),
         ));
         toolsets.register_top_level(AdminAgentAttachSandbox::new(Arc::clone(&agents)));
         toolsets.register_top_level(WorkspaceAgentDetachSandbox::new(
             Arc::clone(&agents),
-            sandboxes.clone(),
+            Arc::clone(&sandboxes),
         ));
         toolsets.register_top_level(AdminAgentDetachSandbox::new(Arc::clone(&agents)));
         toolsets.register_top_level(WorkspaceListAgents::new(Arc::clone(&agents)));
         toolsets.register_top_level(AdminListAgents::new(Arc::clone(&agents)));
-        toolsets.register_top_level(WorkspaceCreateSandbox::new(sandboxes.clone()));
-        toolsets.register_top_level(AdminCreateSandbox::new(sandboxes.clone()));
-        toolsets.register_top_level(WorkspaceListSandboxes::new(sandboxes.clone()));
-        toolsets.register_top_level(AdminListSandboxes::new(sandboxes.clone()));
-        toolsets.register_top_level(WorkspaceGetSandbox::new(sandboxes.clone()));
-        toolsets.register_top_level(AdminGetSandbox::new(sandboxes.clone()));
-        toolsets.register_top_level(WorkspaceInspectSandbox::new(sandboxes.clone()));
-        toolsets.register_top_level(AdminInspectSandbox::new(sandboxes.clone()));
+        toolsets.register_top_level(WorkspaceCreateSandbox::new(Arc::clone(&sandboxes)));
+        toolsets.register_top_level(AdminCreateSandbox::new(Arc::clone(&sandboxes)));
+        toolsets.register_top_level(WorkspaceListSandboxes::new(Arc::clone(&sandboxes)));
+        toolsets.register_top_level(AdminListSandboxes::new(Arc::clone(&sandboxes)));
+        toolsets.register_top_level(WorkspaceGetSandbox::new(Arc::clone(&sandboxes)));
+        toolsets.register_top_level(AdminGetSandbox::new(Arc::clone(&sandboxes)));
+        toolsets.register_top_level(WorkspaceInspectSandbox::new(Arc::clone(&sandboxes)));
+        toolsets.register_top_level(AdminInspectSandbox::new(Arc::clone(&sandboxes)));
 
-        let workspaces = Workspaces::new(pool, Arc::clone(&agents));
-        toolsets.register_top_level(AdminWorkspaceCreate::new(workspaces.clone()));
-        toolsets.register_top_level(AdminWorkspaceList::new(workspaces.clone()));
+        let workspaces = Arc::new(Workspaces::new(pool, Arc::clone(&agents)));
+        toolsets.register_top_level(AdminWorkspaceCreate::new(Arc::clone(&workspaces)));
+        toolsets.register_top_level(AdminWorkspaceList::new(Arc::clone(&workspaces)));
 
         Ok(Self {
-            users: Users::new(pool),
-            mcp_creds,
+            users: Arc::new(Users::new(pool)),
+            mcp_creds: Arc::new(mcp_creds),
             agents: Arc::clone(&agents),
             audit,
             code_assistant,
             toolsets,
             workspaces,
-            workspace_secrets,
+            workspace_secrets: Arc::new(workspace_secrets),
             skills,
             sandboxes,
             github_app,
@@ -252,7 +252,7 @@ impl App {
     }
 
     pub fn github_app(&self) -> Option<&GitHubAppTokenProvider> {
-        self.github_app.as_ref()
+        self.github_app.as_deref()
     }
 }
 

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -36,14 +36,14 @@ use crate::primitives::*;
 pub struct Sandboxes {
     repo: SandboxRepo,
     admin: Arc<dyn AdminClient>,
-    github_app: Option<GitHubAppTokenProvider>,
+    github_app: Option<Arc<GitHubAppTokenProvider>>,
 }
 
 impl Sandboxes {
     pub async fn init(
         pool: &sqlx::PgPool,
         config: SandboxConfig,
-        github_app: Option<GitHubAppTokenProvider>,
+        github_app: Option<Arc<GitHubAppTokenProvider>>,
     ) -> Result<Self, SandboxError> {
         let admin: Arc<dyn AdminClient> = match config.backend {
             SandboxBackendConfig::Local { sandbox_spawn_cmd } => Arc::new(LocalAdminClient::new(

--- a/core/src/skill/mod.rs
+++ b/core/src/skill/mod.rs
@@ -2,6 +2,8 @@ mod entity;
 pub mod error;
 pub(crate) mod repo;
 
+use std::sync::Arc;
+
 use tracing::instrument;
 
 pub use crate::primitives::*;
@@ -13,11 +15,11 @@ use repo::*;
 #[derive(Clone)]
 pub struct Skills {
     repo: SkillRepo,
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl Skills {
-    pub fn new(pool: &sqlx::PgPool, sandboxes: Sandboxes) -> Self {
+    pub fn new(pool: &sqlx::PgPool, sandboxes: Arc<Sandboxes>) -> Self {
         let repo = SkillRepo::new(pool);
         Self { repo, sandboxes }
     }

--- a/core/src/toolset/top_level/agent.rs
+++ b/core/src/toolset/top_level/agent.rs
@@ -176,11 +176,11 @@ impl TopLevelTool for AdminAgentCreate {
 
 pub struct WorkspaceAgentAttachSandbox {
     agents: Arc<Agents>,
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl WorkspaceAgentAttachSandbox {
-    pub fn new(agents: Arc<Agents>, sandboxes: Sandboxes) -> Self {
+    pub fn new(agents: Arc<Agents>, sandboxes: Arc<Sandboxes>) -> Self {
         Self { agents, sandboxes }
     }
 }
@@ -360,11 +360,11 @@ impl TopLevelTool for AdminAgentAttachSandbox {
 
 pub struct WorkspaceAgentDetachSandbox {
     agents: Arc<Agents>,
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl WorkspaceAgentDetachSandbox {
-    pub fn new(agents: Arc<Agents>, sandboxes: Sandboxes) -> Self {
+    pub fn new(agents: Arc<Agents>, sandboxes: Arc<Sandboxes>) -> Self {
         Self { agents, sandboxes }
     }
 }

--- a/core/src/toolset/top_level/bash.rs
+++ b/core/src/toolset/top_level/bash.rs
@@ -13,7 +13,7 @@
 //!   has no write attachment yet, so the model can ask to attach and try
 //!   again instead of being baffled by a missing tool.
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use rmcp::model::{CallToolResult, Content, JsonObject};
 use sandbox::instance_client::ExecuteRequest;
@@ -26,11 +26,11 @@ use super::super::error::ToolSetsError;
 use super::super::traits::TopLevelTool;
 
 pub struct Bash {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl Bash {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }

--- a/core/src/toolset/top_level/glob.rs
+++ b/core/src/toolset/top_level/glob.rs
@@ -4,7 +4,7 @@
 //! Read-only: executable with either `SandboxUseAll` or `SandboxUseReadOnly`.
 //! Server-side handler uses `rg --files -g <pattern>`.
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use rmcp::model::{CallToolResult, Content, JsonObject};
 use sandbox::instance_client::ExecuteRequest;
@@ -16,11 +16,11 @@ use super::super::error::ToolSetsError;
 use super::super::traits::TopLevelTool;
 
 pub struct GlobTool {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl GlobTool {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }

--- a/core/src/toolset/top_level/grep.rs
+++ b/core/src/toolset/top_level/grep.rs
@@ -4,7 +4,7 @@
 //! Read-only: executable with either `SandboxUseAll` or `SandboxUseReadOnly`.
 //! Server-side handler shells out to `rg`.
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use rmcp::model::{CallToolResult, Content, JsonObject};
 use sandbox::instance_client::ExecuteRequest;
@@ -16,11 +16,11 @@ use super::super::error::ToolSetsError;
 use super::super::traits::TopLevelTool;
 
 pub struct Grep {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl Grep {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }

--- a/core/src/toolset/top_level/inspect.rs
+++ b/core/src/toolset/top_level/inspect.rs
@@ -4,7 +4,7 @@
 //! (grep, glob, read, ls) against any sandbox within their workspace.
 //! `inspect_sandbox` is the admin variant with no workspace constraint.
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use rmcp::model::{CallToolResult, Content, JsonObject};
 use sandbox::instance_client::ExecuteRequest;
@@ -21,11 +21,11 @@ use super::super::traits::TopLevelTool;
 // ---------------------------------------------------------------------------
 
 pub struct WorkspaceInspectSandbox {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl WorkspaceInspectSandbox {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }
@@ -82,11 +82,11 @@ impl TopLevelTool for WorkspaceInspectSandbox {
 // ---------------------------------------------------------------------------
 
 pub struct AdminInspectSandbox {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl AdminInspectSandbox {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }

--- a/core/src/toolset/top_level/ls.rs
+++ b/core/src/toolset/top_level/ls.rs
@@ -5,7 +5,7 @@
 //!
 //! Read-only: executable with either `SandboxUseAll` or `SandboxUseReadOnly`.
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use rmcp::model::{CallToolResult, Content, JsonObject};
 use sandbox::instance_client::ExecuteRequest;
@@ -17,11 +17,11 @@ use super::super::error::ToolSetsError;
 use super::super::traits::TopLevelTool;
 
 pub struct Ls {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl Ls {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }

--- a/core/src/toolset/top_level/read.rs
+++ b/core/src/toolset/top_level/read.rs
@@ -5,7 +5,7 @@
 //!
 //! Read-only: executable with either `SandboxUseAll` or `SandboxUseReadOnly`.
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use rmcp::model::{CallToolResult, Content, JsonObject};
 use sandbox::instance_client::ExecuteRequest;
@@ -17,11 +17,11 @@ use super::super::error::ToolSetsError;
 use super::super::traits::TopLevelTool;
 
 pub struct Read {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl Read {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }

--- a/core/src/toolset/top_level/sandbox.rs
+++ b/core/src/toolset/top_level/sandbox.rs
@@ -4,7 +4,7 @@
 //! Workspace-scoped tools require the `WorkspaceAdmin` scope on the
 //! caller's workspace.  Admin-scoped tools require the `Admin` scope.
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use rmcp::model::{CallToolResult, Content, JsonObject};
 
@@ -20,11 +20,11 @@ use super::super::traits::TopLevelTool;
 // ---------------------------------------------------------------------------
 
 pub struct WorkspaceCreateSandbox {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl WorkspaceCreateSandbox {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }
@@ -112,11 +112,11 @@ impl TopLevelTool for WorkspaceCreateSandbox {
 // ---------------------------------------------------------------------------
 
 pub struct AdminCreateSandbox {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl AdminCreateSandbox {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }
@@ -209,11 +209,11 @@ impl TopLevelTool for AdminCreateSandbox {
 // ---------------------------------------------------------------------------
 
 pub struct WorkspaceListSandboxes {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl WorkspaceListSandboxes {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }
@@ -272,11 +272,11 @@ impl TopLevelTool for WorkspaceListSandboxes {
 // ---------------------------------------------------------------------------
 
 pub struct AdminListSandboxes {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl AdminListSandboxes {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }
@@ -343,11 +343,11 @@ impl TopLevelTool for AdminListSandboxes {
 // ---------------------------------------------------------------------------
 
 pub struct WorkspaceGetSandbox {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl WorkspaceGetSandbox {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }
@@ -419,11 +419,11 @@ impl TopLevelTool for WorkspaceGetSandbox {
 // ---------------------------------------------------------------------------
 
 pub struct AdminGetSandbox {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl AdminGetSandbox {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }

--- a/core/src/toolset/top_level/text_editor.rs
+++ b/core/src/toolset/top_level/text_editor.rs
@@ -14,7 +14,7 @@
 //!   attachments calling a write command (clear error, model can ask to
 //!   upgrade the attachment).
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use rmcp::model::{CallToolResult, Content, JsonObject};
 use sandbox::instance_client::ExecuteRequest;
@@ -27,11 +27,11 @@ use super::super::error::ToolSetsError;
 use super::super::traits::TopLevelTool;
 
 pub struct TextEditor {
-    sandboxes: Sandboxes,
+    sandboxes: Arc<Sandboxes>,
 }
 
 impl TextEditor {
-    pub fn new(sandboxes: Sandboxes) -> Self {
+    pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
         Self { sandboxes }
     }
 }

--- a/core/src/toolset/top_level/workspace.rs
+++ b/core/src/toolset/top_level/workspace.rs
@@ -6,7 +6,7 @@
 //! there's no workspace-scoped variant here — workspace creation is
 //! above a workspace (chicken-and-egg).
 
-use std::sync::LazyLock;
+use std::sync::{Arc, LazyLock};
 
 use rmcp::model::{CallToolResult, Content, JsonObject};
 
@@ -22,11 +22,11 @@ use super::super::traits::TopLevelTool;
 // ---------------------------------------------------------------------------
 
 pub struct AdminWorkspaceCreate {
-    workspaces: Workspaces,
+    workspaces: Arc<Workspaces>,
 }
 
 impl AdminWorkspaceCreate {
-    pub fn new(workspaces: Workspaces) -> Self {
+    pub fn new(workspaces: Arc<Workspaces>) -> Self {
         Self { workspaces }
     }
 }
@@ -112,11 +112,11 @@ impl TopLevelTool for AdminWorkspaceCreate {
 // ---------------------------------------------------------------------------
 
 pub struct AdminWorkspaceList {
-    workspaces: Workspaces,
+    workspaces: Arc<Workspaces>,
 }
 
 impl AdminWorkspaceList {
-    pub fn new(workspaces: Workspaces) -> Self {
+    pub fn new(workspaces: Arc<Workspaces>) -> Self {
         Self { workspaces }
     }
 }

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -45,11 +45,23 @@ async fn send_message_round_trip_via_prompt_channel() {
             .expect("init toolsets"),
     );
 
-    let sandboxes = Sandboxes::init(&pool, SandboxConfig::default(), None)
-        .await
-        .expect("init sandboxes");
-    let skills = galoy_agents_core::skill::Skills::new(&pool, sandboxes.clone());
-    let agents = Agents::new(&pool, config, toolsets, prompt_tx, sandboxes, skills);
+    let sandboxes = Arc::new(
+        Sandboxes::init(&pool, SandboxConfig::default(), None)
+            .await
+            .expect("init sandboxes"),
+    );
+    let skills = Arc::new(galoy_agents_core::skill::Skills::new(
+        &pool,
+        Arc::clone(&sandboxes),
+    ));
+    let agents = Agents::new(
+        &pool,
+        config,
+        toolsets,
+        prompt_tx,
+        Arc::clone(&sandboxes),
+        Arc::clone(&skills),
+    );
 
     let agent = agents
         .create(WorkspaceId::new(), AgentRole::WorkspaceLead, "lead", None)
@@ -181,11 +193,23 @@ async fn send_message_dispatches_registered_tool_call() {
     toolsets.register_top_level(PingTool::new());
     let toolsets = Arc::new(toolsets);
 
-    let sandboxes = Sandboxes::init(&pool, SandboxConfig::default(), None)
-        .await
-        .expect("init sandboxes");
-    let skills = galoy_agents_core::skill::Skills::new(&pool, sandboxes.clone());
-    let agents = Agents::new(&pool, config, toolsets, prompt_tx, sandboxes, skills);
+    let sandboxes = Arc::new(
+        Sandboxes::init(&pool, SandboxConfig::default(), None)
+            .await
+            .expect("init sandboxes"),
+    );
+    let skills = Arc::new(galoy_agents_core::skill::Skills::new(
+        &pool,
+        Arc::clone(&sandboxes),
+    ));
+    let agents = Agents::new(
+        &pool,
+        config,
+        toolsets,
+        prompt_tx,
+        Arc::clone(&sandboxes),
+        Arc::clone(&skills),
+    );
 
     let agent = agents
         .create(WorkspaceId::new(), AgentRole::WorkspaceLead, "lead", None)


### PR DESCRIPTION
## Summary
- Store all services as `Arc<T>` in the `App` struct instead of bare structs
- Services that depend on other services now hold `Arc<OtherService>` and accept Arc in constructors
- All toolset tools (Bash, TextEditor, Grep, Glob, Read, Ls, sandbox/agent/workspace management) hold `Arc` references to services
- Eliminates deep clones of repos, configs, and clients — every service hand-off is now a cheap `Arc` pointer increment

## Changes
- **App struct**: All fields now `Arc<T>` (Users, McpCredentials, Workspaces, WorkspaceSecrets, Skills, Sandboxes, GitHubAppTokenProvider)
- **Agents**: `sandboxes` and `skills` fields changed from bare types to `Arc<Sandboxes>` / `Arc<Skills>`
- **Skills**: `sandboxes` field changed to `Arc<Sandboxes>`
- **Sandboxes**: `github_app` field changed to `Option<Arc<GitHubAppTokenProvider>>`
- **15 toolset tools**: Updated to hold `Arc<Sandboxes>` or `Arc<Workspaces>` instead of bare structs
- **Tests**: Updated to match new Arc constructor signatures
- **Public API stable**: All accessor methods still return `&T` via Arc's Deref

## Test plan
- [x] `cargo check` passes
- [x] `cargo clippy --all-targets -- -D warnings` passes clean
- [x] `cargo fmt` — no diff
- [x] `nix flake check` passes (fmt + clippy + nextest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)