### PR TITLE
fix(toolset): add auth_required flag for MCP upstreams

### DIFF
--- a/charts/galoy-agents/templates/configmap.yaml
+++ b/charts/galoy-agents/templates/configmap.yaml
@@ -60,6 +60,9 @@ data:
           {{- if .authHeaderName }}
           auth_header_name: {{ .authHeaderName | quote }}
           {{- end }}
+          {{- if hasKey . "authRequired" }}
+          auth_required: {{ .authRequired }}
+          {{- end }}
           {{- if .category }}
           category: {{ .category | quote }}
           {{- end }}
@@ -85,6 +88,7 @@ data:
       {{- if and $k8sMcp $k8sMcp.enabled }}
         - name: "kubernetes"
           url: "http://{{ .Release.Name }}-kubernetes-mcp-server:{{ $k8sMcp.service.port }}/mcp"
+          auth_required: false
           tool_prefix: "k8s"
           category: "infrastructure"
           category_description: "Kubernetes cluster operations — pods, logs, events, deployments"

--- a/core/src/toolset/config.rs
+++ b/core/src/toolset/config.rs
@@ -26,6 +26,10 @@ pub struct McpUpstreamConfig {
     pub auth_header: String,
     #[serde(default = "default_auth_header_name")]
     pub auth_header_name: String,
+    /// When true (default), the upstream requires authentication and init
+    /// will fail early if the auth header env var is missing.
+    #[serde(default = "default_auth_required")]
+    pub auth_required: bool,
     #[serde(default)]
     pub category: Option<String>,
     #[serde(default)]
@@ -43,6 +47,10 @@ pub struct McpUpstreamConfig {
 
 fn default_auth_header_name() -> String {
     "authorization".to_string()
+}
+
+fn default_auth_required() -> bool {
+    true
 }
 
 #[derive(Clone, Debug, Default, Serialize, Deserialize)]

--- a/core/src/toolset/error.rs
+++ b/core/src/toolset/error.rs
@@ -6,6 +6,8 @@ pub enum ToolSetsError {
     ClientInit(#[from] Box<rmcp::service::ClientInitializeError>),
     #[error("ToolSetsError - Service: {0}")]
     Service(#[from] rmcp::service::ServiceError),
+    #[error("ToolSetsError - MissingAuthHeader: upstream '{name}' requires authentication — set {env_key}")]
+    MissingAuthHeader { name: String, env_key: String },
     #[error("ToolSetsError - InvalidHeader: {0}")]
     InvalidHeader(String),
     #[error("ToolSetsError - ToolNotFound: {0}")]

--- a/core/src/toolset/searchable/upstream.rs
+++ b/core/src/toolset/searchable/upstream.rs
@@ -31,7 +31,15 @@ impl UpstreamToolSet {
         upstream: &McpUpstreamConfig,
     ) -> Result<UpstreamToolSet, ToolSetsError> {
         let mut headers = HashMap::new();
-        if !upstream.auth_header.is_empty() {
+        if upstream.auth_header.is_empty() {
+            if upstream.auth_required {
+                let env_key = format!("{}_AUTH_HEADER", upstream.name.to_uppercase());
+                return Err(ToolSetsError::MissingAuthHeader {
+                    name: upstream.name.clone(),
+                    env_key,
+                });
+            }
+        } else {
             headers.insert(
                 HeaderName::from_bytes(upstream.auth_header_name.as_bytes())
                     .map_err(|e| ToolSetsError::InvalidHeader(e.to_string()))?,

--- a/core/tests/toolset.rs
+++ b/core/tests/toolset.rs
@@ -19,6 +19,7 @@ async fn init_toolsets() {
             url: "https://mcp.honeycomb.io/mcp".to_string(),
             auth_header,
             auth_header_name: "authorization".to_string(),
+            auth_required: true,
             category: Some("observability".to_string()),
             category_description: Some("Distributed traces, SLOs, and query analysis".to_string()),
             tool_prefix: None,


### PR DESCRIPTION
## Summary

- Adds an `auth_required` field (default `true`) to `McpUpstreamConfig` to distinguish between external MCP upstreams that require credentials and internal cluster services that don't
- External upstreams (Honeycomb, Lingo, GitHub) fail early with a clear error naming the missing env var when credentials are absent
- Internal upstreams (kubernetes-mcp-server) opt out with `auth_required: false` in the Helm configmap

Fixes the conflict between 2884d9b (reject missing auth) and f0631b2 (revert — allow all) by making the requirement explicit per-upstream.

## Test plan

- [ ] `cargo check` passes
- [ ] `helm template` renders `auth_required: false` only for kubernetes upstream
- [ ] Upstreams without `auth_required` in config default to `true` (serde default)
- [ ] Deploy with a missing `*_AUTH_HEADER` env var and verify early failure with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)