### PR TITLE
fix(deploy): use external URL for user-facing MCP endpoint

### DIFF
--- a/ci/deploy/galoy-agents/prod-values.yml.tmpl
+++ b/ci/deploy/galoy-agents/prod-values.yml.tmpl
@@ -6,7 +6,7 @@ galoyAgents:
   config:
     server:
       secureCookies: true
-      mcpEndpoint: "http://galoy-agents.galoy-agents.svc.cluster.local:5254/mcp"
+      mcpEndpoint: "https://dashboard.agents.galoy.io/mcp"
     oauth:
       githubClientId: "Ov23livtQjMQ1fB0toPF"
       githubRedirectUri: "https://dashboard.agents.galoy.io/auth/github/callback"


### PR DESCRIPTION
## Summary
- The `mcpEndpoint` in prod values was set to the internal k8s service URL (`http://galoy-agents.galoy-agents.svc.cluster.local:5254/mcp`), causing the generated `claude mcp add-json` command to give users an unreachable address
- Changed it to the public ingress URL (`https://dashboard.agents.galoy.io/mcp`)
- The separate `mcpGatewayUrl` (used for sandbox-to-gateway pod communication) correctly remains as the internal URL

## Test plan
- [ ] Deploy and verify the MCP link shown on the dashboard uses `https://dashboard.agents.galoy.io/mcp`
- [ ] Verify sandbox pods can still reach the MCP gateway via the internal URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)