### PR TITLE
fix(tracing): log MCP upstream init results outside rmcp span

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -100,6 +100,7 @@ impl App {
 
         let audit = Arc::new(Audit::new(pool));
         let mut toolsets = ToolSets::init(config.toolsets).await?;
+        toolsets.log_init_summary();
         if let Some(ca) = code_assistant.as_ref() {
             toolsets.register_searchable(CodeAssistantToolSet::new(Arc::clone(ca)));
         }

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -88,10 +88,12 @@ impl ToolSets {
         })
     }
 
-    /// Log upstream init results. Must be called from OUTSIDE the
-    /// ToolSets::init context — rmcp's RunningService consumes the
-    /// tracing span, making events emitted during init invisible to
-    /// OTel exporters.
+    /// Log upstream init results. Must be called from OUTSIDE
+    /// `ToolSets::init` — rmcp's `serve_inner` captures
+    /// `tracing::Span::current()` and instruments a long-lived background
+    /// task with it. That task holds the span open for the MCP
+    /// connection's lifetime, so `tracing-opentelemetry` never exports it
+    /// (spans export only on close, i.e. when all handles are dropped).
     #[tracing::instrument(name = "domain.toolset.init_summary", skip_all)]
     pub fn log_init_summary(&self) {
         let sets = self.sets.read().expect("toolset lock poisoned");

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -31,36 +31,21 @@ pub struct ToolSets {
     sets: Arc<RwLock<Vec<Arc<dyn SearchableToolSet>>>>,
     top_level: RwLock<HashMap<String, Arc<dyn TopLevelTool>>>,
     audit: Option<Arc<Audit>>,
+    init_errors: Vec<(String, String)>,
 }
 
 impl ToolSets {
-    #[tracing::instrument(name = "toolset.init", skip_all)]
     pub async fn init(config: ToolSetsConfig) -> Result<Self, ToolSetsError> {
         let mut sets: Vec<Arc<dyn SearchableToolSet>> = Vec::new();
+        let mut init_errors: Vec<(String, String)> = Vec::new();
 
         for upstream in &config.mcp_upstreams {
-            tracing::info!(
-                upstream.name = %upstream.name,
-                upstream.url = %upstream.url,
-                "Connecting to MCP upstream"
-            );
             match UpstreamToolSet::init(upstream).await {
                 Ok(ts) => {
-                    tracing::info!(
-                        upstream.name = %upstream.name,
-                        prefix = ts.prefix(),
-                        tools = ts.tools().len(),
-                        "MCP upstream toolset initialized"
-                    );
                     sets.push(Arc::new(ts));
                 }
                 Err(e) => {
-                    tracing::error!(
-                        upstream.name = %upstream.name,
-                        upstream.url = %upstream.url,
-                        error = %e,
-                        "Failed to initialize MCP upstream, skipping"
-                    );
+                    init_errors.push((upstream.name.clone(), e.to_string()));
                 }
             }
         }
@@ -99,7 +84,33 @@ impl ToolSets {
             sets,
             top_level: RwLock::new(top_level),
             audit: None,
+            init_errors,
         })
+    }
+
+    /// Log upstream init results. Must be called from OUTSIDE the
+    /// ToolSets::init context — rmcp's RunningService consumes the
+    /// tracing span, making events emitted during init invisible to
+    /// OTel exporters.
+    #[tracing::instrument(name = "domain.toolset.init_summary", skip_all)]
+    pub fn log_init_summary(&self) {
+        let sets = self.sets.read().expect("toolset lock poisoned");
+        for set in sets.iter() {
+            tracing::info!(
+                upstream.name = set.name(),
+                upstream.prefix = set.prefix(),
+                upstream.tools = set.tools().len(),
+                upstream.category = set.category(),
+                "MCP upstream initialized"
+            );
+        }
+        for (name, error) in &self.init_errors {
+            tracing::error!(
+                upstream.name = %name,
+                error = %error,
+                "Failed to initialize MCP upstream"
+            );
+        }
     }
 
     /// Wire the audit service so tool calls are automatically recorded.


### PR DESCRIPTION
## Summary

- Collect upstream init errors in a Vec instead of logging inline
- Add `log_init_summary()` method with its own `#[instrument]` span (`domain.toolset.init_summary`)
- Call it from `App::init` after `ToolSets::init` returns

## Root cause

rmcp's `serve_inner` ([`service.rs:775-1084`](https://github.com/anthropics/rmcp/blob/v1.5.0/src/service.rs#L775-L1084)) captures the caller's tracing span and attaches it to a long-lived background task:

```rust
let current_span = tracing::Span::current();   // L775 — captures toolset.init
let handle = spawn_service_task(async move {
    // ... MCP serve loop (lives for the app's lifetime) ...
}.instrument(current_span));                     // L1084 — moves span into task
```

`tracing-opentelemetry` only exports a span when all handles are dropped (span closes). Since the spawned task holds the span for the entire MCP connection lifetime, the `toolset.init` span — and all events on it — are **never exported** to the OTel collector.

This is intentional in rmcp (MCP message handling appears as children of `serve_inner`), but it means any ancestor span active when `serve_inner` is called gets held open indefinitely.

Confirmed locally:
- **Without rmcp connection** (auth fails before rmcp): `toolset.init` span shows up in Honeycomb
- **With rmcp connection** (fake MCP server): `toolset.init` span disappears
- **With `log_init_summary()` called after init returns**: `domain.toolset.init_summary` span + events export correctly

## Test plan

- [x] `cargo clippy` passes
- [x] Verified locally: `domain.toolset.init_summary` span + events visible in Honeycomb dev-nb with successful rmcp connection to fake MCP server
- [ ] Deploy to prod and verify kubernetes upstream init error is now visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)