### PR TITLE
feat(sandbox): support specifying git branch when creating a sandbox

### DIFF
--- a/core/src/toolset/top_level/sandbox.rs
+++ b/core/src/toolset/top_level/sandbox.rs
@@ -46,6 +46,10 @@ static WS_CREATE_SANDBOX_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| 
                 "type": "string",
                 "description": "Repository URL to clone (required when mode is 'repo')."
             },
+            "branch": {
+                "type": "string",
+                "description": "Git branch to check out after cloning (optional, defaults to the repo's default branch). Only used when mode is 'repo'."
+            },
             "cpu": {
                 "type": "string",
                 "description": "CPU resource spec (e.g. '500m'). Defaults to '500m'."
@@ -142,6 +146,10 @@ static ADMIN_CREATE_SANDBOX_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(
             "repo_url": {
                 "type": "string",
                 "description": "Repository URL to clone (required when mode is 'repo')."
+            },
+            "branch": {
+                "type": "string",
+                "description": "Git branch to check out after cloning (optional, defaults to the repo's default branch). Only used when mode is 'repo'."
             },
             "cpu": {
                 "type": "string",
@@ -504,7 +512,11 @@ fn parse_sandbox_create_args(
                     ToolSetsError::MissingArgument("repo_url (required for mode=repo)".to_string())
                 })?
                 .to_string();
-            sandbox::SandboxMode::Repo { repo_url }
+            let branch = args
+                .and_then(|a| a.get("branch"))
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+            sandbox::SandboxMode::Repo { repo_url, branch }
         }
         _ => sandbox::SandboxMode::Scratch,
     };

--- a/images/sandbox/server/src/main.rs
+++ b/images/sandbox/server/src/main.rs
@@ -29,6 +29,8 @@ struct InitializeRequest {
     #[serde(default)]
     repo_url: Option<String>,
     #[serde(default)]
+    branch: Option<String>,
+    #[serde(default)]
     github_token: Option<String>,
 }
 
@@ -500,17 +502,24 @@ async fn initialize(Json(req): Json<InitializeRequest>) -> Json<InitializeRespon
         }
     }
 
-    initialize_inner(&workspace_root(), &req.mode, req.repo_url.as_deref()).await
+    initialize_inner(
+        &workspace_root(),
+        &req.mode,
+        req.repo_url.as_deref(),
+        req.branch.as_deref(),
+    )
+    .await
 }
 
 async fn initialize_inner(
     workspace: &str,
     mode: &str,
     repo_url: Option<&str>,
+    branch: Option<&str>,
 ) -> Json<InitializeResponse> {
     let result = match mode {
         "scratch" => initialize_scratch(workspace).await,
-        "repo" => initialize_repo(workspace, repo_url).await,
+        "repo" => initialize_repo(workspace, repo_url, branch).await,
         other => Err(format!(
             "Unknown mode: {other}. Expected 'scratch' or 'repo'."
         )),
@@ -568,6 +577,7 @@ async fn initialize_scratch(workspace: &str) -> Result<InitializeResponse, Strin
 async fn initialize_repo(
     workspace: &str,
     repo_url: Option<&str>,
+    branch: Option<&str>,
 ) -> Result<InitializeResponse, String> {
     let repo_url = repo_url
         .filter(|u| !u.is_empty())
@@ -587,8 +597,14 @@ async fn initialize_repo(
     // dir still triggers a fresh clone.
     let already_cloned = clone_dir.join(".git").is_dir();
     if !already_cloned {
+        let mut args = vec!["clone"];
+        if let Some(b) = branch.filter(|b| !b.is_empty()) {
+            args.extend(["--branch", b]);
+        }
+        args.extend([repo_url, clone_dir.to_str().unwrap()]);
+
         let output = Command::new("git")
-            .args(["clone", repo_url, clone_dir.to_str().unwrap()])
+            .args(&args)
             .output()
             .await
             .map_err(|e| format!("Failed to run git clone: {e}"))?;
@@ -1330,6 +1346,7 @@ mod tests {
         let result = initialize_repo(
             workspace.to_str().unwrap(),
             Some(bare_dir.to_str().unwrap()),
+            None,
         )
         .await;
         assert!(result.is_ok(), "initialize_repo failed: {:?}", result);
@@ -1354,7 +1371,7 @@ mod tests {
 
     #[tokio::test]
     async fn initialize_repo_missing_url_fails() {
-        let result = initialize_repo("/tmp/sandbox-test-missing", None).await;
+        let result = initialize_repo("/tmp/sandbox-test-missing", None, None).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("repo_url"));
     }
@@ -1371,6 +1388,7 @@ mod tests {
         let result = initialize_repo(
             dir.to_str().unwrap(),
             Some("https://invalid.example.com/nonexistent/repo.git"),
+            None,
         )
         .await;
         assert!(result.is_err());

--- a/lib/sandbox/src/instance_client.rs
+++ b/lib/sandbox/src/instance_client.rs
@@ -97,6 +97,8 @@ pub struct InitializeRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub branch: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub github_token: Option<String>,
 }
 
@@ -108,11 +110,13 @@ impl InitializeRequest {
             SandboxMode::Scratch => Self {
                 mode: "scratch".to_string(),
                 repo_url: None,
+                branch: None,
                 github_token,
             },
-            SandboxMode::Repo { repo_url } => Self {
+            SandboxMode::Repo { repo_url, branch } => Self {
                 mode: "repo".to_string(),
                 repo_url: Some(repo_url.clone()),
+                branch: branch.clone(),
                 github_token,
             },
         }

--- a/lib/sandbox/src/types.rs
+++ b/lib/sandbox/src/types.rs
@@ -10,7 +10,13 @@ pub enum SandboxMode {
     Scratch,
     /// `/initialize` clones `repo_url` into `<workspace>/repos/<name>`
     /// and scans the result for CLAUDE.md / .claude/commands/*.md.
-    Repo { repo_url: String },
+    /// When `branch` is set, the clone checks out that branch instead
+    /// of the remote's default.
+    Repo {
+        repo_url: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        branch: Option<String>,
+    },
 }
 
 /// Per-sandbox resource specs supplied at create time.

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -1030,7 +1030,7 @@ async fn workspace_skill_delete(
 fn sandbox_to_view(s: &domain::sandbox::Sandbox) -> SandboxView {
     let (mode_label, repo_url) = match &s.mode {
         SandboxMode::Scratch => ("Scratch".to_string(), None),
-        SandboxMode::Repo { repo_url } => ("Repo".to_string(), Some(repo_url.clone())),
+        SandboxMode::Repo { repo_url, .. } => ("Repo".to_string(), Some(repo_url.clone())),
     };
 
     let exported_system_prompt = s.exported_system_prompt.as_ref().map(|f| ExportedFileView {
@@ -1170,6 +1170,8 @@ struct CreateSandboxForm {
     mode: String,
     #[serde(default)]
     repo_url: Option<String>,
+    #[serde(default)]
+    branch: Option<String>,
     cpu: String,
     memory: String,
     disk_size: String,
@@ -1198,7 +1200,15 @@ async fn workspace_sandbox_create(
                 .filter(|s| !s.is_empty())
                 .map(str::to_string);
             match repo_url {
-                Some(repo_url) => SandboxMode::Repo { repo_url },
+                Some(repo_url) => {
+                    let branch = form
+                        .branch
+                        .as_deref()
+                        .map(str::trim)
+                        .filter(|s| !s.is_empty())
+                        .map(str::to_string);
+                    SandboxMode::Repo { repo_url, branch }
+                }
                 None => {
                     tracing::warn!("repo mode requires a non-empty repo_url");
                     return Redirect::to(&format!("/workspaces/{id}/sandboxes/new"))


### PR DESCRIPTION
## Summary
- Add optional `branch` parameter to sandbox creation (both workspace and admin tools, plus web form)
- Thread it through `InitializeRequest` wire type to the sandbox server
- Sandbox server passes `--branch <branch>` to `git clone` when specified; defaults to repo's default branch when omitted

## Test plan
- [x] All existing tests pass (37 sandbox-tool-server + 21 core sandbox tests)
- [x] `cargo check` and `cargo fmt --check` clean
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)