### PR TITLE
fix(web): friendly page when code assistant is not configured

### DIFF
--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -374,7 +374,7 @@ async fn code_assistant_dashboard(State(state): State<AppState>, session: Sessio
 
     let ca = match state.app.code_assistant() {
         Some(ca) => ca,
-        None => return axum::http::StatusCode::SERVICE_UNAVAILABLE.into_response(),
+        None => return CodeAssistantDisabledTemplate {}.into_response(),
     };
 
     let stats = match ca.logs().dashboard_stats().await {

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -53,6 +53,10 @@ pub struct CodeAssistantTemplate {
 }
 
 #[derive(Template, WebTemplate)]
+#[template(path = "code_assistant_disabled.html")]
+pub struct CodeAssistantDisabledTemplate {}
+
+#[derive(Template, WebTemplate)]
 #[template(path = "code_assistant_recent.html")]
 pub struct CodeAssistantRecentTemplate {
     pub rows: Vec<CodeAssistantRequestRow>,

--- a/web/templates/code_assistant_disabled.html
+++ b/web/templates/code_assistant_disabled.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+
+{% block title %}Code Assistant — Galoy Agents{% endblock %}
+
+{% block nav_code_assistant %}class="active"{% endblock %}
+
+{% block content %}
+<h2>Code Assistant</h2>
+
+<article>
+  <h3>Not configured</h3>
+  <p>The Code Assistant search index has not been built yet. To enable it, run:</p>
+  <pre><code>cd code-assistant && make bootstrap</code></pre>
+  <p>This will clone the configured repositories and build the vector search database.
+     Once the index exists, restart the server and this page will load automatically.</p>
+</article>
+{% endblock %}


### PR DESCRIPTION
## Summary
- When the code-assistant search index (`data/code-assistant.db`) hasn't been built, the `/code-assistant` route returned a bare HTTP 503
- Now renders a styled page (using the existing base template) with a clear explanation and setup instructions (`cd code-assistant && make bootstrap`)

## Test plan
- [ ] Start server without `data/code-assistant.db` present, visit `/code-assistant` — should see the new "Not configured" page instead of a 503
- [ ] Build the index, restart, visit `/code-assistant` — should see the normal dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)