### PR TITLE
refactor(sandbox): nest local_repo_root inside Local backend variant

### DIFF
--- a/core/src/sandbox/config.rs
+++ b/core/src/sandbox/config.rs
@@ -14,6 +14,8 @@ use serde::{Deserialize, Serialize};
 pub enum SandboxBackendConfig {
     Local {
         sandbox_spawn_cmd: String,
+        #[serde(default = "default_local_repo_root")]
+        local_repo_root: PathBuf,
     },
     K8s {
         namespace: String,
@@ -33,6 +35,7 @@ impl Default for SandboxBackendConfig {
     fn default() -> Self {
         Self::Local {
             sandbox_spawn_cmd: "cargo run -q -p sandbox-tool-server --".into(),
+            local_repo_root: default_local_repo_root(),
         }
     }
 }
@@ -41,9 +44,6 @@ impl Default for SandboxBackendConfig {
 pub struct SandboxConfig {
     #[serde(default)]
     pub backend: SandboxBackendConfig,
-    /// For local mode: parent of the `.sandboxes/` directory. Defaults to `.`.
-    #[serde(default = "default_local_repo_root")]
-    pub local_repo_root: PathBuf,
 }
 
 fn default_local_repo_root() -> PathBuf {

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -46,9 +46,12 @@ impl Sandboxes {
         github_app: Option<Arc<GitHubAppTokenProvider>>,
     ) -> Result<Self, SandboxError> {
         let admin: Arc<dyn AdminClient> = match config.backend {
-            SandboxBackendConfig::Local { sandbox_spawn_cmd } => Arc::new(LocalAdminClient::new(
+            SandboxBackendConfig::Local {
+                sandbox_spawn_cmd,
+                local_repo_root,
+            } => Arc::new(LocalAdminClient::new(
                 LocalSandboxConfig { sandbox_spawn_cmd },
-                &config.local_repo_root,
+                &local_repo_root,
             )),
             SandboxBackendConfig::K8s {
                 namespace,

--- a/dev/galoy-agents.default.yml
+++ b/dev/galoy-agents.default.yml
@@ -23,6 +23,6 @@ sandbox:
   backend:
     provider: local
     sandbox_spawn_cmd: cargo run -q -p sandbox-tool-server --
-  local_repo_root: ''
+    local_repo_root: .
 github_app: null
 

--- a/galoy-agents.yml
+++ b/galoy-agents.yml
@@ -43,7 +43,7 @@ sandbox:
   backend:
     provider: local
     sandbox_spawn_cmd: "cargo run -q -p sandbox-tool-server --"
-  local_repo_root: "."
+    local_repo_root: "."
 
 toolsets:
   code_assistant:


### PR DESCRIPTION
## Summary
- Move `local_repo_root` from the top-level `SandboxConfig` struct into the `Local` variant of `SandboxBackendConfig`
- The field is only used by the local sandbox backend, so it belongs alongside `sandbox_spawn_cmd` rather than sitting at the parent level where it's irrelevant to the k8s backend

## Test plan
- [x] `cargo check` passes
- [x] Regenerated `dev/galoy-agents.default.yml` matches `dump-default-config` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)