### PR TITLE
fix(toolset): use if-let for single-pattern match (clippy)

### DIFF
--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -40,9 +40,8 @@ impl ToolSets {
         let mut sets: Vec<Arc<dyn SearchableToolSet>> = Vec::new();
 
         for upstream in &config.mcp_upstreams {
-            match init_upstream(upstream).await {
-                Ok(ts) => sets.push(Arc::new(ts)),
-                Err(_) => {}
+            if let Ok(ts) = init_upstream(upstream).await {
+                sets.push(Arc::new(ts));
             }
         }
 


### PR DESCRIPTION
One-line clippy fix from #131 — `match` with single arm → `if let`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)