### PR TITLE
fix(toolset): reject MCP upstreams with missing auth credentials

### DIFF
--- a/core/src/toolset/error.rs
+++ b/core/src/toolset/error.rs
@@ -6,6 +6,8 @@ pub enum ToolSetsError {
     ClientInit(#[from] Box<rmcp::service::ClientInitializeError>),
     #[error("ToolSetsError - Service: {0}")]
     Service(#[from] rmcp::service::ServiceError),
+    #[error("ToolSetsError - MissingAuthHeader: upstream '{name}' requires authentication — set {env_key}")]
+    MissingAuthHeader { name: String, env_key: String },
     #[error("ToolSetsError - InvalidHeader: {0}")]
     InvalidHeader(String),
     #[error("ToolSetsError - ToolNotFound: {0}")]

--- a/core/src/toolset/searchable/upstream.rs
+++ b/core/src/toolset/searchable/upstream.rs
@@ -30,15 +30,21 @@ impl UpstreamToolSet {
     pub(in super::super) async fn init(
         upstream: &McpUpstreamConfig,
     ) -> Result<UpstreamToolSet, ToolSetsError> {
-        let mut headers = HashMap::new();
-        if !upstream.auth_header.is_empty() {
-            headers.insert(
-                HeaderName::from_bytes(upstream.auth_header_name.as_bytes())
-                    .map_err(|e| ToolSetsError::InvalidHeader(e.to_string()))?,
-                HeaderValue::from_str(&upstream.auth_header)
-                    .map_err(|e| ToolSetsError::InvalidHeader(e.to_string()))?,
-            );
+        if upstream.auth_header.is_empty() {
+            let env_key = format!("{}_AUTH_HEADER", upstream.name.to_uppercase());
+            return Err(ToolSetsError::MissingAuthHeader {
+                name: upstream.name.clone(),
+                env_key,
+            });
         }
+
+        let mut headers = HashMap::new();
+        headers.insert(
+            HeaderName::from_bytes(upstream.auth_header_name.as_bytes())
+                .map_err(|e| ToolSetsError::InvalidHeader(e.to_string()))?,
+            HeaderValue::from_str(&upstream.auth_header)
+                .map_err(|e| ToolSetsError::InvalidHeader(e.to_string()))?,
+        );
 
         let transport_config = StreamableHttpClientTransportConfig::with_uri(upstream.url.as_str())
             .custom_headers(headers);


### PR DESCRIPTION
## Summary
- MCP upstreams that accept unauthenticated handshakes (e.g. Lingo) were silently registering tools that would fail at call time
- Now fail early in `UpstreamToolSet::init` with a `MissingAuthHeader` error naming the env var to set (e.g. `LINGO_AUTH_HEADER`)

## Test plan
- [ ] `make start ARGS="--set oauth.login=dev"` without any `*_AUTH_HEADER` vars — all three upstreams should log a warning with the missing env var name
- [ ] Set `LINGO_AUTH_HEADER` and verify Lingo initializes successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)