### PR TITLE
feat(streaming): move stream accumulation to agent loop for real-time UI deltas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,6 +116,7 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.18",
+ "tokio",
  "tracing",
 ]
 

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -399,7 +399,7 @@ impl Agents {
             let mut output_tokens: u32 = 0;
             loop {
                 turn += 1;
-                let response = match next {
+                let result = match next {
                     Ok(Ok(r)) => r,
                     Ok(Err(e)) => {
                         let _ = tx
@@ -412,9 +412,20 @@ impl Agents {
                     Err(_) => return, // executor dropped the response channel
                 };
 
+                let (response, streamed) = match result {
+                    llm::PromptResult::Stream(handle) => {
+                        match consume_stream(handle, &tx).await {
+                            Some(resp) => (resp, true),
+                            None => return, // stream error — already sent to UI
+                        }
+                    }
+                    llm::PromptResult::Complete(response) => (response, false),
+                };
+
                 input_tokens += response.usage.input_tokens;
                 output_tokens += response.usage.output_tokens;
 
+                // Persist the complete response to the session.
                 let session_response = match sessions
                     .assistant_response_received(id, response.clone())
                     .await
@@ -429,7 +440,12 @@ impl Agents {
                         return;
                     }
                 };
-                forward_response(response, &tx).await;
+
+                // For the Complete path, forward full blocks to UI (streaming
+                // path already forwarded deltas during consumption).
+                if !streamed {
+                    forward_response(response, &tx).await;
+                }
 
                 let next_prompt = match session_response {
                     session::AgentSessionResponse::Done => break,
@@ -506,6 +522,58 @@ impl Agents {
         });
 
         Ok(rx)
+    }
+}
+
+/// Drain a streaming LLM response, forwarding deltas to the UI channel and
+/// accumulating the final [`llm::PromptResponse`]. Returns `None` if the
+/// stream errors — the error is already sent on `tx`.
+async fn consume_stream(
+    handle: llm::StreamHandle,
+    tx: &tokio::sync::mpsc::Sender<ChatOutputEvent>,
+) -> Option<llm::PromptResponse> {
+    let mut acc = llm::stream::StreamAccumulator::new();
+    let mut rx = handle.rx;
+    while let Some(event) = rx.recv().await {
+        match event {
+            Ok(delta) => {
+                if let Some(chat_event) = delta_to_chat_event(&delta) {
+                    let _ = tx.send(chat_event).await;
+                }
+                acc.process(&delta);
+            }
+            Err(e) => {
+                let _ = tx
+                    .send(ChatOutputEvent::Error {
+                        message: e.to_string(),
+                    })
+                    .await;
+                return None; // never persist partial
+            }
+        }
+    }
+    Some(acc.finish())
+}
+
+fn delta_to_chat_event(delta: &llm::stream::StreamDelta) -> Option<ChatOutputEvent> {
+    use llm::stream::{ContentBlockType, StreamDelta};
+    match delta {
+        StreamDelta::TextDelta { text, .. } => {
+            Some(ChatOutputEvent::TextDelta { text: text.clone() })
+        }
+        StreamDelta::ThinkingDelta { text, .. } => {
+            Some(ChatOutputEvent::ThinkingDelta { text: text.clone() })
+        }
+        StreamDelta::ContentBlockStart {
+            block_type: ContentBlockType::ToolUse { name, .. },
+            ..
+        } => Some(ChatOutputEvent::ToolCallStart { name: name.clone() }),
+        StreamDelta::InputJsonDelta { partial_json, .. } => {
+            Some(ChatOutputEvent::ToolCallInputDelta {
+                partial_json: partial_json.clone(),
+            })
+        }
+        _ => None,
     }
 }
 

--- a/core/src/primitives/chat_output_event.rs
+++ b/core/src/primitives/chat_output_event.rs
@@ -20,6 +20,22 @@ pub enum ChatOutputEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         arguments: Option<serde_json::Value>,
     },
+    /// Incremental text token from a streaming assistant response.
+    TextDelta {
+        text: String,
+    },
+    /// Incremental thinking token from a streaming assistant response.
+    ThinkingDelta {
+        text: String,
+    },
+    /// Signals the start of a tool call in a streaming response.
+    ToolCallStart {
+        name: String,
+    },
+    /// Incremental tool-call input JSON fragment.
+    ToolCallInputDelta {
+        partial_json: String,
+    },
     ToolResult {
         name: String,
         is_error: bool,

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -176,7 +176,7 @@ impl ExecutorState {
                 match model.client {
                     ProviderClient::Anthropic(client) => {
                         tokio::spawn(async move {
-                            evaluate_with_anthropic(
+                            evaluate_with_anthropic_streaming(
                                 client,
                                 request.prompt,
                                 request.response_channel,
@@ -190,16 +190,135 @@ impl ExecutorState {
     }
 }
 
-async fn evaluate_with_anthropic(
+#[instrument(name = "domain.prompt_executor.evaluate_streaming", skip_all)]
+async fn evaluate_with_anthropic_streaming(
     client: AnthropicClient,
     prompt: Prompt,
     response: PromptResponseChannel,
 ) {
-    let outcome = client
-        .send_prompt(&prompt)
-        .await
-        .map_err(|e| PromptError::Provider(e.to_string()));
-    let _ = response.send(outcome);
+    let (delta_tx, delta_rx) = mpsc::channel(128);
+
+    // Send StreamHandle immediately so agent loop can start consuming.
+    if response
+        .send(Ok(llm::PromptResult::Stream(llm::StreamHandle {
+            rx: delta_rx,
+        })))
+        .is_err()
+    {
+        return; // caller dropped
+    }
+
+    // Start streaming from Anthropic.
+    match client.send_prompt_streaming(&prompt).await {
+        Ok(mut sse_rx) => {
+            while let Some(sse_result) = sse_rx.recv().await {
+                match sse_result {
+                    Ok(sse_event) => match map_sse_to_delta(&sse_event.data) {
+                        Ok(Some(delta)) => {
+                            if delta_tx.send(Ok(delta)).await.is_err() {
+                                break;
+                            }
+                        }
+                        Ok(None) => {} // ping or unknown event
+                        Err(e) => {
+                            let _ = delta_tx.send(Err(PromptError::Provider(e))).await;
+                            break;
+                        }
+                    },
+                    Err(e) => {
+                        let _ = delta_tx
+                            .send(Err(PromptError::Provider(e.to_string())))
+                            .await;
+                        break;
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            let _ = delta_tx
+                .send(Err(PromptError::Provider(e.to_string())))
+                .await;
+        }
+    }
+}
+
+fn map_sse_to_delta(data: &str) -> Result<Option<llm::stream::StreamDelta>, String> {
+    use anthropic_client::types::*;
+    use llm::stream::{ContentBlockType, StreamDelta};
+
+    let event: AnthropicStreamEvent =
+        serde_json::from_str(data).map_err(|e| format!("JSON parse: {e}"))?;
+    Ok(match event {
+        AnthropicStreamEvent::MessageStart { message } => {
+            let input_tokens = message.usage.map(|u| u.input as u32).unwrap_or(0);
+            Some(StreamDelta::MessageStart { input_tokens })
+        }
+        AnthropicStreamEvent::ContentBlockStart {
+            index,
+            content_block,
+        } => {
+            let block_type = match content_block {
+                AnthropicContentBlock::Text => ContentBlockType::Text,
+                AnthropicContentBlock::ToolUse { id, name } => ContentBlockType::ToolUse {
+                    id: id.unwrap_or_default(),
+                    name: name.unwrap_or_default(),
+                },
+                AnthropicContentBlock::Thinking => ContentBlockType::Thinking,
+            };
+            Some(StreamDelta::ContentBlockStart {
+                index: index as usize,
+                block_type,
+            })
+        }
+        AnthropicStreamEvent::ContentBlockDelta { index, delta } => {
+            let idx = index as usize;
+            match delta {
+                AnthropicDelta::TextDelta { text } => text.map(|t| StreamDelta::TextDelta {
+                    index: idx,
+                    text: t,
+                }),
+                AnthropicDelta::ThinkingDelta { thinking } => {
+                    thinking.map(|t| StreamDelta::ThinkingDelta {
+                        index: idx,
+                        text: t,
+                    })
+                }
+                AnthropicDelta::InputJsonDelta { partial_json } => {
+                    partial_json.map(|j| StreamDelta::InputJsonDelta {
+                        index: idx,
+                        partial_json: j,
+                    })
+                }
+                AnthropicDelta::SignatureDelta { signature } => {
+                    signature.map(|s| StreamDelta::SignatureDelta {
+                        index: idx,
+                        signature: s,
+                    })
+                }
+            }
+        }
+        AnthropicStreamEvent::ContentBlockStop { index } => Some(StreamDelta::ContentBlockStop {
+            index: index as usize,
+        }),
+        AnthropicStreamEvent::MessageDelta { delta, usage } => {
+            let stop_reason = delta.stop_reason.map(|sr| match sr {
+                AnthropicStopReason::EndTurn => llm::StopReason::EndTurn,
+                AnthropicStopReason::MaxTokens => llm::StopReason::MaxTokens,
+                AnthropicStopReason::ToolUse => llm::StopReason::ToolUse,
+                AnthropicStopReason::StopSequence => llm::StopReason::StopSequence,
+            });
+            let output_tokens = usage.map(|u| u.output_tokens as u32).unwrap_or(0);
+            Some(StreamDelta::MessageDelta {
+                stop_reason,
+                output_tokens,
+            })
+        }
+        AnthropicStreamEvent::MessageStop => Some(StreamDelta::MessageStop),
+        AnthropicStreamEvent::Error { error } => Some(StreamDelta::Error {
+            message: error.message,
+        }),
+        AnthropicStreamEvent::Ping => None,
+    })
 }
 
 #[derive(Clone)]

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -208,23 +208,17 @@ async fn evaluate_with_anthropic_streaming(
         return; // caller dropped
     }
 
-    // Start streaming from Anthropic.
+    // The anthropic client already converts SSE → StreamDelta internally,
+    // so we just pipe deltas through to the agent loop.
     match client.send_prompt_streaming(&prompt).await {
-        Ok(mut sse_rx) => {
-            while let Some(sse_result) = sse_rx.recv().await {
-                match sse_result {
-                    Ok(sse_event) => match map_sse_to_delta(&sse_event.data) {
-                        Ok(Some(delta)) => {
-                            if delta_tx.send(Ok(delta)).await.is_err() {
-                                break;
-                            }
-                        }
-                        Ok(None) => {} // ping or unknown event
-                        Err(e) => {
-                            let _ = delta_tx.send(Err(PromptError::Provider(e))).await;
+        Ok(mut delta_rx) => {
+            while let Some(result) = delta_rx.recv().await {
+                match result {
+                    Ok(delta) => {
+                        if delta_tx.send(Ok(delta)).await.is_err() {
                             break;
                         }
-                    },
+                    }
                     Err(e) => {
                         let _ = delta_tx
                             .send(Err(PromptError::Provider(e.to_string())))
@@ -240,85 +234,6 @@ async fn evaluate_with_anthropic_streaming(
                 .await;
         }
     }
-}
-
-fn map_sse_to_delta(data: &str) -> Result<Option<llm::stream::StreamDelta>, String> {
-    use anthropic_client::types::*;
-    use llm::stream::{ContentBlockType, StreamDelta};
-
-    let event: AnthropicStreamEvent =
-        serde_json::from_str(data).map_err(|e| format!("JSON parse: {e}"))?;
-    Ok(match event {
-        AnthropicStreamEvent::MessageStart { message } => {
-            let input_tokens = message.usage.map(|u| u.input as u32).unwrap_or(0);
-            Some(StreamDelta::MessageStart { input_tokens })
-        }
-        AnthropicStreamEvent::ContentBlockStart {
-            index,
-            content_block,
-        } => {
-            let block_type = match content_block {
-                AnthropicContentBlock::Text => ContentBlockType::Text,
-                AnthropicContentBlock::ToolUse { id, name } => ContentBlockType::ToolUse {
-                    id: id.unwrap_or_default(),
-                    name: name.unwrap_or_default(),
-                },
-                AnthropicContentBlock::Thinking => ContentBlockType::Thinking,
-            };
-            Some(StreamDelta::ContentBlockStart {
-                index: index as usize,
-                block_type,
-            })
-        }
-        AnthropicStreamEvent::ContentBlockDelta { index, delta } => {
-            let idx = index as usize;
-            match delta {
-                AnthropicDelta::TextDelta { text } => text.map(|t| StreamDelta::TextDelta {
-                    index: idx,
-                    text: t,
-                }),
-                AnthropicDelta::ThinkingDelta { thinking } => {
-                    thinking.map(|t| StreamDelta::ThinkingDelta {
-                        index: idx,
-                        text: t,
-                    })
-                }
-                AnthropicDelta::InputJsonDelta { partial_json } => {
-                    partial_json.map(|j| StreamDelta::InputJsonDelta {
-                        index: idx,
-                        partial_json: j,
-                    })
-                }
-                AnthropicDelta::SignatureDelta { signature } => {
-                    signature.map(|s| StreamDelta::SignatureDelta {
-                        index: idx,
-                        signature: s,
-                    })
-                }
-            }
-        }
-        AnthropicStreamEvent::ContentBlockStop { index } => Some(StreamDelta::ContentBlockStop {
-            index: index as usize,
-        }),
-        AnthropicStreamEvent::MessageDelta { delta, usage } => {
-            let stop_reason = delta.stop_reason.map(|sr| match sr {
-                AnthropicStopReason::EndTurn => llm::StopReason::EndTurn,
-                AnthropicStopReason::MaxTokens => llm::StopReason::MaxTokens,
-                AnthropicStopReason::ToolUse => llm::StopReason::ToolUse,
-                AnthropicStopReason::StopSequence => llm::StopReason::StopSequence,
-            });
-            let output_tokens = usage.map(|u| u.output_tokens as u32).unwrap_or(0);
-            Some(StreamDelta::MessageDelta {
-                stop_reason,
-                output_tokens,
-            })
-        }
-        AnthropicStreamEvent::MessageStop => Some(StreamDelta::MessageStop),
-        AnthropicStreamEvent::Error { error } => Some(StreamDelta::Error {
-            message: error.message,
-        }),
-        AnthropicStreamEvent::Ping => None,
-    })
 }
 
 #[derive(Clone)]

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -6,7 +6,7 @@ use galoy_agents_core::primitives::{AuthSubject, ChatOutputEvent, UserId, Worksp
 use galoy_agents_core::sandbox::{SandboxConfig, Sandboxes};
 use galoy_agents_core::toolset::{ToolSets, ToolSetsConfig, ToolSetsError, TopLevelTool};
 use llm::prompt::AssistantBlock;
-use llm::{PromptRequest, PromptResponse, Usage};
+use llm::{PromptRequest, PromptResponse, PromptResult, Usage};
 use rmcp::model::{CallToolResult, Content, JsonObject};
 use tokio::sync::mpsc;
 
@@ -83,7 +83,7 @@ async fn send_message_round_trip_via_prompt_channel() {
     let request = prompt_rx.recv().await.expect("prompt request dispatched");
     request
         .response_channel
-        .send(Ok(PromptResponse {
+        .send(Ok(PromptResult::Complete(PromptResponse {
             content: vec![AssistantBlock::Text {
                 text: "Hi user".to_string(),
                 cache_control: None,
@@ -93,7 +93,7 @@ async fn send_message_round_trip_via_prompt_channel() {
                 output_tokens: 3,
             },
             stop_reason: None,
-        }))
+        })))
         .expect("send response");
 
     // Drain the ChatOutputEvent channel until the forwarder closes it.
@@ -239,7 +239,7 @@ async fn send_message_dispatches_registered_tool_call() {
     );
     request
         .response_channel
-        .send(Ok(PromptResponse {
+        .send(Ok(PromptResult::Complete(PromptResponse {
             content: vec![AssistantBlock::ToolUse {
                 id: "tu_1".to_string(),
                 name: "ping".to_string(),
@@ -251,7 +251,7 @@ async fn send_message_dispatches_registered_tool_call() {
                 output_tokens: 4,
             },
             stop_reason: None,
-        }))
+        })))
         .expect("send first response");
 
     // Second turn: the agent should now dispatch a follow-up request that
@@ -262,7 +262,7 @@ async fn send_message_dispatches_registered_tool_call() {
         .expect("second prompt request after tool result");
     request
         .response_channel
-        .send(Ok(PromptResponse {
+        .send(Ok(PromptResult::Complete(PromptResponse {
             content: vec![AssistantBlock::Text {
                 text: "all done".to_string(),
                 cache_control: None,
@@ -272,7 +272,7 @@ async fn send_message_dispatches_registered_tool_call() {
                 output_tokens: 2,
             },
             stop_reason: None,
-        }))
+        })))
         .expect("send second response");
 
     let mut events = Vec::new();

--- a/core/tests/prompt_executor.rs
+++ b/core/tests/prompt_executor.rs
@@ -40,23 +40,37 @@ async fn anthropic_round_trip_via_executor() {
     let (request, response_rx) = PromptRequest::new(prompt);
     prompt_tx.send(request).await.expect("dispatch request");
 
-    let result = response_rx
+    let prompt_result = response_rx
         .await
         .expect("response channel closed without sending")
         .expect("anthropic returned an error");
 
+    // Streaming path: consume deltas into a complete response.
+    let response = match prompt_result {
+        llm::PromptResult::Stream(handle) => {
+            let mut acc = llm::stream::StreamAccumulator::new();
+            let mut rx = handle.rx;
+            while let Some(event) = rx.recv().await {
+                let delta = event.expect("stream delta error");
+                acc.process(&delta);
+            }
+            acc.finish()
+        }
+        llm::PromptResult::Complete(r) => r,
+    };
+
     assert!(
-        !result.content.is_empty(),
+        !response.content.is_empty(),
         "expected at least one content block in the response"
     );
     assert!(
-        result.usage.input_tokens > 0,
+        response.usage.input_tokens > 0,
         "expected non-zero input_tokens, got {:?}",
-        result.usage
+        response.usage
     );
     assert!(
-        result.usage.output_tokens > 0,
+        response.usage.output_tokens > 0,
         "expected non-zero output_tokens, got {:?}",
-        result.usage
+        response.usage
     );
 }

--- a/lib/anthropic-client/Cargo.toml
+++ b/lib/anthropic-client/Cargo.toml
@@ -10,4 +10,5 @@ reqwest = { workspace = true, features = ["stream"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
+tokio = { workspace = true }
 tracing = { workspace = true }

--- a/lib/anthropic-client/src/convert.rs
+++ b/lib/anthropic-client/src/convert.rs
@@ -11,9 +11,12 @@ use llm::prompt::{
 };
 use llm::{PromptResponse, StopReason, Usage};
 
+use llm::stream::{ContentBlockType, StreamDelta};
+
 use crate::stream::{AccumulatedBlock, AccumulatedResponse, AccumulatedStopReason};
 use crate::types::{
-    AnthropicCacheControl, AnthropicContent, AnthropicMessage, AnthropicRequest,
+    AnthropicCacheControl, AnthropicContent, AnthropicContentBlock, AnthropicDelta,
+    AnthropicMessage, AnthropicRequest, AnthropicStopReason, AnthropicStreamEvent,
     AnthropicSystemBlock, AnthropicTool, AnthropicToolChoice, AnthropicToolResultContent,
 };
 
@@ -222,4 +225,87 @@ fn convert_accumulated_block(block: AccumulatedBlock) -> AssistantBlock {
             cache_control: None,
         },
     }
+}
+
+// ============================================================================
+// SSE JSON → StreamDelta
+// ============================================================================
+
+/// Parse a raw SSE data payload (Anthropic JSON) into a provider-agnostic
+/// [`StreamDelta`]. Returns `Ok(None)` for events that have no meaningful
+/// delta (e.g. `Ping`).
+pub(crate) fn sse_data_to_delta(data: &str) -> Result<Option<StreamDelta>, String> {
+    let event: AnthropicStreamEvent =
+        serde_json::from_str(data).map_err(|e| format!("JSON parse: {e}"))?;
+    Ok(match event {
+        AnthropicStreamEvent::MessageStart { message } => {
+            let input_tokens = message.usage.map(|u| u.input as u32).unwrap_or(0);
+            Some(StreamDelta::MessageStart { input_tokens })
+        }
+        AnthropicStreamEvent::ContentBlockStart {
+            index,
+            content_block,
+        } => {
+            let block_type = match content_block {
+                AnthropicContentBlock::Text => ContentBlockType::Text,
+                AnthropicContentBlock::ToolUse { id, name } => ContentBlockType::ToolUse {
+                    id: id.unwrap_or_default(),
+                    name: name.unwrap_or_default(),
+                },
+                AnthropicContentBlock::Thinking => ContentBlockType::Thinking,
+            };
+            Some(StreamDelta::ContentBlockStart {
+                index: index as usize,
+                block_type,
+            })
+        }
+        AnthropicStreamEvent::ContentBlockDelta { index, delta } => {
+            let idx = index as usize;
+            match delta {
+                AnthropicDelta::TextDelta { text } => text.map(|t| StreamDelta::TextDelta {
+                    index: idx,
+                    text: t,
+                }),
+                AnthropicDelta::ThinkingDelta { thinking } => {
+                    thinking.map(|t| StreamDelta::ThinkingDelta {
+                        index: idx,
+                        text: t,
+                    })
+                }
+                AnthropicDelta::InputJsonDelta { partial_json } => {
+                    partial_json.map(|j| StreamDelta::InputJsonDelta {
+                        index: idx,
+                        partial_json: j,
+                    })
+                }
+                AnthropicDelta::SignatureDelta { signature } => {
+                    signature.map(|s| StreamDelta::SignatureDelta {
+                        index: idx,
+                        signature: s,
+                    })
+                }
+            }
+        }
+        AnthropicStreamEvent::ContentBlockStop { index } => Some(StreamDelta::ContentBlockStop {
+            index: index as usize,
+        }),
+        AnthropicStreamEvent::MessageDelta { delta, usage } => {
+            let stop_reason = delta.stop_reason.map(|sr| match sr {
+                AnthropicStopReason::EndTurn => StopReason::EndTurn,
+                AnthropicStopReason::MaxTokens => StopReason::MaxTokens,
+                AnthropicStopReason::ToolUse => StopReason::ToolUse,
+                AnthropicStopReason::StopSequence => StopReason::StopSequence,
+            });
+            let output_tokens = usage.map(|u| u.output_tokens as u32).unwrap_or(0);
+            Some(StreamDelta::MessageDelta {
+                stop_reason,
+                output_tokens,
+            })
+        }
+        AnthropicStreamEvent::MessageStop => Some(StreamDelta::MessageStop),
+        AnthropicStreamEvent::Error { error } => Some(StreamDelta::Error {
+            message: error.message,
+        }),
+        AnthropicStreamEvent::Ping => None,
+    })
 }

--- a/lib/anthropic-client/src/lib.rs
+++ b/lib/anthropic-client/src/lib.rs
@@ -6,16 +6,18 @@
 //! returning a single `PromptResponse`.
 
 mod convert;
-pub mod sse;
+mod sse;
 mod stream;
-pub mod types;
+mod types;
 
 use thiserror::Error;
 use tracing::instrument;
 
 use llm::{Prompt, PromptResponse};
 
-use crate::convert::{accumulated_to_response, prompt_to_request};
+use llm::stream::StreamDelta;
+
+use crate::convert::{accumulated_to_response, prompt_to_request, sse_data_to_delta};
 use crate::sse::{parse_sse_stream, SseError};
 use crate::stream::StreamAccumulator;
 
@@ -128,14 +130,15 @@ impl AnthropicClient {
         Ok(accumulated_to_response(accumulator.finish()))
     }
 
-    /// Issue a streaming Messages API request, yielding raw SSE events via
-    /// channel. Caller is responsible for parsing/accumulating. Ping events
-    /// are filtered out.
+    /// Issue a streaming Messages API request, yielding provider-agnostic
+    /// [`StreamDelta`]s via channel. Ping events and events that carry no
+    /// delta are filtered out. The Anthropic→`StreamDelta` conversion
+    /// happens inside this method so callers never see Anthropic wire types.
     #[instrument(name = "anthropic_client.send_prompt_streaming", skip_all)]
     pub async fn send_prompt_streaming(
         &self,
         prompt: &Prompt,
-    ) -> Result<tokio::sync::mpsc::Receiver<Result<sse::SseEvent, AnthropicError>>, AnthropicError>
+    ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, AnthropicError>>, AnthropicError>
     {
         let request_body = prompt_to_request(prompt);
 
@@ -160,16 +163,23 @@ impl AnthropicClient {
         }
 
         let byte_stream = resp.bytes_stream();
-        let (tx, rx) = tokio::sync::mpsc::channel::<Result<sse::SseEvent, AnthropicError>>(128);
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<StreamDelta, AnthropicError>>(128);
         tokio::spawn(async move {
             let tx_ref = &tx;
-            let _ = parse_sse_stream(byte_stream, |event: sse::SseEvent| {
+            let _ = parse_sse_stream(byte_stream, |event| {
                 if event.event == "ping" {
                     return Ok(());
                 }
-                tx_ref
-                    .try_send(Ok(event))
-                    .map_err(|e| SseError::Processing(e.to_string()))
+                match sse_data_to_delta(&event.data) {
+                    Ok(Some(delta)) => tx_ref
+                        .try_send(Ok(delta))
+                        .map_err(|e| SseError::Processing(e.to_string())),
+                    Ok(None) => Ok(()),
+                    Err(e) => {
+                        let _ = tx_ref.try_send(Err(AnthropicError::Stream(e.clone())));
+                        Err(SseError::Processing(e))
+                    }
+                }
             })
             .await;
         });

--- a/lib/anthropic-client/src/lib.rs
+++ b/lib/anthropic-client/src/lib.rs
@@ -6,9 +6,9 @@
 //! returning a single `PromptResponse`.
 
 mod convert;
-mod sse;
+pub mod sse;
 mod stream;
-mod types;
+pub mod types;
 
 use thiserror::Error;
 use tracing::instrument;
@@ -126,5 +126,53 @@ impl AnthropicClient {
         }
 
         Ok(accumulated_to_response(accumulator.finish()))
+    }
+
+    /// Issue a streaming Messages API request, yielding raw SSE events via
+    /// channel. Caller is responsible for parsing/accumulating. Ping events
+    /// are filtered out.
+    #[instrument(name = "anthropic_client.send_prompt_streaming", skip_all)]
+    pub async fn send_prompt_streaming(
+        &self,
+        prompt: &Prompt,
+    ) -> Result<tokio::sync::mpsc::Receiver<Result<sse::SseEvent, AnthropicError>>, AnthropicError>
+    {
+        let request_body = prompt_to_request(prompt);
+
+        let resp = self
+            .http
+            .post(API_URL)
+            .header("x-api-key", &self.api_key)
+            .header("anthropic-version", API_VERSION)
+            .header("accept", "text/event-stream")
+            .header("content-type", "application/json")
+            .json(&request_body)
+            .send()
+            .await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(AnthropicError::Api {
+                status: status.as_u16(),
+                message,
+            });
+        }
+
+        let byte_stream = resp.bytes_stream();
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<sse::SseEvent, AnthropicError>>(128);
+        tokio::spawn(async move {
+            let tx_ref = &tx;
+            let _ = parse_sse_stream(byte_stream, |event: sse::SseEvent| {
+                if event.event == "ping" {
+                    return Ok(());
+                }
+                tx_ref
+                    .try_send(Ok(event))
+                    .map_err(|e| SseError::Processing(e.to_string()))
+            })
+            .await;
+        });
+        Ok(rx)
     }
 }

--- a/lib/anthropic-client/src/sse.rs
+++ b/lib/anthropic-client/src/sse.rs
@@ -7,8 +7,8 @@
 use futures::StreamExt;
 
 /// A parsed SSE event with its type and data payload.
-#[derive(Debug)]
-pub(crate) struct SseEvent {
+#[derive(Debug, Clone)]
+pub struct SseEvent {
     /// Event type (from "event:" field, defaults to "message").
     pub event: String,
     /// Event data (from "data:" field(s), joined with newlines).
@@ -21,7 +21,7 @@ pub(crate) struct SseEvent {
 /// complete event. This is a pull-based approach that processes the entire
 /// stream — appropriate because `send_prompt` needs the final accumulated
 /// result anyway.
-pub(crate) async fn parse_sse_stream<S, B, F>(mut stream: S, mut handler: F) -> Result<(), SseError>
+pub async fn parse_sse_stream<S, B, F>(mut stream: S, mut handler: F) -> Result<(), SseError>
 where
     S: futures::Stream<Item = Result<B, reqwest::Error>> + Unpin,
     B: AsRef<[u8]>,
@@ -124,7 +124,7 @@ fn parse_single_event(text: &str) -> Option<SseEvent> {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub(crate) enum SseError {
+pub enum SseError {
     #[error("HTTP stream error: {0}")]
     Http(reqwest::Error),
     #[error("Event processing error: {0}")]

--- a/lib/anthropic-client/src/types.rs
+++ b/lib/anthropic-client/src/types.rs
@@ -133,7 +133,7 @@ pub(crate) struct AnthropicSystemBlock {
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub(crate) enum AnthropicStreamEvent {
+pub enum AnthropicStreamEvent {
     MessageStart {
         message: AnthropicMessageStart,
     },
@@ -162,7 +162,7 @@ pub(crate) enum AnthropicStreamEvent {
 }
 
 #[derive(Debug, Deserialize)]
-pub(crate) struct AnthropicMessageStart {
+pub struct AnthropicMessageStart {
     #[serde(default)]
     pub usage: Option<AnthropicUsage>,
 }
@@ -171,7 +171,7 @@ pub(crate) struct AnthropicMessageStart {
 /// Field names match the API response format.
 #[derive(Debug, Deserialize)]
 #[allow(clippy::struct_field_names)]
-pub(crate) struct AnthropicUsage {
+pub struct AnthropicUsage {
     #[serde(rename = "input_tokens")]
     pub input: u64,
     #[serde(default, rename = "cache_read_input_tokens")]
@@ -181,7 +181,7 @@ pub(crate) struct AnthropicUsage {
 }
 
 #[derive(Debug, Deserialize)]
-pub(crate) struct AnthropicDeltaUsage {
+pub struct AnthropicDeltaUsage {
     pub output_tokens: u64,
 }
 
@@ -190,7 +190,7 @@ pub(crate) struct AnthropicDeltaUsage {
 /// Using a tagged enum avoids allocating a `String` for the type field.
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-pub(crate) enum AnthropicContentBlock {
+pub enum AnthropicContentBlock {
     Text,
     Thinking,
     ToolUse {
@@ -209,7 +209,7 @@ pub(crate) enum AnthropicContentBlock {
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[allow(clippy::enum_variant_names)]
-pub(crate) enum AnthropicDelta {
+pub enum AnthropicDelta {
     TextDelta {
         #[serde(default)]
         text: Option<String>,
@@ -233,7 +233,7 @@ pub(crate) enum AnthropicDelta {
 /// Using an enum avoids allocating a `String` for the stop reason.
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(rename_all = "snake_case")]
-pub(crate) enum AnthropicStopReason {
+pub enum AnthropicStopReason {
     EndTurn,
     MaxTokens,
     ToolUse,
@@ -241,12 +241,12 @@ pub(crate) enum AnthropicStopReason {
 }
 
 #[derive(Debug, Deserialize)]
-pub(crate) struct AnthropicMessageDelta {
+pub struct AnthropicMessageDelta {
     #[serde(default)]
     pub stop_reason: Option<AnthropicStopReason>,
 }
 
 #[derive(Debug, Deserialize)]
-pub(crate) struct AnthropicErrorBody {
+pub struct AnthropicErrorBody {
     pub message: String,
 }

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -1,10 +1,14 @@
 pub mod prompt;
 pub mod request;
 pub mod response;
+pub mod stream;
 pub mod tool;
 
 pub use prompt::Prompt;
-pub use request::{PromptError, PromptRequest, PromptRequestChannel, PromptResponseChannel};
+pub use request::{
+    PromptError, PromptRequest, PromptRequestChannel, PromptResponseChannel, PromptResult,
+    StreamHandle,
+};
 pub use response::{PromptResponse, RequestToolUse, StopReason, Usage};
 pub use tool::{
     ToolUseError, ToolUseRequest, ToolUseRequestChannel, ToolUseResponseChannel, ToolUseResult,

--- a/lib/llm/src/request.rs
+++ b/lib/llm/src/request.rs
@@ -1,5 +1,6 @@
 use tokio::sync::{mpsc, oneshot};
 
+use crate::stream::StreamDelta;
 use crate::{Prompt, PromptResponse};
 
 /// A prompt to evaluate, paired with the channel the caller wants the
@@ -13,7 +14,7 @@ pub struct PromptRequest {
 impl PromptRequest {
     /// Build a request for `prompt`, returning the request to dispatch and the
     /// receiver the caller should `await` to get the response.
-    pub fn new(prompt: Prompt) -> (Self, oneshot::Receiver<Result<PromptResponse, PromptError>>) {
+    pub fn new(prompt: Prompt) -> (Self, oneshot::Receiver<Result<PromptResult, PromptError>>) {
         let (tx, rx) = oneshot::channel();
         (
             Self {
@@ -30,7 +31,27 @@ pub type PromptRequestChannel = mpsc::Sender<PromptRequest>;
 
 /// One-shot channel an evaluator uses to send the (single) response for a
 /// `PromptRequest` back to the originator.
-pub type PromptResponseChannel = oneshot::Sender<Result<PromptResponse, PromptError>>;
+pub type PromptResponseChannel = oneshot::Sender<Result<PromptResult, PromptError>>;
+
+/// Handle to a streaming LLM response. The receiver yields deltas as they
+/// arrive from the provider.
+pub struct StreamHandle {
+    pub rx: mpsc::Receiver<Result<StreamDelta, PromptError>>,
+}
+
+impl std::fmt::Debug for StreamHandle {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StreamHandle").finish_non_exhaustive()
+    }
+}
+
+/// Result of a prompt evaluation — either a complete response or a stream
+/// that yields deltas.
+#[derive(Debug)]
+pub enum PromptResult {
+    Complete(PromptResponse),
+    Stream(StreamHandle),
+}
 
 #[derive(Debug, Clone, thiserror::Error)]
 pub enum PromptError {

--- a/lib/llm/src/stream.rs
+++ b/lib/llm/src/stream.rs
@@ -1,0 +1,395 @@
+//! Provider-agnostic streaming types and accumulator.
+//!
+//! [`StreamDelta`] represents a single incremental event from any LLM
+//! provider. The agent loop forwards deltas to the UI in real-time and
+//! feeds them into a [`StreamAccumulator`] that builds the final
+//! [`PromptResponse`] once the stream completes.
+
+use crate::prompt::AssistantBlock;
+use crate::{PromptResponse, StopReason, Usage};
+
+/// Provider-agnostic streaming delta. Forwarded to UI and fed to accumulator.
+#[derive(Debug, Clone)]
+pub enum StreamDelta {
+    MessageStart {
+        input_tokens: u32,
+    },
+    ContentBlockStart {
+        index: usize,
+        block_type: ContentBlockType,
+    },
+    TextDelta {
+        index: usize,
+        text: String,
+    },
+    ThinkingDelta {
+        index: usize,
+        text: String,
+    },
+    InputJsonDelta {
+        index: usize,
+        partial_json: String,
+    },
+    SignatureDelta {
+        index: usize,
+        signature: String,
+    },
+    ContentBlockStop {
+        index: usize,
+    },
+    MessageDelta {
+        stop_reason: Option<StopReason>,
+        output_tokens: u32,
+    },
+    MessageStop,
+    Error {
+        message: String,
+    },
+}
+
+#[derive(Debug, Clone)]
+pub enum ContentBlockType {
+    Text,
+    ToolUse { id: String, name: String },
+    Thinking,
+}
+
+/// Accumulates [`StreamDelta`] events into a complete [`PromptResponse`].
+pub struct StreamAccumulator {
+    blocks: Vec<BlockBuilder>,
+    usage: Usage,
+    stop_reason: Option<StopReason>,
+    done: bool,
+}
+
+enum BlockBuilder {
+    Text(String),
+    Thinking {
+        text: String,
+        signature: Option<String>,
+    },
+    ToolUse {
+        id: String,
+        name: String,
+        json_buf: String,
+    },
+}
+
+impl StreamAccumulator {
+    pub fn new() -> Self {
+        Self {
+            blocks: Vec::new(),
+            usage: Usage::default(),
+            stop_reason: None,
+            done: false,
+        }
+    }
+
+    /// Process a delta. The delta is consumed for accumulation.
+    /// This does NOT return anything — the caller forwards the delta to UI
+    /// separately.
+    pub fn process(&mut self, delta: &StreamDelta) {
+        match delta {
+            StreamDelta::MessageStart { input_tokens } => {
+                self.usage.input_tokens = *input_tokens;
+            }
+            StreamDelta::ContentBlockStart { block_type, .. } => match block_type {
+                ContentBlockType::Text => self.blocks.push(BlockBuilder::Text(String::new())),
+                ContentBlockType::ToolUse { id, name } => {
+                    self.blocks.push(BlockBuilder::ToolUse {
+                        id: id.clone(),
+                        name: name.clone(),
+                        json_buf: String::new(),
+                    });
+                }
+                ContentBlockType::Thinking => {
+                    self.blocks.push(BlockBuilder::Thinking {
+                        text: String::new(),
+                        signature: None,
+                    });
+                }
+            },
+            StreamDelta::TextDelta { index, text } => {
+                if let Some(BlockBuilder::Text(ref mut t)) = self.blocks.get_mut(*index) {
+                    t.push_str(text);
+                }
+            }
+            StreamDelta::ThinkingDelta { index, text } => {
+                if let Some(BlockBuilder::Thinking {
+                    text: ref mut t, ..
+                }) = self.blocks.get_mut(*index)
+                {
+                    t.push_str(text);
+                }
+            }
+            StreamDelta::InputJsonDelta {
+                index,
+                partial_json,
+            } => {
+                if let Some(BlockBuilder::ToolUse {
+                    ref mut json_buf, ..
+                }) = self.blocks.get_mut(*index)
+                {
+                    json_buf.push_str(partial_json);
+                }
+            }
+            StreamDelta::SignatureDelta { index, signature } => {
+                if let Some(BlockBuilder::Thinking {
+                    signature: ref mut s,
+                    ..
+                }) = self.blocks.get_mut(*index)
+                {
+                    *s = Some(signature.clone());
+                }
+            }
+            StreamDelta::ContentBlockStop { .. } => { /* blocks finalized in finish() */ }
+            StreamDelta::MessageDelta {
+                stop_reason,
+                output_tokens,
+            } => {
+                self.stop_reason = *stop_reason;
+                self.usage.output_tokens = *output_tokens;
+            }
+            StreamDelta::MessageStop => {
+                self.done = true;
+            }
+            StreamDelta::Error { .. } => {
+                self.done = true;
+            }
+        }
+    }
+
+    pub fn is_done(&self) -> bool {
+        self.done
+    }
+
+    pub fn finish(self) -> PromptResponse {
+        let content = self
+            .blocks
+            .into_iter()
+            .map(|b| match b {
+                BlockBuilder::Text(text) => AssistantBlock::Text {
+                    text,
+                    cache_control: None,
+                },
+                BlockBuilder::Thinking { text, signature } => {
+                    AssistantBlock::Thinking { text, signature }
+                }
+                BlockBuilder::ToolUse { id, name, json_buf } => {
+                    let input = serde_json::from_str(&json_buf).unwrap_or(serde_json::Value::Null);
+                    AssistantBlock::ToolUse {
+                        id,
+                        name,
+                        input,
+                        cache_control: None,
+                    }
+                }
+            })
+            .collect();
+        PromptResponse {
+            content,
+            usage: self.usage,
+            stop_reason: self.stop_reason,
+        }
+    }
+}
+
+impl Default for StreamAccumulator {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accumulates_text_only() {
+        let mut acc = StreamAccumulator::new();
+        acc.process(&StreamDelta::MessageStart { input_tokens: 10 });
+        acc.process(&StreamDelta::ContentBlockStart {
+            index: 0,
+            block_type: ContentBlockType::Text,
+        });
+        acc.process(&StreamDelta::TextDelta {
+            index: 0,
+            text: "Hello".to_string(),
+        });
+        acc.process(&StreamDelta::TextDelta {
+            index: 0,
+            text: " world".to_string(),
+        });
+        acc.process(&StreamDelta::ContentBlockStop { index: 0 });
+        acc.process(&StreamDelta::MessageDelta {
+            stop_reason: Some(StopReason::EndTurn),
+            output_tokens: 5,
+        });
+        acc.process(&StreamDelta::MessageStop);
+
+        assert!(acc.is_done());
+        let resp = acc.finish();
+        assert_eq!(resp.content.len(), 1);
+        match &resp.content[0] {
+            AssistantBlock::Text { text, .. } => assert_eq!(text, "Hello world"),
+            _ => panic!("expected text block"),
+        }
+        assert_eq!(resp.usage.input_tokens, 10);
+        assert_eq!(resp.usage.output_tokens, 5);
+        assert_eq!(resp.stop_reason, Some(StopReason::EndTurn));
+    }
+
+    #[test]
+    fn accumulates_tool_use() {
+        let mut acc = StreamAccumulator::new();
+        acc.process(&StreamDelta::MessageStart { input_tokens: 0 });
+        acc.process(&StreamDelta::ContentBlockStart {
+            index: 0,
+            block_type: ContentBlockType::ToolUse {
+                id: "tu_1".to_string(),
+                name: "get_weather".to_string(),
+            },
+        });
+        acc.process(&StreamDelta::InputJsonDelta {
+            index: 0,
+            partial_json: r#"{"loc"#.to_string(),
+        });
+        acc.process(&StreamDelta::InputJsonDelta {
+            index: 0,
+            partial_json: r#"ation":"NYC"}"#.to_string(),
+        });
+        acc.process(&StreamDelta::ContentBlockStop { index: 0 });
+        acc.process(&StreamDelta::MessageDelta {
+            stop_reason: Some(StopReason::ToolUse),
+            output_tokens: 20,
+        });
+        acc.process(&StreamDelta::MessageStop);
+
+        let resp = acc.finish();
+        assert_eq!(resp.content.len(), 1);
+        match &resp.content[0] {
+            AssistantBlock::ToolUse {
+                id, name, input, ..
+            } => {
+                assert_eq!(id, "tu_1");
+                assert_eq!(name, "get_weather");
+                assert_eq!(input, &serde_json::json!({"location": "NYC"}));
+            }
+            _ => panic!("expected tool use block"),
+        }
+        assert_eq!(resp.stop_reason, Some(StopReason::ToolUse));
+    }
+
+    #[test]
+    fn accumulates_thinking() {
+        let mut acc = StreamAccumulator::new();
+        acc.process(&StreamDelta::MessageStart { input_tokens: 5 });
+        acc.process(&StreamDelta::ContentBlockStart {
+            index: 0,
+            block_type: ContentBlockType::Thinking,
+        });
+        acc.process(&StreamDelta::ThinkingDelta {
+            index: 0,
+            text: "Let me think".to_string(),
+        });
+        acc.process(&StreamDelta::ThinkingDelta {
+            index: 0,
+            text: " about this.".to_string(),
+        });
+        acc.process(&StreamDelta::SignatureDelta {
+            index: 0,
+            signature: "sig123".to_string(),
+        });
+        acc.process(&StreamDelta::ContentBlockStop { index: 0 });
+        acc.process(&StreamDelta::MessageDelta {
+            stop_reason: Some(StopReason::EndTurn),
+            output_tokens: 8,
+        });
+        acc.process(&StreamDelta::MessageStop);
+
+        let resp = acc.finish();
+        assert_eq!(resp.content.len(), 1);
+        match &resp.content[0] {
+            AssistantBlock::Thinking { text, signature } => {
+                assert_eq!(text, "Let me think about this.");
+                assert_eq!(signature.as_deref(), Some("sig123"));
+            }
+            _ => panic!("expected thinking block"),
+        }
+    }
+
+    #[test]
+    fn accumulates_mixed_multi_block() {
+        let mut acc = StreamAccumulator::new();
+        acc.process(&StreamDelta::MessageStart { input_tokens: 15 });
+        // Block 0: Thinking
+        acc.process(&StreamDelta::ContentBlockStart {
+            index: 0,
+            block_type: ContentBlockType::Thinking,
+        });
+        acc.process(&StreamDelta::ThinkingDelta {
+            index: 0,
+            text: "hmm".to_string(),
+        });
+        acc.process(&StreamDelta::ContentBlockStop { index: 0 });
+        // Block 1: Text
+        acc.process(&StreamDelta::ContentBlockStart {
+            index: 1,
+            block_type: ContentBlockType::Text,
+        });
+        acc.process(&StreamDelta::TextDelta {
+            index: 1,
+            text: "Hello".to_string(),
+        });
+        acc.process(&StreamDelta::ContentBlockStop { index: 1 });
+        // Block 2: Tool use
+        acc.process(&StreamDelta::ContentBlockStart {
+            index: 2,
+            block_type: ContentBlockType::ToolUse {
+                id: "tu_2".to_string(),
+                name: "calc".to_string(),
+            },
+        });
+        acc.process(&StreamDelta::InputJsonDelta {
+            index: 2,
+            partial_json: r#"{"x":1}"#.to_string(),
+        });
+        acc.process(&StreamDelta::ContentBlockStop { index: 2 });
+        acc.process(&StreamDelta::MessageDelta {
+            stop_reason: Some(StopReason::ToolUse),
+            output_tokens: 30,
+        });
+        acc.process(&StreamDelta::MessageStop);
+
+        let resp = acc.finish();
+        assert_eq!(resp.content.len(), 3);
+        assert!(matches!(&resp.content[0], AssistantBlock::Thinking { .. }));
+        assert!(matches!(&resp.content[1], AssistantBlock::Text { .. }));
+        assert!(matches!(&resp.content[2], AssistantBlock::ToolUse { .. }));
+    }
+
+    #[test]
+    fn error_mid_stream_marks_done() {
+        let mut acc = StreamAccumulator::new();
+        acc.process(&StreamDelta::MessageStart { input_tokens: 5 });
+        acc.process(&StreamDelta::ContentBlockStart {
+            index: 0,
+            block_type: ContentBlockType::Text,
+        });
+        acc.process(&StreamDelta::TextDelta {
+            index: 0,
+            text: "partial".to_string(),
+        });
+        acc.process(&StreamDelta::Error {
+            message: "rate limited".to_string(),
+        });
+
+        assert!(acc.is_done());
+        let resp = acc.finish();
+        assert_eq!(resp.content.len(), 1);
+        match &resp.content[0] {
+            AssistantBlock::Text { text, .. } => assert_eq!(text, "partial"),
+            _ => panic!("expected text block"),
+        }
+    }
+}

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -1724,6 +1724,12 @@ async fn api_agent_message(
                 domain::primitives::ChatOutputEvent::AssistantText { .. } => "assistant_text",
                 domain::primitives::ChatOutputEvent::Thinking { .. } => "thinking",
                 domain::primitives::ChatOutputEvent::ToolCall { .. } => "tool_call",
+                domain::primitives::ChatOutputEvent::TextDelta { .. } => "text_delta",
+                domain::primitives::ChatOutputEvent::ThinkingDelta { .. } => "thinking_delta",
+                domain::primitives::ChatOutputEvent::ToolCallStart { .. } => "tool_call_start",
+                domain::primitives::ChatOutputEvent::ToolCallInputDelta { .. } => {
+                    "tool_call_input_delta"
+                }
                 domain::primitives::ChatOutputEvent::ToolResult { .. } => "tool_result",
                 domain::primitives::ChatOutputEvent::AssistantDone { .. } => "assistant_done",
                 domain::primitives::ChatOutputEvent::Error { .. } => "error",

--- a/web/templates/workspace_chat.html
+++ b/web/templates/workspace_chat.html
@@ -93,6 +93,21 @@ function appendMsg(cls, text) {
   container.scrollTop = container.scrollHeight;
 }
 
+function appendOrStream(cls, text) {
+  const container = document.getElementById('messages');
+  const last = container.lastElementChild;
+  if (last && last.classList.contains(cls) && last.dataset.streaming === '1') {
+    last.textContent += text;
+  } else {
+    const el = document.createElement('div');
+    el.className = 'msg ' + cls;
+    el.dataset.streaming = '1';
+    el.textContent = text;
+    container.appendChild(el);
+  }
+  container.scrollTop = container.scrollHeight;
+}
+
 async function sendMessage() {
   const textarea = document.getElementById('prompt');
   const prompt = textarea.value.trim();
@@ -137,7 +152,15 @@ async function sendMessage() {
           if (!data) continue;
           try {
             const parsed = JSON.parse(data);
-            if (parsed.type === 'assistant_text') {
+            if (parsed.type === 'text_delta') {
+              appendOrStream('msg-assistant', parsed.text);
+            } else if (parsed.type === 'thinking_delta') {
+              appendOrStream('msg-system', parsed.text);
+            } else if (parsed.type === 'tool_call_start') {
+              appendMsg('msg-system', 'Calling tool: ' + parsed.name + '...');
+            } else if (parsed.type === 'tool_call_input_delta') {
+              // partial JSON — ignore in UI
+            } else if (parsed.type === 'assistant_text') {
               appendMsg('msg-assistant', parsed.text);
             } else if (parsed.type === 'thinking') {
               appendMsg('msg-system', '(thinking) ' + parsed.text);
@@ -148,7 +171,7 @@ async function sendMessage() {
               appendMsg('msg-system', 'tool: ' + parsed.name + args);
             } else if (parsed.type === 'tool_result') {
               appendMsg('msg-system', (parsed.is_error ? 'error: ' : 'ok: ') + parsed.name);
-            } else if (parsed.type === 'done') {
+            } else if (parsed.type === 'assistant_done' || parsed.type === 'done') {
               const tokens = (parsed.input_tokens || 0) + (parsed.output_tokens || 0);
               const parts = [(parsed.turns || 0) + ' turns', tokens + ' tokens'];
               if (parsed.duration_ms) parts.push((parsed.duration_ms / 1000).toFixed(1) + 's');

--- a/web/templates/workspace_hub.html
+++ b/web/templates/workspace_hub.html
@@ -235,6 +235,21 @@
         container.scrollTop = container.scrollHeight;
       }
 
+      function appendOrStream(cls, text) {
+        const container = document.getElementById('messages');
+        const last = container.lastElementChild;
+        if (last && last.classList.contains(cls) && last.dataset.streaming === '1') {
+          last.textContent += text;
+        } else {
+          const el = document.createElement('div');
+          el.className = 'msg ' + cls;
+          el.dataset.streaming = '1';
+          el.textContent = text;
+          container.appendChild(el);
+        }
+        container.scrollTop = container.scrollHeight;
+      }
+
       async function sendMessage() {
         const textarea = document.getElementById('prompt');
         const prompt = textarea.value.trim();
@@ -279,7 +294,15 @@
                 if (!data) continue;
                 try {
                   const parsed = JSON.parse(data);
-                  if (parsed.type === 'assistant_text') {
+                  if (parsed.type === 'text_delta') {
+                    appendOrStream('msg-assistant', parsed.text);
+                  } else if (parsed.type === 'thinking_delta') {
+                    appendOrStream('msg-system', parsed.text);
+                  } else if (parsed.type === 'tool_call_start') {
+                    appendMsg('msg-system', 'Calling tool: ' + parsed.name + '...');
+                  } else if (parsed.type === 'tool_call_input_delta') {
+                    // partial JSON — ignore in UI
+                  } else if (parsed.type === 'assistant_text') {
                     appendMsg('msg-assistant', parsed.text);
                   } else if (parsed.type === 'thinking') {
                     appendMsg('msg-system', '(thinking) ' + parsed.text);
@@ -290,7 +313,7 @@
                     appendMsg('msg-system', 'tool: ' + parsed.name + args);
                   } else if (parsed.type === 'tool_result') {
                     appendMsg('msg-system', (parsed.is_error ? 'error: ' : 'ok: ') + parsed.name);
-                  } else if (parsed.type === 'done') {
+                  } else if (parsed.type === 'assistant_done' || parsed.type === 'done') {
                     const tokens = (parsed.input_tokens || 0) + (parsed.output_tokens || 0);
                     const parts = [(parsed.turns || 0) + ' turns', tokens + ' tokens'];
                     if (parsed.duration_ms) parts.push((parsed.duration_ms / 1000).toFixed(1) + 's');


### PR DESCRIPTION
## Summary
- **Move SSE stream accumulation** from `anthropic-client` (internal) up into the agent loop so streaming deltas are forwarded to the UI in real-time, while the session only receives the final complete message
- **New provider-agnostic streaming types** in `lib/llm/src/stream.rs`: `StreamDelta` enum, `ContentBlockType`, and `StreamAccumulator` with 5 unit tests
- **6-layer change** across 16 files (783 insertions): anthropic-client `send_prompt_streaming()`, `PromptResult` enum (Complete/Stream), streaming executor dispatch, `consume_stream()` in agent loop, new `ChatOutputEvent` delta variants, SSE mapping + browser JS `appendOrStream()` helper

## Architecture

```
Browser ←SSE deltas── Web (routes.rs) ←mpsc── Agent Loop ←StreamHandle── Executor ←SSE── Anthropic
                                                   │                         │
                                            accumulates deltas         sends StreamHandle
                                            forwards to UI             immediately, pipes
                                            persists AFTER done        SSE→StreamDelta
```

### Key design decisions
- **Never persist partial messages** — if stream errors mid-way, send `Error` event and return without touching session state
- **Complete fallback** preserved — `PromptResult::Complete` path still works for tests and non-streaming providers
- **Session receives only the final `PromptResponse`** after the entire stream finishes

### Changed layers
1. `lib/anthropic-client` — `send_prompt_streaming()`, public SSE/streaming types
2. `lib/llm/src/stream.rs` — `StreamDelta`, `StreamAccumulator` (new file)
3. `lib/llm/src/request.rs` — `StreamHandle`, `PromptResult` enum
4. `core/src/prompt_executor.rs` — streaming dispatch, `map_sse_to_delta()`
5. `core/src/agent/mod.rs` — `consume_stream()`, `delta_to_chat_event()`
6. `ChatOutputEvent` + `routes.rs` + browser JS — `TextDelta`, `ThinkingDelta`, `ToolCallStart`, `ToolCallInputDelta`

## Test plan
- [x] `lib/llm` stream accumulator: 5 unit tests (text-only, tool-use, thinking, mixed multi-block, error mid-stream)
- [x] `anthropic-client` existing tests pass (10/10)
- [x] `core/tests/agent.rs` updated for `PromptResult::Complete` wrapper
- [x] `core/tests/prompt_executor.rs` updated to consume stream
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `nix flake check` passes (fmt + clippy + nextest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)