### PR TITLE
refactor(drua): restructure TUI into state/chat/handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1043,6 +1043,7 @@ checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
  "bitflags",
  "crossterm_winapi",
+ "futures-core",
  "mio",
  "parking_lot",
  "rustix 0.38.44",
@@ -1317,6 +1318,7 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs",
+ "futures",
  "ratatui",
  "reqwest 0.12.28",
  "serde",

--- a/drua/Cargo.toml
+++ b/drua/Cargo.toml
@@ -16,4 +16,5 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 ratatui = { workspace = true }
-crossterm = { workspace = true }
+crossterm = { workspace = true, features = ["event-stream"] }
+futures = { workspace = true }

--- a/drua/src/commands/dashboard.rs
+++ b/drua/src/commands/dashboard.rs
@@ -1,19 +1,25 @@
 use std::io;
+use std::time::Duration;
 
 use anyhow::Result;
 use crossterm::{
-    event::{self, Event, KeyCode, KeyModifiers},
+    event::{Event, EventStream, KeyEventKind},
     execute,
     terminal::{disable_raw_mode, enable_raw_mode, EnterAlternateScreen, LeaveAlternateScreen},
 };
+use futures::StreamExt;
 use ratatui::{backend::CrosstermBackend, Terminal};
 use serde::Deserialize;
 use tokio::sync::mpsc;
 
 use crate::config::Config;
 use crate::graphql::GraphqlClient;
-use crate::tui::app::{AgentItem, App, Focus, Mode, WorkspaceItem};
-use crate::tui::ui;
+use crate::tui::state::{AgentItem, ScreenState, WorkspaceItem};
+use crate::tui::{handlers, ui};
+
+// ---------------------------------------------------------------------------
+// GraphQL response types
+// ---------------------------------------------------------------------------
 
 #[derive(Debug, Deserialize)]
 struct MeResponse {
@@ -107,71 +113,16 @@ struct CreatedWorkspace {
     name: String,
 }
 
+// ---------------------------------------------------------------------------
+// Chat streaming
+// ---------------------------------------------------------------------------
+
 enum ChatStreamEvent {
     Delta(String),
     ToolUse(String),
     ToolResult(String),
     Error(String),
     Done,
-}
-
-async fn create_workspace(client: &GraphqlClient, name: &str, description: &str) -> Result<String> {
-    let mut input = serde_json::json!({ "name": name });
-    if !description.is_empty() {
-        input["description"] = serde_json::json!(description);
-    }
-    let resp: WorkspaceCreateResponse = client
-        .query(
-            WORKSPACE_CREATE_MUTATION,
-            serde_json::json!({ "input": input }),
-        )
-        .await?;
-    Ok(resp.workspace_create.workspace.name)
-}
-
-async fn fetch_workspaces(client: &GraphqlClient) -> Result<Vec<WorkspaceItem>> {
-    let resp: WorkspacesResponse = client
-        .query(WORKSPACES_QUERY, serde_json::json!({}))
-        .await?;
-
-    let items = resp
-        .workspaces
-        .edges
-        .into_iter()
-        .map(|edge| {
-            let node = edge.node;
-            WorkspaceItem {
-                id: node.id,
-                name: node.name,
-                description: node.description,
-                created_at: node.created_at,
-                lead: node.lead.map(|a| AgentItem {
-                    id: a.id,
-                    name: a.name,
-                    role: a.role,
-                }),
-            }
-        })
-        .collect();
-
-    Ok(items)
-}
-
-async fn fetch_user_name(client: &GraphqlClient) -> Result<String> {
-    let resp: MeResponse = client
-        .query(
-            "{ me { githubUsername name email } }",
-            serde_json::json!({}),
-        )
-        .await?;
-    let user = resp
-        .me
-        .ok_or_else(|| anyhow::anyhow!("not authenticated"))?;
-    Ok(user
-        .github_username
-        .or(user.name)
-        .or(user.email)
-        .unwrap_or_else(|| "unknown".to_string()))
 }
 
 fn spawn_chat_stream(
@@ -301,6 +252,100 @@ fn parse_sse_block(block: &str) -> Option<ChatStreamEvent> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Data fetching
+// ---------------------------------------------------------------------------
+
+async fn create_workspace(client: &GraphqlClient, name: &str, description: &str) -> Result<String> {
+    let mut input = serde_json::json!({ "name": name });
+    if !description.is_empty() {
+        input["description"] = serde_json::json!(description);
+    }
+    let resp: WorkspaceCreateResponse = client
+        .query(
+            WORKSPACE_CREATE_MUTATION,
+            serde_json::json!({ "input": input }),
+        )
+        .await?;
+    Ok(resp.workspace_create.workspace.name)
+}
+
+async fn fetch_workspaces(client: &GraphqlClient) -> Result<Vec<WorkspaceItem>> {
+    let resp: WorkspacesResponse = client
+        .query(WORKSPACES_QUERY, serde_json::json!({}))
+        .await?;
+
+    let items = resp
+        .workspaces
+        .edges
+        .into_iter()
+        .map(|edge| {
+            let node = edge.node;
+            WorkspaceItem {
+                id: node.id,
+                name: node.name,
+                description: node.description,
+                created_at: node.created_at,
+                lead: node.lead.map(|a| AgentItem {
+                    id: a.id,
+                    name: a.name,
+                    role: a.role,
+                }),
+            }
+        })
+        .collect();
+
+    Ok(items)
+}
+
+async fn fetch_user_name(client: &GraphqlClient) -> Result<String> {
+    let resp: MeResponse = client
+        .query(
+            "{ me { githubUsername name email } }",
+            serde_json::json!({}),
+        )
+        .await?;
+    let user = resp
+        .me
+        .ok_or_else(|| anyhow::anyhow!("not authenticated"))?;
+    Ok(user
+        .github_username
+        .or(user.name)
+        .or(user.email)
+        .unwrap_or_else(|| "unknown".to_string()))
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch stream events → AssistantChat
+// ---------------------------------------------------------------------------
+
+fn dispatch_stream_event(state: &mut ScreenState, evt: ChatStreamEvent) {
+    match evt {
+        ChatStreamEvent::Delta(text) => {
+            state.chat_view.assistant.append_text(&text);
+        }
+        ChatStreamEvent::ToolUse(name) => {
+            state
+                .chat_view
+                .assistant
+                .add_tool_activity(format!("calling {name}…"));
+        }
+        ChatStreamEvent::ToolResult(summary) => {
+            state.chat_view.assistant.add_tool_activity(summary);
+        }
+        ChatStreamEvent::Error(msg) => {
+            state.chat_view.assistant.add_error(msg);
+        }
+        ChatStreamEvent::Done => {
+            state.chat_view.assistant.finish_streaming();
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Auth bootstrap — delegate to login flow when credentials are missing/stale
+// ---------------------------------------------------------------------------
+
 async fn ensure_authenticated(server: Option<String>) -> Result<(Config, GraphqlClient, String)> {
     // Try existing config first
     if let Ok(config) = Config::load() {
@@ -322,11 +367,15 @@ async fn ensure_authenticated(server: Option<String>) -> Result<(Config, Graphql
     Ok((config, client, user_name))
 }
 
+// ---------------------------------------------------------------------------
+// Entry point & event loop
+// ---------------------------------------------------------------------------
+
 pub async fn run(server: Option<String>) -> Result<()> {
     let (config, client, user_name) = ensure_authenticated(server).await?;
     let workspaces = fetch_workspaces(&client).await?;
 
-    let mut app = App::new(workspaces, config.server_url.clone(), user_name);
+    let mut state = ScreenState::new(workspaces, config.server_url.clone(), user_name);
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();
@@ -334,7 +383,7 @@ pub async fn run(server: Option<String>) -> Result<()> {
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend)?;
 
-    let result = run_event_loop(&mut terminal, &mut app, &client, &config).await;
+    let result = run_event_loop(&mut terminal, &mut state, &client, &config).await;
 
     disable_raw_mode()?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen)?;
@@ -345,142 +394,72 @@ pub async fn run(server: Option<String>) -> Result<()> {
 
 async fn run_event_loop(
     terminal: &mut Terminal<CrosstermBackend<io::Stdout>>,
-    app: &mut App,
+    state: &mut ScreenState,
     client: &GraphqlClient,
     config: &Config,
 ) -> Result<()> {
     let (stream_tx, mut stream_rx) = mpsc::unbounded_channel::<ChatStreamEvent>();
+    let mut event_stream = EventStream::new();
 
     loop {
-        // Drain pending stream events
-        while let Ok(evt) = stream_rx.try_recv() {
-            match evt {
-                ChatStreamEvent::Delta(text) => {
-                    app.append_to_last_assistant(&text);
-                }
-                ChatStreamEvent::ToolUse(name) => {
-                    app.push_chat_message("tool", format!("calling {name}…"));
-                }
-                ChatStreamEvent::ToolResult(summary) => {
-                    app.push_chat_message("tool", summary);
-                }
-                ChatStreamEvent::Error(msg) => {
-                    app.push_chat_message("system", format!("Error: {msg}"));
-                    app.chat_streaming = false;
-                }
-                ChatStreamEvent::Done => {
-                    app.chat_streaming = false;
-                }
-            }
-        }
+        terminal.draw(|frame| ui::draw(frame, state))?;
 
-        terminal.draw(|frame| ui::draw(frame, app))?;
-
-        if app.should_quit {
+        if state.should_quit {
             break;
         }
 
-        if event::poll(std::time::Duration::from_millis(50))? {
-            if let Event::Key(key) = event::read()? {
-                if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
-                    app.should_quit = true;
-                    continue;
-                }
+        let timeout = if state.chat_view.assistant.streaming {
+            Duration::from_millis(50)
+        } else {
+            Duration::from_millis(500)
+        };
 
-                match app.mode {
-                    Mode::Browse => match app.focus {
-                        Focus::Sidebar => {
-                            app.status_message = None;
-                            match key.code {
-                                KeyCode::Char('q') => app.should_quit = true,
-                                KeyCode::Char('j') | KeyCode::Down => app.cursor_down(),
-                                KeyCode::Char('k') | KeyCode::Up => app.cursor_up(),
-                                KeyCode::Char('n') => app.enter_create_mode(),
-                                KeyCode::Char('r') => {
-                                    if let Ok(workspaces) = fetch_workspaces(client).await {
-                                        app.replace_workspaces(workspaces);
-                                    }
+        tokio::select! {
+            event = event_stream.next() => {
+                if let Some(Ok(Event::Key(key))) = event {
+                    if key.kind == KeyEventKind::Press {
+                        match handlers::handle_key(state, key) {
+                            handlers::Action::Quit => state.should_quit = true,
+                            handlers::Action::Refresh => {
+                                if let Ok(workspaces) = fetch_workspaces(client).await {
+                                    state.replace_workspaces(workspaces);
                                 }
-                                KeyCode::Tab => app.toggle_focus(),
-                                _ => {}
                             }
-                        }
-                        Focus::Chat => match key.code {
-                            KeyCode::Esc => {
-                                app.focus = Focus::Sidebar;
-                            }
-                            KeyCode::Tab => app.toggle_focus(),
-                            KeyCode::Enter => {
-                                let input = app.chat_input.trim().to_string();
-                                if !input.is_empty() {
-                                    if let Some(agent_id) = app.selected_lead_id.clone() {
-                                        app.push_chat_message("user", &input);
-                                        app.chat_input.clear();
-                                        app.chat_streaming = true;
-                                        spawn_chat_stream(
-                                            config.server_url.clone(),
-                                            config.auth_token.clone(),
-                                            agent_id,
-                                            input,
-                                            stream_tx.clone(),
-                                        );
-                                    } else {
-                                        app.status_message =
-                                            Some("No lead agent selected".to_string());
+                            handlers::Action::CreateWorkspace { name, description } => {
+                                match create_workspace(client, &name, &description).await {
+                                    Ok(ws_name) => {
+                                        state.exit_create_mode();
+                                        if let Ok(workspaces) = fetch_workspaces(client).await {
+                                            state.replace_workspaces(workspaces);
+                                        }
+                                        state.status_message =
+                                            Some(format!("Created workspace: {ws_name}"));
+                                    }
+                                    Err(e) => {
+                                        state.status_message = Some(format!("Error: {e}"));
                                     }
                                 }
                             }
-                            KeyCode::Backspace => {
-                                app.chat_input.pop();
+                            handlers::Action::SendChat { agent_id, prompt } => {
+                                spawn_chat_stream(
+                                    config.server_url.clone(),
+                                    config.auth_token.clone(),
+                                    agent_id,
+                                    prompt,
+                                    stream_tx.clone(),
+                                );
                             }
-                            KeyCode::Up => {
-                                app.chat_scroll = app.chat_scroll.saturating_add(1);
-                            }
-                            KeyCode::Down => {
-                                app.chat_scroll = app.chat_scroll.saturating_sub(1);
-                            }
-                            KeyCode::Char(c) => {
-                                app.chat_input.push(c);
-                            }
-                            _ => {}
-                        },
-                    },
-                    Mode::CreateWorkspace => match key.code {
-                        KeyCode::Esc => app.exit_create_mode(),
-                        KeyCode::Tab | KeyCode::BackTab => {
-                            app.input_field = (app.input_field + 1) % 2;
+                            handlers::Action::None => {}
                         }
-                        KeyCode::Backspace => {
-                            app.active_input_mut().pop();
-                        }
-                        KeyCode::Char(c) => {
-                            app.active_input_mut().push(c);
-                        }
-                        KeyCode::Enter => {
-                            if app.input_name.trim().is_empty() {
-                                app.status_message = Some("Name is required".to_string());
-                                continue;
-                            }
-                            let name = app.input_name.trim().to_string();
-                            let desc = app.input_description.trim().to_string();
-                            match create_workspace(client, &name, &desc).await {
-                                Ok(ws_name) => {
-                                    app.exit_create_mode();
-                                    if let Ok(workspaces) = fetch_workspaces(client).await {
-                                        app.replace_workspaces(workspaces);
-                                    }
-                                    app.status_message =
-                                        Some(format!("Created workspace: {ws_name}"));
-                                }
-                                Err(e) => {
-                                    app.status_message = Some(format!("Error: {e}"));
-                                }
-                            }
-                        }
-                        _ => {}
-                    },
+                    }
                 }
             }
+            event = stream_rx.recv() => {
+                if let Some(evt) = event {
+                    dispatch_stream_event(state, evt);
+                }
+            }
+            _ = tokio::time::sleep(timeout) => {}
         }
     }
     Ok(())

--- a/drua/src/tui/chat.rs
+++ b/drua/src/tui/chat.rs
@@ -1,0 +1,95 @@
+/// Structured chat content: interleaved text and tool-use blocks.
+pub enum ContentBlock {
+    Text(String),
+    ToolUse(String),
+}
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum ChatRole {
+    User,
+    Assistant,
+    System,
+}
+
+pub struct ChatMessage {
+    pub role: ChatRole,
+    pub blocks: Vec<ContentBlock>,
+}
+
+/// Manages the conversation with a workspace lead agent.
+///
+/// Streaming flow:
+/// 1. `add_user_message(text)` → pushes user msg + empty assistant msg, sets streaming
+/// 2. `append_text(text)` / `add_tool_activity(name)` → fills the current assistant msg
+/// 3. `finish_streaming()` or `add_error(msg)` → clears streaming flag
+#[derive(Default)]
+pub struct AssistantChat {
+    pub messages: Vec<ChatMessage>,
+    pub streaming: bool,
+}
+
+impl AssistantChat {
+    /// Push a user message and prepare an empty assistant reply.
+    pub fn add_user_message(&mut self, text: impl Into<String>) {
+        self.messages.push(ChatMessage {
+            role: ChatRole::User,
+            blocks: vec![ContentBlock::Text(text.into())],
+        });
+        self.messages.push(ChatMessage {
+            role: ChatRole::Assistant,
+            blocks: Vec::new(),
+        });
+        self.streaming = true;
+    }
+
+    /// Append text to the current assistant message's last text block,
+    /// creating a new text block if the last block is a tool-use or empty.
+    pub fn append_text(&mut self, text: &str) {
+        let msg = match self.messages.last_mut() {
+            Some(m) if m.role == ChatRole::Assistant => m,
+            _ => {
+                self.messages.push(ChatMessage {
+                    role: ChatRole::Assistant,
+                    blocks: Vec::new(),
+                });
+                self.messages.last_mut().unwrap()
+            }
+        };
+
+        match msg.blocks.last_mut() {
+            Some(ContentBlock::Text(existing)) => existing.push_str(text),
+            _ => msg.blocks.push(ContentBlock::Text(text.to_string())),
+        }
+    }
+
+    /// Record a tool invocation inline in the current assistant message.
+    pub fn add_tool_activity(&mut self, name: impl Into<String>) {
+        if let Some(msg) = self
+            .messages
+            .last_mut()
+            .filter(|m| m.role == ChatRole::Assistant)
+        {
+            msg.blocks.push(ContentBlock::ToolUse(name.into()));
+        }
+    }
+
+    /// Append an error as a system message and stop streaming.
+    pub fn add_error(&mut self, msg: impl Into<String>) {
+        self.messages.push(ChatMessage {
+            role: ChatRole::System,
+            blocks: vec![ContentBlock::Text(format!("[Error: {}]", msg.into()))],
+        });
+        self.streaming = false;
+    }
+
+    /// Mark the current stream as complete.
+    pub fn finish_streaming(&mut self) {
+        self.streaming = false;
+    }
+
+    /// Reset all conversation state.
+    pub fn clear(&mut self) {
+        self.messages.clear();
+        self.streaming = false;
+    }
+}

--- a/drua/src/tui/handlers.rs
+++ b/drua/src/tui/handlers.rs
@@ -1,0 +1,134 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+use super::state::{Focus, Mode, ScreenState};
+
+/// Async side-effects returned from key handlers for the event loop to execute.
+pub enum Action {
+    None,
+    Quit,
+    Refresh,
+    CreateWorkspace { name: String, description: String },
+    SendChat { agent_id: String, prompt: String },
+}
+
+/// Top-level key dispatcher — routes to mode/focus-specific handlers.
+pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    if key.modifiers.contains(KeyModifiers::CONTROL) && key.code == KeyCode::Char('c') {
+        return Action::Quit;
+    }
+
+    match state.mode {
+        Mode::Browse => match state.focus {
+            Focus::Sidebar => handle_sidebar_key(state, key),
+            Focus::Chat => handle_chat_key(state, key),
+        },
+        Mode::CreateWorkspace => handle_create_key(state, key),
+    }
+}
+
+fn handle_sidebar_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    state.status_message = None;
+    match key.code {
+        KeyCode::Char('q') => Action::Quit,
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.cursor_down();
+            Action::None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.cursor_up();
+            Action::None
+        }
+        KeyCode::Char('n') => {
+            state.enter_create_mode();
+            Action::None
+        }
+        KeyCode::Char('r') => Action::Refresh,
+        KeyCode::Tab => {
+            state.toggle_focus();
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn handle_chat_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Esc => {
+            state.focus = Focus::Sidebar;
+            Action::None
+        }
+        KeyCode::Tab => {
+            state.toggle_focus();
+            Action::None
+        }
+        KeyCode::Enter => {
+            let input = state.chat_input.trim().to_string();
+            if input.is_empty() {
+                return Action::None;
+            }
+            match state.selected_lead_id.clone() {
+                Some(agent_id) => {
+                    state.chat_view.assistant.add_user_message(&input);
+                    state.chat_input.clear();
+                    state.chat_view.reset_scroll();
+                    Action::SendChat {
+                        agent_id,
+                        prompt: input,
+                    }
+                }
+                None => {
+                    state.status_message = Some("No lead agent selected".to_string());
+                    Action::None
+                }
+            }
+        }
+        KeyCode::Backspace => {
+            state.chat_input.pop();
+            Action::None
+        }
+        KeyCode::Up => {
+            state.chat_view.scroll_up();
+            Action::None
+        }
+        KeyCode::Down => {
+            state.chat_view.scroll_down();
+            Action::None
+        }
+        KeyCode::Char(c) => {
+            state.chat_input.push(c);
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn handle_create_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Esc => {
+            state.exit_create_mode();
+            Action::None
+        }
+        KeyCode::Tab | KeyCode::BackTab => {
+            state.input_field = (state.input_field + 1) % 2;
+            Action::None
+        }
+        KeyCode::Backspace => {
+            state.active_input_mut().pop();
+            Action::None
+        }
+        KeyCode::Char(c) => {
+            state.active_input_mut().push(c);
+            Action::None
+        }
+        KeyCode::Enter => {
+            if state.input_name.trim().is_empty() {
+                state.status_message = Some("Name is required".to_string());
+                return Action::None;
+            }
+            let name = state.input_name.trim().to_string();
+            let description = state.input_description.trim().to_string();
+            Action::CreateWorkspace { name, description }
+        }
+        _ => Action::None,
+    }
+}

--- a/drua/src/tui/mod.rs
+++ b/drua/src/tui/mod.rs
@@ -1,2 +1,4 @@
-pub mod app;
+pub mod chat;
+pub mod handlers;
+pub mod state;
 pub mod ui;

--- a/drua/src/tui/state.rs
+++ b/drua/src/tui/state.rs
@@ -1,3 +1,5 @@
+use super::chat::AssistantChat;
+
 #[allow(dead_code)]
 pub struct WorkspaceItem {
     pub id: String,
@@ -28,33 +30,61 @@ pub enum Focus {
     Chat,
 }
 
-pub struct ChatMessage {
-    pub role: String,
-    pub text: String,
+/// Scroll and viewport state for the chat message area.
+#[derive(Default)]
+pub struct ChatViewState {
+    pub assistant: AssistantChat,
+    pub chat_scroll: u16,
+    chat_viewport_height: u16,
 }
 
-pub struct App {
+impl ChatViewState {
+    pub fn scroll_up(&mut self) {
+        let jump = (self.chat_viewport_height / 2).max(1);
+        self.chat_scroll = self.chat_scroll.saturating_add(jump);
+    }
+
+    pub fn scroll_down(&mut self) {
+        let jump = (self.chat_viewport_height / 2).max(1);
+        self.chat_scroll = self.chat_scroll.saturating_sub(jump);
+    }
+
+    pub fn reset_scroll(&mut self) {
+        self.chat_scroll = 0;
+    }
+
+    /// Called from the render path to record the available height.
+    pub fn update_viewport_height(&mut self, h: u16) {
+        self.chat_viewport_height = h;
+    }
+}
+
+/// Top-level TUI state — replaces the old flat `App` struct.
+pub struct ScreenState {
+    // Workspace browsing
     pub workspaces: Vec<WorkspaceItem>,
     pub cursor: usize,
+    pub selected_lead_id: Option<String>,
+
+    // Global
     pub server_url: String,
     pub user_name: String,
     pub should_quit: bool,
-
-    pub mode: Mode,
     pub focus: Focus,
+    pub status_message: Option<String>,
+
+    // Chat
+    pub chat_view: ChatViewState,
+    pub chat_input: String,
+
+    // Create workspace modal
+    pub mode: Mode,
     pub input_name: String,
     pub input_description: String,
     pub input_field: u8,
-    pub status_message: Option<String>,
-
-    pub chat_messages: Vec<ChatMessage>,
-    pub chat_input: String,
-    pub chat_scroll: u16,
-    pub chat_streaming: bool,
-    pub selected_lead_id: Option<String>,
 }
 
-impl App {
+impl ScreenState {
     pub fn new(workspaces: Vec<WorkspaceItem>, server_url: String, user_name: String) -> Self {
         let selected_lead_id = workspaces
             .first()
@@ -67,16 +97,16 @@ impl App {
             server_url,
             user_name,
             should_quit: false,
-            mode: Mode::default(),
             focus: Focus::default(),
+            status_message: None,
+
+            chat_view: ChatViewState::default(),
+            chat_input: String::new(),
+
+            mode: Mode::default(),
             input_name: String::new(),
             input_description: String::new(),
             input_field: 0,
-            status_message: None,
-            chat_messages: Vec::new(),
-            chat_input: String::new(),
-            chat_scroll: 0,
-            chat_streaming: false,
             selected_lead_id,
         }
     }
@@ -136,36 +166,13 @@ impl App {
         };
     }
 
-    pub fn push_chat_message(&mut self, role: impl Into<String>, text: impl Into<String>) {
-        self.chat_messages.push(ChatMessage {
-            role: role.into(),
-            text: text.into(),
-        });
-        self.chat_scroll = 0;
-    }
-
-    pub fn append_to_last_assistant(&mut self, text: &str) {
-        if let Some(last) = self.chat_messages.last_mut() {
-            if last.role == "assistant" {
-                last.text.push_str(text);
-                return;
-            }
-        }
-        self.push_chat_message("assistant", text);
-    }
-
-    pub fn clear_chat(&mut self) {
-        self.chat_messages.clear();
-        self.chat_input.clear();
-        self.chat_scroll = 0;
-        self.chat_streaming = false;
-    }
-
     fn sync_lead_and_clear_chat(&mut self) {
         self.selected_lead_id = self
             .selected_workspace()
             .and_then(|ws| ws.lead.as_ref())
             .map(|l| l.id.clone());
-        self.clear_chat();
+        self.chat_view.assistant.clear();
+        self.chat_input.clear();
+        self.chat_view.reset_scroll();
     }
 }

--- a/drua/src/tui/ui.rs
+++ b/drua/src/tui/ui.rs
@@ -6,9 +6,10 @@ use ratatui::{
     Frame,
 };
 
-use super::app::{App, Focus, Mode};
+use super::chat::{ChatMessage, ChatRole, ContentBlock};
+use super::state::{Focus, Mode, ScreenState};
 
-pub fn draw(frame: &mut Frame, app: &App) {
+pub fn draw(frame: &mut Frame, state: &mut ScreenState) {
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(1), Constraint::Length(1)])
@@ -22,33 +23,33 @@ pub fn draw(frame: &mut Frame, app: &App) {
         .constraints([Constraint::Length(28), Constraint::Min(1)])
         .split(main_area);
 
-    draw_workspace_list(frame, app, panels[0]);
-    draw_chat_pane(frame, app, panels[1]);
-    draw_status_bar(frame, app, status_area);
+    draw_workspace_list(frame, state, panels[0]);
+    draw_chat_pane(frame, state, panels[1]);
+    draw_status_bar(frame, state, status_area);
 
-    if app.mode == Mode::CreateWorkspace {
-        draw_create_modal(frame, app);
+    if state.mode == Mode::CreateWorkspace {
+        draw_create_modal(frame, state);
     }
 }
 
-fn draw_workspace_list(frame: &mut Frame, app: &App, area: Rect) {
+fn draw_workspace_list(frame: &mut Frame, state: &ScreenState, area: Rect) {
     let title = format!(
         " Workspaces ({}/{}) ",
-        if app.workspaces.is_empty() {
+        if state.workspaces.is_empty() {
             0
         } else {
-            app.cursor + 1
+            state.cursor + 1
         },
-        app.workspaces.len()
+        state.workspaces.len()
     );
 
-    let items: Vec<ListItem> = app
+    let items: Vec<ListItem> = state
         .workspaces
         .iter()
         .enumerate()
         .map(|(i, ws)| {
-            let prefix = if i == app.cursor { ">" } else { " " };
-            let style = if i == app.cursor {
+            let prefix = if i == state.cursor { ">" } else { " " };
+            let style = if i == state.cursor {
                 Style::default()
                     .fg(Color::Yellow)
                     .add_modifier(Modifier::BOLD)
@@ -62,7 +63,7 @@ fn draw_workspace_list(frame: &mut Frame, app: &App, area: Rect) {
         })
         .collect();
 
-    let border_color = if app.focus == Focus::Sidebar {
+    let border_color = if state.focus == Focus::Sidebar {
         Color::Yellow
     } else {
         Color::Cyan
@@ -78,7 +79,7 @@ fn draw_workspace_list(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(list, area);
 }
 
-fn draw_chat_pane(frame: &mut Frame, app: &App, area: Rect) {
+fn draw_chat_pane(frame: &mut Frame, state: &mut ScreenState, area: Rect) {
     let chat_layout = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(1), Constraint::Length(3)])
@@ -87,18 +88,24 @@ fn draw_chat_pane(frame: &mut Frame, app: &App, area: Rect) {
     let messages_area = chat_layout[0];
     let input_area = chat_layout[1];
 
-    draw_chat_messages(frame, app, messages_area);
-    draw_chat_input(frame, app, input_area);
+    // Record viewport height so scroll_up/scroll_down can do half-page jumps.
+    // Subtract 2 for the border lines.
+    state
+        .chat_view
+        .update_viewport_height(messages_area.height.saturating_sub(2));
+
+    draw_chat_messages(frame, state, messages_area);
+    draw_chat_input(frame, state, input_area);
 }
 
-fn draw_chat_messages(frame: &mut Frame, app: &App, area: Rect) {
-    let border_color = if app.focus == Focus::Chat {
+fn draw_chat_messages(frame: &mut Frame, state: &ScreenState, area: Rect) {
+    let border_color = if state.focus == Focus::Chat {
         Color::Yellow
     } else {
         Color::Cyan
     };
 
-    let title = match app.selected_workspace() {
+    let title = match state.selected_workspace() {
         Some(ws) => match &ws.lead {
             Some(lead) => format!(" Chat — {} ", lead.name),
             None => " Chat — no lead agent ".to_string(),
@@ -111,8 +118,10 @@ fn draw_chat_messages(frame: &mut Frame, app: &App, area: Rect) {
         .title(title)
         .border_style(Style::default().fg(border_color));
 
-    if app.chat_messages.is_empty() {
-        let hint = if app.selected_lead_id.is_some() {
+    let messages = &state.chat_view.assistant.messages;
+
+    if messages.is_empty() {
+        let hint = if state.selected_lead_id.is_some() {
             "Press Tab then type a message…"
         } else {
             "Select a workspace with a lead agent"
@@ -127,13 +136,13 @@ fn draw_chat_messages(frame: &mut Frame, app: &App, area: Rect) {
     }
 
     let mut lines: Vec<Line> = Vec::new();
-    for msg in &app.chat_messages {
-        let styled_lines = format_chat_message(msg);
-        lines.extend(styled_lines);
+    for msg in messages {
+        let styled = format_chat_message(msg);
+        lines.extend(styled);
         lines.push(Line::from(""));
     }
 
-    if app.chat_streaming {
+    if state.chat_view.assistant.streaming {
         lines.push(Line::from(Span::styled(
             "▍",
             Style::default().fg(Color::Yellow),
@@ -143,55 +152,85 @@ fn draw_chat_messages(frame: &mut Frame, app: &App, area: Rect) {
     let paragraph = Paragraph::new(lines)
         .block(block)
         .wrap(Wrap { trim: false })
-        .scroll((app.chat_scroll, 0));
+        .scroll((state.chat_view.chat_scroll, 0));
 
     frame.render_widget(paragraph, area);
 }
 
-fn format_chat_message(msg: &super::app::ChatMessage) -> Vec<Line<'static>> {
-    match msg.role.as_str() {
-        "user" => msg
-            .text
-            .lines()
-            .map(|l| {
-                Line::from(Span::styled(
-                    format!("> {l}"),
-                    Style::default().fg(Color::Cyan),
-                ))
+fn format_chat_message(msg: &ChatMessage) -> Vec<Line<'static>> {
+    match msg.role {
+        ChatRole::User => msg
+            .blocks
+            .iter()
+            .flat_map(|b| match b {
+                ContentBlock::Text(text) => text
+                    .lines()
+                    .map(|l| {
+                        Line::from(Span::styled(
+                            format!("> {l}"),
+                            Style::default().fg(Color::Cyan),
+                        ))
+                    })
+                    .collect::<Vec<_>>(),
+                ContentBlock::ToolUse(_) => vec![],
             })
             .collect(),
-        "assistant" => msg
-            .text
-            .lines()
-            .map(|l| {
-                Line::from(Span::styled(
-                    l.to_string(),
-                    Style::default().fg(Color::White),
-                ))
+        ChatRole::Assistant => {
+            let mut lines = Vec::new();
+            for block in &msg.blocks {
+                match block {
+                    ContentBlock::Text(text) => {
+                        for l in text.lines() {
+                            lines.push(Line::from(Span::styled(
+                                l.to_string(),
+                                Style::default().fg(Color::White),
+                            )));
+                        }
+                    }
+                    ContentBlock::ToolUse(name) => {
+                        lines.push(Line::from(Span::styled(
+                            format!("[{name}]"),
+                            Style::default().fg(Color::Yellow),
+                        )));
+                    }
+                }
+            }
+            lines
+        }
+        ChatRole::System => msg
+            .blocks
+            .iter()
+            .flat_map(|b| match b {
+                ContentBlock::Text(text) => text
+                    .lines()
+                    .map(|l| {
+                        Line::from(Span::styled(
+                            l.to_string(),
+                            Style::default()
+                                .fg(Color::DarkGray)
+                                .add_modifier(Modifier::ITALIC),
+                        ))
+                    })
+                    .collect::<Vec<_>>(),
+                ContentBlock::ToolUse(_) => vec![],
             })
             .collect(),
-        "tool" => vec![Line::from(Span::styled(
-            format!("[tool: {}]", msg.text),
-            Style::default().fg(Color::DarkGray),
-        ))],
-        _ => vec![Line::from(Span::styled(
-            msg.text.clone(),
-            Style::default()
-                .fg(Color::DarkGray)
-                .add_modifier(Modifier::ITALIC),
-        ))],
     }
 }
 
-fn draw_chat_input(frame: &mut Frame, app: &App, area: Rect) {
-    let border_color = if app.focus == Focus::Chat {
+fn draw_chat_input(frame: &mut Frame, state: &ScreenState, area: Rect) {
+    let border_color = if state.focus == Focus::Chat {
         Color::Yellow
     } else {
         Color::Cyan
     };
 
-    let cursor = if app.focus == Focus::Chat { "▎" } else { "" };
-    let display = format!("{}{cursor}", app.chat_input);
+    let cursor = if state.focus == Focus::Chat {
+        "▎"
+    } else {
+        ""
+    };
+    let display = format!("{}{cursor}", state.chat_input);
 
     let paragraph = Paragraph::new(display).block(
         Block::default()
@@ -203,26 +242,26 @@ fn draw_chat_input(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(paragraph, area);
 }
 
-fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
-    let user_short = if app.user_name.len() > 12 {
-        format!("{}…", &app.user_name[..12])
+fn draw_status_bar(frame: &mut Frame, state: &ScreenState, area: Rect) {
+    let user_short = if state.user_name.len() > 12 {
+        format!("{}…", &state.user_name[..12])
     } else {
-        app.user_name.clone()
+        state.user_name.clone()
     };
 
     let mut spans = vec![
         Span::styled(" Server: ", Style::default().fg(Color::DarkGray)),
-        Span::styled(&app.server_url, Style::default().fg(Color::White)),
+        Span::styled(&state.server_url, Style::default().fg(Color::White)),
         Span::styled(" │ User: ", Style::default().fg(Color::DarkGray)),
         Span::styled(user_short, Style::default().fg(Color::White)),
     ];
 
-    if let Some(msg) = &app.status_message {
+    if let Some(msg) = &state.status_message {
         spans.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
         spans.push(Span::styled(msg, Style::default().fg(Color::Green)));
     }
 
-    let keys = match app.focus {
+    let keys = match state.focus {
         Focus::Sidebar => " │ ↑/↓:nav  n:new  r:refresh  Tab:chat  q:quit ",
         Focus::Chat => " │ Enter:send  Esc:sidebar  ↑/↓:scroll ",
     };
@@ -233,7 +272,7 @@ fn draw_status_bar(frame: &mut Frame, app: &App, area: Rect) {
     frame.render_widget(paragraph, area);
 }
 
-fn draw_create_modal(frame: &mut Frame, app: &App) {
+fn draw_create_modal(frame: &mut Frame, state: &ScreenState) {
     let area = centered_rect(52, 10, frame.area());
     frame.render_widget(Clear, area);
 
@@ -242,31 +281,31 @@ fn draw_create_modal(frame: &mut Frame, app: &App) {
         .title(" Create Workspace ")
         .border_style(Style::default().fg(Color::Yellow));
 
-    let name_style = if app.input_field == 0 {
+    let name_style = if state.input_field == 0 {
         Style::default().fg(Color::Yellow)
     } else {
         Style::default().fg(Color::White)
     };
-    let desc_style = if app.input_field == 1 {
+    let desc_style = if state.input_field == 1 {
         Style::default().fg(Color::Yellow)
     } else {
         Style::default().fg(Color::White)
     };
 
-    let cursor_name = if app.input_field == 0 { "▎" } else { "" };
-    let cursor_desc = if app.input_field == 1 { "▎" } else { "" };
+    let cursor_name = if state.input_field == 0 { "▎" } else { "" };
+    let cursor_desc = if state.input_field == 1 { "▎" } else { "" };
 
     let lines = vec![
         Line::from(""),
         Line::from(vec![
             Span::styled("  Name:        ", Style::default().fg(Color::DarkGray)),
-            Span::styled(format!("{}{cursor_name}", app.input_name), name_style),
+            Span::styled(format!("{}{cursor_name}", state.input_name), name_style),
         ]),
         Line::from(""),
         Line::from(vec![
             Span::styled("  Description: ", Style::default().fg(Color::DarkGray)),
             Span::styled(
-                format!("{}{cursor_desc}", app.input_description),
+                format!("{}{cursor_desc}", state.input_description),
                 desc_style,
             ),
         ]),


### PR DESCRIPTION
## Summary
- Split flat `App` struct into separated concerns: `chat.rs` (ContentBlock + AssistantChat), `state.rs` (ScreenState + ChatViewState), `handlers.rs` (Action enum + pure key dispatch)
- Refactored `dashboard.rs` event loop to use `tokio::select!` with crossterm `EventStream` instead of manual polling
- Tool invocations now render as inline yellow `[name]` spans within assistant messages via `ContentBlock::ToolUse`

## Test plan
- [ ] `nix flake check` passes (fmt, clippy, nextest)
- [ ] `drua dashboard` → navigate workspaces with j/k
- [ ] Tab to chat → type message + Enter → verify streaming renders with tool-use blocks inline
- [ ] Half-page scroll with ↑/↓ in chat pane
- [ ] `n` to create workspace modal, Esc to cancel

🤖 Generated with [Claude Code](https://claude.com/claude-code)