### PR TITLE
feat(dev): add podman support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,15 +2,20 @@ PG_CON ?= postgres://user:password@localhost:5432/galoy_agents
 GITHUB_CLIENT_SECRET ?= dev-secret
 ANTHROPIC_API_KEY ?= $(shell echo $$ANTHROPIC_API_KEY)
 
+# ── Container engine ─────────────────────────────────────────────────────────────
+# Set by the nix devShell shellHook. Override with: make start ENGINE_DEFAULT=docker
+ENGINE_DEFAULT ?= $(shell command -v podman >/dev/null 2>&1 && echo podman || echo docker)
+COMPOSE_CMD = $(ENGINE_DEFAULT) compose
+
 clean-deps:
-	docker compose down -v
+	$(COMPOSE_CMD) down -v
 
 start-deps:
-	docker compose up -d
+	$(COMPOSE_CMD) up -d
 
 setup-db:
 	@echo "Waiting for PostgreSQL..."
-	@until docker compose exec postgres pg_isready -U user -d galoy_agents > /dev/null 2>&1; do sleep 1; done
+	@until $(COMPOSE_CMD) exec postgres pg_isready -U user -d galoy_agents > /dev/null 2>&1; do sleep 1; done
 	@echo "PostgreSQL ready"
 	DATABASE_URL=$(PG_CON) cargo sqlx migrate run --source core/migrations
 

--- a/flake.nix
+++ b/flake.nix
@@ -305,6 +305,8 @@
             pkgs.postgresql
             pkgs.pkg-config
             pkgs.docker-compose
+            pkgs.podman
+            pkgs.podman-compose
             pkgs.opentofu
             pkgs.ytt
             pkgs.kubernetes-helm
@@ -317,7 +319,17 @@
           ];
 
           shellHook = ''
-            echo "galoy-agents dev shell loaded"
+            # Container engine auto-detection
+            unset DOCKER_HOST
+            if [[ -n "''${ENGINE_DEFAULT:-}" ]]; then
+              :
+            elif command -v podman &>/dev/null && ! command -v docker &>/dev/null; then
+              export ENGINE_DEFAULT=podman
+            else
+              export ENGINE_DEFAULT=docker
+            fi
+
+            echo "galoy-agents dev shell loaded (engine: $ENGINE_DEFAULT)"
           '';
         };
       }


### PR DESCRIPTION
## Summary
- Replace hardcoded `docker compose` in Makefile with `$(ENGINE_DEFAULT) compose`, auto-detected from PATH or overridable via env var
- Add `podman` and `podman-compose` to the nix devShell
- Add engine auto-detection to the devShell shellHook (prefers podman when docker is absent, otherwise docker; explicit `ENGINE_DEFAULT` in `.env` takes priority)

## Test plan
- [ ] `direnv reload` picks up the new shellHook and prints detected engine
- [ ] `make start-deps` uses `podman compose` when `ENGINE_DEFAULT=podman`
- [ ] `make start-deps` still uses `docker compose` when docker is the default
- [ ] CI (bats workflow) unaffected — it uses `nix run .#bats` with its own `COMPOSE_CMD`

🤖 Generated with [Claude Code](https://claude.com/claude-code)