### PR TITLE
feat(auth): add dev login bypass

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -6,7 +6,7 @@ use galoy_agents_core::agent::AgentsConfig;
 use galoy_agents_core::prompt_executor::{ModelConfig, PromptExecutorConfig, Provider};
 use galoy_agents_core::sandbox::SandboxConfig;
 use galoy_agents_core::toolset::ToolSetsConfig;
-use galoy_agents_web::auth::config::AuthConfig;
+use galoy_agents_web::auth::config::{AuthConfig, LoginMethod};
 
 #[derive(Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -116,6 +116,8 @@ impl Default for ServerConfig {
 #[serde(deny_unknown_fields)]
 pub struct OAuthConfig {
     #[serde(default)]
+    pub login: LoginMethod,
+    #[serde(default)]
     pub github_redirect_uri: String,
     #[serde(default)]
     pub github_client_id: String,
@@ -190,6 +192,7 @@ impl Config {
 
     pub fn auth_config(&self) -> AuthConfig {
         AuthConfig {
+            login: self.oauth.login.clone(),
             github_client_id: self.oauth.github_client_id.clone(),
             github_client_secret: self.oauth.github_client_secret.clone(),
             github_redirect_uri: self.oauth.github_redirect_uri.clone(),

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -17,7 +17,7 @@ struct Cli {
     pg_con: String,
 
     /// GitHub OAuth client secret
-    #[arg(long, env = "GITHUB_CLIENT_SECRET")]
+    #[arg(long, env = "GITHUB_CLIENT_SECRET", default_value = "")]
     github_client_secret: String,
 
     /// Comma-separated list of allowed GitHub teams (org/team-slug format).
@@ -100,6 +100,7 @@ async fn main() -> anyhow::Result<()> {
     let mut app_state = galoy_agents_web::AppState::new(
         app,
         oauth_client,
+        auth_config.login,
         config.server.mcp_endpoint.clone(),
         auth_config.github_allowed_teams,
     );

--- a/galoy-agents.yml
+++ b/galoy-agents.yml
@@ -4,7 +4,7 @@ server:
   secure_cookies: false
   mcp_endpoint: "http://localhost:4200/mcp"
 oauth:
-  login: dev
+  login: github
   github_client_id: "Ov23li9ZTNnKjiTRwDcb"
   github_redirect_uri: "http://localhost:4200/auth/github/callback"
   github_allowed_teams: []

--- a/galoy-agents.yml
+++ b/galoy-agents.yml
@@ -4,6 +4,7 @@ server:
   secure_cookies: false
   mcp_endpoint: "http://localhost:4200/mcp"
 oauth:
+  login: dev
   github_client_id: "Ov23li9ZTNnKjiTRwDcb"
   github_redirect_uri: "http://localhost:4200/auth/github/callback"
   github_allowed_teams: []

--- a/web/src/auth/config.rs
+++ b/web/src/auth/config.rs
@@ -3,6 +3,7 @@ use oauth2::{
     RevocationErrorResponseType, StandardErrorResponse, StandardRevocableToken,
     StandardTokenIntrospectionResponse, StandardTokenResponse, TokenUrl,
 };
+use serde::Deserialize;
 
 const GITHUB_AUTH_URL: &str = "https://github.com/login/oauth/authorize";
 const GITHUB_TOKEN_URL: &str = "https://github.com/login/oauth/access_token";
@@ -24,8 +25,17 @@ pub type OAuthClient = oauth2::Client<
     EndpointSet,
 >;
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LoginMethod {
+    Dev,
+    #[default]
+    GitHub,
+}
+
 #[derive(Debug, Clone)]
 pub struct AuthConfig {
+    pub login: LoginMethod,
     pub github_client_id: String,
     pub github_client_secret: String,
     pub github_redirect_uri: String,

--- a/web/src/auth/mod.rs
+++ b/web/src/auth/mod.rs
@@ -4,7 +4,13 @@ mod oauth;
 pub mod sa_token;
 pub mod session_store;
 
-use axum::{extract::Request, middleware::Next, response::Response, routing::get, Router};
+use axum::{
+    extract::{Request, State},
+    middleware::Next,
+    response::Response,
+    routing::{get, post},
+    Router,
+};
 use tower_sessions::Session;
 use tracing::instrument;
 
@@ -19,11 +25,12 @@ use domain::primitives::UserId;
 
 use crate::AppState;
 
-/// Build the router for GitHub OAuth endpoints.
+/// Build the router for GitHub OAuth and dev-login endpoints.
 pub fn auth_router() -> Router<AppState> {
     Router::new()
         .route("/auth/github", get(oauth::github_redirect))
         .route("/auth/github/callback", get(oauth::github_callback))
+        .route("/auth/dev", post(dev_login))
         .route("/auth/logout", get(logout))
 }
 
@@ -128,6 +135,35 @@ async fn resolve_auth_context(
     }
 
     AuthSubject::Anonymous
+}
+
+#[instrument(name = "web.auth.dev_login", skip_all)]
+async fn dev_login(
+    State(state): State<AppState>,
+    session: Session,
+) -> Result<axum::response::Redirect, AuthError> {
+    if state.login != crate::auth::config::LoginMethod::Dev {
+        return Err(AuthError::OAuth("Dev login is not enabled".into()));
+    }
+
+    let dev_github_id = "dev-local";
+    let user = match state.app.users().find_by_github_id(dev_github_id).await? {
+        Some(user) => user,
+        None => {
+            state
+                .app
+                .users()
+                .create_from_github_login(
+                    dev_github_id.to_string(),
+                    Some("dev@localhost".to_string()),
+                    Some("Dev User".to_string()),
+                )
+                .await?
+        }
+    };
+
+    session.insert("user_id", user.id).await?;
+    Ok(axum::response::Redirect::to("/"))
 }
 
 #[instrument(name = "web.auth.logout", skip_all)]

--- a/web/src/lib.rs
+++ b/web/src/lib.rs
@@ -9,7 +9,7 @@ use galoy_agents_core as domain;
 
 use domain::App;
 
-use auth::config::OAuthClient;
+use auth::config::{LoginMethod, OAuthClient};
 use auth::sa_token::SaTokenValidator;
 use domain::code_assistant::CodeAssistant;
 
@@ -18,6 +18,7 @@ use domain::code_assistant::CodeAssistant;
 pub struct AppState {
     pub app: App,
     pub oauth_client: OAuthClient,
+    pub login: LoginMethod,
     pub mcp_endpoint: String,
     pub github_allowed_teams: Vec<String>,
     pub code_assistant: Option<CodeAssistant>,
@@ -29,6 +30,7 @@ impl AppState {
     pub fn new(
         app: App,
         oauth_client: OAuthClient,
+        login: LoginMethod,
         mcp_endpoint: String,
         github_allowed_teams: Vec<String>,
     ) -> Self {
@@ -36,6 +38,7 @@ impl AppState {
         Self {
             app,
             oauth_client,
+            login,
             mcp_endpoint,
             github_allowed_teams,
             code_assistant,

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -120,12 +120,17 @@ fn mcp_creds_to_view(creds: &McpCreds) -> McpCredsView {
 }
 
 #[instrument(name = "web.index", skip_all)]
-async fn index(session: Session, Query(params): Query<IndexParams>) -> Response {
+async fn index(
+    State(state): State<AppState>,
+    session: Session,
+    Query(params): Query<IndexParams>,
+) -> Response {
     if extract_user_id(&session).await.is_some() {
         return Redirect::to("/dashboard").into_response();
     }
     LoginTemplate {
         error: params.error,
+        dev_auth: state.login == crate::auth::config::LoginMethod::Dev,
     }
     .into_response()
 }

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -15,6 +15,7 @@ pub struct McpCredsView {
 #[template(path = "login.html")]
 pub struct LoginTemplate {
     pub error: Option<String>,
+    pub dev_auth: bool,
 }
 
 #[derive(Template, WebTemplate)]

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -24,10 +24,11 @@
           Login as Dev User
         </button>
       </form>
-      {% endif %}
-      <a href="/auth/github" role="button" {% if dev_auth %}class="secondary"{% endif %} style="display: block; text-align: center;">
+      {% else %}
+      <a href="/auth/github" role="button" style="display: block; text-align: center;">
         Sign in with GitHub
       </a>
+      {% endif %}
     </article>
   </main>
 </body>

--- a/web/templates/login.html
+++ b/web/templates/login.html
@@ -18,7 +18,14 @@
         {{ msg }}
       </div>
       {% endif %}
-      <a href="/auth/github" role="button" style="display: block; text-align: center;">
+      {% if dev_auth %}
+      <form method="post" action="/auth/dev">
+        <button type="submit" style="display: block; width: 100%; text-align: center;">
+          Login as Dev User
+        </button>
+      </form>
+      {% endif %}
+      <a href="/auth/github" role="button" {% if dev_auth %}class="secondary"{% endif %} style="display: block; text-align: center;">
         Sign in with GitHub
       </a>
     </article>


### PR DESCRIPTION
## Summary
- Adds a configurable `login` method enum (`dev` | `github`) under `oauth:` in `galoy-agents.yml`
- When `login: dev`, the login page shows a "Login as Dev User" button that creates a local dev user without needing GitHub OAuth
- `GITHUB_CLIENT_SECRET` env var is now optional (defaults to `""`)
- Default config ships with `login: dev` for local development; production defaults to `github`

## Test plan
- [ ] `make start` with `login: dev` — verify "Login as Dev User" button appears and logs in
- [ ] `make start` with `login: github` + real OAuth creds — verify GitHub login still works
- [ ] `POST /auth/dev` with `login: github` returns error (route is guarded)
- [ ] Verify no regression on existing bearer token / SA token auth paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)