### PR TITLE
chore: make start uses dev login by default

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,10 +5,10 @@
 # root loads `.env` automatically via `dotenv` (requires direnv).
 # =============================================================================
 
-# ── Required ─────────────────────────────────────────────────────────────────
+# ── Postgres ─────────────────────────────────────────────────────────────────
 
-# PostgreSQL connection string.
-# Start the bundled Postgres with `make start-deps`.
+# PostgreSQL connection string. This default matches the bundled compose stack
+# started by `make start-deps`, so you can leave it as-is for local dev.
 PG_CON=postgres://user:password@localhost:5432/galoy_agents
 
 # ── Recommended ──────────────────────────────────────────────────────────────

--- a/.env.example
+++ b/.env.example
@@ -11,10 +11,6 @@
 # Start the bundled Postgres with `make start-deps`.
 PG_CON=postgres://user:password@localhost:5432/galoy_agents
 
-# GitHub OAuth client secret for user login.
-# Create a GitHub OAuth App: https://github.com/settings/developers
-GITHUB_CLIENT_SECRET=
-
 # ── Recommended ──────────────────────────────────────────────────────────────
 
 # Anthropic API key for the agent LLM runtime.
@@ -23,6 +19,12 @@ GITHUB_CLIENT_SECRET=
 ANTHROPIC_API_KEY=
 
 # ── Optional — OAuth & Access Control ────────────────────────────────────────
+
+# GitHub OAuth client secret for user login.
+# Only needed when using GitHub OAuth (oauth.login: github in config).
+# `make start` uses dev login mode and does not require this.
+# Create a GitHub OAuth App: https://github.com/settings/developers
+# GITHUB_CLIENT_SECRET=
 
 # Comma-separated list of GitHub teams allowed to log in (org/team-slug).
 # Empty = all GitHub users can log in.

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PG_CON ?= postgres://user:password@localhost:5432/galoy_agents
-GITHUB_CLIENT_SECRET ?= dev-secret
+GITHUB_CLIENT_SECRET ?= $(shell echo $$GITHUB_CLIENT_SECRET)
 ANTHROPIC_API_KEY ?= $(shell echo $$ANTHROPIC_API_KEY)
 
 # ── Container engine ─────────────────────────────────────────────────────────────
@@ -36,4 +36,5 @@ nix-run-server:
 sdl-rust:
 	SQLX_OFFLINE=true cargo run --bin write_sdl > web/src/graphql/schema.graphql
 
-start: reset-deps run-server
+start: reset-deps
+	@PG_CON=$(PG_CON) ANTHROPIC_API_KEY=$(ANTHROPIC_API_KEY) cargo run -p galoy-agents-cli -- --set oauth.login=dev $(ARGS)

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A complete `.env.example` is provided at the repo root.
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `PG_CON` | **Yes** | — | PostgreSQL connection URL. |
+| `PG_CON` | No | `postgres://user:password@localhost:5432/galoy_agents` | PostgreSQL connection URL. The Makefile provides this default, which matches the bundled compose stack. |
 | `GITHUB_CLIENT_SECRET` | No | `dev-secret` | GitHub OAuth App client secret (only needed when `oauth.login: github`). |
 | `ANTHROPIC_API_KEY` | No | `""` | Anthropic API key for the agent LLM runtime. Server starts without it but agent prompts will fail. |
 | `GALOY_AGENTS_CONFIG` | No | `galoy-agents.yml` | Path to the YAML config file. |

--- a/README.md
+++ b/README.md
@@ -12,19 +12,17 @@ direnv allow          # loads the nix devShell + .env
 
 # 2. Copy and fill in secrets
 cp .env.example .env
-$EDITOR .env          # at minimum set PG_CON and GITHUB_CLIENT_SECRET
+$EDITOR .env          # at minimum set ANTHROPIC_API_KEY
 
-# 3. Start Postgres and run migrations
-make start-deps       # docker/podman compose up
-make setup-db         # runs sqlx migrations
-
-# 4. Run the server
-make run-server       # builds sandbox binary, then starts on :4200
+# 3. Start everything (Postgres, migrations, server with dev login)
+make start            # full reset + server on :4200
 ```
 
-The web UI is at `http://localhost:4200`. Login uses GitHub OAuth (configure an
-[OAuth App](https://github.com/settings/developers) with callback
-`http://localhost:4200/auth/github/callback`).
+The web UI is at `http://localhost:4200`. `make start` uses dev login mode
+(no GitHub OAuth required). For production GitHub OAuth, use `make run-server`
+with `GITHUB_CLIENT_SECRET` set and an
+[OAuth App](https://github.com/settings/developers) configured with callback
+`http://localhost:4200/auth/github/callback`.
 
 ## Environment Variables
 
@@ -37,7 +35,7 @@ A complete `.env.example` is provided at the repo root.
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `PG_CON` | **Yes** | — | PostgreSQL connection URL. |
-| `GITHUB_CLIENT_SECRET` | **Yes** | — | GitHub OAuth App client secret. |
+| `GITHUB_CLIENT_SECRET` | No | `dev-secret` | GitHub OAuth App client secret (only needed when `oauth.login: github`). |
 | `ANTHROPIC_API_KEY` | No | `""` | Anthropic API key for the agent LLM runtime. Server starts without it but agent prompts will fail. |
 | `GALOY_AGENTS_CONFIG` | No | `galoy-agents.yml` | Path to the YAML config file. |
 | `GITHUB_ALLOWED_TEAMS` | No | `""` (all users) | Comma-separated GitHub teams allowed to log in (`org/team-slug`). |
@@ -111,4 +109,4 @@ charts/         Helm chart for Kubernetes deployment
 | `make nix-run-server` | Run server via `nix run .` |
 | `make build-sandbox` | Build only the sandbox tool server |
 | `make sqlx-prepare` | Regenerate SQLx offline query data |
-| `make start` | Full reset: `reset-deps` then `run-server` |
+| `make start` | Full reset: `reset-deps` then server with dev login |


### PR DESCRIPTION
## Summary
- `make start` now bakes in `--set oauth.login=dev` so local dev no longer requires GitHub OAuth setup
- `GITHUB_CLIENT_SECRET` moved from required to optional in README and `.env.example`
- Quick start simplified to a single `make start` command

## Test plan
- [ ] Run `make start` and verify the server starts with dev login (no GitHub OAuth needed)
- [ ] Run `make run-server` with `GITHUB_CLIENT_SECRET` set to verify production OAuth still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)