### PR TITLE
refactor(anthropic-client): replace internals with Pi streaming impl

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,9 +110,11 @@ dependencies = [
 name = "anthropic-client"
 version = "0.1.0"
 dependencies = [
+ "futures",
  "llm",
  "reqwest 0.12.28",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tracing",
 ]

--- a/lib/anthropic-client/Cargo.toml
+++ b/lib/anthropic-client/Cargo.toml
@@ -4,8 +4,10 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+futures = { workspace = true }
 llm = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["stream"] }
 serde = { workspace = true }
+serde_json = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/lib/anthropic-client/src/convert.rs
+++ b/lib/anthropic-client/src/convert.rs
@@ -1,0 +1,225 @@
+//! Conversion functions between the provider-agnostic `llm` types and the
+//! Anthropic-specific internal types.
+//!
+//! These adapters sit at the boundary of `AnthropicClient`: inbound `Prompt`
+//! values are converted to `AnthropicRequest` for the wire, and the
+//! accumulated streaming result is converted back to `PromptResponse`.
+
+use llm::prompt::{
+    AssistantBlock, CacheControl, CacheTtl, Message, SystemBlock, Tool, ToolChoice,
+    ToolResultBlock, UserBlock,
+};
+use llm::{PromptResponse, StopReason, Usage};
+
+use crate::stream::{AccumulatedBlock, AccumulatedResponse, AccumulatedStopReason};
+use crate::types::{
+    AnthropicCacheControl, AnthropicContent, AnthropicMessage, AnthropicRequest,
+    AnthropicSystemBlock, AnthropicTool, AnthropicToolChoice, AnthropicToolResultContent,
+};
+
+// ============================================================================
+// Prompt → AnthropicRequest
+// ============================================================================
+
+/// Convert a provider-agnostic `Prompt` into an Anthropic-specific request
+/// body with `stream: true`.
+pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> AnthropicRequest {
+    let messages: Vec<AnthropicMessage> = prompt.messages.iter().map(convert_message).collect();
+
+    let system = if prompt.system.is_empty() {
+        None
+    } else {
+        Some(prompt.system.iter().map(convert_system_block).collect())
+    };
+
+    let tools = if prompt.tools.is_empty() {
+        None
+    } else {
+        Some(prompt.tools.iter().map(convert_tool).collect())
+    };
+
+    let tool_choice = prompt.tool_choice.as_ref().map(convert_tool_choice);
+
+    AnthropicRequest {
+        model: prompt.model.clone(),
+        messages,
+        system,
+        max_tokens: prompt.max_tokens.unwrap_or(8192),
+        temperature: None,
+        tools,
+        tool_choice,
+        stream: true,
+        thinking: None,
+    }
+}
+
+fn convert_system_block(block: &SystemBlock) -> AnthropicSystemBlock {
+    match block {
+        SystemBlock::Text {
+            text,
+            cache_control,
+        } => AnthropicSystemBlock {
+            r#type: "text".to_string(),
+            text: text.clone(),
+            cache_control: cache_control.as_ref().map(convert_cache_control),
+        },
+    }
+}
+
+fn convert_message(message: &Message) -> AnthropicMessage {
+    match message {
+        Message::User { content } => AnthropicMessage {
+            role: "user",
+            content: content.iter().map(convert_user_block).collect(),
+        },
+        Message::Assistant { content } => AnthropicMessage {
+            role: "assistant",
+            content: content.iter().map(convert_assistant_block).collect(),
+        },
+    }
+}
+
+fn convert_user_block(block: &UserBlock) -> AnthropicContent {
+    match block {
+        UserBlock::Text {
+            text,
+            cache_control,
+        } => AnthropicContent::Text {
+            text: text.clone(),
+            cache_control: cache_control.as_ref().map(convert_cache_control),
+        },
+        UserBlock::ToolResult {
+            tool_use_id,
+            content,
+            is_error,
+            cache_control,
+        } => AnthropicContent::ToolResult {
+            tool_use_id: tool_use_id.clone(),
+            content: content.iter().map(convert_tool_result_block).collect(),
+            is_error: if *is_error { Some(true) } else { None },
+            cache_control: cache_control.as_ref().map(convert_cache_control),
+        },
+    }
+}
+
+fn convert_tool_result_block(block: &ToolResultBlock) -> AnthropicToolResultContent {
+    match block {
+        ToolResultBlock::Text { text } => AnthropicToolResultContent::Text { text: text.clone() },
+    }
+}
+
+fn convert_assistant_block(block: &AssistantBlock) -> AnthropicContent {
+    match block {
+        AssistantBlock::Text {
+            text,
+            cache_control,
+        } => AnthropicContent::Text {
+            text: text.clone(),
+            cache_control: cache_control.as_ref().map(convert_cache_control),
+        },
+        AssistantBlock::ToolUse {
+            id,
+            name,
+            input,
+            cache_control,
+        } => AnthropicContent::ToolUse {
+            id: id.clone(),
+            name: name.clone(),
+            input: input.clone(),
+            cache_control: cache_control.as_ref().map(convert_cache_control),
+        },
+        AssistantBlock::Thinking { text, signature } => AnthropicContent::Thinking {
+            thinking: text.clone(),
+            signature: signature.clone().unwrap_or_default(),
+        },
+    }
+}
+
+fn convert_tool(tool: &Tool) -> AnthropicTool {
+    AnthropicTool {
+        name: tool.name.clone(),
+        description: tool.description.clone(),
+        input_schema: tool.input_schema.clone(),
+        cache_control: tool.cache_control.as_ref().map(convert_cache_control),
+    }
+}
+
+fn convert_tool_choice(choice: &ToolChoice) -> AnthropicToolChoice {
+    match choice {
+        ToolChoice::Auto => AnthropicToolChoice::Auto,
+        ToolChoice::Any => AnthropicToolChoice::Any,
+        ToolChoice::None => AnthropicToolChoice::None,
+        ToolChoice::Tool { name } => AnthropicToolChoice::Tool { name: name.clone() },
+    }
+}
+
+fn convert_cache_control(cc: &CacheControl) -> AnthropicCacheControl {
+    match cc {
+        CacheControl::Ephemeral { ttl } => AnthropicCacheControl {
+            r#type: "ephemeral".to_string(),
+            ttl: ttl.as_ref().map(|t| match t {
+                CacheTtl::FiveMinutes => "5m".to_string(),
+                CacheTtl::OneHour => "1h".to_string(),
+            }),
+        },
+    }
+}
+
+// ============================================================================
+// AccumulatedResponse → PromptResponse
+// ============================================================================
+
+/// Convert the internally-accumulated streaming result back to the
+/// provider-agnostic `PromptResponse` that callers expect.
+pub(crate) fn accumulated_to_response(acc: AccumulatedResponse) -> PromptResponse {
+    let content = acc
+        .content
+        .into_iter()
+        .map(convert_accumulated_block)
+        .collect();
+
+    let stop_reason = acc.stop_reason.map(|sr| match sr {
+        AccumulatedStopReason::EndTurn => StopReason::EndTurn,
+        AccumulatedStopReason::MaxTokens => StopReason::MaxTokens,
+        AccumulatedStopReason::ToolUse => StopReason::ToolUse,
+        AccumulatedStopReason::StopSequence => StopReason::StopSequence,
+    });
+
+    // Truncate u64 → u32 (safe for realistic token counts).
+    let usage = Usage {
+        input_tokens: acc.usage.input_tokens as u32,
+        output_tokens: acc.usage.output_tokens as u32,
+    };
+
+    PromptResponse {
+        content,
+        usage,
+        stop_reason,
+    }
+}
+
+fn convert_accumulated_block(block: AccumulatedBlock) -> AssistantBlock {
+    match block {
+        AccumulatedBlock::Text { text } => AssistantBlock::Text {
+            text,
+            cache_control: None,
+        },
+        AccumulatedBlock::Thinking {
+            thinking,
+            signature,
+        } => AssistantBlock::Thinking {
+            text: thinking,
+            signature,
+        },
+        AccumulatedBlock::ToolUse {
+            id,
+            name,
+            arguments,
+        } => AssistantBlock::ToolUse {
+            id,
+            name,
+            input: arguments,
+            cache_control: None,
+        },
+    }
+}

--- a/lib/anthropic-client/src/lib.rs
+++ b/lib/anthropic-client/src/lib.rs
@@ -1,9 +1,23 @@
-use serde::Deserialize;
+//! Anthropic Messages API client.
+//!
+//! Accepts the provider-agnostic types from `lib/llm` at the public boundary
+//! and uses Anthropic-specific types (ported from the Pi agent crate)
+//! internally. Streams SSE events and accumulates the response before
+//! returning a single `PromptResponse`.
+
+mod convert;
+mod sse;
+mod stream;
+mod types;
+
 use thiserror::Error;
 use tracing::instrument;
 
-use llm::prompt::AssistantBlock;
-use llm::{Prompt, PromptResponse, StopReason, Usage};
+use llm::{Prompt, PromptResponse};
+
+use crate::convert::{accumulated_to_response, prompt_to_request};
+use crate::sse::{parse_sse_stream, SseError};
+use crate::stream::StreamAccumulator;
 
 const API_URL: &str = "https://api.anthropic.com/v1/messages";
 const API_VERSION: &str = "2023-06-01";
@@ -14,11 +28,27 @@ pub enum AnthropicError {
     Http(#[from] reqwest::Error),
     #[error("AnthropicError - API: status={status}, message={message}")]
     Api { status: u16, message: String },
+    #[error("AnthropicError - SSE: {0}")]
+    Sse(String),
+    #[error("AnthropicError - Stream: {0}")]
+    Stream(String),
 }
 
-/// Thin Anthropic Messages API client. Accepts the provider-agnostic types
-/// from `lib/llm` and returns a single `PromptResponse` per call. Streaming
-/// onto channels is the executor's job — this crate is just the HTTP boundary.
+impl From<SseError> for AnthropicError {
+    fn from(e: SseError) -> Self {
+        match e {
+            SseError::Http(e) => Self::Http(e),
+            SseError::Processing(msg) => Self::Sse(msg),
+        }
+    }
+}
+
+/// Anthropic Messages API client. Converts provider-agnostic `Prompt` values
+/// into Anthropic-specific wire types, streams the SSE response, and
+/// accumulates the result into a single `PromptResponse`.
+///
+/// Internally uses types ported from the Pi agent crate. The public interface
+/// (`new`, `send_prompt`) remains unchanged so callers need no modifications.
 #[derive(Clone)]
 pub struct AnthropicClient {
     http: reqwest::Client,
@@ -33,19 +63,25 @@ impl AnthropicClient {
         }
     }
 
-    /// Issue a single Messages API request and return the assistant's reply.
-    /// The provider-agnostic [`Prompt`] is serialized straight to Anthropic's
-    /// wire format — caller is responsible for setting `max_tokens` (the API
-    /// requires it).
+    /// Issue a streaming Messages API request and return the fully-accumulated
+    /// assistant reply.
+    ///
+    /// Internally converts the provider-agnostic [`Prompt`] to Anthropic's
+    /// wire format, sends a streaming request, parses SSE events, and
+    /// accumulates text/tool-use/thinking blocks into a single
+    /// [`PromptResponse`].
     #[instrument(name = "anthropic_client.send_prompt", skip_all)]
     pub async fn send_prompt(&self, prompt: &Prompt) -> Result<PromptResponse, AnthropicError> {
+        let request_body = prompt_to_request(prompt);
+
         let resp = self
             .http
             .post(API_URL)
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", API_VERSION)
+            .header("accept", "text/event-stream")
             .header("content-type", "application/json")
-            .json(prompt)
+            .json(&request_body)
             .send()
             .await?;
 
@@ -58,21 +94,37 @@ impl AnthropicClient {
             });
         }
 
-        let wire: WireResponse = resp.json().await?;
-        Ok(PromptResponse {
-            content: wire.content,
-            usage: wire.usage,
-            stop_reason: wire.stop_reason,
-        })
-    }
-}
+        // Stream SSE events and accumulate the response.
+        let byte_stream = resp.bytes_stream();
+        let mut accumulator = StreamAccumulator::new();
 
-/// Subset of Anthropic's `messages` response we care about; ignores the
-/// envelope fields (`id`, `type`, `role`, `model`, `stop_sequence`).
-#[derive(Deserialize)]
-struct WireResponse {
-    content: Vec<AssistantBlock>,
-    usage: Usage,
-    #[serde(default)]
-    stop_reason: Option<StopReason>,
+        // We need to move the accumulator into the closure but also get it
+        // back after parsing completes. Use a mutable reference captured by
+        // the closure — `parse_sse_stream` takes `FnMut`.
+        let acc_ref = &mut accumulator;
+        let sse_result: Result<(), SseError> = parse_sse_stream(byte_stream, |event| {
+            // Skip ping events (keep-alive).
+            if event.event == "ping" {
+                return Ok(());
+            }
+            acc_ref
+                .process_event(&event.data)
+                .map_err(SseError::Processing)
+        })
+        .await;
+
+        // An SSE-level error from the API (e.g. `{"type":"error","error":{...}}`)
+        // is captured by the accumulator; HTTP/transport errors bubble up here.
+        if let Err(e) = sse_result {
+            // If the accumulator already captured partial content and the stream
+            // simply ended, return what we have. Otherwise propagate the error.
+            if accumulator.is_done() {
+                tracing::warn!(error = %e, "SSE stream error after message completed, returning partial response");
+            } else {
+                return Err(e.into());
+            }
+        }
+
+        Ok(accumulated_to_response(accumulator.finish()))
+    }
 }

--- a/lib/anthropic-client/src/sse.rs
+++ b/lib/anthropic-client/src/sse.rs
@@ -1,0 +1,189 @@
+//! Lightweight SSE (Server-Sent Events) parser for reqwest byte streams.
+//!
+//! Implements just enough of the SSE protocol to parse Anthropic's streaming
+//! responses. Adapted from the Pi agent crate's full SSE implementation but
+//! simplified to work with `reqwest::Response::bytes_stream()`.
+
+use futures::StreamExt;
+
+/// A parsed SSE event with its type and data payload.
+#[derive(Debug)]
+pub(crate) struct SseEvent {
+    /// Event type (from "event:" field, defaults to "message").
+    pub event: String,
+    /// Event data (from "data:" field(s), joined with newlines).
+    pub data: String,
+}
+
+/// Parse SSE events from a reqwest response's byte stream.
+///
+/// Collects all SSE events from the stream, calling `handler` for each
+/// complete event. This is a pull-based approach that processes the entire
+/// stream — appropriate because `send_prompt` needs the final accumulated
+/// result anyway.
+pub(crate) async fn parse_sse_stream<S, B, F>(mut stream: S, mut handler: F) -> Result<(), SseError>
+where
+    S: futures::Stream<Item = Result<B, reqwest::Error>> + Unpin,
+    B: AsRef<[u8]>,
+    F: FnMut(SseEvent) -> Result<(), SseError>,
+{
+    let mut buffer = String::new();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(SseError::Http)?;
+        buffer.push_str(&String::from_utf8_lossy(chunk.as_ref()));
+
+        // Process all complete events in the buffer.
+        // An event is terminated by a blank line (\n\n or \r\n\r\n).
+        loop {
+            let event_end = find_event_boundary(&buffer);
+            let Some(end_pos) = event_end else {
+                break;
+            };
+
+            let event_text = &buffer[..end_pos.text_end];
+            if let Some(event) = parse_single_event(event_text) {
+                handler(event)?;
+            }
+
+            // Remove the processed event + boundary from buffer
+            buffer.drain(..end_pos.drain_end);
+        }
+    }
+
+    // Process any trailing data in the buffer (stream closed mid-event)
+    if !buffer.trim().is_empty() {
+        if let Some(event) = parse_single_event(&buffer) {
+            handler(event)?;
+        }
+    }
+
+    Ok(())
+}
+
+struct EventBoundary {
+    /// End of the event text (before the blank-line separator).
+    text_end: usize,
+    /// Position to drain up to (past the blank-line separator).
+    drain_end: usize,
+}
+
+/// Find the position of the next event boundary (blank line) in the buffer.
+fn find_event_boundary(buf: &str) -> Option<EventBoundary> {
+    // Look for \n\n (the standard SSE event separator)
+    if let Some(pos) = buf.find("\n\n") {
+        return Some(EventBoundary {
+            text_end: pos,
+            drain_end: pos + 2,
+        });
+    }
+    // Also handle \r\n\r\n
+    if let Some(pos) = buf.find("\r\n\r\n") {
+        return Some(EventBoundary {
+            text_end: pos,
+            drain_end: pos + 4,
+        });
+    }
+    None
+}
+
+/// Parse a single SSE event from its text (lines between blank-line boundaries).
+fn parse_single_event(text: &str) -> Option<SseEvent> {
+    let mut event_type = String::from("message");
+    let mut data_lines: Vec<&str> = Vec::new();
+
+    for line in text.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with(':') {
+            // Comment line — skip
+            continue;
+        }
+        if let Some((field, value)) = line.split_once(':') {
+            let value = value.strip_prefix(' ').unwrap_or(value);
+            match field {
+                "event" => event_type = value.to_string(),
+                "data" => data_lines.push(value),
+                _ => {} // Ignore unknown fields (id, retry, etc.)
+            }
+        } else if line == "data" {
+            // Field with no colon — treat as field with empty value
+            data_lines.push("");
+        }
+    }
+
+    if data_lines.is_empty() {
+        return None;
+    }
+
+    Some(SseEvent {
+        event: event_type,
+        data: data_lines.join("\n"),
+    })
+}
+
+#[derive(Debug, thiserror::Error)]
+pub(crate) enum SseError {
+    #[error("HTTP stream error: {0}")]
+    Http(reqwest::Error),
+    #[error("Event processing error: {0}")]
+    Processing(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_simple_event() {
+        let text = "event: message_start\ndata: {\"type\":\"message_start\"}";
+        let event = parse_single_event(text).unwrap();
+        assert_eq!(event.event, "message_start");
+        assert_eq!(event.data, "{\"type\":\"message_start\"}");
+    }
+
+    #[test]
+    fn parse_event_with_default_type() {
+        let text = "data: hello";
+        let event = parse_single_event(text).unwrap();
+        assert_eq!(event.event, "message");
+        assert_eq!(event.data, "hello");
+    }
+
+    #[test]
+    fn parse_event_with_multiple_data_lines() {
+        let text = "data: line1\ndata: line2\ndata: line3";
+        let event = parse_single_event(text).unwrap();
+        assert_eq!(event.data, "line1\nline2\nline3");
+    }
+
+    #[test]
+    fn skip_comment_lines() {
+        let text = ": this is a comment\ndata: payload";
+        let event = parse_single_event(text).unwrap();
+        assert_eq!(event.data, "payload");
+    }
+
+    #[test]
+    fn no_event_without_data() {
+        let text = "event: ping";
+        assert!(parse_single_event(text).is_none());
+    }
+
+    #[test]
+    fn find_boundary_lf() {
+        let buf = "data: hello\n\ndata: world\n\n";
+        let b = find_event_boundary(buf).unwrap();
+        assert_eq!(&buf[..b.text_end], "data: hello");
+        assert_eq!(b.drain_end, 13);
+    }
+
+    #[test]
+    fn find_boundary_crlf() {
+        let buf = "data: hello\r\n\r\ndata: world\r\n\r\n";
+        let b = find_event_boundary(buf).unwrap();
+        assert_eq!(&buf[..b.text_end], "data: hello");
+        assert_eq!(b.drain_end, 15);
+    }
+}

--- a/lib/anthropic-client/src/stream.rs
+++ b/lib/anthropic-client/src/stream.rs
@@ -1,0 +1,362 @@
+//! Stream accumulator for Anthropic SSE events.
+//!
+//! Adapted from the Pi agent crate's `StreamState`. Processes streaming events
+//! one at a time and accumulates text blocks, tool calls, thinking blocks, and
+//! usage statistics into a final result that can be converted to `PromptResponse`.
+
+use crate::types::{
+    AnthropicContentBlock, AnthropicDelta, AnthropicDeltaUsage, AnthropicMessageDelta,
+    AnthropicMessageStart, AnthropicStopReason, AnthropicStreamEvent,
+};
+
+// ============================================================================
+// Accumulated content blocks (Pi-style internal types)
+// ============================================================================
+
+#[derive(Debug, Clone)]
+pub(crate) enum AccumulatedBlock {
+    Text {
+        text: String,
+    },
+    Thinking {
+        thinking: String,
+        signature: Option<String>,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        arguments: serde_json::Value,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum AccumulatedStopReason {
+    EndTurn,
+    MaxTokens,
+    ToolUse,
+    StopSequence,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct AccumulatedUsage {
+    pub input_tokens: u64,
+    pub output_tokens: u64,
+    pub cache_read_tokens: u64,
+    pub cache_write_tokens: u64,
+}
+
+/// Final accumulated result from processing a complete SSE stream.
+#[derive(Debug)]
+pub(crate) struct AccumulatedResponse {
+    pub content: Vec<AccumulatedBlock>,
+    pub usage: AccumulatedUsage,
+    pub stop_reason: Option<AccumulatedStopReason>,
+}
+
+// ============================================================================
+// Stream Accumulator
+// ============================================================================
+
+/// Stateful accumulator that processes `AnthropicStreamEvent`s and builds up
+/// the final response. Mirrors the Pi agent crate's `StreamState` but without
+/// the async stream machinery — we just call `process_event` for each SSE
+/// event and then `finish` to get the result.
+pub(crate) struct StreamAccumulator {
+    content: Vec<AccumulatedBlock>,
+    usage: AccumulatedUsage,
+    stop_reason: Option<AccumulatedStopReason>,
+    /// Buffer for tool-call JSON arguments being streamed incrementally.
+    current_tool_json: String,
+    current_tool_id: Option<String>,
+    current_tool_name: Option<String>,
+    /// Set to true once we've seen `MessageStop` or `Error`.
+    done: bool,
+    /// Error message from the API, if any.
+    error_message: Option<String>,
+}
+
+impl StreamAccumulator {
+    pub fn new() -> Self {
+        Self {
+            content: Vec::new(),
+            usage: AccumulatedUsage::default(),
+            stop_reason: None,
+            current_tool_json: String::new(),
+            current_tool_id: None,
+            current_tool_name: None,
+            done: false,
+            error_message: None,
+        }
+    }
+
+    /// Returns true if the stream is complete (MessageStop or Error received).
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
+    /// Process a single SSE event's JSON data. Returns an error string if the
+    /// API sent an error event.
+    pub fn process_event(&mut self, data: &str) -> Result<(), String> {
+        let event: AnthropicStreamEvent = serde_json::from_str(data)
+            .map_err(|e| format!("JSON parse error: {e}\nData: {data}"))?;
+
+        match event {
+            AnthropicStreamEvent::MessageStart { message } => {
+                self.handle_message_start(message);
+            }
+            AnthropicStreamEvent::ContentBlockStart {
+                index: _,
+                content_block,
+            } => {
+                self.handle_content_block_start(content_block);
+            }
+            AnthropicStreamEvent::ContentBlockDelta { index, delta } => {
+                self.handle_content_block_delta(index, delta);
+            }
+            AnthropicStreamEvent::ContentBlockStop { index } => {
+                self.handle_content_block_stop(index);
+            }
+            AnthropicStreamEvent::MessageDelta { delta, usage } => {
+                self.handle_message_delta(&delta, usage);
+            }
+            AnthropicStreamEvent::MessageStop => {
+                self.done = true;
+            }
+            AnthropicStreamEvent::Error { error } => {
+                self.done = true;
+                self.error_message = Some(error.message.clone());
+                return Err(error.message);
+            }
+            AnthropicStreamEvent::Ping => {}
+        }
+
+        Ok(())
+    }
+
+    /// Consume the accumulator and return the final response.
+    pub fn finish(self) -> AccumulatedResponse {
+        AccumulatedResponse {
+            content: self.content,
+            usage: self.usage,
+            stop_reason: self.stop_reason,
+        }
+    }
+
+    fn handle_message_start(&mut self, message: AnthropicMessageStart) {
+        if let Some(usage) = message.usage {
+            self.usage.input_tokens = usage.input;
+            self.usage.cache_read_tokens = usage.cache_read.unwrap_or(0);
+            self.usage.cache_write_tokens = usage.cache_write.unwrap_or(0);
+        }
+    }
+
+    fn handle_content_block_start(&mut self, content_block: AnthropicContentBlock) {
+        match content_block {
+            AnthropicContentBlock::Text => {
+                self.content.push(AccumulatedBlock::Text {
+                    text: String::new(),
+                });
+            }
+            AnthropicContentBlock::Thinking => {
+                self.content.push(AccumulatedBlock::Thinking {
+                    thinking: String::new(),
+                    signature: None,
+                });
+            }
+            AnthropicContentBlock::ToolUse { id, name } => {
+                self.current_tool_json.clear();
+                self.current_tool_id = id;
+                self.current_tool_name = name;
+                self.content.push(AccumulatedBlock::ToolUse {
+                    id: self.current_tool_id.clone().unwrap_or_default(),
+                    name: self.current_tool_name.clone().unwrap_or_default(),
+                    arguments: serde_json::Value::Null,
+                });
+            }
+        }
+    }
+
+    fn handle_content_block_delta(&mut self, index: u32, delta: AnthropicDelta) {
+        let idx = index as usize;
+
+        match delta {
+            AnthropicDelta::TextDelta { text } => {
+                if let Some(text) = text {
+                    if let Some(AccumulatedBlock::Text { text: ref mut t }) =
+                        self.content.get_mut(idx)
+                    {
+                        t.push_str(&text);
+                    }
+                }
+            }
+            AnthropicDelta::ThinkingDelta { thinking } => {
+                if let Some(thinking) = thinking {
+                    if let Some(AccumulatedBlock::Thinking {
+                        thinking: ref mut t,
+                        ..
+                    }) = self.content.get_mut(idx)
+                    {
+                        t.push_str(&thinking);
+                    }
+                }
+            }
+            AnthropicDelta::InputJsonDelta { partial_json } => {
+                if let Some(partial_json) = partial_json {
+                    self.current_tool_json.push_str(&partial_json);
+                }
+            }
+            AnthropicDelta::SignatureDelta { signature } => {
+                if let Some(sig) = signature {
+                    if let Some(AccumulatedBlock::Thinking {
+                        signature: ref mut s,
+                        ..
+                    }) = self.content.get_mut(idx)
+                    {
+                        *s = Some(sig);
+                    }
+                }
+            }
+        }
+    }
+
+    fn handle_content_block_stop(&mut self, index: u32) {
+        let idx = index as usize;
+
+        if let Some(AccumulatedBlock::ToolUse {
+            ref mut arguments, ..
+        }) = self.content.get_mut(idx)
+        {
+            // Parse the accumulated JSON string into a Value.
+            *arguments = match serde_json::from_str(&self.current_tool_json) {
+                Ok(args) => args,
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        raw = %self.current_tool_json,
+                        "Failed to parse tool arguments as JSON"
+                    );
+                    serde_json::Value::Null
+                }
+            };
+            self.current_tool_json.clear();
+        }
+    }
+
+    fn handle_message_delta(
+        &mut self,
+        delta: &AnthropicMessageDelta,
+        usage: Option<AnthropicDeltaUsage>,
+    ) {
+        if let Some(stop_reason) = delta.stop_reason {
+            self.stop_reason = Some(match stop_reason {
+                AnthropicStopReason::EndTurn => AccumulatedStopReason::EndTurn,
+                AnthropicStopReason::MaxTokens => AccumulatedStopReason::MaxTokens,
+                AnthropicStopReason::ToolUse => AccumulatedStopReason::ToolUse,
+                AnthropicStopReason::StopSequence => AccumulatedStopReason::StopSequence,
+            });
+        }
+
+        if let Some(u) = usage {
+            self.usage.output_tokens = u.output_tokens;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accumulates_text_block() {
+        let mut acc = StreamAccumulator::new();
+
+        // message_start
+        acc.process_event(r#"{"type":"message_start","message":{"usage":{"input_tokens":10}}}"#)
+            .unwrap();
+
+        // content_block_start (text)
+        acc.process_event(
+            r#"{"type":"content_block_start","index":0,"content_block":{"type":"text"}}"#,
+        )
+        .unwrap();
+
+        // text deltas
+        acc.process_event(r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"Hello"}}"#)
+            .unwrap();
+        acc.process_event(r#"{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":" world"}}"#)
+            .unwrap();
+
+        // content_block_stop
+        acc.process_event(r#"{"type":"content_block_stop","index":0}"#)
+            .unwrap();
+
+        // message_delta with stop reason
+        acc.process_event(r#"{"type":"message_delta","delta":{"stop_reason":"end_turn"},"usage":{"output_tokens":5}}"#)
+            .unwrap();
+
+        // message_stop
+        acc.process_event(r#"{"type":"message_stop"}"#).unwrap();
+
+        assert!(acc.is_done());
+        let result = acc.finish();
+
+        assert_eq!(result.content.len(), 1);
+        match &result.content[0] {
+            AccumulatedBlock::Text { text } => assert_eq!(text, "Hello world"),
+            _ => panic!("expected text block"),
+        }
+        assert_eq!(result.usage.input_tokens, 10);
+        assert_eq!(result.usage.output_tokens, 5);
+        assert!(matches!(
+            result.stop_reason,
+            Some(AccumulatedStopReason::EndTurn)
+        ));
+    }
+
+    #[test]
+    fn accumulates_tool_use() {
+        let mut acc = StreamAccumulator::new();
+
+        acc.process_event(r#"{"type":"message_start","message":{}}"#)
+            .unwrap();
+        acc.process_event(r#"{"type":"content_block_start","index":0,"content_block":{"type":"tool_use","id":"tu_1","name":"get_weather"}}"#)
+            .unwrap();
+        acc.process_event(r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"{\"loc"}}"#)
+            .unwrap();
+        acc.process_event(r#"{"type":"content_block_delta","index":0,"delta":{"type":"input_json_delta","partial_json":"ation\":\"NYC\"}"}}"#)
+            .unwrap();
+        acc.process_event(r#"{"type":"content_block_stop","index":0}"#)
+            .unwrap();
+        acc.process_event(r#"{"type":"message_delta","delta":{"stop_reason":"tool_use"},"usage":{"output_tokens":20}}"#)
+            .unwrap();
+        acc.process_event(r#"{"type":"message_stop"}"#).unwrap();
+
+        let result = acc.finish();
+        assert_eq!(result.content.len(), 1);
+        match &result.content[0] {
+            AccumulatedBlock::ToolUse {
+                id,
+                name,
+                arguments,
+            } => {
+                assert_eq!(id, "tu_1");
+                assert_eq!(name, "get_weather");
+                assert_eq!(arguments, &serde_json::json!({"location": "NYC"}));
+            }
+            _ => panic!("expected tool use block"),
+        }
+        assert!(matches!(
+            result.stop_reason,
+            Some(AccumulatedStopReason::ToolUse)
+        ));
+    }
+
+    #[test]
+    fn handles_api_error() {
+        let mut acc = StreamAccumulator::new();
+        let result = acc.process_event(r#"{"type":"error","error":{"message":"rate limited"}}"#);
+        assert!(result.is_err());
+        assert_eq!(result.unwrap_err(), "rate limited");
+        assert!(acc.is_done());
+    }
+}

--- a/lib/anthropic-client/src/types.rs
+++ b/lib/anthropic-client/src/types.rs
@@ -1,0 +1,252 @@
+//! Anthropic Messages API types ported from the Pi agent crate.
+//!
+//! These types model the Anthropic wire format for both requests and streaming
+//! responses. They are used internally by `AnthropicClient` and are NOT exposed
+//! to callers — the public boundary uses the provider-agnostic types from
+//! `lib/llm`.
+
+use serde::{Deserialize, Serialize};
+
+// ============================================================================
+// Request Types
+// ============================================================================
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AnthropicRequest {
+    pub model: String,
+    pub messages: Vec<AnthropicMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system: Option<Vec<AnthropicSystemBlock>>,
+    pub max_tokens: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<AnthropicTool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<AnthropicToolChoice>,
+    pub stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub thinking: Option<AnthropicThinking>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AnthropicThinking {
+    pub r#type: &'static str,
+    pub budget_tokens: u32,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AnthropicMessage {
+    pub role: &'static str,
+    pub content: Vec<AnthropicContent>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum AnthropicContent {
+    Text {
+        text: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<AnthropicCacheControl>,
+    },
+    Thinking {
+        thinking: String,
+        signature: String,
+    },
+    #[allow(dead_code)]
+    Image {
+        source: AnthropicImageSource,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        input: serde_json::Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<AnthropicCacheControl>,
+    },
+    ToolResult {
+        tool_use_id: String,
+        content: Vec<AnthropicToolResultContent>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        is_error: Option<bool>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cache_control: Option<AnthropicCacheControl>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct AnthropicCacheControl {
+    pub r#type: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ttl: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AnthropicImageSource {
+    pub r#type: &'static str,
+    pub media_type: String,
+    pub data: String,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum AnthropicToolResultContent {
+    Text {
+        text: String,
+    },
+    #[allow(dead_code)]
+    Image {
+        source: AnthropicImageSource,
+    },
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AnthropicTool {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub input_schema: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<AnthropicCacheControl>,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum AnthropicToolChoice {
+    Auto,
+    Any,
+    None,
+    Tool { name: String },
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct AnthropicSystemBlock {
+    pub r#type: String,
+    pub text: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cache_control: Option<AnthropicCacheControl>,
+}
+
+// ============================================================================
+// Streaming Response Types
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum AnthropicStreamEvent {
+    MessageStart {
+        message: AnthropicMessageStart,
+    },
+    ContentBlockStart {
+        #[allow(dead_code)]
+        index: u32,
+        content_block: AnthropicContentBlock,
+    },
+    ContentBlockDelta {
+        index: u32,
+        delta: AnthropicDelta,
+    },
+    ContentBlockStop {
+        index: u32,
+    },
+    MessageDelta {
+        delta: AnthropicMessageDelta,
+        #[serde(default)]
+        usage: Option<AnthropicDeltaUsage>,
+    },
+    MessageStop,
+    Error {
+        error: AnthropicErrorBody,
+    },
+    Ping,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AnthropicMessageStart {
+    #[serde(default)]
+    pub usage: Option<AnthropicUsage>,
+}
+
+/// Usage statistics from Anthropic API.
+/// Field names match the API response format.
+#[derive(Debug, Deserialize)]
+#[allow(clippy::struct_field_names)]
+pub(crate) struct AnthropicUsage {
+    #[serde(rename = "input_tokens")]
+    pub input: u64,
+    #[serde(default, rename = "cache_read_input_tokens")]
+    pub cache_read: Option<u64>,
+    #[serde(default, rename = "cache_creation_input_tokens")]
+    pub cache_write: Option<u64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AnthropicDeltaUsage {
+    pub output_tokens: u64,
+}
+
+/// Content block type from `content_block_start`.
+///
+/// Using a tagged enum avoids allocating a `String` for the type field.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum AnthropicContentBlock {
+    Text,
+    Thinking,
+    ToolUse {
+        #[serde(default)]
+        id: Option<String>,
+        #[serde(default)]
+        name: Option<String>,
+    },
+}
+
+/// Per-token delta from the Anthropic streaming API.
+///
+/// Using a tagged enum instead of a flat struct with `r#type: String` avoids
+/// allocating a `String` for the type discriminant on every content_block_delta
+/// event (the hottest path -- one allocation per streamed token).
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+#[allow(clippy::enum_variant_names)]
+pub(crate) enum AnthropicDelta {
+    TextDelta {
+        #[serde(default)]
+        text: Option<String>,
+    },
+    ThinkingDelta {
+        #[serde(default)]
+        thinking: Option<String>,
+    },
+    InputJsonDelta {
+        #[serde(default)]
+        partial_json: Option<String>,
+    },
+    SignatureDelta {
+        #[serde(default)]
+        signature: Option<String>,
+    },
+}
+
+/// Stop reason from `message_delta`.
+///
+/// Using an enum avoids allocating a `String` for the stop reason.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum AnthropicStopReason {
+    EndTurn,
+    MaxTokens,
+    ToolUse,
+    StopSequence,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AnthropicMessageDelta {
+    #[serde(default)]
+    pub stop_reason: Option<AnthropicStopReason>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct AnthropicErrorBody {
+    pub message: String,
+}


### PR DESCRIPTION
## Summary
- Replace the thin non-streaming HTTP wrapper in `lib/anthropic-client` with an SSE-streaming implementation ported from the Pi agent crate
- Public API (`AnthropicClient::new`, `send_prompt`) is **unchanged** — callers need zero modifications
- Internally, requests now use `stream: true` and parse SSE events, accumulating the response before returning

## Changes
| New module | Purpose |
|---|---|
| `types.rs` | Anthropic-specific request & streaming response types from Pi (tagged enums for stream events, content blocks, deltas, stop reasons) |
| `sse.rs` | Lightweight SSE parser for reqwest byte streams |
| `stream.rs` | `StreamAccumulator` adapted from Pi's `StreamState` — processes SSE events, accumulates text/tool-use/thinking blocks and usage |
| `convert.rs` | Boundary adapters: `Prompt` → `AnthropicRequest` and `AccumulatedResponse` → `PromptResponse` |

## Test plan
- [x] All 10 anthropic-client unit tests pass (SSE parsing, stream accumulation, error handling)
- [x] All 7 llm crate tests pass
- [x] Full workspace compiles (`cargo check`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `nix flake check` passes (fmt + clippy + nextest)
- [ ] Integration test with live Anthropic API (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)