### PR TITLE
chore(ci): switch to Ubicloud runners

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -1,0 +1,20 @@
+name: "setup-nix"
+
+description: "Install Nix and configure Cachix."
+
+inputs:
+  cachix_auth_token:
+    description: "Cachix authentication token."
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - uses: DeterminateSystems/nix-installer-action@v16
+    - uses: cachix/cachix-action@v17
+      if: inputs.cachix_auth_token != ''
+      with:
+        name: galoy-agents
+        authToken: ${{ inputs.cachix_auth_token }}
+        skipPush: false

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   bats:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-8
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main

--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -5,11 +5,17 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   bats:
     runs-on: ubicloud-standard-8
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-nix
+        with:
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - run: COMPOSE_CMD="docker compose" nix run .#bats

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,11 +5,17 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
     runs-on: ubicloud-standard-8
+    timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
-      - uses: DeterminateSystems/nix-installer-action@main
-      - uses: DeterminateSystems/magic-nix-cache-action@main
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup-nix
+        with:
+          cachix_auth_token: ${{ secrets.CACHIX_AUTH_TOKEN }}
       - run: nix flake check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check:
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-8
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main


### PR DESCRIPTION
## Summary
- Switch GitHub Actions runners from `ubuntu-latest` to `ubicloud-standard-8`
- Faster and cheaper CI runs, matching lana-bank's setup

## Test plan
- [ ] Verify `check` workflow passes on Ubicloud runner
- [ ] Verify `bats` workflow passes on Ubicloud runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)