### PR TITLE
fix(ci): use correct Cachix cache name

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -15,6 +15,6 @@ runs:
     - uses: cachix/cachix-action@v17
       if: inputs.cachix_auth_token != ''
       with:
-        name: galoy-agents
+        name: galoy-agents-github-action
         authToken: ${{ inputs.cachix_auth_token }}
         skipPush: false


### PR DESCRIPTION
Use galoy-agents-github-action cache (separate from Concourse's galoy-agents cache).