### PR TITLE
fix(sandbox): correct misleading Suspended state doc comment

### DIFF
--- a/core/src/sandbox/entity.rs
+++ b/core/src/sandbox/entity.rs
@@ -33,9 +33,11 @@ pub enum SandboxState {
     /// `/execute` calls.
     Ready,
     /// The sandbox has been suspended via the admin client — the underlying
-    /// pod/process has been deleted, but workspace state survives (k8s: the
-    /// PVC is retained; local: the `.sandboxes/<name>/` directory is left
-    /// in place). Recreating with the same name resumes from that state.
+    /// pod/process has been deleted. On the local backend the
+    /// `.sandboxes/<name>/` directory is left in place so workspace state
+    /// survives a restart. On k8s, workspace state is ephemeral unless
+    /// persistence is configured via `K8sAdminClient::with_persistence`;
+    /// without it, a restart re-clones from scratch.
     Suspended,
     /// A step in the provisioning / restart lifecycle failed. The failure
     /// reason is recorded on the entity as `last_error` and emitted as a


### PR DESCRIPTION
## Summary
- The `Suspended` state doc comment claimed workspace state always survives on k8s via a retained PVC
- In reality, `K8sAdminClient::with_persistence()` is never called — sandbox pods use ephemeral storage, and a restart re-clones from scratch
- Updated the comment to accurately describe the behavior on each backend

## Test plan
- [ ] Verify the comment reads correctly in `core/src/sandbox/entity.rs`
- [ ] No behavioral changes — doc comment only

🤖 Generated with [Claude Code](https://claude.com/claude-code)