### PR TITLE
feat(toolset): add whoami tool for auth debugging

### DIFF
--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -13,7 +13,7 @@ pub use top_level::{
     AdminAgentAttachSandbox, AdminAgentCreate, AdminAgentDetachSandbox, AdminAllLogs,
     AdminCreateSandbox, AdminGetSandbox, AdminInspectSandbox, AdminListAgents, AdminListSandboxes,
     AdminWorkspaceCreate, AdminWorkspaceList, Bash, CallCatalogTool, DescribeCatalogTool, GlobTool,
-    Grep, Ls, Ping, Read, SearchCatalog, TextEditor, WorkspaceAgentAttachSandbox,
+    Grep, Ls, Ping, Read, SearchCatalog, TextEditor, WhoAmI, WorkspaceAgentAttachSandbox,
     WorkspaceAgentCreate, WorkspaceAgentDetachSandbox, WorkspaceCreateSandbox, WorkspaceGetSandbox,
     WorkspaceInspectSandbox, WorkspaceListAgents, WorkspaceListSandboxes, WorkspaceLog,
 };
@@ -70,6 +70,7 @@ impl ToolSets {
         let describe = Arc::new(DescribeCatalogTool::new(Arc::clone(&sets)));
         let call = Arc::new(CallCatalogTool::new(Arc::clone(&sets)));
         let ping = Arc::new(Ping::new());
+        let whoami = Arc::new(WhoAmI::new());
 
         let mut top_level = HashMap::new();
         top_level.insert(search.name().to_string(), search as Arc<dyn TopLevelTool>);
@@ -79,6 +80,7 @@ impl ToolSets {
         );
         top_level.insert(call.name().to_string(), call as Arc<dyn TopLevelTool>);
         top_level.insert(ping.name().to_string(), ping as Arc<dyn TopLevelTool>);
+        top_level.insert(whoami.name().to_string(), whoami as Arc<dyn TopLevelTool>);
 
         Ok(Self {
             sets,

--- a/core/src/toolset/top_level/mod.rs
+++ b/core/src/toolset/top_level/mod.rs
@@ -96,6 +96,7 @@ mod ping;
 mod read;
 mod sandbox;
 mod text_editor;
+mod whoami;
 mod workspace;
 
 pub use agent::{
@@ -117,4 +118,5 @@ pub use sandbox::{
     WorkspaceGetSandbox, WorkspaceListSandboxes,
 };
 pub use text_editor::TextEditor;
+pub use whoami::WhoAmI;
 pub use workspace::{AdminWorkspaceCreate, AdminWorkspaceList};

--- a/core/src/toolset/top_level/whoami.rs
+++ b/core/src/toolset/top_level/whoami.rs
@@ -1,0 +1,102 @@
+//! `whoami` — returns the current auth subject type, scopes, and identity.
+//! Useful for debugging visibility / authorization issues.
+
+use std::sync::LazyLock;
+
+use rmcp::model::{CallToolResult, Content, JsonObject};
+
+use crate::auth::AuthSubject;
+
+use super::super::error::ToolSetsError;
+use super::super::traits::TopLevelTool;
+
+pub struct WhoAmI;
+
+impl WhoAmI {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for WhoAmI {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+static WHOAMI_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
+    serde_json::json!({
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false,
+    })
+});
+
+#[async_trait::async_trait]
+impl TopLevelTool for WhoAmI {
+    fn name(&self) -> &str {
+        "whoami"
+    }
+
+    fn description(&self) -> &str {
+        "Returns the current authentication subject: identity type, scopes, and associated IDs. Useful for debugging tool visibility and authorization."
+    }
+
+    fn input_schema(&self) -> &serde_json::Value {
+        &WHOAMI_SCHEMA
+    }
+
+    async fn call(
+        &self,
+        subject: &AuthSubject,
+        _arguments: Option<JsonObject>,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        let mut info = serde_json::Map::new();
+
+        match subject {
+            AuthSubject::User(user_id) => {
+                info.insert("type".into(), "user".into());
+                info.insert("user_id".into(), user_id.to_string().into());
+                info.insert(
+                    "note".into(),
+                    "Users implicitly have all scopes".into(),
+                );
+            }
+            AuthSubject::ExportedAgent(user_id, creds_id, scopes) => {
+                info.insert("type".into(), "exported_agent".into());
+                info.insert("user_id".into(), user_id.to_string().into());
+                info.insert("creds_id".into(), creds_id.to_string().into());
+                info.insert(
+                    "scopes".into(),
+                    scopes.iter().map(|s| s.to_string()).collect::<Vec<_>>().into(),
+                );
+            }
+            AuthSubject::Agent(workspace_id, agent_id, scopes) => {
+                info.insert("type".into(), "agent".into());
+                info.insert("workspace_id".into(), workspace_id.to_string().into());
+                info.insert("agent_id".into(), agent_id.to_string().into());
+                info.insert(
+                    "scopes".into(),
+                    scopes.iter().map(|s| s.to_string()).collect::<Vec<_>>().into(),
+                );
+            }
+            AuthSubject::AgentOnBehalfOfUser(user_id, workspace_id, agent_id, scopes) => {
+                info.insert("type".into(), "agent_on_behalf_of_user".into());
+                info.insert("user_id".into(), user_id.to_string().into());
+                info.insert("workspace_id".into(), workspace_id.to_string().into());
+                info.insert("agent_id".into(), agent_id.to_string().into());
+                info.insert(
+                    "scopes".into(),
+                    scopes.iter().map(|s| s.to_string()).collect::<Vec<_>>().into(),
+                );
+            }
+            AuthSubject::Anonymous => {
+                info.insert("type".into(), "anonymous".into());
+            }
+        }
+
+        let text = serde_json::to_string_pretty(&info)
+            .unwrap_or_else(|_| format!("{info:?}"));
+        Ok(CallToolResult::success(vec![Content::text(text)]))
+    }
+}

--- a/core/src/toolset/top_level/whoami.rs
+++ b/core/src/toolset/top_level/whoami.rs
@@ -57,10 +57,7 @@ impl TopLevelTool for WhoAmI {
             AuthSubject::User(user_id) => {
                 info.insert("type".into(), "user".into());
                 info.insert("user_id".into(), user_id.to_string().into());
-                info.insert(
-                    "note".into(),
-                    "Users implicitly have all scopes".into(),
-                );
+                info.insert("note".into(), "Users implicitly have all scopes".into());
             }
             AuthSubject::ExportedAgent(user_id, creds_id, scopes) => {
                 info.insert("type".into(), "exported_agent".into());
@@ -68,7 +65,11 @@ impl TopLevelTool for WhoAmI {
                 info.insert("creds_id".into(), creds_id.to_string().into());
                 info.insert(
                     "scopes".into(),
-                    scopes.iter().map(|s| s.to_string()).collect::<Vec<_>>().into(),
+                    scopes
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect::<Vec<_>>()
+                        .into(),
                 );
             }
             AuthSubject::Agent(workspace_id, agent_id, scopes) => {
@@ -77,7 +78,11 @@ impl TopLevelTool for WhoAmI {
                 info.insert("agent_id".into(), agent_id.to_string().into());
                 info.insert(
                     "scopes".into(),
-                    scopes.iter().map(|s| s.to_string()).collect::<Vec<_>>().into(),
+                    scopes
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect::<Vec<_>>()
+                        .into(),
                 );
             }
             AuthSubject::AgentOnBehalfOfUser(user_id, workspace_id, agent_id, scopes) => {
@@ -87,7 +92,11 @@ impl TopLevelTool for WhoAmI {
                 info.insert("agent_id".into(), agent_id.to_string().into());
                 info.insert(
                     "scopes".into(),
-                    scopes.iter().map(|s| s.to_string()).collect::<Vec<_>>().into(),
+                    scopes
+                        .iter()
+                        .map(|s| s.to_string())
+                        .collect::<Vec<_>>()
+                        .into(),
                 );
             }
             AuthSubject::Anonymous => {
@@ -95,8 +104,7 @@ impl TopLevelTool for WhoAmI {
             }
         }
 
-        let text = serde_json::to_string_pretty(&info)
-            .unwrap_or_else(|_| format!("{info:?}"));
+        let text = serde_json::to_string_pretty(&info).unwrap_or_else(|_| format!("{info:?}"));
         Ok(CallToolResult::success(vec![Content::text(text)]))
     }
 }


### PR DESCRIPTION
## Summary

Adds a `whoami` top-level MCP tool that returns the current auth subject's type, scopes, and IDs.

Example output for an exported agent credential:
```json
{
  "type": "exported_agent",
  "user_id": "...",
  "creds_id": "...",
  "scopes": ["admin"]
}
```

## Context

We spent time debugging why k8s tools weren't visible — turned out the MCP credential was created without the `admin` scope, and the kubernetes upstream requires `required_scopes: ["admin"]`. This tool would have made that immediately obvious.

## Test plan

- [x] `cargo clippy` passes
- [ ] Deploy and call `whoami` via MCP to verify output

🤖 Generated with [Claude Code](https://claude.com/claude-code)