### PR TITLE
chore: add cargo profiles to speed up compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,22 @@ resolver = "2"
 edition = "2021"
 version = "0.1.0"
 
+[profile.dev]
+debug = false
+
+[profile.dev.package."*"]
+debug = false
+
+[profile.debugging]
+inherits = "dev"
+debug = true
+
+[profile.release]
+incremental = false
+codegen-units = 64
+opt-level = 0
+strip = true
+
 [workspace.metadata.crane]
 name = "galoy-agents"
 


### PR DESCRIPTION
## Summary
- Add `[profile.dev]` and `[profile.dev.package."*"]` with `debug = false` to reduce dev build time and disk usage
- Add `[profile.release]` with `opt-level = 0`, `codegen-units = 64`, and `strip = true` for much faster release compilation (trading runtime perf for build speed)
- Add `[profile.debugging]` that inherits dev but re-enables debug info when needed
- Matches the same profile settings used in lana-bank

## Test plan
- [ ] Verify dev builds still work (`cargo build`)
- [ ] Verify release builds still work (`cargo build --release`)
- [ ] Confirm Nix/crane builds pick up the new profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)