### PR TITLE
fix(tracing): flush startup spans so init errors reach Honeycomb

### DIFF
--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -115,6 +115,7 @@ async fn main() -> anyhow::Result<()> {
     };
 
     let app = galoy_agents_core::App::init(&pool, app_config).await?;
+    tracing_init::flush_tracer();
     let auth_config = config.auth_config();
     let oauth_client = auth_config.oauth_client();
     let server_config = galoy_agents_web::server::ServerConfig {

--- a/cli/src/tracing_init.rs
+++ b/cli/src/tracing_init.rs
@@ -130,6 +130,18 @@ pub fn init_tracer(config: TracingConfig) -> anyhow::Result<()> {
     Ok(())
 }
 
+pub fn flush_tracer() {
+    let handle = {
+        let guard = TRACER_HANDLE.lock().expect("Failed to lock tracer handle");
+        guard.clone()
+    };
+    if let Some(handle) = handle {
+        if let Err(e) = handle.provider.force_flush() {
+            eprintln!("Failed to flush tracer: {e}");
+        }
+    }
+}
+
 pub fn shutdown_tracer() -> Result<(), TracingError> {
     let handle = {
         let guard = TRACER_HANDLE.lock().expect("Failed to lock tracer handle");


### PR DESCRIPTION
## Summary

- Add `flush_tracer()` that force-flushes all pending OTel spans
- Call it after `App::init()` completes so startup spans (toolset init, MCP upstream connections) are exported before the server starts accepting traffic

The `BatchSpanProcessor` exports on a background timer (~5s default). Spans created during `App::init` — including `toolset.init` and its `tracing::warn!` for failed MCP upstreams — complete before the first batch flush, so they never reach Honeycomb. This makes it impossible to diagnose why an upstream (like the kubernetes MCP server) failed to initialize.

## Context

The kubernetes MCP toolset is configured but not showing up in the gateway. The `tracing::warn!` that logs the init failure exists in the code but was never reaching Honeycomb — confirmed by querying for `toolset.init` spans (zero results) while request-time spans are flowing normally.

## Test plan

- [x] `cargo check` passes
- [ ] Deploy and verify `toolset.init` span + child events appear in Honeycomb
- [ ] If kubernetes upstream is failing, the error will now be visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)