### PR TITLE
feat(web): expose sandbox branch field in web UI

### DIFF
--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -1028,9 +1028,11 @@ async fn workspace_skill_delete(
 // ---------------------------------------------------------------------------
 
 fn sandbox_to_view(s: &domain::sandbox::Sandbox) -> SandboxView {
-    let (mode_label, repo_url) = match &s.mode {
-        SandboxMode::Scratch => ("Scratch".to_string(), None),
-        SandboxMode::Repo { repo_url, .. } => ("Repo".to_string(), Some(repo_url.clone())),
+    let (mode_label, repo_url, branch) = match &s.mode {
+        SandboxMode::Scratch => ("Scratch".to_string(), None, None),
+        SandboxMode::Repo { repo_url, branch } => {
+            ("Repo".to_string(), Some(repo_url.clone()), branch.clone())
+        }
     };
 
     let exported_system_prompt = s.exported_system_prompt.as_ref().map(|f| ExportedFileView {
@@ -1063,6 +1065,7 @@ fn sandbox_to_view(s: &domain::sandbox::Sandbox) -> SandboxView {
         last_error: s.last_error.clone(),
         mode_label,
         repo_url,
+        branch,
         cpu: s.specs.cpu.clone(),
         memory: s.specs.memory.clone(),
         disk_size: s.specs.disk_size.clone(),

--- a/web/src/templates.rs
+++ b/web/src/templates.rs
@@ -191,6 +191,7 @@ pub struct SandboxView {
     pub last_error: Option<String>,
     pub mode_label: String,
     pub repo_url: Option<String>,
+    pub branch: Option<String>,
     pub cpu: String,
     pub memory: String,
     pub disk_size: String,

--- a/web/templates/workspace_sandbox_detail.html
+++ b/web/templates/workspace_sandbox_detail.html
@@ -170,6 +170,11 @@
       {% match sandbox.repo_url %}
         {% when Some with (url) %}
           <br><small><code>{{ url }}</code></small>
+          {% match sandbox.branch %}
+            {% when Some with (b) %}
+              <br><small>branch: <code>{{ b }}</code></small>
+            {% when None %}
+          {% endmatch %}
         {% when None %}
       {% endmatch %}
     </dd>

--- a/web/templates/workspace_sandbox_new.html
+++ b/web/templates/workspace_sandbox_new.html
@@ -121,6 +121,11 @@
     <input type="text" name="repo_url" placeholder="https://github.com/org/repo">
   </label>
 
+  <label>
+    Branch <small>(optional, only used in repo mode — defaults to repo's default branch)</small>
+    <input type="text" name="branch" placeholder="main">
+  </label>
+
   <div style="display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1rem;">
     <label>
       CPU


### PR DESCRIPTION
## Summary
- Add a "Branch" input field to the sandbox creation form (only used in repo mode)
- Display the branch on the sandbox detail page when set
- Wire up the existing backend `branch` parameter that was added in #121 but not exposed in the UI

## Test plan
- [ ] Create a sandbox in repo mode without specifying a branch — should use repo default
- [ ] Create a sandbox in repo mode with a specific branch — should clone that branch
- [ ] Verify branch displays on the sandbox detail page
- [ ] Verify scratch mode still works (branch field ignored)

🤖 Generated with [Claude Code](https://claude.com/claude-code)