### PR TITLE
feat(dev): send local traces to Honeycomb via OTel collector

### DIFF
--- a/dev/otel-agent-config.yaml
+++ b/dev/otel-agent-config.yaml
@@ -8,7 +8,11 @@ receivers:
 
 exporters:
   debug:
-    verbosity: basic
+    verbosity: detailed
+  otlp/honeycomb:
+    endpoint: "api.honeycomb.io:443"
+    headers:
+      "x-honeycomb-team": ${HONEYCOMB_API_KEY}
 
 extensions:
   health_check:
@@ -19,4 +23,4 @@ service:
     traces:
       receivers: [otlp]
       processors: []
-      exporters: [debug]
+      exporters: [otlp/honeycomb, debug]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,8 @@ services:
   otel-agent:
     image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.133.0
     command: --config=/etc/otel-agent-config.yaml
+    environment:
+      - HONEYCOMB_API_KEY=${INGEST_HONEYCOMB_API_KEY}
     ports:
       - "4317:4317"
       - "4318:4318"


### PR DESCRIPTION
## Summary

- Add `otlp/honeycomb` exporter to `dev/otel-agent-config.yaml` alongside `debug`
- Pass `INGEST_HONEYCOMB_API_KEY` from `.env` to the OTel container via `docker-compose.yml`

Local traces now reach the Honeycomb dev environment, making it possible to iterate on tracing changes without deploying to production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)