### PR TITLE
fix(dev): add local otel-agent to silence trace export errors

### DIFF
--- a/dev/otel-agent-config.yaml
+++ b/dev/otel-agent-config.yaml
@@ -1,0 +1,22 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+exporters:
+  debug:
+    verbosity: basic
+
+extensions:
+  health_check:
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: []
+      exporters: [debug]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,5 +10,14 @@ services:
     volumes:
       - pgdata:/var/lib/postgresql/data
 
+  otel-agent:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.133.0
+    command: --config=/etc/otel-agent-config.yaml
+    ports:
+      - "4317:4317"
+      - "4318:4318"
+    volumes:
+      - ./dev/otel-agent-config.yaml:/etc/otel-agent-config.yaml
+
 volumes:
   pgdata:


### PR DESCRIPTION
## Summary
- Adds an `otel-agent` (opentelemetry-collector-contrib) container to `docker-compose.yml`
- Adds minimal collector config in `dev/otel-agent-config.yaml` that accepts OTLP traces and exports to `debug`
- Eliminates the noisy `BatchSpanProcessor.ExportError` / `Connection refused` errors when running `make start`

## Test plan
- [x] Ran `make start` locally and confirmed zero OTEL errors in logs
- [ ] Verify `make reset-deps` starts both postgres and otel-agent cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)