### PR TITLE
chore(sandbox): use gitMinimal to reduce image size

### DIFF
--- a/images/sandbox/default.nix
+++ b/images/sandbox/default.nix
@@ -50,7 +50,7 @@ pkgs.dockerTools.buildLayeredImage {
     group
     pkgs.bashInteractive
     pkgs.coreutils
-    pkgs.git
+    pkgs.gitMinimal
     pkgs.curl
     pkgs.cacert
     pkgs.findutils


### PR DESCRIPTION
## Summary
- Switch sandbox image from `pkgs.git` to `pkgs.gitMinimal`
- Drops perl, python, apple-sdk, clang, and other extras not needed for basic clone/credential operations
- ~10x reduction on macOS: 1.5 GiB → 146 MB
- ~2x reduction on Linux: 348 MB → 152 MB

## Test plan
- [ ] Verify sandbox can still clone repos (public and private via credential helper)
- [ ] Verify `git` commands used by agents work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)