### PR TITLE
feat(cli): add --set flag for YAML config overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,9 +28,9 @@ build-sandbox:
 	cargo build -p sandbox-tool-server
 
 run-server: build-sandbox
-	@PG_CON=$(PG_CON) GITHUB_CLIENT_SECRET=$(GITHUB_CLIENT_SECRET) ANTHROPIC_API_KEY=$(ANTHROPIC_API_KEY) cargo run -p galoy-agents-cli
+	@PG_CON=$(PG_CON) GITHUB_CLIENT_SECRET=$(GITHUB_CLIENT_SECRET) ANTHROPIC_API_KEY=$(ANTHROPIC_API_KEY) cargo run -p galoy-agents-cli -- $(ARGS)
 
 nix-run-server:
-	@PG_CON=$(PG_CON) GITHUB_CLIENT_SECRET=$(GITHUB_CLIENT_SECRET) ANTHROPIC_API_KEY=$(ANTHROPIC_API_KEY) nix run .
+	@PG_CON=$(PG_CON) GITHUB_CLIENT_SECRET=$(GITHUB_CLIENT_SECRET) ANTHROPIC_API_KEY=$(ANTHROPIC_API_KEY) nix run . -- $(ARGS)
 
 start: reset-deps run-server

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use anyhow::Context;
 use serde::Deserialize;
 
 use galoy_agents_core::agent::AgentsConfig;
@@ -142,7 +143,11 @@ pub struct EnvSecrets {
 }
 
 impl Config {
-    pub fn try_new(path: impl AsRef<Path>, secrets: EnvSecrets) -> anyhow::Result<Self> {
+    pub fn try_new(
+        path: impl AsRef<Path>,
+        secrets: EnvSecrets,
+        config_overrides: &[String],
+    ) -> anyhow::Result<Self> {
         let config_file = std::fs::read_to_string(&path).map_err(|e| {
             anyhow::anyhow!(
                 "Couldn't read config file {:?}: {}",
@@ -151,7 +156,17 @@ impl Config {
             )
         })?;
 
-        let mut config: Config = serde_yaml::from_str(&config_file)
+        let mut yaml_value: serde_yaml::Value = serde_yaml::from_str(&config_file)
+            .map_err(|e| anyhow::anyhow!("Invalid config: {e}"))?;
+
+        for override_str in config_overrides {
+            let (key, value) = override_str.split_once('=').context(format!(
+                "Invalid override format '{override_str}', expected KEY=VALUE"
+            ))?;
+            apply_yaml_override(&mut yaml_value, key, value)?;
+        }
+
+        let mut config: Config = serde_yaml::from_value(yaml_value)
             .map_err(|e| anyhow::anyhow!("Invalid config: {e}"))?;
 
         config.db.pg_con = secrets.pg_con;
@@ -199,4 +214,30 @@ impl Config {
             github_allowed_teams: self.oauth.github_allowed_teams.clone(),
         }
     }
+}
+
+fn apply_yaml_override(
+    root: &mut serde_yaml::Value,
+    key: &str,
+    value: &str,
+) -> anyhow::Result<()> {
+    let parts: Vec<&str> = key.split('.').collect();
+    let mut current = root;
+
+    for (i, part) in parts.iter().enumerate() {
+        if i == parts.len() - 1 {
+            let parsed_value = serde_yaml::from_str(value)
+                .unwrap_or_else(|_| serde_yaml::Value::String(value.to_string()));
+            current[*part] = parsed_value;
+        } else {
+            if !current.get(*part).is_some_and(|v| v.is_mapping()) {
+                current[*part] = serde_yaml::Value::Mapping(serde_yaml::Mapping::new());
+            }
+            current = current
+                .get_mut(*part)
+                .context(format!("Failed to traverse config key '{key}'"))?;
+        }
+    }
+
+    Ok(())
 }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -216,11 +216,7 @@ impl Config {
     }
 }
 
-fn apply_yaml_override(
-    root: &mut serde_yaml::Value,
-    key: &str,
-    value: &str,
-) -> anyhow::Result<()> {
+fn apply_yaml_override(root: &mut serde_yaml::Value, key: &str, value: &str) -> anyhow::Result<()> {
     let parts: Vec<&str> = key.split('.').collect();
     let mut current = root;
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -28,6 +28,11 @@ struct Cli {
     /// Anthropic API key for the light agent runtime.
     #[arg(long, env = "ANTHROPIC_API_KEY", default_value = "")]
     anthropic_api_key: String,
+
+    /// Override values in the YAML config file using dot-separated paths.
+    /// Example: --set oauth.login=dev
+    #[clap(long = "set", value_name = "KEY=VALUE")]
+    config_overrides: Vec<String>,
 }
 
 #[tokio::main]
@@ -57,6 +62,7 @@ async fn main() -> anyhow::Result<()> {
             github_allowed_teams: allowed_teams,
             anthropic_api_key: cli.anthropic_api_key,
         },
+        &cli.config_overrides,
     )?;
 
     let pool = sqlx::PgPool::connect(&config.db.pg_con).await?;


### PR DESCRIPTION
## Summary
- Adds `--set KEY=VALUE` CLI flag (repeatable) to override any YAML config value using dot-separated paths
- Overrides are applied to the raw YAML before deserialization, so any config field is overridable
- Values are parsed as YAML first (booleans, numbers), falling back to plain strings
- Matches the same pattern used by lana-cli

Example usage:
```bash
make start ARGS="--set oauth.login=dev"
# or directly:
cargo run -p galoy-agents-cli -- --set oauth.login=dev --set server.port=4201
```

## Test plan
- [ ] `--set oauth.login=dev` overrides login method without changing the YAML file
- [ ] `--set server.port=4201` correctly parses as number
- [ ] `--set server.secure_cookies=false` correctly parses as boolean
- [ ] Multiple `--set` flags work together
- [ ] Invalid format (missing `=`) produces a clear error
- [ ] No `--set` flags preserves existing behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)