### PR TITLE
feat(graphql): expose app config via appConfig query

### DIFF
--- a/server/src/graphql/mod.rs
+++ b/server/src/graphql/mod.rs
@@ -27,8 +27,11 @@ use tokio_stream::{self as stream, StreamExt};
 use crate::AppState;
 
 pub use mutation::Mutation;
+pub use primitives::Yaml;
 pub use query::Query;
 pub use subscription::Subscription;
+
+pub struct AppConfigYaml(pub Yaml);
 
 pub type AgentsSchema = Schema<Query, Mutation, Subscription>;
 
@@ -72,6 +75,9 @@ async fn graphql_handler(
         .map(|Extension(sub)| sub)
         .unwrap_or(domain::auth::AuthSubject::Anonymous);
     request = request.data(auth_subject);
+
+    // Inject the serialized app config YAML so the `appConfig` query can return it.
+    request = request.data(AppConfigYaml(state.app_config_yaml.clone()));
 
     // Override the REST middleware's generic "api: POST /graphql" entrypoint
     // with the concrete operation name so audit entries are useful.

--- a/server/src/graphql/primitives.rs
+++ b/server/src/graphql/primitives.rs
@@ -15,6 +15,17 @@ pub use drua_core::auth::AuthSubject;
 
 pub use es_entity::graphql::UUID;
 
+#[derive(Clone, Serialize, Deserialize, Default)]
+#[serde(transparent)]
+pub struct Yaml(String);
+async_graphql::scalar!(Yaml);
+
+impl From<String> for Yaml {
+    fn from(s: String) -> Self {
+        Self(s)
+    }
+}
+
 #[derive(Clone, Copy, Serialize, Deserialize)]
 #[serde(transparent)]
 pub struct Timestamp(chrono::DateTime<chrono::Utc>);

--- a/server/src/graphql/query.rs
+++ b/server/src/graphql/query.rs
@@ -6,6 +6,7 @@ use async_graphql::{
 use super::agent::Agent;
 use super::primitives::*;
 use super::workspace::Workspace;
+use super::AppConfigYaml;
 
 use drua_core::workspace::WorkspaceByCreatedAtCursor;
 
@@ -23,6 +24,10 @@ pub struct Query;
 impl Query {
     async fn ping(&self) -> &str {
         "pong"
+    }
+
+    async fn app_config(&self, ctx: &Context<'_>) -> Yaml {
+        ctx.data_unchecked::<AppConfigYaml>().0.clone()
     }
 
     /// The currently authenticated user, if any.

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -110,6 +110,7 @@ type Query {
 	Look up a single agent by ID.
 	"""
 	agent(id: AgentId!): Agent
+	appConfig: Yaml!
 	"""
 	Export a thread as Pi-compatible JSONL (v3 format).
 	
@@ -363,6 +364,8 @@ input WorkspaceUpdateInput {
 type WorkspaceUpdatePayload {
 	workspace: Workspace!
 }
+
+scalar Yaml
 
 """
 Directs the executor to include this field or fragment only when the `if` argument is true.

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -26,6 +26,8 @@ pub struct AppState {
     pub mcp_endpoint: String,
     pub github_allowed_teams: Vec<String>,
     pub code_assistant: Option<CodeAssistant>,
+    /// Serialized YAML config exposed via the `appConfig` GraphQL query.
+    pub app_config_yaml: graphql::Yaml,
     /// Optional SA token validator — present when running in-cluster.
     pub sa_token_validator: Option<SaTokenValidator>,
     /// Postgres-backed session store shared with the session layer.
@@ -40,6 +42,7 @@ impl AppState {
         login: LoginMethod,
         mcp_endpoint: String,
         github_allowed_teams: Vec<String>,
+        app_config_yaml: graphql::Yaml,
     ) -> Self {
         let code_assistant = app.code_assistant().cloned();
         Self {
@@ -49,6 +52,7 @@ impl AppState {
             mcp_endpoint,
             github_allowed_teams,
             code_assistant,
+            app_config_yaml,
             sa_token_validator: None,
             session_store: PgSessionStore::new(pool),
         }
@@ -156,6 +160,8 @@ pub async fn run_server(args: RunServerArgs) -> anyhow::Result<()> {
 
     let mcp_service = drua_mcp_gateway::McpGateway::service(app.clone());
 
+    let app_config_yaml: graphql::Yaml = serde_yaml::to_string(&config)?.into();
+
     let mut app_state = AppState::new(
         &pool,
         app,
@@ -163,6 +169,7 @@ pub async fn run_server(args: RunServerArgs) -> anyhow::Result<()> {
         auth_config.login,
         config.server.mcp_endpoint.clone(),
         auth_config.github_allowed_teams,
+        app_config_yaml,
     );
 
     if let Some(validator) = auth::sa_token::SaTokenValidator::try_from_env("drua-mcp").await {


### PR DESCRIPTION
## Summary
- Adds a `Yaml` scalar type and an `appConfig: Yaml!` query to the GraphQL API
- Serializes the loaded `Config` to YAML at startup and injects it into the GraphQL context via `AppState`
- Follows the same pattern as [lana-bank](https://github.com/GaloyMoney/lana-bank/blob/main/lana/admin-server/src/graphql/schema.graphql#L3128)
- Secrets (`anthropic_api_key`, `pg_con`, `github_client_secret`) are excluded automatically via `#[serde(skip)]`

## Test plan
- [ ] Verify `{ appConfig }` query returns valid YAML with config values
- [ ] Confirm no secrets appear in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)