### PR TITLE
ci: remove push-to-main trigger from GitHub Actions

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -1,8 +1,6 @@
 name: Bats E2E
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 concurrency:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,8 +1,6 @@
 name: Check
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 concurrency:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,8 +1,6 @@
 name: Integration Tests
 
 on:
-  push:
-    branches: [main]
   pull_request:
 
 concurrency:


### PR DESCRIPTION
## Summary
- Remove `push: branches: [main]` trigger from `bats.yml`, `check.yml`, and `integration.yml`
- These tests already run on Concourse for main, so the GitHub Actions runs were redundant

## Test plan
- [ ] Verify workflows still trigger on pull requests
- [ ] Confirm no duplicate runs on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)