### PR TITLE
fix(tracing): use inline events for upstream init

### DIFF
--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -23,7 +23,6 @@ use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
 use rmcp::model::{CallToolResult, JsonObject};
-use tracing::instrument;
 
 use crate::audit::Audit;
 use crate::auth::AuthSubject;
@@ -40,8 +39,29 @@ impl ToolSets {
         let mut sets: Vec<Arc<dyn SearchableToolSet>> = Vec::new();
 
         for upstream in &config.mcp_upstreams {
-            if let Ok(ts) = init_upstream(upstream).await {
-                sets.push(Arc::new(ts));
+            tracing::info!(
+                upstream.name = %upstream.name,
+                upstream.url = %upstream.url,
+                "Connecting to MCP upstream"
+            );
+            match UpstreamToolSet::init(upstream).await {
+                Ok(ts) => {
+                    tracing::info!(
+                        upstream.name = %upstream.name,
+                        prefix = ts.prefix(),
+                        tools = ts.tools().len(),
+                        "MCP upstream toolset initialized"
+                    );
+                    sets.push(Arc::new(ts));
+                }
+                Err(e) => {
+                    tracing::error!(
+                        upstream.name = %upstream.name,
+                        upstream.url = %upstream.url,
+                        error = %e,
+                        "Failed to initialize MCP upstream, skipping"
+                    );
+                }
             }
         }
 
@@ -215,27 +235,6 @@ impl ToolSets {
         }
         .with_event_context(seed)
         .await
-    }
-}
-
-#[instrument(name = "domain.toolset.init_upstream", skip_all, fields(upstream.name, upstream.url))]
-async fn init_upstream(upstream: &McpUpstreamConfig) -> Result<UpstreamToolSet, ToolSetsError> {
-    tracing::Span::current()
-        .record("upstream.name", &upstream.name)
-        .record("upstream.url", &upstream.url);
-    match UpstreamToolSet::init(upstream).await {
-        Ok(ts) => {
-            tracing::info!(
-                prefix = ts.prefix(),
-                tools = ts.tools().len(),
-                "MCP upstream toolset initialized"
-            );
-            Ok(ts)
-        }
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to initialize MCP upstream, skipping");
-            Err(e)
-        }
     }
 }
 


### PR DESCRIPTION
## Summary

Replace the `#[instrument]` function with plain `tracing::info!`/`tracing::error!` events inline in the init loop.

## Context

Two previous attempts to get upstream init visibility in Honeycomb failed:
- PR #130: `force_flush()` after init — startup spans still missing
- PR #131: standalone `#[instrument]` function — also never shows up

The common factor is rmcp's `RunningService` which appears to consume or interfere with the tracing span context. Plain `tracing::info!`/`tracing::error!` events emitted *before* and *after* the rmcp call should survive as span events on whatever parent span exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)