### PR TITLE
docs: add README and .env.example with env var reference

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,73 @@
+# =============================================================================
+# Galoy Agents — Environment Variables
+# =============================================================================
+# Copy this file to `.env` and fill in your values. The `.envrc` at the repo
+# root loads `.env` automatically via `dotenv` (requires direnv).
+# =============================================================================
+
+# ── Required ─────────────────────────────────────────────────────────────────
+
+# PostgreSQL connection string.
+# Start the bundled Postgres with `make start-deps`.
+PG_CON=postgres://user:password@localhost:5432/galoy_agents
+
+# GitHub OAuth client secret for user login.
+# Create a GitHub OAuth App: https://github.com/settings/developers
+GITHUB_CLIENT_SECRET=
+
+# ── Recommended ──────────────────────────────────────────────────────────────
+
+# Anthropic API key for the agent LLM runtime.
+# The server starts without it, but all agent prompts will fail.
+# Get one at https://console.anthropic.com/
+ANTHROPIC_API_KEY=
+
+# ── Optional — OAuth & Access Control ────────────────────────────────────────
+
+# Comma-separated list of GitHub teams allowed to log in (org/team-slug).
+# Empty = all GitHub users can log in.
+# GITHUB_ALLOWED_TEAMS=myorg/engineering,myorg/devops
+
+# ── Optional — Config File ───────────────────────────────────────────────────
+
+# Path to the YAML config file. Defaults to `galoy-agents.yml` in the CWD.
+# GALOY_AGENTS_CONFIG=galoy-agents.yml
+
+# ── Optional — Concourse CI ──────────────────────────────────────────────────
+
+# Credentials for the Concourse CI toolset. Only needed when
+# `toolsets.concourse.enabled: true` in the config file.
+# CONCOURSE_USERNAME=
+# CONCOURSE_PASSWORD=
+
+# ── Optional — MCP Upstream Auth Headers ─────────────────────────────────────
+# Each MCP upstream defined in the config file can have its auth header
+# injected via an env var named `{NAME}_AUTH_HEADER` (name uppercased).
+#
+# HONEYCOMB_AUTH_HEADER=Bearer hcaik_01j...
+# GITHUB_AUTH_HEADER=Bearer ghp_...
+# LINGO_AUTH_HEADER=your-lingo-api-key
+
+# ── Optional — GitHub App (token auto-provisioning for sandboxes) ────────────
+# Requires `github_app` section in the config file with client_id and
+# installation_id. The private key path is injected here.
+#
+# GITHUB_APP_PRIVATE_KEY_PATH=/path/to/private-key.pem
+
+# ── Optional — Observability ─────────────────────────────────────────────────
+
+# OpenTelemetry OTLP exporter endpoint. Defaults to http://localhost:4317.
+# Set OTEL_SDK_DISABLED=true to disable tracing entirely.
+# OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+# OTEL_SDK_DISABLED=false
+
+# Tracing log filter (standard RUST_LOG / EnvFilter syntax).
+# RUST_LOG=info
+
+# ── Sandbox Tool Server (sandbox pods only) ──────────────────────────────────
+# These are set automatically by the local sandbox spawner or by K8s pod spec.
+# You do NOT need to set them for the main server.
+#
+# PORT=3000
+# WORKSPACE_ROOT=/workspace
+# GITHUB_TOKEN_PATH=/run/secrets/github-token

--- a/README.md
+++ b/README.md
@@ -1,0 +1,114 @@
+# Galoy Agents
+
+An MCP-gateway platform that orchestrates AI agents with tool access across
+Concourse CI, Honeycomb observability, GitHub source control, Kubernetes, and
+code-search — all behind a unified progressive-disclosure interface.
+
+## Quick Start
+
+```bash
+# 1. Install Nix (https://nixos.org) and direnv, then:
+direnv allow          # loads the nix devShell + .env
+
+# 2. Copy and fill in secrets
+cp .env.example .env
+$EDITOR .env          # at minimum set PG_CON and GITHUB_CLIENT_SECRET
+
+# 3. Start Postgres and run migrations
+make start-deps       # docker/podman compose up
+make setup-db         # runs sqlx migrations
+
+# 4. Run the server
+make run-server       # builds sandbox binary, then starts on :4200
+```
+
+The web UI is at `http://localhost:4200`. Login uses GitHub OAuth (configure an
+[OAuth App](https://github.com/settings/developers) with callback
+`http://localhost:4200/auth/github/callback`).
+
+## Environment Variables
+
+All secrets are loaded from environment variables (or CLI flags). Non-secret
+configuration lives in a YAML config file (`galoy-agents.yml` by default).
+A complete `.env.example` is provided at the repo root.
+
+### Main Server (`galoy-agents-cli`)
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `PG_CON` | **Yes** | — | PostgreSQL connection URL. |
+| `GITHUB_CLIENT_SECRET` | **Yes** | — | GitHub OAuth App client secret. |
+| `ANTHROPIC_API_KEY` | No | `""` | Anthropic API key for the agent LLM runtime. Server starts without it but agent prompts will fail. |
+| `GALOY_AGENTS_CONFIG` | No | `galoy-agents.yml` | Path to the YAML config file. |
+| `GITHUB_ALLOWED_TEAMS` | No | `""` (all users) | Comma-separated GitHub teams allowed to log in (`org/team-slug`). |
+| `CONCOURSE_USERNAME` | No | — | Concourse CI basic-auth username (when concourse toolset is enabled). |
+| `CONCOURSE_PASSWORD` | No | — | Concourse CI basic-auth password. |
+| `{UPSTREAM}_AUTH_HEADER` | No | — | Auth header for each MCP upstream. Name is uppercased from the config, e.g. `HONEYCOMB_AUTH_HEADER`, `GITHUB_AUTH_HEADER`, `LINGO_AUTH_HEADER`. |
+| `GITHUB_APP_PRIVATE_KEY_PATH` | No | — | Filesystem path to the GitHub App PEM private key (for sandbox token auto-provisioning). Requires `github_app` section in config. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | No | `http://localhost:4317` | OpenTelemetry OTLP gRPC endpoint. |
+| `OTEL_SDK_DISABLED` | No | `false` | Set to `true` to disable OpenTelemetry tracing entirely. |
+| `RUST_LOG` | No | `info` | Standard `tracing` / `EnvFilter` log level directive. |
+
+### Sandbox Tool Server (`sandbox-tool-server`)
+
+These variables are set **automatically** by the local sandbox spawner (or by
+the K8s pod spec). You only need them when running the sandbox server directly.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `PORT` | No | `3000` | HTTP listen port. |
+| `WORKSPACE_ROOT` | No | `/workspace` | Root directory for sandbox file operations. |
+| `GITHUB_TOKEN_PATH` | No | `/run/secrets/github-token` | Path to the GitHub token file (injected by the platform). |
+
+### Test-Only Variables
+
+These are only needed when running specific integration tests:
+
+| Variable | Test File | Description |
+|---|---|---|
+| `ANTHROPIC_API_KEY` | `core/tests/prompt_executor.rs` | Anthropic round-trip test. |
+| `DATABASE_URL` | `core/tests/agent.rs` | Postgres URL for agent integration tests. |
+| `HONEYCOMB_AUTH_HEADER` | `core/tests/toolset.rs` | Auth header for MCP upstream toolset test. |
+
+## Config File Reference
+
+The YAML config file (`galoy-agents.yml`) holds non-secret configuration. See
+the included `galoy-agents.yml` for a complete local-dev example. Key sections:
+
+| Section | Purpose |
+|---|---|
+| `server` | Host, port, secure cookies, MCP endpoint URL |
+| `oauth` | GitHub OAuth client ID, redirect URI, allowed teams |
+| `agents.builtin_roles` | Per-role LLM model, system prompt, max tokens, auto-reset timer |
+| `toolsets.concourse` | Concourse CI URL, team, enabled flag |
+| `toolsets.mcp_upstreams[]` | MCP upstream services (name, URL, category, allowed tools, auth header name) |
+| `toolsets.code_assistant` | Path to the code-assistant SQLite DB |
+| `sandbox.backend` | `local` (child process) or `k8s` (namespace + template) |
+| `github_app` | GitHub App client ID and installation ID (private key via env) |
+
+## Project Layout
+
+```
+cli/            CLI entrypoint (config loading, main server binary)
+core/           Domain logic (agents, sessions, toolsets, sandbox, encryption)
+web/            Axum web server (routes, OAuth, templates)
+mcp-gateway/    MCP protocol gateway (rmcp-based)
+lib/            Shared libraries (anthropic-client, sandbox admin client, LLM)
+images/sandbox/ Sandbox tool server (runs inside sandbox pods)
+code-assistant/ Semantic code search toolset
+charts/         Helm chart for Kubernetes deployment
+```
+
+## Make Targets
+
+| Target | Description |
+|---|---|
+| `make start-deps` | Start Postgres via docker/podman compose |
+| `make clean-deps` | Tear down Postgres and volumes |
+| `make setup-db` | Wait for Postgres and run SQLx migrations |
+| `make reset-deps` | `clean-deps` + `start-deps` + `setup-db` |
+| `make run-server` | Build sandbox binary and start the server |
+| `make nix-run-server` | Run server via `nix run .` |
+| `make build-sandbox` | Build only the sandbox tool server |
+| `make sqlx-prepare` | Regenerate SQLx offline query data |
+| `make start` | Full reset: `reset-deps` then `run-server` |


### PR DESCRIPTION
## Summary
- Add `README.md` with quick-start guide, environment variable reference table, config file overview, project layout, and make targets
- Add `.env.example` with all environment variables, organized by category with descriptions and sensible placeholders
- Covers main server, sandbox tool server, and test-only variables with required/optional status and defaults

## Test plan
- [ ] Verify `make start` works with a fresh `.env` copy
- [ ] Confirm all documented env vars match actual codebase usage
- [ ] Check README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)