### PR TITLE
feat(tunnel): outbound tunnel connector as alternative to Envoy proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5485,8 +5485,12 @@ checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
 dependencies = [
  "futures-util",
  "log",
+ "rustls",
+ "rustls-pki-types",
  "tokio",
+ "tokio-rustls",
  "tungstenite 0.26.2",
+ "webpki-roots 0.26.11",
 ]
 
 [[package]]
@@ -5881,6 +5885,8 @@ dependencies = [
  "httparse",
  "log",
  "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
@@ -5900,6 +5906,25 @@ dependencies = [
  "rand 0.9.4",
  "sha1",
  "thiserror 2.0.18",
+]
+
+[[package]]
+name = "tunnel-connector"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "futures",
+ "reqwest 0.13.2",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite 0.26.2",
+ "tracing",
+ "tracing-subscriber",
+ "url",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5915,6 +5915,7 @@ dependencies = [
  "anyhow",
  "clap",
  "futures",
+ "rand 0.8.6",
  "reqwest 0.13.2",
  "rmcp",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
   "code-assistant/crates/core",
   "code-assistant/crates/cli",
   "images/sandbox/server",
+  "images/tunnel-connector",
 ]
 resolver = "2"
 

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -12,6 +12,7 @@ groups:
   - test-sandbox
   - build-edge-image
   - build-sandbox-image
+  - build-tunnel-connector-image
   - deploy-to-prod
   - train-classifier
   - build-code-assistant-index
@@ -361,6 +362,38 @@ jobs:
     get_params:
       skip_download: true
 
+- name: build-tunnel-connector-image
+  serial: true
+  plan:
+  - get: repo-tunnel-connector
+    trigger: true
+    passed: [check-code]
+  - task: build-image
+    config:
+      platform: linux
+      image_resource: #@ nix_flake_image_config()
+      inputs:
+      - name: repo-tunnel-connector
+        path: repo
+      outputs:
+      - name: image
+      caches:
+      - path: /nix-cache
+      run:
+        path: repo/ci/tasks/with-nix-cache.sh
+        args:
+          - sh
+          - -exc
+          - |
+            cd repo
+            nix build .#tunnel-connector-image
+            gunzip -c result > ../image/image.tar
+  - put: tunnel-connector-edge-image
+    params:
+      image: image/image.tar
+    get_params:
+      skip_download: true
+
 resource_types:
 - name: terraform
   type: registry-image
@@ -402,6 +435,18 @@ resources:
     - bats/sandbox.bats
     - bats/sandbox-helpers.bash
     - flake.nix
+
+- name: repo-tunnel-connector
+  type: git
+  source:
+    uri: #@ data.values.git_uri
+    branch: #@ data.values.git_branch
+    private_key: #@ data.values.github_private_key
+    paths:
+    - images/tunnel-connector/
+    - flake.nix
+    - Cargo.toml
+    - Cargo.lock
 
 - name: repo-labels
   type: git
@@ -472,6 +517,14 @@ resources:
     username: #@ data.values.gar_registry_user
     password: #@ data.values.gar_registry_password
     repository: #@ data.values.gar_registry + "/sandbox"
+
+- name: tunnel-connector-edge-image
+  type: registry-image
+  source:
+    tag: edge
+    username: #@ data.values.gar_registry_user
+    password: #@ data.values.gar_registry_password
+    repository: #@ data.values.gar_registry + "/tunnel-connector"
 
 - name: tf-galoy-agents-prod
   type: terraform

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -367,7 +367,6 @@ jobs:
   plan:
   - get: repo-tunnel-connector
     trigger: true
-    passed: [check-code]
   - task: build-image
     config:
       platform: linux

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -51,4 +51,4 @@ llm = { workspace = true }
 rmcp = { workspace = true }
 serde_json = "1.0"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "json"] }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "test-util"] }

--- a/core/src/auth/scope.rs
+++ b/core/src/auth/scope.rs
@@ -29,6 +29,11 @@ pub enum AuthScope {
     /// Read-only access — the agent may invoke sandbox tools that
     /// don't modify state. Granted on a `Read` attach.
     SandboxRead(SandboxId),
+    /// Authorizes the holder to register a tunnel connector for a specific
+    /// `deployment_id`. The `/tunnel/ws` handler matches this scope against
+    /// the `deployment_id` in the connector's Register frame; a token scoped
+    /// to `Tunnel("galoy-staging")` cannot register as `galoy-production`.
+    Tunnel(String),
     /// An externally-defined scope string. Grants access only to
     /// [`AuthResource::External`] resources whose name matches.
     External(String),
@@ -65,6 +70,11 @@ impl AuthScope {
                     )
             }
 
+            // Tunnel scopes don't grant AuthVerb/AuthResource access — they
+            // gate a side door (the `/tunnel/ws` handler) and are checked
+            // there by name, not through `permits`.
+            AuthScope::Tunnel(_) => false,
+
             // External scopes match External resources by name.
             AuthScope::External(name) => {
                 matches!(resource, AuthResource::External(res_name) if res_name == name)
@@ -84,6 +94,7 @@ impl fmt::Display for AuthScope {
             AuthScope::WorkspaceAdmin(id) => write!(f, "ws:{id}:admin"),
             AuthScope::SandboxUse(id) => write!(f, "sandbox:{id}:use"),
             AuthScope::SandboxRead(id) => write!(f, "sandbox:{id}:read"),
+            AuthScope::Tunnel(id) => write!(f, "tunnel:{id}"),
             AuthScope::External(s) => f.write_str(s),
         }
     }
@@ -125,6 +136,17 @@ impl FromStr for AuthScope {
                 if let Ok(uuid) = uuid_str.parse::<uuid::Uuid>() {
                     return Ok(AuthScope::SandboxRead(SandboxId::from(uuid)));
                 }
+            }
+        }
+
+        // Parse "tunnel:{deployment_id}". An empty deployment_id must NOT
+        // silently become `Tunnel("")` — that would match any connector
+        // registration via the `==` check in `can_register_tunnel`.
+        // Fall through to External so malformed tokens never satisfy a
+        // `Tunnel(X)` gate.
+        if let Some(deployment_id) = s.strip_prefix("tunnel:") {
+            if !deployment_id.is_empty() {
+                return Ok(AuthScope::Tunnel(deployment_id.to_owned()));
             }
         }
 
@@ -190,6 +212,7 @@ mod tests {
             AuthScope::WorkspaceAdmin(ws_id),
             AuthScope::SandboxUse(sb_id),
             AuthScope::SandboxRead(sb_id),
+            AuthScope::Tunnel("galoy-staging".to_owned()),
             AuthScope::External("custom:thing".to_owned()),
         ];
 
@@ -277,6 +300,24 @@ mod tests {
         assert_eq!(scope, AuthScope::External("read".to_owned()));
     }
 
+    #[test]
+    fn tunnel_round_trip() {
+        let scope = AuthScope::Tunnel("galoy-staging".to_owned());
+        assert_eq!(scope.to_string(), "tunnel:galoy-staging");
+        let parsed: AuthScope = "tunnel:galoy-staging".parse().unwrap();
+        assert_eq!(parsed, scope);
+    }
+
+    /// `tunnel:` with no id must not silently become a Tunnel scope —
+    /// guards against a malformed token accidentally matching any
+    /// deployment. It falls through to External, which never matches a
+    /// `Tunnel(X)` check.
+    #[test]
+    fn tunnel_empty_deployment_id_falls_back_to_external() {
+        let scope: AuthScope = "tunnel:".parse().unwrap();
+        assert_eq!(scope, AuthScope::External("tunnel:".to_owned()));
+    }
+
     /// Eq-based comparison works across all variants.
     #[test]
     fn eq_all_variants() {
@@ -310,6 +351,10 @@ mod tests {
             (
                 AuthScope::WorkspaceAdmin(ws_id),
                 r#""ws:a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8:admin""#,
+            ),
+            (
+                AuthScope::Tunnel("galoy-staging".to_owned()),
+                r#""tunnel:galoy-staging""#,
             ),
             (AuthScope::External("custom".to_owned()), r#""custom""#),
         ];

--- a/core/src/auth/subject.rs
+++ b/core/src/auth/subject.rs
@@ -192,8 +192,8 @@ impl AuthSubject {
 
 #[cfg(test)]
 mod tests {
-    use crate::primitives::{AgentId, McpCredsId, UserId};
     use super::*;
+    use crate::primitives::{AgentId, McpCredsId, UserId};
 
     fn a_user_id() -> UserId {
         UserId::from(uuid::Uuid::new_v4())

--- a/core/src/auth/subject.rs
+++ b/core/src/auth/subject.rs
@@ -152,6 +152,25 @@ impl AuthSubject {
         })
     }
 
+    /// True when the subject carries an [`AuthScope::Tunnel`] authorizing
+    /// registration of a tunnel connector for `deployment_id`. Session
+    /// `User` subjects bypass this check (they already have effectively
+    /// all scopes); bearer-authenticated subjects must hold the exact
+    /// scope — a token scoped to `galoy-staging` cannot register as
+    /// `galoy-production`.
+    pub fn can_register_tunnel(&self, deployment_id: &str) -> bool {
+        // Short-circuit for session-authenticated humans — session auth
+        // already implies full scopes (see `has_scope`). Also avoids a
+        // `String` allocation on every check when the Tunnel scope is
+        // unused.
+        if matches!(self, AuthSubject::User(_)) {
+            return true;
+        }
+        self.scopes()
+            .iter()
+            .any(|s| matches!(s, AuthScope::Tunnel(id) if id == deployment_id))
+    }
+
     /// Convert the subject into the principal that should be recorded as the
     /// originator of a message. Panics for `Anonymous` (callers must
     /// authenticate before sending messages).
@@ -168,5 +187,81 @@ impl AuthSubject {
             },
             AuthSubject::Anonymous => panic!("Anonymous subject has no message source"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::primitives::{AgentId, McpCredsId, UserId};
+    use super::*;
+
+    fn a_user_id() -> UserId {
+        UserId::from(uuid::Uuid::new_v4())
+    }
+
+    fn exported_agent_with(scopes: Vec<AuthScope>) -> AuthSubject {
+        AuthSubject::ExportedAgent(a_user_id(), McpCredsId::from(uuid::Uuid::new_v4()), scopes)
+    }
+
+    fn agent_with(scopes: Vec<AuthScope>) -> AuthSubject {
+        AuthSubject::Agent(
+            WorkspaceId::from(uuid::Uuid::new_v4()),
+            AgentId::from(uuid::Uuid::new_v4()),
+            scopes,
+        )
+    }
+
+    #[test]
+    fn can_register_tunnel_matches_scoped_deployment_id() {
+        let subject = exported_agent_with(vec![AuthScope::Tunnel("galoy-staging".to_owned())]);
+        assert!(subject.can_register_tunnel("galoy-staging"));
+    }
+
+    /// The core auth guarantee: a token scoped to one deployment cannot
+    /// register as another.
+    #[test]
+    fn can_register_tunnel_rejects_different_deployment_id() {
+        let subject = exported_agent_with(vec![AuthScope::Tunnel("galoy-staging".to_owned())]);
+        assert!(!subject.can_register_tunnel("galoy-production"));
+    }
+
+    /// A token without any Tunnel scope cannot register as anything —
+    /// even for a deployment_id that happens to match an External scope string.
+    #[test]
+    fn can_register_tunnel_rejects_no_tunnel_scope() {
+        let subject = exported_agent_with(vec![AuthScope::Admin]);
+        assert!(!subject.can_register_tunnel("galoy-staging"));
+
+        let subject_ext =
+            exported_agent_with(vec![AuthScope::External("galoy-staging".to_owned())]);
+        assert!(!subject_ext.can_register_tunnel("galoy-staging"));
+    }
+
+    /// Session `User` subjects bypass the check (session auth implies
+    /// all scopes everywhere in the codebase).
+    #[test]
+    fn can_register_tunnel_user_subject_bypasses() {
+        let subject = AuthSubject::User(a_user_id());
+        assert!(subject.can_register_tunnel("anything"));
+        assert!(subject.can_register_tunnel("galoy-production"));
+    }
+
+    /// Anonymous and scope-free Agent subjects cannot register tunnels.
+    #[test]
+    fn can_register_tunnel_rejects_anonymous_and_scopeless() {
+        assert!(!AuthSubject::Anonymous.can_register_tunnel("galoy-staging"));
+        assert!(!agent_with(vec![]).can_register_tunnel("galoy-staging"));
+    }
+
+    /// A subject can hold multiple Tunnel scopes and match any of them.
+    #[test]
+    fn can_register_tunnel_multiple_scopes() {
+        let subject = exported_agent_with(vec![
+            AuthScope::Tunnel("galoy-staging".to_owned()),
+            AuthScope::Tunnel("galoy-qa".to_owned()),
+        ]);
+        assert!(subject.can_register_tunnel("galoy-staging"));
+        assert!(subject.can_register_tunnel("galoy-qa"));
+        assert!(!subject.can_register_tunnel("galoy-production"));
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -51,6 +51,11 @@ pub struct App {
     skills: Arc<Skills>,
     sandboxes: Arc<Sandboxes>,
     github_app: Option<Arc<GitHubAppTokenProvider>>,
+    /// Registry of currently-live tunnel connectors, keyed by
+    /// `deployment_id`. Used by the `/tunnel/ws` handler to evict a
+    /// previous tunnel when a new connector registers the same
+    /// `deployment_id`. See [`tunnel::TunnelRegistry`].
+    tunnels: Arc<tunnel::TunnelRegistry>,
     /// Held so the executor's worker task stays alive for the lifetime of
     /// `App`; dropped on shutdown which aborts the task.
     _prompt_executor: Arc<PromptExecutor>,
@@ -206,6 +211,7 @@ impl App {
             skills,
             sandboxes,
             github_app,
+            tunnels: Arc::new(tunnel::TunnelRegistry::new()),
             _prompt_executor: prompt_executor,
         })
     }
@@ -252,6 +258,10 @@ impl App {
 
     pub fn github_app(&self) -> Option<&GitHubAppTokenProvider> {
         self.github_app.as_deref()
+    }
+
+    pub fn tunnels(&self) -> &tunnel::TunnelRegistry {
+        &self.tunnels
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod prompt_executor;
 pub mod sandbox;
 pub mod skill;
 pub mod toolset;
+pub mod tunnel;
 pub mod user;
 pub mod workspace;
 pub mod workspace_secret;

--- a/core/src/toolset/error.rs
+++ b/core/src/toolset/error.rs
@@ -28,6 +28,8 @@ pub enum ToolSetsError {
     Sandbox(String),
     #[error("ToolSetsError - Workspace: {0}")]
     Workspace(String),
+    #[error("ToolSetsError - Tunnel: {0}")]
+    Tunnel(String),
     #[error("ToolSetsError - Unauthorized")]
     Unauthorized,
 }

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -165,7 +165,9 @@ impl ToolSets {
         let mut sets = self.sets.write().expect("toolset lock poisoned");
         let before = sets.len();
         sets.retain(|s| match s.scope() {
-            Some(ToolSetScope::Tunnel { deployment_id: d, .. }) => d != deployment_id,
+            Some(ToolSetScope::Tunnel {
+                deployment_id: d, ..
+            }) => d != deployment_id,
             _ => true,
         });
         let removed = before - sets.len();
@@ -189,7 +191,9 @@ impl ToolSets {
         let mut sets = self.sets.write().expect("toolset lock poisoned");
         let before = sets.len();
         sets.retain(|s| match s.scope() {
-            Some(ToolSetScope::Tunnel { session_id: sid, .. }) => *sid != session_id,
+            Some(ToolSetScope::Tunnel {
+                session_id: sid, ..
+            }) => *sid != session_id,
             _ => true,
         });
         let removed = before - sets.len();

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -143,14 +143,62 @@ impl ToolSets {
         sets.push(toolset);
     }
 
-    /// Remove a searchable toolset by name. Used when a tunnel disconnects
-    /// so its tools are no longer advertised.
-    pub fn unregister_searchable(&self, name: &str) {
+    /// Atomically replace every tunnel toolset currently registered under
+    /// `deployment_id` with `new_sets`. Done under a single write lock, which:
+    ///
+    /// 1. closes the overlap window between a new connector's registration
+    ///    and the evicted connector's cleanup — without this, first-match
+    ///    routing in the append-only vec would temporarily send calls to
+    ///    the dying connector;
+    /// 2. prevents duplicate toolset names for a deployment, so
+    ///    `describe_tool` / `search_tools` never show two copies of the
+    ///    same entry during takeover.
+    ///
+    /// The evicted loop's later [`Self::unregister_searchable_by_session`]
+    /// call will find nothing matching its own session_id and no-op,
+    /// leaving the freshly-registered entries intact.
+    pub fn replace_tunnel_toolsets(
+        &self,
+        deployment_id: &str,
+        new_sets: Vec<Arc<dyn SearchableToolSet>>,
+    ) {
         let mut sets = self.sets.write().expect("toolset lock poisoned");
         let before = sets.len();
-        sets.retain(|s| s.name() != name);
-        if sets.len() < before {
-            tracing::info!(name = %name, "Unregistered toolset");
+        sets.retain(|s| match s.scope() {
+            Some(ToolSetScope::Tunnel { deployment_id: d, .. }) => d != deployment_id,
+            _ => true,
+        });
+        let removed = before - sets.len();
+        let added = new_sets.len();
+        sets.extend(new_sets);
+        tracing::info!(
+            deployment_id = %deployment_id,
+            removed,
+            added,
+            "Replaced tunnel toolsets"
+        );
+    }
+
+    /// Remove every tunnel-scoped toolset owned by `session_id`. Called
+    /// from a WS loop's cleanup path. If the session was already evicted
+    /// by a newer connector (which reused the `deployment_id` via
+    /// [`Self::replace_tunnel_toolsets`]), this is a no-op — the new
+    /// session has a different `session_id` and its entries are not
+    /// touched. This is the invariant that makes takeover safe.
+    pub fn unregister_searchable_by_session(&self, session_id: uuid::Uuid) {
+        let mut sets = self.sets.write().expect("toolset lock poisoned");
+        let before = sets.len();
+        sets.retain(|s| match s.scope() {
+            Some(ToolSetScope::Tunnel { session_id: sid, .. }) => *sid != session_id,
+            _ => true,
+        });
+        let removed = before - sets.len();
+        if removed > 0 {
+            tracing::info!(
+                session_id = %session_id,
+                removed,
+                "Unregistered toolsets for session"
+            );
         }
     }
 
@@ -268,4 +316,184 @@ pub fn estimate_tokens(result: &CallToolResult) -> u64 {
         })
         .sum();
     (total_chars / 4).max(1) as u64
+}
+
+#[cfg(test)]
+impl ToolSets {
+    /// Test-only: construct an empty ToolSets without running `init`'s
+    /// I/O (upstream MCP dialers, Concourse client). Tests exercising the
+    /// catalog's dynamic-registration primitives don't need any of that.
+    pub fn empty_for_test() -> Self {
+        Self {
+            sets: Arc::new(RwLock::new(Vec::new())),
+            top_level: RwLock::new(HashMap::new()),
+            audit: None,
+            init_errors: Vec::new(),
+        }
+    }
+
+    /// Test-only: snapshot the current set of toolset names, in
+    /// registration order. Used to assert takeover semantics without
+    /// exposing the internal Vec.
+    pub fn toolset_names_for_test(&self) -> Vec<String> {
+        self.sets
+            .read()
+            .expect("toolset lock poisoned")
+            .iter()
+            .map(|s| s.name().to_string())
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rmcp::model::CallToolResult;
+
+    /// A minimal stub to exercise `replace_tunnel_toolsets` /
+    /// `unregister_searchable_by_session` without spinning up a real
+    /// tunnel. Its `call()` will never be invoked by these tests.
+    struct StubToolSet {
+        name: String,
+        scope: Option<ToolSetScope>,
+        tools: Vec<ToolSetEntry>,
+    }
+
+    impl StubToolSet {
+        fn tunnel(name: &str, deployment_id: &str, session_id: uuid::Uuid) -> Self {
+            Self {
+                name: name.to_string(),
+                scope: Some(ToolSetScope::Tunnel {
+                    deployment_id: deployment_id.to_string(),
+                    session_id,
+                }),
+                tools: Vec::new(),
+            }
+        }
+
+        fn static_(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+                scope: None,
+                tools: Vec::new(),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl SearchableToolSet for StubToolSet {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn category(&self) -> &str {
+            "stub"
+        }
+        fn category_description(&self) -> &str {
+            "stub"
+        }
+        fn tools(&self) -> &[ToolSetEntry] {
+            &self.tools
+        }
+        fn scope(&self) -> Option<&ToolSetScope> {
+            self.scope.as_ref()
+        }
+        async fn call(
+            &self,
+            _subject: &AuthSubject,
+            _tool_name: &str,
+            _arguments: Option<JsonObject>,
+        ) -> Result<CallToolResult, ToolSetsError> {
+            unreachable!("stub: call should not be invoked by these tests")
+        }
+    }
+
+    /// Atomic swap: `replace_tunnel_toolsets` drops every toolset whose
+    /// scope is `Tunnel(deployment_id, _)` and appends the new ones —
+    /// in one write-lock, so routing never sees the old entries.
+    #[test]
+    fn replace_tunnel_toolsets_swaps_by_deployment() {
+        let toolsets = ToolSets::empty_for_test();
+        let old_session = uuid::Uuid::new_v4();
+        toolsets.register_searchable(StubToolSet::tunnel("stg-k8s", "staging", old_session));
+        toolsets.register_searchable(StubToolSet::tunnel("stg-pg", "staging", old_session));
+        toolsets.register_searchable(StubToolSet::static_("concourse"));
+        assert_eq!(
+            toolsets.toolset_names_for_test(),
+            vec!["stg-k8s", "stg-pg", "concourse"]
+        );
+
+        let new_session = uuid::Uuid::new_v4();
+        let new_sets: Vec<Arc<dyn SearchableToolSet>> = vec![Arc::new(StubToolSet::tunnel(
+            "stg-k8s",
+            "staging",
+            new_session,
+        ))];
+        toolsets.replace_tunnel_toolsets("staging", new_sets);
+
+        // Both old "staging" entries gone; static "concourse" untouched;
+        // new "stg-k8s" appended.
+        assert_eq!(
+            toolsets.toolset_names_for_test(),
+            vec!["concourse", "stg-k8s"]
+        );
+    }
+
+    /// Atomic swap only touches the target deployment — other
+    /// deployments' tunnel toolsets are preserved.
+    #[test]
+    fn replace_tunnel_toolsets_spares_other_deployments() {
+        let toolsets = ToolSets::empty_for_test();
+        let staging_session = uuid::Uuid::new_v4();
+        let prod_session = uuid::Uuid::new_v4();
+        toolsets.register_searchable(StubToolSet::tunnel("stg-k8s", "staging", staging_session));
+        toolsets.register_searchable(StubToolSet::tunnel("prd-k8s", "production", prod_session));
+
+        toolsets.replace_tunnel_toolsets("staging", Vec::new());
+
+        assert_eq!(toolsets.toolset_names_for_test(), vec!["prd-k8s"]);
+    }
+
+    /// Session-aware unregister: after an eviction-style replace, the
+    /// evicted loop's `unregister_searchable_by_session(old_session)` is a
+    /// no-op — it only matches entries whose scope carries `old_session`,
+    /// of which there are none after the swap. The new session's entries
+    /// survive.
+    #[test]
+    fn unregister_by_session_is_noop_for_evicted_session() {
+        let toolsets = ToolSets::empty_for_test();
+        let old_session = uuid::Uuid::new_v4();
+        let new_session = uuid::Uuid::new_v4();
+
+        toolsets.register_searchable(StubToolSet::tunnel("stg-k8s", "staging", old_session));
+        toolsets.replace_tunnel_toolsets(
+            "staging",
+            vec![Arc::new(StubToolSet::tunnel(
+                "stg-k8s",
+                "staging",
+                new_session,
+            ))],
+        );
+
+        // Evicted loop's late cleanup must not remove the new session's entries.
+        toolsets.unregister_searchable_by_session(old_session);
+        assert_eq!(toolsets.toolset_names_for_test(), vec!["stg-k8s"]);
+
+        // The real owner can still release itself.
+        toolsets.unregister_searchable_by_session(new_session);
+        assert!(toolsets.toolset_names_for_test().is_empty());
+    }
+
+    /// Clean disconnect path (no takeover): a session registers toolsets,
+    /// then `unregister_searchable_by_session` with its own id cleans them up.
+    #[test]
+    fn unregister_by_session_clean_disconnect() {
+        let toolsets = ToolSets::empty_for_test();
+        let session = uuid::Uuid::new_v4();
+        toolsets.register_searchable(StubToolSet::tunnel("stg-k8s", "staging", session));
+        toolsets.register_searchable(StubToolSet::static_("concourse"));
+
+        toolsets.unregister_searchable_by_session(session);
+        // Static toolsets are never removed by session-based unregister.
+        assert_eq!(toolsets.toolset_names_for_test(), vec!["concourse"]);
+    }
 }

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -143,6 +143,17 @@ impl ToolSets {
         sets.push(toolset);
     }
 
+    /// Remove a searchable toolset by name. Used when a tunnel disconnects
+    /// so its tools are no longer advertised.
+    pub fn unregister_searchable(&self, name: &str) {
+        let mut sets = self.sets.write().expect("toolset lock poisoned");
+        let before = sets.len();
+        sets.retain(|s| s.name() != name);
+        if sets.len() < before {
+            tracing::info!(name = %name, "Unregistered toolset");
+        }
+    }
+
     /// Human-readable summary of available toolsets — used as the MCP
     /// server's `instructions` payload so clients know how to discover and
     /// call upstream tools.

--- a/core/src/toolset/traits.rs
+++ b/core/src/toolset/traits.rs
@@ -13,6 +13,26 @@ pub struct ToolSetEntry {
     pub default_output_filter: Option<OutputFilter>,
 }
 
+/// Dynamic-registration provenance carried by a [`SearchableToolSet`].
+///
+/// Returned by [`SearchableToolSet::scope`] so that the [`super::ToolSets`]
+/// container can (a) atomically replace all toolsets owned by a particular
+/// scope and (b) reject stale cleanup calls from an evicted owner. Static
+/// toolsets (configured upstreams, Concourse, code-assistant, etc.) return
+/// `None` and are never eligible for scope-based removal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ToolSetScope {
+    /// A tunnel-registered toolset. Two keys — `deployment_id` identifies
+    /// *which* tunnel's toolsets to atomically replace on takeover;
+    /// `session_id` identifies *which specific session* is the current
+    /// owner, so an evicted WS loop's late cleanup can be distinguished
+    /// from the live session and ignored.
+    Tunnel {
+        deployment_id: String,
+        session_id: uuid::Uuid,
+    },
+}
+
 /// A single tool exposed to the agent at the top level — e.g. `search_tools`,
 /// `describe_tool`, `call_tool`, or later built-ins like `read` / `bash`.
 ///
@@ -65,6 +85,15 @@ pub trait SearchableToolSet: Send + Sync {
     /// visible. Override to hide a toolset behind a scope or role.
     fn is_visible(&self, _subject: &AuthSubject) -> bool {
         true
+    }
+
+    /// Provenance for dynamically-registered toolsets. Static toolsets
+    /// (configured upstreams, Concourse, code-assistant) leave this at
+    /// the default `None`; tunnel-backed toolsets return `Some(..)` so
+    /// that takeover can atomically replace them and stale cleanup can
+    /// distinguish live from evicted ownership. See [`ToolSetScope`].
+    fn scope(&self) -> Option<&ToolSetScope> {
+        None
     }
 
     async fn call(

--- a/core/src/tunnel.rs
+++ b/core/src/tunnel.rs
@@ -104,7 +104,9 @@ impl TunnelHandle {
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let id = uuid::Uuid::new_v4().to_string();
-        let result = self.call_tool_inner(&id, upstream, tool_name, arguments).await;
+        let result = self
+            .call_tool_inner(&id, upstream, tool_name, arguments)
+            .await;
         // Single cleanup point: remove is a no-op if a successful `resolve`
         // already took the entry out. Covers timeout, send failure, and
         // serialization failure without repeating cleanup at each `?`.

--- a/core/src/tunnel.rs
+++ b/core/src/tunnel.rs
@@ -26,7 +26,7 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{mpsc, oneshot, Mutex};
 
 use crate::auth::AuthSubject;
-use crate::toolset::{SearchableToolSet, ToolSetEntry, ToolSetsError};
+use crate::toolset::{SearchableToolSet, ToolSetEntry, ToolSetScope, ToolSetsError};
 
 // ---------------------------------------------------------------------------
 // Wire protocol
@@ -90,6 +90,13 @@ impl TunnelHandle {
     }
 
     /// Send a tool call through the tunnel and wait for the result.
+    ///
+    /// Every non-happy-path exit (timeout, tunnel closed mid-call, send
+    /// failure) removes the id from `pending` before returning — otherwise
+    /// the entry (and the `oneshot::Sender` it holds) would linger for the
+    /// lifetime of every cloned [`TunnelHandle`], which is the entire
+    /// registered `TunnelToolSet`. That's the leak the PR #127 review
+    /// flagged.
     pub async fn call_tool(
         &self,
         upstream: &str,
@@ -97,15 +104,30 @@ impl TunnelHandle {
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let id = uuid::Uuid::new_v4().to_string();
+        let result = self.call_tool_inner(&id, upstream, tool_name, arguments).await;
+        // Single cleanup point: remove is a no-op if a successful `resolve`
+        // already took the entry out. Covers timeout, send failure, and
+        // serialization failure without repeating cleanup at each `?`.
+        self.pending.lock().await.remove(&id);
+        result
+    }
+
+    async fn call_tool_inner(
+        &self,
+        id: &str,
+        upstream: &str,
+        tool_name: &str,
+        arguments: Option<JsonObject>,
+    ) -> Result<CallToolResult, ToolSetsError> {
         let (resp_tx, resp_rx) = oneshot::channel();
 
         {
             let mut pending = self.pending.lock().await;
-            pending.insert(id.clone(), resp_tx);
+            pending.insert(id.to_string(), resp_tx);
         }
 
         let msg = TunnelMessage::CallTool {
-            id: id.clone(),
+            id: id.to_string(),
             upstream: upstream.to_string(),
             tool_name: tool_name.to_string(),
             arguments,
@@ -115,18 +137,14 @@ impl TunnelHandle {
             .map_err(|e| ToolSetsError::Tunnel(format!("serialize: {e}")))?;
 
         if self.tx.send(json).await.is_err() {
-            let mut pending = self.pending.lock().await;
-            pending.remove(&id);
             return Err(ToolSetsError::Tunnel("tunnel disconnected".to_string()));
         }
 
-        let result = tokio::time::timeout(std::time::Duration::from_secs(120), resp_rx)
+        tokio::time::timeout(std::time::Duration::from_secs(120), resp_rx)
             .await
             .map_err(|_| ToolSetsError::Tunnel("tool call timed out after 120s".to_string()))?
             .map_err(|_| ToolSetsError::Tunnel("tunnel disconnected".to_string()))?
-            .map_err(ToolSetsError::Tunnel)?;
-
-        Ok(result)
+            .map_err(ToolSetsError::Tunnel)
     }
 
     /// Resolve a pending call with a result (called by the WebSocket handler).
@@ -135,6 +153,30 @@ impl TunnelHandle {
         if let Some(tx) = pending.remove(id) {
             let _ = tx.send(result);
         }
+    }
+
+    /// Drain every outstanding pending call with `error`. Called from the
+    /// WS handler's cleanup block when the relay loop exits, so in-flight
+    /// callers fail immediately instead of waiting the full 120s timeout
+    /// for a response that will never arrive.
+    ///
+    /// Cleanup ordering in the WS handler (see `web/src/tunnel.rs`):
+    ///   1. `unregister_searchable_by_session` — no new calls can reach us.
+    ///   2. `fail_all_pending` — drain anything that beat the unregister.
+    ///   3. `TunnelRegistry::release`.
+    pub async fn fail_all_pending(&self, error: &str) {
+        let mut pending = self.pending.lock().await;
+        let drained: Vec<_> = pending.drain().collect();
+        drop(pending);
+        for (_, tx) in drained {
+            let _ = tx.send(Err(error.to_string()));
+        }
+    }
+
+    /// Number of outstanding pending tool calls. Test/observability helper.
+    #[cfg(test)]
+    pub async fn pending_len(&self) -> usize {
+        self.pending.lock().await.len()
     }
 }
 
@@ -247,6 +289,12 @@ pub struct TunnelToolSet {
     upstream_name: String,
     tools: Vec<ToolSetEntry>,
     handle: TunnelHandle,
+    /// Scope tag — both the `deployment_id` (so
+    /// [`super::toolset::ToolSets::replace_tunnel_toolsets`] can atomically
+    /// swap a deployment's toolsets on takeover) and the `session_id`
+    /// (so an evicted WS loop's cleanup doesn't remove the live session's
+    /// entries).
+    scope: ToolSetScope,
 }
 
 impl TunnelToolSet {
@@ -255,8 +303,11 @@ impl TunnelToolSet {
     /// The `name` is scoped to the deployment (e.g. `staging-kubernetes`)
     /// and the `prefix` is scoped similarly (e.g. `staging_k8s`) so that
     /// multiple deployments' toolsets don't collide in the catalog.
+    /// `session_id` identifies the WS session that owns this toolset —
+    /// cleanup keys on it so takeover is safe.
     pub fn new(
         deployment_id: &str,
+        session_id: uuid::Uuid,
         registration: &RegisteredToolSet,
         handle: TunnelHandle,
     ) -> Result<Self, String> {
@@ -284,6 +335,10 @@ impl TunnelToolSet {
             upstream_name: registration.name.clone(),
             tools,
             handle,
+            scope: ToolSetScope::Tunnel {
+                deployment_id: deployment_id.to_string(),
+                session_id,
+            },
         })
     }
 }
@@ -308,6 +363,10 @@ impl SearchableToolSet for TunnelToolSet {
 
     fn tools(&self) -> &[ToolSetEntry] {
         &self.tools
+    }
+
+    fn scope(&self) -> Option<&ToolSetScope> {
+        Some(&self.scope)
     }
 
     async fn call(
@@ -423,5 +482,116 @@ mod tests {
         // Fresh session can still release itself.
         registry.release("galoy-staging", fresh_session);
         assert!(registry.is_empty());
+    }
+
+    // ── TunnelHandle pending-map tests ──────────────────────────────────
+    //
+    // Each scenario below proves that `pending` does not leak under an
+    // abnormal exit path. Before these fixes, an in-flight call that hit
+    // a disconnect-after-send or a timeout would leave its `oneshot::Sender`
+    // in the map forever, pinned alive by cloned `TunnelHandle`s inside
+    // the registered `TunnelToolSet`s.
+
+    /// Successful resolve: happy path — entry is removed by `resolve`,
+    /// and the outer cleanup in `call_tool` is a no-op.
+    #[tokio::test]
+    async fn pending_cleared_on_success() {
+        let (tx, mut rx) = mpsc::channel::<String>(8);
+        let handle = TunnelHandle::new(tx);
+
+        // Consume the outbound message so send doesn't block the channel.
+        // Resolve after a brief delay so the caller is already awaiting.
+        let handle_bg = handle.clone();
+        let resolver = tokio::spawn(async move {
+            let json = rx.recv().await.expect("outbound");
+            let parsed: TunnelMessage = serde_json::from_str(&json).unwrap();
+            let id = match parsed {
+                TunnelMessage::CallTool { id, .. } => id,
+                _ => panic!("expected CallTool"),
+            };
+            let result: CallToolResult =
+                serde_json::from_value(serde_json::json!({ "content": [], "isError": false }))
+                    .unwrap();
+            handle_bg.resolve(&id, Ok(result)).await;
+        });
+
+        let result = handle.call_tool("kubernetes", "list_pods", None).await;
+        assert!(result.is_ok());
+        resolver.await.unwrap();
+        assert_eq!(handle.pending_len().await, 0);
+    }
+
+    /// Send failure: outbound receiver dropped before the call goes out.
+    /// The entry must still be cleaned up — otherwise every call after a
+    /// disconnect would leak.
+    #[tokio::test]
+    async fn pending_cleared_on_send_failure() {
+        let (tx, rx) = mpsc::channel::<String>(8);
+        let handle = TunnelHandle::new(tx);
+        drop(rx); // simulate relay loop already gone
+
+        let result = handle.call_tool("kubernetes", "list_pods", None).await;
+        assert!(matches!(result, Err(ToolSetsError::Tunnel(_))));
+        assert_eq!(handle.pending_len().await, 0);
+    }
+
+    /// `fail_all_pending` drains outstanding calls and fails them
+    /// immediately, instead of them sitting on the full 120s timeout.
+    /// This is the fix for PR #127's "callers sit 120s after tunnel
+    /// death" review comment.
+    #[tokio::test(start_paused = true)]
+    async fn fail_all_pending_drains_immediately() {
+        let (tx, _rx) = mpsc::channel::<String>(8);
+        let handle = TunnelHandle::new(tx);
+
+        // Launch a call that will park on resp_rx forever without intervention.
+        let caller = {
+            let h = handle.clone();
+            tokio::spawn(async move { h.call_tool("k8s", "get_pods", None).await })
+        };
+
+        // Let the caller reach the await point and register in pending.
+        tokio::task::yield_now().await;
+        // Spin until the pending entry is visible — avoids a timing race
+        // on slow runners without real-wall-clock sleep (tokio is paused).
+        for _ in 0..100 {
+            if handle.pending_len().await == 1 {
+                break;
+            }
+            tokio::task::yield_now().await;
+        }
+        assert_eq!(handle.pending_len().await, 1);
+
+        handle.fail_all_pending("tunnel disconnected").await;
+
+        // Caller should return essentially immediately, not after 120s.
+        let result = caller.await.unwrap();
+        assert!(matches!(result, Err(ToolSetsError::Tunnel(_))));
+        assert_eq!(handle.pending_len().await, 0);
+    }
+
+    /// Timeout path: a call whose resp_rx never fires must clean its own
+    /// pending entry. Using `start_paused = true` so the 120s timeout
+    /// fires in virtual time without blocking the test for 2 minutes.
+    #[tokio::test(start_paused = true)]
+    async fn pending_cleared_on_timeout() {
+        let (tx, mut rx) = mpsc::channel::<String>(8);
+        let handle = TunnelHandle::new(tx);
+
+        let caller = {
+            let h = handle.clone();
+            tokio::spawn(async move { h.call_tool("k8s", "get_pods", None).await })
+        };
+
+        // Drain the outbound queue so send succeeds — otherwise the call
+        // would exit via the send-failure path instead of timeout.
+        let _outbound = rx.recv().await.expect("outbound message");
+
+        // Advance past the 120s timeout.
+        tokio::time::advance(std::time::Duration::from_secs(121)).await;
+
+        let result = caller.await.unwrap();
+        assert!(matches!(result, Err(ToolSetsError::Tunnel(_))));
+        assert_eq!(handle.pending_len().await, 0);
     }
 }

--- a/core/src/tunnel.rs
+++ b/core/src/tunnel.rs
@@ -1,0 +1,226 @@
+//! Tunnel transport for deployment-side MCP servers.
+//!
+//! Instead of exposing MCP servers on a public endpoint with JWT auth,
+//! a lightweight connector in the target cluster dials *out* to galoy-agents
+//! over WebSocket. Tool calls are relayed through the already-authenticated
+//! tunnel — no ingress, Envoy, or JWT validation required in the target
+//! cluster.
+//!
+//! # Wire protocol
+//!
+//! All messages are JSON text frames:
+//!
+//! - **Register** (connector → server): sent once after connect; carries
+//!   deployment identity and the full tool catalog discovered from local
+//!   MCP servers.
+//! - **CallTool** (server → connector): a tool invocation request with a
+//!   correlation `id`.
+//! - **CallToolResult / CallToolError** (connector → server): the response,
+//!   matched by `id`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use rmcp::model::{CallToolResult, JsonObject, Tool};
+use serde::{Deserialize, Serialize};
+use tokio::sync::{mpsc, oneshot, Mutex};
+
+use crate::auth::AuthSubject;
+use crate::toolset::{SearchableToolSet, ToolSetEntry, ToolSetsError};
+
+// ---------------------------------------------------------------------------
+// Wire protocol
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TunnelMessage {
+    /// Connector → Server: register deployment and discovered tools.
+    Register {
+        deployment_id: String,
+        toolsets: Vec<RegisteredToolSet>,
+    },
+    /// Server → Connector: invoke a tool on a local MCP server.
+    CallTool {
+        id: String,
+        upstream: String,
+        tool_name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        arguments: Option<serde_json::Map<String, serde_json::Value>>,
+    },
+    /// Connector → Server: successful tool result.
+    CallToolResult {
+        id: String,
+        result: serde_json::Value,
+    },
+    /// Connector → Server: tool call failed.
+    CallToolError { id: String, error: String },
+}
+
+/// A toolset advertised by the connector during registration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RegisteredToolSet {
+    pub name: String,
+    pub prefix: String,
+    pub category: String,
+    pub category_description: String,
+    /// Each entry is a JSON-serialized `rmcp::model::Tool`.
+    pub tools: Vec<serde_json::Value>,
+}
+
+// ---------------------------------------------------------------------------
+// Tunnel handle — one per WebSocket connection
+// ---------------------------------------------------------------------------
+
+type PendingMap = Arc<Mutex<HashMap<String, oneshot::Sender<Result<CallToolResult, String>>>>>;
+
+/// Shared handle for sending tool calls through a tunnel and awaiting results.
+#[derive(Clone)]
+pub struct TunnelHandle {
+    tx: mpsc::Sender<String>,
+    pending: PendingMap,
+}
+
+impl TunnelHandle {
+    pub fn new(tx: mpsc::Sender<String>) -> Self {
+        Self {
+            tx,
+            pending: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Send a tool call through the tunnel and wait for the result.
+    pub async fn call_tool(
+        &self,
+        upstream: &str,
+        tool_name: &str,
+        arguments: Option<JsonObject>,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        let id = uuid::Uuid::new_v4().to_string();
+        let (resp_tx, resp_rx) = oneshot::channel();
+
+        {
+            let mut pending = self.pending.lock().await;
+            pending.insert(id.clone(), resp_tx);
+        }
+
+        let msg = TunnelMessage::CallTool {
+            id: id.clone(),
+            upstream: upstream.to_string(),
+            tool_name: tool_name.to_string(),
+            arguments,
+        };
+
+        let json = serde_json::to_string(&msg)
+            .map_err(|e| ToolSetsError::Tunnel(format!("serialize: {e}")))?;
+
+        if self.tx.send(json).await.is_err() {
+            let mut pending = self.pending.lock().await;
+            pending.remove(&id);
+            return Err(ToolSetsError::Tunnel("tunnel disconnected".to_string()));
+        }
+
+        let result = tokio::time::timeout(std::time::Duration::from_secs(120), resp_rx)
+            .await
+            .map_err(|_| ToolSetsError::Tunnel("tool call timed out after 120s".to_string()))?
+            .map_err(|_| ToolSetsError::Tunnel("tunnel disconnected".to_string()))?
+            .map_err(ToolSetsError::Tunnel)?;
+
+        Ok(result)
+    }
+
+    /// Resolve a pending call with a result (called by the WebSocket handler).
+    pub async fn resolve(&self, id: &str, result: Result<CallToolResult, String>) {
+        let mut pending = self.pending.lock().await;
+        if let Some(tx) = pending.remove(id) {
+            let _ = tx.send(result);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TunnelToolSet — SearchableToolSet backed by a tunnel connection
+// ---------------------------------------------------------------------------
+
+pub struct TunnelToolSet {
+    name: String,
+    prefix: String,
+    category: String,
+    category_description: String,
+    upstream_name: String,
+    tools: Vec<ToolSetEntry>,
+    handle: TunnelHandle,
+}
+
+impl TunnelToolSet {
+    /// Build a toolset from a connector's registration entry.
+    ///
+    /// The `name` is scoped to the deployment (e.g. `staging-kubernetes`)
+    /// and the `prefix` is scoped similarly (e.g. `staging_k8s`) so that
+    /// multiple deployments' toolsets don't collide in the catalog.
+    pub fn new(
+        deployment_id: &str,
+        registration: &RegisteredToolSet,
+        handle: TunnelHandle,
+    ) -> Result<Self, String> {
+        let tools: Vec<ToolSetEntry> = registration
+            .tools
+            .iter()
+            .filter_map(|t| {
+                let tool: Tool = serde_json::from_value(t.clone()).ok()?;
+                Some(ToolSetEntry {
+                    name: tool.name.to_string(),
+                    description: tool,
+                    default_output_filter: None,
+                })
+            })
+            .collect();
+
+        let name = format!("{}-{}", deployment_id, registration.name);
+        let prefix = format!("{}_{}", deployment_id, registration.prefix);
+
+        Ok(Self {
+            name,
+            prefix,
+            category: registration.category.clone(),
+            category_description: registration.category_description.clone(),
+            upstream_name: registration.name.clone(),
+            tools,
+            handle,
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl SearchableToolSet for TunnelToolSet {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn prefix(&self) -> &str {
+        &self.prefix
+    }
+
+    fn category(&self) -> &str {
+        &self.category
+    }
+
+    fn category_description(&self) -> &str {
+        &self.category_description
+    }
+
+    fn tools(&self) -> &[ToolSetEntry] {
+        &self.tools
+    }
+
+    async fn call(
+        &self,
+        _subject: &AuthSubject,
+        tool_name: &str,
+        arguments: Option<JsonObject>,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        self.handle
+            .call_tool(&self.upstream_name, tool_name, arguments)
+            .await
+    }
+}

--- a/core/src/tunnel.rs
+++ b/core/src/tunnel.rs
@@ -139,6 +139,103 @@ impl TunnelHandle {
 }
 
 // ---------------------------------------------------------------------------
+// TunnelRegistry — enforces one live tunnel per deployment_id
+// ---------------------------------------------------------------------------
+
+/// Per-live-tunnel entry. The `close_tx` is how the registry signals the
+/// old WS loop to shut down when a new connector takes over the same
+/// `deployment_id`. The `session_id` lets an evicted loop avoid
+/// accidentally removing the *new* entry during its own cleanup.
+struct RegisteredTunnel {
+    session_id: uuid::Uuid,
+    close_tx: mpsc::Sender<()>,
+}
+
+/// Maps `deployment_id` → the currently live tunnel session for that
+/// deployment. At most one entry per `deployment_id` at any time — a
+/// new Register for an already-registered id evicts the previous
+/// connection (closes its WS with a `POLICY` close frame).
+///
+/// This closes gap #2 from drua#127's original "Known security gaps"
+/// list: without the registry, two connectors holding the same
+/// `deployment_id` would race-fight for tool call results via the
+/// shared `TunnelHandle::resolve` pending map. With the registry,
+/// the second connector's registration cleanly replaces the first.
+#[derive(Clone)]
+pub struct TunnelRegistry {
+    inner: Arc<std::sync::Mutex<HashMap<String, RegisteredTunnel>>>,
+}
+
+impl TunnelRegistry {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(std::sync::Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Claim `deployment_id` for a new session. If an entry already
+    /// exists, its `close_tx` is taken out, the new one inserted under
+    /// the lock, and the old `close_tx` signaled *after* the lock is
+    /// released (await outside the critical section). Returns `true` if
+    /// an existing tunnel was evicted.
+    pub async fn claim(
+        &self,
+        deployment_id: &str,
+        session_id: uuid::Uuid,
+        close_tx: mpsc::Sender<()>,
+    ) -> bool {
+        let evicted = {
+            let mut map = self.inner.lock().expect("tunnel registry lock poisoned");
+            map.insert(
+                deployment_id.to_string(),
+                RegisteredTunnel {
+                    session_id,
+                    close_tx,
+                },
+            )
+        };
+        if let Some(old) = evicted {
+            // Channel capacity is 1; ignore send errors — if the receiver
+            // already dropped, the old loop is already on its way out.
+            let _ = old.close_tx.send(()).await;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Remove the entry for `deployment_id` only if it still belongs to
+    /// `session_id`. Called during cleanup so an evicted loop doesn't
+    /// accidentally remove the *new* tunnel's registry entry.
+    pub fn release(&self, deployment_id: &str, session_id: uuid::Uuid) {
+        let mut map = self.inner.lock().expect("tunnel registry lock poisoned");
+        if let Some(entry) = map.get(deployment_id) {
+            if entry.session_id == session_id {
+                map.remove(deployment_id);
+            }
+        }
+    }
+
+    /// Number of currently-registered deployments. Test/observability helper.
+    pub fn len(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("tunnel registry lock poisoned")
+            .len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Default for TunnelRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // TunnelToolSet — SearchableToolSet backed by a tunnel connection
 // ---------------------------------------------------------------------------
 
@@ -222,5 +319,109 @@ impl SearchableToolSet for TunnelToolSet {
         self.handle
             .call_tool(&self.upstream_name, tool_name, arguments)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fresh registry starts empty.
+    #[tokio::test]
+    async fn registry_starts_empty() {
+        let registry = TunnelRegistry::new();
+        assert!(registry.is_empty());
+    }
+
+    /// First claim for a deployment_id succeeds without eviction.
+    #[tokio::test]
+    async fn claim_first_does_not_evict() {
+        let registry = TunnelRegistry::new();
+        let (tx, _rx) = mpsc::channel::<()>(1);
+        let evicted = registry
+            .claim("galoy-staging", uuid::Uuid::new_v4(), tx)
+            .await;
+        assert!(!evicted);
+        assert_eq!(registry.len(), 1);
+    }
+
+    /// A second claim for the same deployment_id evicts the first.
+    /// The first session's `close_rx` receives the eviction signal.
+    #[tokio::test]
+    async fn second_claim_evicts_first() {
+        let registry = TunnelRegistry::new();
+
+        let (tx_a, mut rx_a) = mpsc::channel::<()>(1);
+        registry
+            .claim("galoy-staging", uuid::Uuid::new_v4(), tx_a)
+            .await;
+
+        let (tx_b, _rx_b) = mpsc::channel::<()>(1);
+        let evicted = registry
+            .claim("galoy-staging", uuid::Uuid::new_v4(), tx_b)
+            .await;
+
+        assert!(evicted);
+        // Still one entry — the new one replaced the old.
+        assert_eq!(registry.len(), 1);
+        // The evicted session received the close signal.
+        assert!(rx_a.try_recv().is_ok());
+    }
+
+    /// Different deployment_ids coexist without eviction.
+    #[tokio::test]
+    async fn distinct_deployments_coexist() {
+        let registry = TunnelRegistry::new();
+        let (tx_a, _rx_a) = mpsc::channel::<()>(1);
+        let (tx_b, _rx_b) = mpsc::channel::<()>(1);
+
+        assert!(
+            !registry
+                .claim("galoy-staging", uuid::Uuid::new_v4(), tx_a)
+                .await
+        );
+        assert!(
+            !registry
+                .claim("galoy-production", uuid::Uuid::new_v4(), tx_b)
+                .await
+        );
+        assert_eq!(registry.len(), 2);
+    }
+
+    /// `release` with the current session_id removes the entry.
+    #[tokio::test]
+    async fn release_removes_current_entry() {
+        let registry = TunnelRegistry::new();
+        let session = uuid::Uuid::new_v4();
+        let (tx, _rx) = mpsc::channel::<()>(1);
+        registry.claim("galoy-staging", session, tx).await;
+
+        registry.release("galoy-staging", session);
+        assert!(registry.is_empty());
+    }
+
+    /// `release` with a *stale* session_id (e.g. an evicted loop cleaning
+    /// up after the new loop has taken over) must not remove the new
+    /// entry. This is the invariant that keeps eviction safe.
+    #[tokio::test]
+    async fn release_with_stale_session_id_is_noop() {
+        let registry = TunnelRegistry::new();
+
+        let stale_session = uuid::Uuid::new_v4();
+        let (tx_a, _rx_a) = mpsc::channel::<()>(1);
+        registry.claim("galoy-staging", stale_session, tx_a).await;
+
+        let fresh_session = uuid::Uuid::new_v4();
+        let (tx_b, _rx_b) = mpsc::channel::<()>(1);
+        registry.claim("galoy-staging", fresh_session, tx_b).await;
+
+        // Evicted loop calls release with its own (now stale) session id.
+        // Should not affect the fresh entry.
+        registry.release("galoy-staging", stale_session);
+        assert_eq!(registry.len(), 1);
+
+        // Fresh session can still release itself.
+        registry.release("galoy-staging", fresh_session);
+        assert!(registry.is_empty());
     }
 }

--- a/flake.nix
+++ b/flake.nix
@@ -417,6 +417,17 @@
           sandbox-tool-server = self.packages.${system}.sandbox-tool-server;
         };
 
+        packages.tunnel-connector = craneLib.buildPackage (commonArgs // {
+          inherit cargoArtifacts;
+          pname = "tunnel-connector";
+          cargoExtraArgs = "-p tunnel-connector";
+        });
+
+        packages.tunnel-connector-image = import ./images/tunnel-connector/default.nix {
+          inherit pkgs;
+          tunnel-connector = self.packages.${system}.tunnel-connector;
+        };
+
         devShells.training = pkgs.mkShell {
           buildInputs = [ pythonEnv ];
           shellHook = ''

--- a/images/tunnel-connector/Cargo.toml
+++ b/images/tunnel-connector/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "tunnel-connector"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "tunnel-connector"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+clap = { workspace = true }
+futures = { workspace = true }
+reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
+rmcp = { workspace = true }
+serde = { workspace = true }
+serde_json = "1"
+tokio = { workspace = true }
+tokio-tungstenite = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+url = { workspace = true }
+uuid = { workspace = true }

--- a/images/tunnel-connector/Cargo.toml
+++ b/images/tunnel-connector/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 anyhow = { workspace = true }
 clap = { workspace = true }
 futures = { workspace = true }
+rand = { workspace = true }
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 rmcp = { workspace = true }
 serde = { workspace = true }

--- a/images/tunnel-connector/default.nix
+++ b/images/tunnel-connector/default.nix
@@ -1,0 +1,25 @@
+{ pkgs, tunnel-connector }:
+# Minimal container image for the outbound tunnel-connector. Runs in a
+# target deployment cluster and dials *out* to drua over WebSocket.
+# Shape is intentionally narrow — one Rust binary plus CA certs.
+#
+# No shell, no nix-daemon, no bubblewrap, no writable workspace, no user
+# passwd/group files. Clap in `tunnel-connector` reads all config from
+# `TUNNEL_*` env vars, which is how the galoy-charts tunnel-connector
+# chart wires it.
+pkgs.dockerTools.buildLayeredImage {
+  name = "tunnel-connector";
+  tag = "latest";
+  contents = [
+    pkgs.cacert
+    tunnel-connector
+  ];
+  config = {
+    Entrypoint = [ "${tunnel-connector}/bin/tunnel-connector" ];
+    User = "65534:65534"; # nobody:nogroup
+    Env = [
+      "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+      "RUST_LOG=info"
+    ];
+  };
+}

--- a/images/tunnel-connector/src/main.rs
+++ b/images/tunnel-connector/src/main.rs
@@ -114,6 +114,14 @@ fn parse_upstreams(raw: &str) -> Vec<UpstreamConfig> {
 // Main
 // ---------------------------------------------------------------------------
 
+// Reconnect backoff: start at 1s and double up to 60s between attempts,
+// with ±jitter_ms of random jitter added on top so a fleet of connectors
+// reconnecting simultaneously after a central drua rollout doesn't
+// resonate into a thundering herd.
+const INITIAL_BACKOFF: std::time::Duration = std::time::Duration::from_secs(1);
+const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(60);
+const JITTER_MS_MAX: u64 = 1_000;
+
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     tracing_subscriber::fmt::init();
@@ -125,17 +133,30 @@ async fn main() -> anyhow::Result<()> {
         anyhow::bail!("no upstreams configured — provide at least one name=url pair");
     }
 
+    let mut backoff = INITIAL_BACKOFF;
     loop {
-        match run_tunnel(&cli, &upstreams).await {
+        // `run_tunnel` resets `backoff` to `INITIAL_BACKOFF` once it has
+        // successfully sent the Register frame. That way a long-lived
+        // session that eventually errors out doesn't start its *next*
+        // reconnect from a stale high backoff.
+        match run_tunnel(&cli, &upstreams, &mut backoff).await {
             Ok(()) => tracing::info!("tunnel closed cleanly"),
             Err(e) => tracing::error!(error = %e, "tunnel session failed"),
         }
-        tracing::info!("reconnecting in 5 seconds...");
-        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+        let jitter =
+            std::time::Duration::from_millis(rand::random::<u64>() % JITTER_MS_MAX);
+        let delay = backoff + jitter;
+        tracing::info!(delay_ms = %delay.as_millis(), "reconnecting");
+        tokio::time::sleep(delay).await;
+        backoff = (backoff * 2).min(MAX_BACKOFF);
     }
 }
 
-async fn run_tunnel(cli: &Cli, upstreams: &[UpstreamConfig]) -> anyhow::Result<()> {
+async fn run_tunnel(
+    cli: &Cli,
+    upstreams: &[UpstreamConfig],
+    backoff: &mut std::time::Duration,
+) -> anyhow::Result<()> {
     // ── 1. Discover tools from local MCP servers ──────────────────────────
     let mut mcp_clients: HashMap<String, RunningService<RoleClient, ()>> = HashMap::new();
     let mut registrations: Vec<RegisteredToolSet> = Vec::new();
@@ -197,6 +218,11 @@ async fn run_tunnel(cli: &Cli, upstreams: &[UpstreamConfig]) -> anyhow::Result<(
     let json = serde_json::to_string(&register_msg)?;
     ws_tx.send(tungstenite::Message::Text(json.into())).await?;
     tracing::info!("registration sent");
+
+    // Past the connect-and-register gauntlet — this session is working.
+    // Reset reconnect backoff so a later in-session failure starts the
+    // next attempt fresh, instead of inheriting stale doubling.
+    *backoff = INITIAL_BACKOFF;
 
     // ── 4. Relay loop ─────────────────────────────────────────────────────
     while let Some(msg) = ws_rx.next().await {

--- a/images/tunnel-connector/src/main.rs
+++ b/images/tunnel-connector/src/main.rs
@@ -143,8 +143,7 @@ async fn main() -> anyhow::Result<()> {
             Ok(()) => tracing::info!("tunnel closed cleanly"),
             Err(e) => tracing::error!(error = %e, "tunnel session failed"),
         }
-        let jitter =
-            std::time::Duration::from_millis(rand::random::<u64>() % JITTER_MS_MAX);
+        let jitter = std::time::Duration::from_millis(rand::random::<u64>() % JITTER_MS_MAX);
         let delay = backoff + jitter;
         tracing::info!(delay_ms = %delay.as_millis(), "reconnecting");
         tokio::time::sleep(delay).await;

--- a/images/tunnel-connector/src/main.rs
+++ b/images/tunnel-connector/src/main.rs
@@ -1,0 +1,280 @@
+//! Tunnel connector — runs in a target cluster and relays MCP tool calls
+//! from galoy-agents to local MCP servers over an outbound WebSocket.
+//!
+//! # Usage
+//!
+//! ```text
+//! tunnel-connector \
+//!   --server-url wss://mcp.agents.galoy.io/tunnel/ws \
+//!   --auth-token <bearer-token> \
+//!   --deployment-id galoy-staging \
+//!   --upstreams "kubernetes=http://k8s-mcp:8080/mcp,postgres=http://pg-mcp:8000/mcp"
+//! ```
+//!
+//! The connector discovers tools from each upstream MCP server at startup,
+//! connects to galoy-agents, registers the tool catalog, and enters a
+//! relay loop. On disconnect it automatically reconnects.
+
+use std::collections::HashMap;
+
+use clap::Parser;
+use futures::{SinkExt, StreamExt};
+use rmcp::{
+    model::CallToolRequestParams,
+    service::RunningService,
+    transport::streamable_http_client::{
+        StreamableHttpClientTransportConfig, StreamableHttpClientWorker,
+    },
+    RoleClient, ServiceExt,
+};
+use serde::{Deserialize, Serialize};
+use tokio_tungstenite::tungstenite;
+
+// ---------------------------------------------------------------------------
+// Wire protocol (mirrored from galoy-agents-core::tunnel)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum TunnelMessage {
+    Register {
+        deployment_id: String,
+        toolsets: Vec<RegisteredToolSet>,
+    },
+    CallTool {
+        id: String,
+        upstream: String,
+        tool_name: String,
+        arguments: Option<serde_json::Map<String, serde_json::Value>>,
+    },
+    CallToolResult {
+        id: String,
+        result: serde_json::Value,
+    },
+    CallToolError {
+        id: String,
+        error: String,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct RegisteredToolSet {
+    name: String,
+    prefix: String,
+    category: String,
+    category_description: String,
+    tools: Vec<serde_json::Value>,
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+#[derive(Parser)]
+#[command(
+    name = "tunnel-connector",
+    about = "Outbound tunnel from a deployment cluster to galoy-agents"
+)]
+struct Cli {
+    /// galoy-agents tunnel WebSocket URL
+    #[arg(long, env = "TUNNEL_SERVER_URL")]
+    server_url: String,
+
+    /// Bearer token for authentication
+    #[arg(long, env = "TUNNEL_AUTH_TOKEN")]
+    auth_token: String,
+
+    /// Deployment identifier (e.g. "galoy-staging")
+    #[arg(long, env = "TUNNEL_DEPLOYMENT_ID")]
+    deployment_id: String,
+
+    /// Comma-separated upstream MCP servers: name=url[,name=url,...]
+    #[arg(long, env = "TUNNEL_UPSTREAMS")]
+    upstreams: String,
+}
+
+struct UpstreamConfig {
+    name: String,
+    url: String,
+}
+
+fn parse_upstreams(raw: &str) -> Vec<UpstreamConfig> {
+    raw.split(',')
+        .filter_map(|pair| {
+            let (name, url) = pair.split_once('=')?;
+            Some(UpstreamConfig {
+                name: name.trim().to_string(),
+                url: url.trim().to_string(),
+            })
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt::init();
+
+    let cli = Cli::parse();
+    let upstreams = parse_upstreams(&cli.upstreams);
+
+    if upstreams.is_empty() {
+        anyhow::bail!("no upstreams configured — provide at least one name=url pair");
+    }
+
+    loop {
+        match run_tunnel(&cli, &upstreams).await {
+            Ok(()) => tracing::info!("tunnel closed cleanly"),
+            Err(e) => tracing::error!(error = %e, "tunnel session failed"),
+        }
+        tracing::info!("reconnecting in 5 seconds...");
+        tokio::time::sleep(std::time::Duration::from_secs(5)).await;
+    }
+}
+
+async fn run_tunnel(cli: &Cli, upstreams: &[UpstreamConfig]) -> anyhow::Result<()> {
+    // ── 1. Discover tools from local MCP servers ──────────────────────────
+    let mut mcp_clients: HashMap<String, RunningService<RoleClient, ()>> = HashMap::new();
+    let mut registrations: Vec<RegisteredToolSet> = Vec::new();
+
+    for upstream in upstreams {
+        tracing::info!(name = %upstream.name, url = %upstream.url, "connecting to local MCP server");
+
+        let config = StreamableHttpClientTransportConfig::with_uri(upstream.url.as_str());
+        let worker = StreamableHttpClientWorker::new(reqwest::Client::new(), config);
+        let client: RunningService<RoleClient, ()> = ().serve(worker).await?;
+
+        let tools: Vec<serde_json::Value> = client
+            .list_all_tools()
+            .await?
+            .into_iter()
+            .filter_map(|t| serde_json::to_value(t).ok())
+            .collect();
+
+        tracing::info!(name = %upstream.name, tools = tools.len(), "discovered tools");
+
+        registrations.push(RegisteredToolSet {
+            name: upstream.name.clone(),
+            prefix: upstream.name.clone(),
+            category: "deployment".to_string(),
+            category_description: format!("{} deployment", cli.deployment_id),
+            tools,
+        });
+
+        mcp_clients.insert(upstream.name.clone(), client);
+    }
+
+    // ── 2. Connect WebSocket to galoy-agents ──────────────────────────────
+    let parsed_url = url::Url::parse(&cli.server_url)?;
+    let host = parsed_url.host_str().unwrap_or("localhost").to_string();
+
+    let request = tungstenite::http::Request::builder()
+        .uri(&cli.server_url)
+        .header("Authorization", format!("Bearer {}", cli.auth_token))
+        .header("Host", &host)
+        .header("Connection", "Upgrade")
+        .header("Upgrade", "websocket")
+        .header("Sec-WebSocket-Version", "13")
+        .header(
+            "Sec-WebSocket-Key",
+            tungstenite::handshake::client::generate_key(),
+        )
+        .body(())?;
+
+    let (ws_stream, _response) = tokio_tungstenite::connect_async(request).await?;
+    let (mut ws_tx, mut ws_rx) = ws_stream.split();
+
+    tracing::info!(server = %cli.server_url, "connected to galoy-agents");
+
+    // ── 3. Send registration ──────────────────────────────────────────────
+    let register_msg = TunnelMessage::Register {
+        deployment_id: cli.deployment_id.clone(),
+        toolsets: registrations,
+    };
+    let json = serde_json::to_string(&register_msg)?;
+    ws_tx.send(tungstenite::Message::Text(json.into())).await?;
+    tracing::info!("registration sent");
+
+    // ── 4. Relay loop ─────────────────────────────────────────────────────
+    while let Some(msg) = ws_rx.next().await {
+        let msg = msg?;
+        match msg {
+            tungstenite::Message::Text(text) => {
+                let tunnel_msg: TunnelMessage = match serde_json::from_str(&text) {
+                    Ok(m) => m,
+                    Err(e) => {
+                        tracing::warn!(error = %e, "ignoring unparseable message");
+                        continue;
+                    }
+                };
+
+                match tunnel_msg {
+                    TunnelMessage::CallTool {
+                        id,
+                        upstream,
+                        tool_name,
+                        arguments,
+                    } => {
+                        let response =
+                            handle_call(&mcp_clients, id, &upstream, &tool_name, arguments).await;
+                        let json = serde_json::to_string(&response)?;
+                        ws_tx.send(tungstenite::Message::Text(json.into())).await?;
+                    }
+                    _ => {
+                        tracing::warn!("unexpected message type from server");
+                    }
+                }
+            }
+            tungstenite::Message::Ping(data) => {
+                ws_tx.send(tungstenite::Message::Pong(data)).await?;
+            }
+            tungstenite::Message::Close(_) => {
+                tracing::info!("server closed connection");
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(())
+}
+
+async fn handle_call(
+    clients: &HashMap<String, RunningService<RoleClient, ()>>,
+    id: String,
+    upstream: &str,
+    tool_name: &str,
+    arguments: Option<serde_json::Map<String, serde_json::Value>>,
+) -> TunnelMessage {
+    let client = match clients.get(upstream) {
+        Some(c) => c,
+        None => {
+            return TunnelMessage::CallToolError {
+                id,
+                error: format!("unknown upstream: {upstream}"),
+            }
+        }
+    };
+
+    let mut params = CallToolRequestParams::new(tool_name.to_string());
+    if let Some(args) = arguments {
+        params = params.with_arguments(args);
+    }
+
+    match client.peer().call_tool(params).await {
+        Ok(result) => match serde_json::to_value(&result) {
+            Ok(value) => TunnelMessage::CallToolResult { id, result: value },
+            Err(e) => TunnelMessage::CallToolError {
+                id,
+                error: format!("serialize result: {e}"),
+            },
+        },
+        Err(e) => TunnelMessage::CallToolError {
+            id,
+            error: e.to_string(),
+        },
+    }
+}

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -18,7 +18,7 @@ anyhow = "1"
 askama = "0.15"
 askama_web = { version = "0.15", features = ["axum-0.8"] }
 async-trait = "0.1"
-axum = "0.8"
+axum = { version = "0.8", features = ["ws"] }
 axum-extra = { version = "0.10", features = ["cookie"] }
 chrono = "0.4"
 clap = { version = "4", features = ["derive", "env"] }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -5,6 +5,7 @@ mod routes;
 pub mod server;
 mod templates;
 pub mod tracing_init;
+pub mod tunnel;
 
 use axum::Router;
 

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -163,6 +163,12 @@ pub struct CreateMcpCredsForm {
     name: String,
     #[serde(default)]
     admin: Option<String>,
+    /// When non-empty, the credential receives `AuthScope::Tunnel(<id>)`
+    /// — authorizes the holder to register a tunnel connector for that
+    /// exact `deployment_id` (and only that one). Leave empty for
+    /// regular user tokens.
+    #[serde(default)]
+    tunnel_deployment_id: Option<String>,
 }
 
 fn build_mcp_config(mcp_endpoint: &str, token: &str) -> (String, String) {
@@ -195,11 +201,20 @@ async fn create_mcp_creds(
     let (raw_token, token_hash) = generate_token();
 
     let sub = AuthSubject::User(user_id);
-    let scopes = if form.admin.as_deref() == Some("true") {
-        vec![domain::primitives::AuthScope::Admin]
-    } else {
-        vec![]
-    };
+    let mut scopes: Vec<domain::primitives::AuthScope> = Vec::new();
+    if form.admin.as_deref() == Some("true") {
+        scopes.push(domain::primitives::AuthScope::Admin);
+    }
+    if let Some(deployment_id) = form
+        .tunnel_deployment_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        scopes.push(domain::primitives::AuthScope::Tunnel(
+            deployment_id.to_owned(),
+        ));
+    }
 
     match state
         .app

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1743,7 +1743,9 @@ async fn workspace_chat(
 // ---------------------------------------------------------------------------
 
 pub fn api_router() -> Router<AppState> {
-    Router::new().route("/api/v1/agents/{id}/secrets", get(api_agent_secrets))
+    Router::new()
+        .route("/api/v1/agents/{id}/secrets", get(api_agent_secrets))
+        .route("/tunnel/ws", get(crate::tunnel::tunnel_ws_handler))
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/tunnel.rs
+++ b/server/src/tunnel.rs
@@ -102,21 +102,25 @@ async fn handle_tunnel(mut socket: WebSocket, state: AppState, auth: AuthSubject
         );
     }
 
-    // ── 3. Register toolsets ──────────────────────────────────────────────
-    let mut registered_names = Vec::new();
+    // ── 3. Build + atomically swap toolsets ───────────────────────────────
+    // `replace_tunnel_toolsets` retains any evicted session's entries out
+    // of the catalog and appends the new ones under a single write lock,
+    // so (a) first-match routing never sees stale entries for this
+    // deployment, and (b) the evicted loop's later session-scoped
+    // cleanup is a no-op on the new entries.
+    let mut new_sets: Vec<std::sync::Arc<dyn SearchableToolSet>> =
+        Vec::with_capacity(toolset_registrations.len());
     for reg in &toolset_registrations {
-        match TunnelToolSet::new(&deployment_id, reg, handle.clone()) {
+        match TunnelToolSet::new(&deployment_id, session_id, reg, handle.clone()) {
             Ok(ts) => {
-                let name = ts.name().to_string();
-                state.app.toolsets().register_searchable(ts);
-                registered_names.push(name.clone());
                 tracing::info!(
                     deployment_id = %deployment_id,
                     toolset = %reg.name,
                     tools = reg.tools.len(),
-                    registered_as = %name,
-                    "tunnel toolset registered"
+                    registered_as = %ts.name(),
+                    "tunnel toolset prepared"
                 );
+                new_sets.push(std::sync::Arc::new(ts));
             }
             Err(e) => {
                 tracing::warn!(
@@ -128,6 +132,11 @@ async fn handle_tunnel(mut socket: WebSocket, state: AppState, auth: AuthSubject
             }
         }
     }
+    let registered_count = new_sets.len();
+    state
+        .app
+        .toolsets()
+        .replace_tunnel_toolsets(&deployment_id, new_sets);
 
     // ── 4. Relay loop ─────────────────────────────────────────────────────
     loop {
@@ -182,16 +191,29 @@ async fn handle_tunnel(mut socket: WebSocket, state: AppState, auth: AuthSubject
     }
 
     // ── 5. Cleanup ────────────────────────────────────────────────────────
-    for name in &registered_names {
-        state.app.toolsets().unregister_searchable(name);
-    }
-    // `release` is a no-op if we were evicted (the new session owns the
-    // entry now) — the session_id check in `TunnelRegistry::release`
-    // ensures we only remove an entry that's still ours.
+    // Ordering matters here:
+    //
+    //   1. `unregister_searchable_by_session` — removes our entries from the
+    //      catalog so no *new* tool calls can reach our handle. Session-scoped
+    //      so an already-evicted loop (whose entries were replaced by a newer
+    //      connector via `replace_tunnel_toolsets`) is a safe no-op.
+    //
+    //   2. `fail_all_pending` — drains any call that slipped in between the
+    //      tunnel going down and the unregister completing. Without this,
+    //      those callers wait the full 120s timeout for a response that
+    //      will never arrive (the `TunnelHandle` clones inside the now-
+    //      unregistered `TunnelToolSet`s kept the pending map alive).
+    //
+    //   3. `TunnelRegistry::release` — same session_id invariant as above.
+    state
+        .app
+        .toolsets()
+        .unregister_searchable_by_session(session_id);
+    handle.fail_all_pending("tunnel disconnected").await;
     state.app.tunnels().release(&deployment_id, session_id);
     tracing::info!(
         deployment_id = %deployment_id,
-        toolsets = registered_names.len(),
+        toolsets = registered_count,
         "tunnel toolsets unregistered"
     );
 }

--- a/server/src/tunnel.rs
+++ b/server/src/tunnel.rs
@@ -45,13 +45,36 @@ pub async fn tunnel_ws_handler(
     ws.on_upgrade(move |socket| handle_tunnel(socket, state, auth))
 }
 
-/// Main tunnel lifecycle: registration → relay loop → cleanup.
-async fn handle_tunnel(mut socket: WebSocket, state: AppState, _auth: AuthSubject) {
+/// Main tunnel lifecycle: registration → scope check → relay loop → cleanup.
+async fn handle_tunnel(mut socket: WebSocket, state: AppState, auth: AuthSubject) {
     // ── 1. Wait for registration ──────────────────────────────────────────
     let (deployment_id, toolset_registrations) = match read_registration(&mut socket).await {
         Some(r) => r,
         None => return,
     };
+
+    // ── 1b. Scope check ───────────────────────────────────────────────────
+    // The caller's bearer token must carry `AuthScope::Tunnel(deployment_id)`
+    // (session `User` subjects bypass — they already have all scopes).
+    // This stops a credential scoped to one deployment from registering
+    // as another: a `Tunnel("galoy-staging")`-scoped token cannot claim
+    // `galoy-production`.
+    if !auth.can_register_tunnel(&deployment_id) {
+        tracing::warn!(
+            deployment_id = %deployment_id,
+            "tunnel registration rejected: caller lacks Tunnel scope for this deployment_id"
+        );
+        let _ = socket
+            .send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                code: axum::extract::ws::close_code::POLICY,
+                reason: format!(
+                    "missing AuthScope::Tunnel({deployment_id}) on caller credentials"
+                )
+                .into(),
+            })))
+            .await;
+        return;
+    }
 
     tracing::info!(
         deployment_id = %deployment_id,
@@ -62,6 +85,22 @@ async fn handle_tunnel(mut socket: WebSocket, state: AppState, _auth: AuthSubjec
     // ── 2. Create channel and handle ──────────────────────────────────────
     let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel::<String>(256);
     let handle = TunnelHandle::new(outbound_tx);
+
+    // ── 2b. Claim deployment_id, evict previous tunnel if any ─────────────
+    // Capacity-1 channel: a single eviction signal is all we ever send.
+    let (close_tx, mut close_rx) = tokio::sync::mpsc::channel::<()>(1);
+    let session_id = uuid::Uuid::new_v4();
+    let evicted = state
+        .app
+        .tunnels()
+        .claim(&deployment_id, session_id, close_tx)
+        .await;
+    if evicted {
+        tracing::warn!(
+            deployment_id = %deployment_id,
+            "evicted previous tunnel with same deployment_id; new connector takes over"
+        );
+    }
 
     // ── 3. Register toolsets ──────────────────────────────────────────────
     let mut registered_names = Vec::new();
@@ -93,6 +132,22 @@ async fn handle_tunnel(mut socket: WebSocket, state: AppState, _auth: AuthSubjec
     // ── 4. Relay loop ─────────────────────────────────────────────────────
     loop {
         tokio::select! {
+            // `biased` so an eviction signal always beats in-flight traffic.
+            biased;
+            // Eviction: another connector claimed the same deployment_id.
+            _ = close_rx.recv() => {
+                tracing::info!(
+                    deployment_id = %deployment_id,
+                    "tunnel evicted by new registration for the same deployment_id; closing"
+                );
+                let _ = socket
+                    .send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                        code: axum::extract::ws::close_code::POLICY,
+                        reason: "evicted by a new tunnel registration for the same deployment_id".into(),
+                    })))
+                    .await;
+                break;
+            }
             // Inbound: messages from the connector (tool results)
             ws_msg = socket.recv() => {
                 match ws_msg {
@@ -130,6 +185,10 @@ async fn handle_tunnel(mut socket: WebSocket, state: AppState, _auth: AuthSubjec
     for name in &registered_names {
         state.app.toolsets().unregister_searchable(name);
     }
+    // `release` is a no-op if we were evicted (the new session owns the
+    // entry now) — the session_id check in `TunnelRegistry::release`
+    // ensures we only remove an entry that's still ours.
+    state.app.tunnels().release(&deployment_id, session_id);
     tracing::info!(
         deployment_id = %deployment_id,
         toolsets = registered_names.len(),

--- a/server/src/tunnel.rs
+++ b/server/src/tunnel.rs
@@ -1,0 +1,198 @@
+//! WebSocket endpoint for tunnel connections from deployment connectors.
+//!
+//! A connector in a target cluster dials out to `/tunnel/ws`, authenticates
+//! via Bearer token (resolved by the existing auth middleware), sends a
+//! registration message listing the tools its local MCP servers expose,
+//! and then enters a relay loop: the server pushes `CallTool` requests
+//! down the WebSocket and the connector returns results.
+
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        State,
+    },
+    response::{IntoResponse, Response},
+    Extension,
+};
+use tracing::instrument;
+
+use drua_core as domain;
+
+use domain::auth::AuthSubject;
+use domain::toolset::SearchableToolSet;
+use domain::tunnel::{TunnelHandle, TunnelMessage, TunnelToolSet};
+
+use crate::AppState;
+
+/// HTTP handler — upgrades to WebSocket if the caller is authenticated.
+#[instrument(name = "web.tunnel.ws", skip_all)]
+pub async fn tunnel_ws_handler(
+    ws: WebSocketUpgrade,
+    Extension(auth): Extension<AuthSubject>,
+    State(state): State<AppState>,
+) -> Response {
+    match &auth {
+        AuthSubject::ExportedAgent(_, _, _) | AuthSubject::User(_) => {}
+        _ => {
+            return (
+                axum::http::StatusCode::UNAUTHORIZED,
+                "tunnel requires authentication",
+            )
+                .into_response()
+        }
+    }
+
+    ws.on_upgrade(move |socket| handle_tunnel(socket, state, auth))
+}
+
+/// Main tunnel lifecycle: registration → relay loop → cleanup.
+async fn handle_tunnel(mut socket: WebSocket, state: AppState, _auth: AuthSubject) {
+    // ── 1. Wait for registration ──────────────────────────────────────────
+    let (deployment_id, toolset_registrations) = match read_registration(&mut socket).await {
+        Some(r) => r,
+        None => return,
+    };
+
+    tracing::info!(
+        deployment_id = %deployment_id,
+        toolsets = toolset_registrations.len(),
+        "tunnel connector registered"
+    );
+
+    // ── 2. Create channel and handle ──────────────────────────────────────
+    let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel::<String>(256);
+    let handle = TunnelHandle::new(outbound_tx);
+
+    // ── 3. Register toolsets ──────────────────────────────────────────────
+    let mut registered_names = Vec::new();
+    for reg in &toolset_registrations {
+        match TunnelToolSet::new(&deployment_id, reg, handle.clone()) {
+            Ok(ts) => {
+                let name = ts.name().to_string();
+                state.app.toolsets().register_searchable(ts);
+                registered_names.push(name.clone());
+                tracing::info!(
+                    deployment_id = %deployment_id,
+                    toolset = %reg.name,
+                    tools = reg.tools.len(),
+                    registered_as = %name,
+                    "tunnel toolset registered"
+                );
+            }
+            Err(e) => {
+                tracing::warn!(
+                    deployment_id = %deployment_id,
+                    toolset = %reg.name,
+                    error = %e,
+                    "failed to create tunnel toolset, skipping"
+                );
+            }
+        }
+    }
+
+    // ── 4. Relay loop ─────────────────────────────────────────────────────
+    loop {
+        tokio::select! {
+            // Inbound: messages from the connector (tool results)
+            ws_msg = socket.recv() => {
+                match ws_msg {
+                    Some(Ok(Message::Text(text))) => {
+                        handle_inbound(&handle, &text).await;
+                    }
+                    Some(Ok(Message::Ping(_) | Message::Pong(_))) => {}
+                    Some(Ok(Message::Close(_))) | None => {
+                        tracing::info!(deployment_id = %deployment_id, "tunnel disconnected");
+                        break;
+                    }
+                    Some(Err(e)) => {
+                        tracing::error!(deployment_id = %deployment_id, error = %e, "tunnel read error");
+                        break;
+                    }
+                    Some(Ok(Message::Binary(_))) => {}
+                }
+            }
+            // Outbound: tool call requests to send to the connector
+            msg = outbound_rx.recv() => {
+                match msg {
+                    Some(text) => {
+                        if socket.send(Message::Text(text.into())).await.is_err() {
+                            tracing::error!(deployment_id = %deployment_id, "tunnel write error");
+                            break;
+                        }
+                    }
+                    None => break, // all senders dropped
+                }
+            }
+        }
+    }
+
+    // ── 5. Cleanup ────────────────────────────────────────────────────────
+    for name in &registered_names {
+        state.app.toolsets().unregister_searchable(name);
+    }
+    tracing::info!(
+        deployment_id = %deployment_id,
+        toolsets = registered_names.len(),
+        "tunnel toolsets unregistered"
+    );
+}
+
+/// Read and validate the first WebSocket message as a `Register`.
+async fn read_registration(
+    socket: &mut WebSocket,
+) -> Option<(String, Vec<domain::tunnel::RegisteredToolSet>)> {
+    let msg = match socket.recv().await {
+        Some(Ok(Message::Text(text))) => text,
+        _ => {
+            tracing::error!("tunnel: expected text registration message");
+            return None;
+        }
+    };
+
+    let parsed: TunnelMessage = match serde_json::from_str(&msg) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::error!(error = %e, "tunnel: invalid registration JSON");
+            return None;
+        }
+    };
+
+    match parsed {
+        TunnelMessage::Register {
+            deployment_id,
+            toolsets,
+        } => Some((deployment_id, toolsets)),
+        _ => {
+            tracing::error!("tunnel: first message must be register");
+            None
+        }
+    }
+}
+
+/// Route an inbound message (tool result or error) to the pending request.
+async fn handle_inbound(handle: &TunnelHandle, text: &str) {
+    let msg: TunnelMessage = match serde_json::from_str(text) {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::warn!(error = %e, "tunnel: ignoring unparseable inbound message");
+            return;
+        }
+    };
+
+    match msg {
+        TunnelMessage::CallToolResult { id, result } => match serde_json::from_value(result) {
+            Ok(call_result) => handle.resolve(&id, Ok(call_result)).await,
+            Err(e) => {
+                handle
+                    .resolve(&id, Err(format!("deserialize result: {e}")))
+                    .await
+            }
+        },
+        TunnelMessage::CallToolError { id, error } => {
+            handle.resolve(&id, Err(error)).await;
+        }
+        _ => {
+            tracing::warn!("tunnel: unexpected inbound message type");
+        }
+    }
+}

--- a/server/src/tunnel.rs
+++ b/server/src/tunnel.rs
@@ -67,10 +67,8 @@ async fn handle_tunnel(mut socket: WebSocket, state: AppState, auth: AuthSubject
         let _ = socket
             .send(Message::Close(Some(axum::extract::ws::CloseFrame {
                 code: axum::extract::ws::close_code::POLICY,
-                reason: format!(
-                    "missing AuthScope::Tunnel({deployment_id}) on caller credentials"
-                )
-                .into(),
+                reason: format!("missing AuthScope::Tunnel({deployment_id}) on caller credentials")
+                    .into(),
             })))
             .await;
         return;

--- a/server/templates/dashboard.html
+++ b/server/templates/dashboard.html
@@ -18,6 +18,11 @@
       <input type="checkbox" name="admin" value="true">
       Admin scope (grants access to workspace &amp; agent management tools)
     </label>
+    <label>
+      Tunnel deployment ID (optional)
+      <input type="text" name="tunnel_deployment_id" placeholder="galoy-staging">
+      <small>Fill in to mint a token scoped to a single tunnel connector registration. Leave empty for a regular user token.</small>
+    </label>
     <button type="submit">Create Credentials</button>
   </form>
   <div id="creds-result"></div>


### PR DESCRIPTION
## Proposed Architecture

![Untitled-2026-04-20-1522](https://github.com/user-attachments/assets/433b8184-49fc-4c96-9ebf-b798632b093c)


## Summary

Adds a tunnel-based alternative to the Envoy proxy approach proposed in GaloyMoney/galoy-charts#250. Instead of exposing MCP servers on a public endpoint with JWT/JWKS authentication, a lightweight connector in the target cluster connects **outbound** to drua over WebSocket.

```
Client (sandbox)
  → drua (central platform)
    → WebSocket tunnel (outbound from target cluster)
      → connector pod
        → k8s-mcp / pg-mcp (cluster-local)
```

### What's added

- **`core/src/tunnel.rs`** — wire protocol (`Register`, `CallTool`, `CallToolResult`), `TunnelHandle` for request correlation via oneshot channels, `TunnelRegistry` enforcing one live tunnel per `deployment_id` (eviction-on-duplicate), and `TunnelToolSet` implementing `SearchableToolSet` backed by a tunnel connection.
- **`web/src/tunnel.rs`** — WebSocket endpoint at `/tunnel/ws` that authenticates + scope-checks connector registrations, atomically swaps a deployment's toolsets on takeover, and relays tool calls through the tunnel.
- **`images/tunnel-connector/`** — outbound connector binary (discovers tools from local MCP servers via rmcp, relays `call_tool` requests), plus a minimal Nix container image consumed by galoy-charts#252.
- **`core/src/toolset/`** — `ToolSetScope::Tunnel { deployment_id, session_id }` on the `SearchableToolSet` trait, plus atomic `replace_tunnel_toolsets` and session-aware `unregister_searchable_by_session` on `ToolSets` (see review response below).
- **`ci/pipeline.yml`** — `build-tunnel-connector-image` job that publishes `tunnel-connector:edge` on changes to `images/tunnel-connector/` or the workspace.

### What this eliminates in the target cluster (vs Envoy approach)

- No Envoy proxy (3 manifests + ConfigMap)
- No public Ingress or TLS certificate
- No JWT validation / JWKS endpoint
- No IP allowlisting
- No inbound network exposure at all

### Consumer contract

Deploy the connector in the target cluster:

```yaml
env:
  - name: TUNNEL_SERVER_URL
    value: "wss://mcp.agents.galoy.io/tunnel/ws"
  - name: TUNNEL_AUTH_TOKEN
    valueFrom:
      secretKeyRef:
        name: drua-tunnel
        key: token
  - name: TUNNEL_DEPLOYMENT_ID
    value: "galoy-staging"
  - name: TUNNEL_UPSTREAMS
    value: "kubernetes=http://k8s-mcp:8080/mcp,postgres=http://pg-mcp:8000/mcp"
```

The `TUNNEL_AUTH_TOKEN` must carry `AuthScope::Tunnel("galoy-staging")` — a staging-scoped token cannot register as `galoy-production`. Tokens are provisioned via the MCP credentials UI (`tunnel_deployment_id` field on the create-creds form).

## Review response — fixes in this PR

### #154 review: session-aware takeover at the toolset layer (blocking, resolved)

The reviewer pointed out that `TunnelRegistry` fixed ownership at the registry but `ToolSets` was still name-keyed and append-only — an evicted connector's `unregister_searchable(name)` would remove the *new* session's toolsets, and first-match routing during overlap would temporarily send calls to the dying connector.

Resolved in `fix(tunnel): address review — session-aware takeover + pending cleanup`:

- `SearchableToolSet::scope() -> Option<&ToolSetScope>` — tunnel toolsets tag themselves with `{deployment_id, session_id}`; static toolsets return `None`.
- `ToolSets::replace_tunnel_toolsets(deployment_id, new)` — single write lock: retains-not-matching + extends. Eliminates the overlap window.
- `ToolSets::unregister_searchable_by_session(session_id)` — replaces `unregister_searchable(name)`. An evicted loop's late cleanup is a safe no-op after takeover because its `session_id` no longer matches anything.
- Takeover and stale-session no-op both covered by unit tests (`replace_tunnel_toolsets_swaps_by_deployment`, `unregister_by_session_is_noop_for_evicted_session`, etc.).

### #127 review: pending-map leak on timeout / tunnel death (resolved)

The reviewer noted that on timeout or disconnect-after-send, `TunnelHandle::call_tool` left entries in the pending map; the senders were pinned alive by every cloned `TunnelHandle` inside registered `TunnelToolSet`s, so callers waited the full 120s even after the tunnel was dead.

Resolved in the same commit:

- Single cleanup point in `call_tool`: `pending.remove(id)` runs after the inner async (covers timeout, send-failure, and serialization-failure in one place; no-op if `resolve` already took the entry).
- New `TunnelHandle::fail_all_pending(err)` drains outstanding oneshots and fails callers immediately. `handle_tunnel` calls it after session-scoped unregister (no new calls can race in) and before `TunnelRegistry::release`.
- `pending_cleared_on_{success, send_failure, timeout}` + `fail_all_pending_drains_immediately`. Timeout test runs under tokio's paused clock so it doesn't sit for 120s.

## Follow-ups — explicitly deferred

These are real concerns but out of scope for this PR (tracked against the parent issue GaloyMoney/volcano-wip#729):

- **Drua HA / multi-replica routing.** `TunnelRegistry` is an in-process `HashMap` and `/tunnel/ws` state is per-replica. Works for N=1; at N>1 we need sticky routing by `deployment_id` or a shared registry (NATS/Redis). Flag this before scaling drua.
- **Tool-schema refresh without reconnect.** Connector discovers tools once at startup. Today: operationally we pick up schema changes on connector restart (rolling update). Follow-up: periodic re-register, or re-register on upstream schema error.
- **Per-deployment metrics.** Active-tunnel count, per-call latency histogram, error rate by `deployment_id`. Cheap to add once the feature is in use and we know what we want to alert on.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo test -p drua-core --lib tunnel` — 20 tests pass (14 registry/auth + 6 new for takeover and pending cleanup)
- [x] `nix flake check` — flake evaluates
- [x] Rebased on latest `drua/main` (includes `refactor: rename galoy-agents to drua`)
- [ ] Deploy connector + k8s-mcp in a staging cluster and verify tools appear in catalog (galoy-charts#252)

## Related

- Alternative to GaloyMoney/galoy-charts#250 (Envoy proxy approach)
- Consumed by GaloyMoney/galoy-charts#252 (tunnel-connector-client chart)
- Parent: GaloyMoney/volcano-wip#729

🤖 Generated with [Claude Code](https://claude.com/claude-code)