### PR TITLE
refactor(auth): thread AuthSubject through all service boundaries

### DIFF
--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -81,9 +81,10 @@ impl Agents {
         &self.skills
     }
 
-    #[instrument(name = "domain.agent.create", skip(self))]
+    #[instrument(name = "domain.agent.create", skip(self, _sub))]
     pub async fn create(
         &self,
+        _sub: &AuthSubject,
         workspace_id: WorkspaceId,
         agent_role: AgentRole,
         name: impl Into<String> + std::fmt::Debug,
@@ -182,17 +183,19 @@ impl Agents {
         Ok(agent)
     }
 
-    #[instrument(name = "domain.agent.find_by_id", skip(self))]
+    #[instrument(name = "domain.agent.find_by_id", skip(self, _sub))]
     pub async fn find_by_id(
         &self,
+        _sub: &AuthSubject,
         id: impl Into<AgentId> + std::fmt::Debug,
     ) -> Result<Agent, AgentError> {
         Ok(self.repo.find_by_id(id.into()).await?)
     }
 
-    #[instrument(name = "domain.agent.list_for_workspace", skip(self))]
+    #[instrument(name = "domain.agent.list_for_workspace", skip(self, _sub))]
     pub async fn list_for_workspace(
         &self,
+        _sub: &AuthSubject,
         workspace_id: WorkspaceId,
     ) -> Result<Vec<Agent>, AgentError> {
         let query = es_entity::PaginatedQueryArgs {

--- a/core/src/mcp_creds/mod.rs
+++ b/core/src/mcp_creds/mod.rs
@@ -10,6 +10,7 @@ use entity::*;
 pub use error::*;
 use repo::*;
 
+use crate::auth::AuthSubject;
 use crate::primitives::*;
 
 #[derive(Clone)]
@@ -23,9 +24,10 @@ impl McpCredentials {
         Self { repo }
     }
 
-    #[instrument(name = "domain.mcp_creds.create_for_user", skip(self))]
+    #[instrument(name = "domain.mcp_creds.create_for_user", skip(self, _sub))]
     pub async fn create_for_user(
         &self,
+        _sub: &AuthSubject,
         user_id: UserId,
         name: impl Into<String> + std::fmt::Debug,
         token_hash: impl Into<String> + std::fmt::Debug,
@@ -66,9 +68,10 @@ impl McpCredentials {
         Ok(creds)
     }
 
-    #[instrument(name = "domain.mcp_creds.revoke", skip(self))]
+    #[instrument(name = "domain.mcp_creds.revoke", skip(self, _sub))]
     pub async fn revoke(
         &self,
+        _sub: &AuthSubject,
         user_id: UserId,
         id: impl Into<McpCredsId> + std::fmt::Debug,
     ) -> Result<McpCreds, McpCredsError> {
@@ -104,9 +107,10 @@ impl McpCredentials {
         Ok(creds)
     }
 
-    #[instrument(name = "domain.mcp_creds.list_for_user", skip(self))]
+    #[instrument(name = "domain.mcp_creds.list_for_user", skip(self, _sub))]
     pub async fn list_for_user(
         &self,
+        _sub: &AuthSubject,
         user_id: UserId,
         query: es_entity::PaginatedQueryArgs<repo::mcp_creds_cursor::McpCredsByCreatedAtCursor>,
         direction: es_entity::ListDirection,
@@ -121,8 +125,12 @@ impl McpCredentials {
             .await?)
     }
 
-    #[instrument(name = "domain.mcp_creds.list_all_for_user", skip(self))]
-    pub async fn list_all_for_user(&self, user_id: UserId) -> Result<Vec<McpCreds>, McpCredsError> {
+    #[instrument(name = "domain.mcp_creds.list_all_for_user", skip(self, _sub))]
+    pub async fn list_all_for_user(
+        &self,
+        _sub: &AuthSubject,
+        user_id: UserId,
+    ) -> Result<Vec<McpCreds>, McpCredsError> {
         let query = es_entity::PaginatedQueryArgs {
             first: 100,
             after: None,

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -27,6 +27,8 @@ use repo::*;
 
 use crate::primitives::*;
 
+use crate::auth::AuthSubject;
+
 /// Service for managing sandbox lifecycle. Wraps a backend-agnostic
 /// [`AdminClient`] (k8s or local) and persists per-sandbox lifecycle state
 /// in the `sandboxes` table. Optionally holds a [`GitHubAppTokenProvider`]
@@ -81,9 +83,10 @@ impl Sandboxes {
         })
     }
 
-    #[instrument(name = "domain.sandbox.create", skip(self))]
+    #[instrument(name = "domain.sandbox.create", skip(self, _sub))]
     pub async fn create(
         &self,
+        _sub: &AuthSubject,
         workspace_id: impl Into<WorkspaceId> + std::fmt::Debug,
         name: impl Into<String> + std::fmt::Debug,
         specs: SandboxSpecs,
@@ -310,9 +313,10 @@ impl Sandboxes {
         Ok(())
     }
 
-    #[instrument(name = "domain.sandbox.find_by_id", skip(self))]
+    #[instrument(name = "domain.sandbox.find_by_id", skip(self, _sub))]
     pub async fn find_by_id(
         &self,
+        _sub: &AuthSubject,
         id: impl Into<SandboxId> + std::fmt::Debug,
     ) -> Result<Sandbox, SandboxError> {
         Ok(self.repo.find_by_id(id.into()).await?)
@@ -337,9 +341,10 @@ impl Sandboxes {
     /// the entity isn't in [`SandboxState::Ready`] (the only state where
     /// a `base_url` is guaranteed). Used by tools that act inside the
     /// sandbox (e.g. the `bash` top-level tool).
-    #[instrument(name = "domain.sandbox.instance_client_for", skip(self))]
+    #[instrument(name = "domain.sandbox.instance_client_for", skip(self, _sub))]
     pub async fn instance_client_for(
         &self,
+        _sub: &AuthSubject,
         id: impl Into<SandboxId> + std::fmt::Debug,
     ) -> Result<InstanceClient, SandboxError> {
         let id = id.into();
@@ -355,9 +360,10 @@ impl Sandboxes {
         })
     }
 
-    #[instrument(name = "domain.sandbox.list_for_workspace", skip(self))]
+    #[instrument(name = "domain.sandbox.list_for_workspace", skip(self, _sub))]
     pub async fn list_for_workspace(
         &self,
+        _sub: &AuthSubject,
         workspace_id: impl Into<WorkspaceId> + std::fmt::Debug,
     ) -> Result<Vec<Sandbox>, SandboxError> {
         const PAGE_SIZE: usize = 100;
@@ -388,9 +394,10 @@ impl Sandboxes {
     /// workspace dir), then `/initialize` is called again. The server's
     /// `/initialize` is idempotent — it overwrites the GitHub token and
     /// skips re-cloning when the repo is already on disk.
-    #[instrument(name = "domain.sandbox.restart", skip(self))]
+    #[instrument(name = "domain.sandbox.restart", skip(self, _sub))]
     pub async fn restart(
         &self,
+        _sub: &AuthSubject,
         id: impl Into<SandboxId> + std::fmt::Debug,
     ) -> Result<Sandbox, SandboxError> {
         let id = id.into();
@@ -456,9 +463,10 @@ impl Sandboxes {
         Ok(sandbox)
     }
 
-    #[instrument(name = "domain.sandbox.suspend", skip(self))]
+    #[instrument(name = "domain.sandbox.suspend", skip(self, _sub))]
     pub async fn suspend(
         &self,
+        _sub: &AuthSubject,
         id: impl Into<SandboxId> + std::fmt::Debug,
     ) -> Result<Sandbox, SandboxError> {
         let mut op = self.repo.begin_op().await?;

--- a/core/src/skill/mod.rs
+++ b/core/src/skill/mod.rs
@@ -29,7 +29,7 @@ impl Skills {
     }
 
     #[instrument(name = "skill.create", skip_all)]
-    pub async fn create(&self, new: NewSkill) -> Result<Skill, SkillError> {
+    pub async fn create(&self, _sub: &AuthSubject, new: NewSkill) -> Result<Skill, SkillError> {
         let skill = self.repo.create(new).await?;
         Ok(skill)
     }
@@ -45,7 +45,7 @@ impl Skills {
     }
 
     #[instrument(name = "skill.find_by_id", skip_all)]
-    pub async fn find_by_id(&self, id: SkillId) -> Result<Skill, SkillError> {
+    pub async fn find_by_id(&self, _sub: &AuthSubject, id: SkillId) -> Result<Skill, SkillError> {
         Ok(self.repo.find_by_id(id).await?)
     }
 
@@ -93,6 +93,7 @@ impl Skills {
     #[instrument(name = "skill.list_by_workspace_id", skip_all)]
     pub async fn list_by_workspace_id(
         &self,
+        _sub: &AuthSubject,
         workspace_id: WorkspaceId,
     ) -> Result<Vec<Skill>, SkillError> {
         let query = es_entity::PaginatedQueryArgs {
@@ -111,13 +112,13 @@ impl Skills {
     }
 
     #[instrument(name = "skill.update", skip_all)]
-    pub async fn update(&self, skill: &mut Skill) -> Result<(), SkillError> {
+    pub async fn update(&self, _sub: &AuthSubject, skill: &mut Skill) -> Result<(), SkillError> {
         self.repo.update(skill).await?;
         Ok(())
     }
 
     #[instrument(name = "skill.delete", skip_all)]
-    pub async fn delete(&self, id: SkillId) -> Result<(), SkillError> {
+    pub async fn delete(&self, _sub: &AuthSubject, id: SkillId) -> Result<(), SkillError> {
         let skill = self.repo.find_by_id(id).await?;
         self.repo.delete(skill).await?;
         Ok(())

--- a/core/src/toolset/top_level/agent.rs
+++ b/core/src/toolset/top_level/agent.rs
@@ -116,7 +116,7 @@ impl TopLevelTool for WorkspaceAgentCreate {
 
         let agent = self
             .agents
-            .create(workspace_id, AgentRole::Agent, &params.name, None)
+            .create(subject, workspace_id, AgentRole::Agent, &params.name, None)
             .await
             .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
 
@@ -163,14 +163,20 @@ impl TopLevelTool for AdminAgentCreate {
 
     async fn call(
         &self,
-        _subject: &AuthSubject,
+        subject: &AuthSubject,
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let params: AdminAgentCreateParams = parse_params(arguments)?;
 
         let agent = self
             .agents
-            .create(params.workspace_id, AgentRole::Agent, &params.name, None)
+            .create(
+                subject,
+                params.workspace_id,
+                AgentRole::Agent,
+                &params.name,
+                None,
+            )
             .await
             .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
 
@@ -226,7 +232,7 @@ impl TopLevelTool for WorkspaceAgentAttachSandbox {
 
         let sandbox = self
             .sandboxes
-            .find_by_id(params.sandbox_id)
+            .find_by_id(subject, params.sandbox_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
         if sandbox.workspace_id != workspace_id {
@@ -345,7 +351,7 @@ impl TopLevelTool for WorkspaceAgentDetachSandbox {
 
         let existing = self
             .agents
-            .find_by_id(params.agent_id)
+            .find_by_id(subject, params.agent_id)
             .await
             .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
         if existing.workspace_id != workspace_id {
@@ -354,7 +360,7 @@ impl TopLevelTool for WorkspaceAgentDetachSandbox {
 
         let sandbox = self
             .sandboxes
-            .find_by_id(params.sandbox_id)
+            .find_by_id(subject, params.sandbox_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
         if sandbox.workspace_id != workspace_id {
@@ -473,7 +479,7 @@ impl TopLevelTool for WorkspaceListAgents {
 
         let agents = self
             .agents
-            .list_for_workspace(workspace_id)
+            .list_for_workspace(subject, workspace_id)
             .await
             .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
 
@@ -520,14 +526,14 @@ impl TopLevelTool for AdminListAgents {
 
     async fn call(
         &self,
-        _subject: &AuthSubject,
+        subject: &AuthSubject,
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let params: AdminListAgentsParams = parse_params(arguments)?;
 
         let agents = self
             .agents
-            .list_for_workspace(params.workspace_id)
+            .list_for_workspace(subject, params.workspace_id)
             .await
             .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
 

--- a/core/src/toolset/top_level/bash.rs
+++ b/core/src/toolset/top_level/bash.rs
@@ -103,7 +103,7 @@ impl TopLevelTool for Bash {
 
         let client = self
             .sandboxes
-            .instance_client_for(sandbox_id)
+            .instance_client_for(subject, sandbox_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 

--- a/core/src/toolset/top_level/glob.rs
+++ b/core/src/toolset/top_level/glob.rs
@@ -75,7 +75,7 @@ impl TopLevelTool for GlobTool {
 
         let client = self
             .sandboxes
-            .instance_client_for(sandbox_id)
+            .instance_client_for(subject, sandbox_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 

--- a/core/src/toolset/top_level/grep.rs
+++ b/core/src/toolset/top_level/grep.rs
@@ -116,7 +116,7 @@ impl TopLevelTool for Grep {
 
         let client = self
             .sandboxes
-            .instance_client_for(sandbox_id)
+            .instance_client_for(subject, sandbox_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 

--- a/core/src/toolset/top_level/inspect.rs
+++ b/core/src/toolset/top_level/inspect.rs
@@ -92,14 +92,14 @@ impl TopLevelTool for WorkspaceInspectSandbox {
 
         let sandbox = self
             .sandboxes
-            .find_by_id(params.sandbox_id)
+            .find_by_id(subject, params.sandbox_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
         if sandbox.workspace_id != workspace_id {
             return Err(ToolSetsError::Unauthorized);
         }
 
-        execute_inspect(&self.sandboxes, params).await
+        execute_inspect(subject, &self.sandboxes, params).await
     }
 }
 
@@ -140,12 +140,12 @@ impl TopLevelTool for AdminInspectSandbox {
 
     async fn call(
         &self,
-        _subject: &AuthSubject,
+        subject: &AuthSubject,
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let params: InspectParams = parse_params(arguments)?;
 
-        execute_inspect(&self.sandboxes, params).await
+        execute_inspect(subject, &self.sandboxes, params).await
     }
 }
 
@@ -155,6 +155,7 @@ impl TopLevelTool for AdminInspectSandbox {
 
 /// Shared execution logic for both workspace and admin inspect tools.
 async fn execute_inspect(
+    sub: &AuthSubject,
     sandboxes: &Sandboxes,
     params: InspectParams,
 ) -> Result<CallToolResult, ToolSetsError> {
@@ -190,7 +191,7 @@ async fn execute_inspect(
     };
 
     let client = sandboxes
-        .instance_client_for(params.sandbox_id)
+        .instance_client_for(sub, params.sandbox_id)
         .await
         .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 

--- a/core/src/toolset/top_level/ls.rs
+++ b/core/src/toolset/top_level/ls.rs
@@ -79,7 +79,7 @@ impl TopLevelTool for Ls {
 
         let client = self
             .sandboxes
-            .instance_client_for(sandbox_id)
+            .instance_client_for(subject, sandbox_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 

--- a/core/src/toolset/top_level/read.rs
+++ b/core/src/toolset/top_level/read.rs
@@ -98,7 +98,7 @@ impl TopLevelTool for Read {
 
         let client = self
             .sandboxes
-            .instance_client_for(sandbox_id)
+            .instance_client_for(subject, sandbox_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 

--- a/core/src/toolset/top_level/sandbox.rs
+++ b/core/src/toolset/top_level/sandbox.rs
@@ -159,7 +159,7 @@ impl TopLevelTool for WorkspaceCreateSandbox {
 
         let sandbox = self
             .sandboxes
-            .create(workspace_id, name, specs, mode)
+            .create(subject, workspace_id, name, specs, mode)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 
@@ -206,7 +206,7 @@ impl TopLevelTool for AdminCreateSandbox {
 
     async fn call(
         &self,
-        _subject: &AuthSubject,
+        subject: &AuthSubject,
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let params: AdminCreateSandboxParams = parse_params(arguments)?;
@@ -214,7 +214,7 @@ impl TopLevelTool for AdminCreateSandbox {
 
         let sandbox = self
             .sandboxes
-            .create(params.workspace_id, name, specs, mode)
+            .create(subject, params.workspace_id, name, specs, mode)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 
@@ -273,7 +273,7 @@ impl TopLevelTool for WorkspaceListSandboxes {
 
         let sandboxes = self
             .sandboxes
-            .list_for_workspace(workspace_id)
+            .list_for_workspace(subject, workspace_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 
@@ -320,14 +320,14 @@ impl TopLevelTool for AdminListSandboxes {
 
     async fn call(
         &self,
-        _subject: &AuthSubject,
+        subject: &AuthSubject,
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let params: AdminListSandboxesParams = parse_params(arguments)?;
 
         let sandboxes = self
             .sandboxes
-            .list_for_workspace(params.workspace_id)
+            .list_for_workspace(subject, params.workspace_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 
@@ -382,7 +382,7 @@ impl TopLevelTool for WorkspaceGetSandbox {
 
         let sandbox = self
             .sandboxes
-            .find_by_id(params.sandbox_id)
+            .find_by_id(subject, params.sandbox_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 
@@ -430,14 +430,14 @@ impl TopLevelTool for AdminGetSandbox {
 
     async fn call(
         &self,
-        _subject: &AuthSubject,
+        subject: &AuthSubject,
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let params: GetSandboxParams = parse_params(arguments)?;
 
         let sandbox = self
             .sandboxes
-            .find_by_id(params.sandbox_id)
+            .find_by_id(subject, params.sandbox_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 

--- a/core/src/toolset/top_level/text_editor.rs
+++ b/core/src/toolset/top_level/text_editor.rs
@@ -144,7 +144,7 @@ impl TopLevelTool for TextEditor {
 
         let client = self
             .sandboxes
-            .instance_client_for(sandbox_id)
+            .instance_client_for(subject, sandbox_id)
             .await
             .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 

--- a/core/src/toolset/top_level/workspace.rs
+++ b/core/src/toolset/top_level/workspace.rs
@@ -137,12 +137,12 @@ impl TopLevelTool for AdminWorkspaceList {
 
     async fn call(
         &self,
-        _subject: &AuthSubject,
+        subject: &AuthSubject,
         _arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let all = self
             .workspaces
-            .list_all()
+            .list_all(subject)
             .await
             .map_err(|e| ToolSetsError::Workspace(e.to_string()))?;
 

--- a/core/src/workspace/mod.rs
+++ b/core/src/workspace/mod.rs
@@ -65,9 +65,10 @@ impl Workspaces {
         Ok(workspace)
     }
 
-    #[instrument(name = "domain.workspace.find_by_id", skip(self))]
+    #[instrument(name = "domain.workspace.find_by_id", skip(self, _sub))]
     pub async fn find_by_id(
         &self,
+        _sub: &AuthSubject,
         id: impl Into<WorkspaceId> + std::fmt::Debug,
     ) -> Result<Workspace, WorkspaceError> {
         Ok(self.repo.find_by_id(id.into()).await?)
@@ -83,8 +84,8 @@ impl Workspaces {
         Ok(self.repo.list_by_created_at(query, direction).await?)
     }
 
-    #[instrument(name = "domain.workspace.list_all", skip(self))]
-    pub async fn list_all(&self) -> Result<Vec<Workspace>, WorkspaceError> {
+    #[instrument(name = "domain.workspace.list_all", skip(self, _sub))]
+    pub async fn list_all(&self, _sub: &AuthSubject) -> Result<Vec<Workspace>, WorkspaceError> {
         Ok(self.repo.list_all().await?)
     }
 
@@ -105,19 +106,20 @@ impl Workspaces {
     #[instrument(name = "domain.workspace.delete", skip(self))]
     pub async fn delete(
         &self,
-        _sub: &AuthSubject,
+        sub: &AuthSubject,
         id: impl Into<WorkspaceId> + std::fmt::Debug,
     ) -> Result<Workspace, WorkspaceError> {
         let mut op = self.repo.begin_op().await?;
-        let workspace = self.delete_in_op(&mut op, id).await?;
+        let workspace = self.delete_in_op(&mut op, sub, id).await?;
         op.commit().await?;
         Ok(workspace)
     }
 
-    #[instrument(name = "domain.workspace.delete_in_op", skip(self, op))]
+    #[instrument(name = "domain.workspace.delete_in_op", skip(self, op, _sub))]
     pub async fn delete_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,
+        _sub: &AuthSubject,
         id: impl Into<WorkspaceId> + std::fmt::Debug,
     ) -> Result<Workspace, WorkspaceError> {
         let id = id.into();
@@ -128,7 +130,7 @@ impl Workspaces {
         }
 
         // Cascade: soft-delete agents (which also destroys their sandboxes)
-        let agent_list = self.agents.list_for_workspace(id).await?;
+        let agent_list = self.agents.list_for_workspace(_sub, id).await?;
         for agent in &agent_list {
             if let Err(e) = self.agents.delete_in_op(op, agent.id).await {
                 tracing::warn!(

--- a/core/src/workspace_secret/mod.rs
+++ b/core/src/workspace_secret/mod.rs
@@ -40,6 +40,7 @@ impl WorkspaceSecrets {
     #[instrument(name = "workspace_secret.create", skip_all)]
     pub async fn create(
         &self,
+        _sub: &AuthSubject,
         workspace_id: WorkspaceId,
         name: &str,
         secret_type: SecretType,
@@ -63,6 +64,7 @@ impl WorkspaceSecrets {
     #[instrument(name = "workspace_secret.list_by_workspace", skip_all)]
     pub async fn list_by_workspace(
         &self,
+        _sub: &AuthSubject,
         workspace_id: WorkspaceId,
     ) -> Result<Vec<WorkspaceSecret>, WorkspaceSecretError> {
         self.list_all_for_workspace(workspace_id).await
@@ -91,6 +93,7 @@ impl WorkspaceSecrets {
     #[instrument(name = "workspace_secret.find_by_id", skip_all)]
     pub async fn find_by_id(
         &self,
+        _sub: &AuthSubject,
         id: WorkspaceSecretId,
     ) -> Result<WorkspaceSecret, WorkspaceSecretError> {
         Ok(self.repo.find_by_id(id).await?)
@@ -100,6 +103,7 @@ impl WorkspaceSecrets {
     #[instrument(name = "workspace_secret.update_value", skip_all)]
     pub async fn update_value(
         &self,
+        _sub: &AuthSubject,
         id: WorkspaceSecretId,
         value: &str,
     ) -> Result<WorkspaceSecret, WorkspaceSecretError> {
@@ -113,7 +117,11 @@ impl WorkspaceSecrets {
 
     /// Delete a secret (soft delete via archive).
     #[instrument(name = "workspace_secret.delete", skip_all)]
-    pub async fn delete(&self, id: WorkspaceSecretId) -> Result<(), WorkspaceSecretError> {
+    pub async fn delete(
+        &self,
+        _sub: &AuthSubject,
+        id: WorkspaceSecretId,
+    ) -> Result<(), WorkspaceSecretError> {
         let secret = self.repo.find_by_id(id).await?;
         self.repo.delete(secret).await?;
         Ok(())
@@ -123,6 +131,7 @@ impl WorkspaceSecrets {
     #[instrument(name = "workspace_secret.list_decrypted", skip_all)]
     pub async fn list_decrypted(
         &self,
+        _sub: &AuthSubject,
         workspace_id: WorkspaceId,
     ) -> Result<Vec<DecryptedSecret>, WorkspaceSecretError> {
         let secrets = self.list_all_for_workspace(workspace_id).await?;

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -60,17 +60,20 @@ async fn send_message_round_trip_via_prompt_channel() {
         Arc::clone(&skills),
     );
 
+    let sub = AuthSubject::User(UserId::new());
     let agent = agents
-        .create(WorkspaceId::new(), AgentRole::WorkspaceLead, "lead", None)
+        .create(
+            &sub,
+            WorkspaceId::new(),
+            AgentRole::WorkspaceLead,
+            "lead",
+            None,
+        )
         .await
         .expect("create agent");
 
     let mut events_rx = agents
-        .send_message(
-            AuthSubject::User(UserId::new()),
-            agent.id,
-            "Hello agent".to_string(),
-        )
+        .send_message(sub, agent.id, "Hello agent".to_string())
         .await
         .expect("send_message");
 
@@ -207,17 +210,20 @@ async fn send_message_dispatches_registered_tool_call() {
         Arc::clone(&skills),
     );
 
+    let sub = AuthSubject::User(UserId::new());
     let agent = agents
-        .create(WorkspaceId::new(), AgentRole::WorkspaceLead, "lead", None)
+        .create(
+            &sub,
+            WorkspaceId::new(),
+            AgentRole::WorkspaceLead,
+            "lead",
+            None,
+        )
         .await
         .expect("create agent");
 
     let mut events_rx = agents
-        .send_message(
-            AuthSubject::User(UserId::new()),
-            agent.id,
-            "Call ping".to_string(),
-        )
+        .send_message(sub, agent.id, "Call ping".to_string())
         .await
         .expect("send_message");
 

--- a/core/tests/workspace_secret.rs
+++ b/core/tests/workspace_secret.rs
@@ -1,6 +1,10 @@
 use galoy_agents_core::encryption::EncryptionKey;
-use galoy_agents_core::primitives::WorkspaceId;
+use galoy_agents_core::primitives::{AuthSubject, UserId, WorkspaceId};
 use galoy_agents_core::workspace_secret::{SecretType, WorkspaceSecrets};
+
+fn test_sub() -> AuthSubject {
+    AuthSubject::User(UserId::new())
+}
 
 const PG_CON: &str = "postgres://user:password@localhost:5432/galoy_agents";
 
@@ -33,9 +37,10 @@ async fn create_and_find_by_id() {
     let pool = pool().await;
     let svc = workspace_secrets(&pool);
     let ws_id = create_workspace(&pool).await;
+    let sub = test_sub();
 
     let created = svc
-        .create(ws_id, "API_KEY", SecretType::EnvVar, "sk-test-123")
+        .create(&sub, ws_id, "API_KEY", SecretType::EnvVar, "sk-test-123")
         .await
         .expect("create secret");
 
@@ -43,7 +48,7 @@ async fn create_and_find_by_id() {
     assert_eq!(created.secret_type, SecretType::EnvVar);
     assert_eq!(created.workspace_id, ws_id);
 
-    let found = svc.find_by_id(created.id).await.expect("find by id");
+    let found = svc.find_by_id(&sub, created.id).await.expect("find by id");
     assert_eq!(found.id, created.id);
     assert_eq!(found.name, "API_KEY");
 }
@@ -53,12 +58,16 @@ async fn create_and_decrypt_round_trip() {
     let pool = pool().await;
     let svc = workspace_secrets(&pool);
     let ws_id = create_workspace(&pool).await;
+    let sub = test_sub();
 
-    svc.create(ws_id, "DB_PASSWORD", SecretType::File, "super-secret")
+    svc.create(&sub, ws_id, "DB_PASSWORD", SecretType::File, "super-secret")
         .await
         .expect("create secret");
 
-    let decrypted = svc.list_decrypted(ws_id).await.expect("list decrypted");
+    let decrypted = svc
+        .list_decrypted(&sub, ws_id)
+        .await
+        .expect("list decrypted");
 
     let entry = decrypted
         .iter()
@@ -73,17 +82,21 @@ async fn update_value_changes_decrypted_output() {
     let pool = pool().await;
     let svc = workspace_secrets(&pool);
     let ws_id = create_workspace(&pool).await;
+    let sub = test_sub();
 
     let created = svc
-        .create(ws_id, "TOKEN", SecretType::EnvVar, "old-value")
+        .create(&sub, ws_id, "TOKEN", SecretType::EnvVar, "old-value")
         .await
         .expect("create");
 
-    svc.update_value(created.id, "new-value")
+    svc.update_value(&sub, created.id, "new-value")
         .await
         .expect("update value");
 
-    let decrypted = svc.list_decrypted(ws_id).await.expect("list decrypted");
+    let decrypted = svc
+        .list_decrypted(&sub, ws_id)
+        .await
+        .expect("list decrypted");
     let entry = decrypted
         .iter()
         .find(|d| d.name == "TOKEN")
@@ -96,15 +109,22 @@ async fn delete_removes_from_listing() {
     let pool = pool().await;
     let svc = workspace_secrets(&pool);
     let ws_id = create_workspace(&pool).await;
+    let sub = test_sub();
 
     let secret = svc
-        .create(ws_id, "TEMP_KEY", SecretType::EnvVar, "will-be-deleted")
+        .create(
+            &sub,
+            ws_id,
+            "TEMP_KEY",
+            SecretType::EnvVar,
+            "will-be-deleted",
+        )
         .await
         .expect("create");
 
-    svc.delete(secret.id).await.expect("delete");
+    svc.delete(&sub, secret.id).await.expect("delete");
 
-    let listed = svc.list_by_workspace(ws_id).await.expect("list");
+    let listed = svc.list_by_workspace(&sub, ws_id).await.expect("list");
     assert!(
         !listed.iter().any(|s| s.id == secret.id),
         "deleted secret should not appear in listing"
@@ -117,19 +137,20 @@ async fn list_by_workspace_returns_only_own_secrets() {
     let svc = workspace_secrets(&pool);
     let ws_a = create_workspace(&pool).await;
     let ws_b = create_workspace(&pool).await;
+    let sub = test_sub();
 
-    svc.create(ws_a, "SECRET_A", SecretType::EnvVar, "a-val")
+    svc.create(&sub, ws_a, "SECRET_A", SecretType::EnvVar, "a-val")
         .await
         .expect("create A");
-    svc.create(ws_b, "SECRET_B", SecretType::File, "b-val")
+    svc.create(&sub, ws_b, "SECRET_B", SecretType::File, "b-val")
         .await
         .expect("create B");
 
-    let listed_a = svc.list_by_workspace(ws_a).await.expect("list A");
+    let listed_a = svc.list_by_workspace(&sub, ws_a).await.expect("list A");
     assert!(listed_a.iter().all(|s| s.workspace_id == ws_a));
     assert!(listed_a.iter().any(|s| s.name == "SECRET_A"));
 
-    let listed_b = svc.list_by_workspace(ws_b).await.expect("list B");
+    let listed_b = svc.list_by_workspace(&sub, ws_b).await.expect("list B");
     assert!(listed_b.iter().all(|s| s.workspace_id == ws_b));
     assert!(listed_b.iter().any(|s| s.name == "SECRET_B"));
 }
@@ -139,13 +160,14 @@ async fn duplicate_name_in_same_workspace_fails() {
     let pool = pool().await;
     let svc = workspace_secrets(&pool);
     let ws_id = create_workspace(&pool).await;
+    let sub = test_sub();
 
-    svc.create(ws_id, "UNIQUE_KEY", SecretType::EnvVar, "first")
+    svc.create(&sub, ws_id, "UNIQUE_KEY", SecretType::EnvVar, "first")
         .await
         .expect("create first");
 
     let result = svc
-        .create(ws_id, "UNIQUE_KEY", SecretType::EnvVar, "second")
+        .create(&sub, ws_id, "UNIQUE_KEY", SecretType::EnvVar, "second")
         .await;
 
     assert!(
@@ -160,12 +182,13 @@ async fn same_name_in_different_workspaces_ok() {
     let svc = workspace_secrets(&pool);
     let ws_a = create_workspace(&pool).await;
     let ws_b = create_workspace(&pool).await;
+    let sub = test_sub();
 
-    svc.create(ws_a, "SHARED_NAME", SecretType::EnvVar, "val-a")
+    svc.create(&sub, ws_a, "SHARED_NAME", SecretType::EnvVar, "val-a")
         .await
         .expect("create in workspace A");
 
-    svc.create(ws_b, "SHARED_NAME", SecretType::EnvVar, "val-b")
+    svc.create(&sub, ws_b, "SHARED_NAME", SecretType::EnvVar, "val-b")
         .await
         .expect("create in workspace B should succeed");
 }
@@ -174,10 +197,12 @@ async fn same_name_in_different_workspaces_ok() {
 async fn wrong_key_fails_decryption() {
     let pool = pool().await;
     let ws_id = create_workspace(&pool).await;
+    let sub = test_sub();
 
     // Create with one key
     let svc = WorkspaceSecrets::new(&pool, EncryptionKey::new([1u8; 32]));
     svc.create(
+        &sub,
         ws_id,
         "MISMATCHED",
         SecretType::EnvVar,
@@ -188,7 +213,7 @@ async fn wrong_key_fails_decryption() {
 
     // Try to decrypt with a different key
     let svc_wrong_key = WorkspaceSecrets::new(&pool, EncryptionKey::new([2u8; 32]));
-    let result = svc_wrong_key.list_decrypted(ws_id).await;
+    let result = svc_wrong_key.list_decrypted(&sub, ws_id).await;
 
     assert!(result.is_err(), "decryption with wrong key should fail");
 }

--- a/web/src/auth/mod.rs
+++ b/web/src/auth/mod.rs
@@ -121,7 +121,12 @@ async fn resolve_auth_context(
                     let agent_id = domain::primitives::AgentId::from(
                         id_str.parse::<uuid::Uuid>().expect("validated as UUID"),
                     );
-                    if let Ok(agent) = state.app.agents().find_by_id(agent_id).await {
+                    if let Ok(agent) = state
+                        .app
+                        .agents()
+                        .find_by_id(&AuthSubject::Anonymous, agent_id)
+                        .await
+                    {
                         return agent.auth_subject();
                     }
                 }
@@ -185,11 +190,12 @@ async fn logout(session: Session) -> axum::response::Redirect {
 async fn cli_login(State(state): State<AppState>, session: Session) -> Result<Response, AuthError> {
     // If user is already logged in, auto-create a token and display it
     if let Ok(Some(user_id)) = session.get::<UserId>("user_id").await {
+        let sub = AuthSubject::User(user_id);
         let (raw_token, token_hash) = generate_token();
         state
             .app
             .mcp_creds()
-            .create_for_user(user_id, "cli", token_hash, vec![])
+            .create_for_user(&sub, user_id, "cli", token_hash, vec![])
             .await?;
         return Ok(CliTokenTemplate { token: raw_token }.into_response());
     }

--- a/web/src/graphql/query.rs
+++ b/web/src/graphql/query.rs
@@ -46,8 +46,8 @@ impl Query {
         ctx: &Context<'_>,
         id: WorkspaceId,
     ) -> async_graphql::Result<Option<Workspace>> {
-        let (app, _sub) = app_and_sub_from_ctx!(ctx);
-        match app.workspaces().find_by_id(id).await {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        match app.workspaces().find_by_id(sub, id).await {
             Ok(ws) => Ok(Some(Workspace::from(ws))),
             Err(galoy_agents_core::workspace::WorkspaceError::Find(_)) => Ok(None),
             Err(e) => Err(e.into()),

--- a/web/src/graphql/workspace.rs
+++ b/web/src/graphql/workspace.rs
@@ -26,8 +26,11 @@ impl Workspace {
 
     /// The workspace lead agent.
     async fn lead(&self, ctx: &Context<'_>) -> async_graphql::Result<Agent> {
-        let (app, _sub) = app_and_sub_from_ctx!(ctx);
-        let agent = app.agents().find_by_id(self.entity.lead_agent_id).await?;
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let agent = app
+            .agents()
+            .find_by_id(sub, self.entity.lead_agent_id)
+            .await?;
         Ok(Agent::from(agent))
     }
 }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -147,10 +147,11 @@ async fn dashboard(State(state): State<AppState>, session: Session) -> Response 
         Err(_) => return Redirect::to("/").into_response(),
     };
 
+    let sub = AuthSubject::User(user_id);
     let mcp_creds = state
         .app
         .mcp_creds()
-        .list_all_for_user(user.id)
+        .list_all_for_user(&sub, user.id)
         .await
         .unwrap_or_default();
 
@@ -202,6 +203,7 @@ async fn create_mcp_creds(
 
     let (raw_token, token_hash) = generate_token();
 
+    let sub = AuthSubject::User(user_id);
     let scopes = if form.admin.as_deref() == Some("true") {
         vec![domain::primitives::AuthScope::Admin]
     } else {
@@ -211,7 +213,7 @@ async fn create_mcp_creds(
     match state
         .app
         .mcp_creds()
-        .create_for_user(user_id, &form.name, token_hash, scopes)
+        .create_for_user(&sub, user_id, &form.name, token_hash, scopes)
         .await
     {
         Ok(_) => {
@@ -238,8 +240,9 @@ async fn revoke_mcp_creds(
         None => return Redirect::to("/").into_response(),
     };
 
+    let sub = AuthSubject::User(user_id);
     let creds_id = McpCredsId::from(id);
-    match state.app.mcp_creds().revoke(user_id, creds_id).await {
+    match state.app.mcp_creds().revoke(&sub, user_id, creds_id).await {
         Ok(creds) => McpCredsRowTemplate {
             creds: mcp_creds_to_view(&creds),
         }
@@ -254,11 +257,12 @@ async fn mcp_creds_list(State(state): State<AppState>, session: Session) -> Resp
         Some(id) => id,
         None => return Redirect::to("/").into_response(),
     };
+    let sub = AuthSubject::User(user_id);
 
     let mcp_creds = state
         .app
         .mcp_creds()
-        .list_all_for_user(user_id)
+        .list_all_for_user(&sub, user_id)
         .await
         .unwrap_or_default();
 
@@ -278,9 +282,11 @@ async fn audit_page(session: Session) -> Response {
 
 #[instrument(name = "web.audit_entries", skip_all)]
 async fn audit_entries(State(state): State<AppState>, session: Session) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return axum::http::StatusCode::UNAUTHORIZED.into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let entries = state.app.audit().list_recent(50).await;
 
@@ -293,11 +299,11 @@ async fn audit_entries(State(state): State<AppState>, session: Session) -> Respo
                     None => None,
                 };
                 let workspace = match entry.workspace_id() {
-                    Some(id) => Some(lookup_workspace_label(&state.app, id).await),
+                    Some(id) => Some(lookup_workspace_label(&sub, &state.app, id).await),
                     None => None,
                 };
                 let acting_agent = match entry.acting_agent_id {
-                    Some(id) => Some(lookup_agent_label(&state.app, id).await),
+                    Some(id) => Some(lookup_agent_label(&sub, &state.app, id).await),
                     None => None,
                 };
                 let on_behalf_of = match entry.on_behalf_of_user_id {
@@ -345,22 +351,24 @@ async fn lookup_user_label(
 }
 
 async fn lookup_agent_label(
+    sub: &AuthSubject,
     app: &galoy_agents_core::App,
     agent_id: galoy_agents_core::primitives::AgentId,
 ) -> String {
     app.agents()
-        .find_by_id(agent_id)
+        .find_by_id(sub, agent_id)
         .await
         .map(|a| a.name.clone())
         .unwrap_or_else(|_| agent_id.to_string())
 }
 
 async fn lookup_workspace_label(
+    sub: &AuthSubject,
     app: &galoy_agents_core::App,
     workspace_id: galoy_agents_core::primitives::WorkspaceId,
 ) -> String {
     app.workspaces()
-        .find_by_id(workspace_id)
+        .find_by_id(sub, workspace_id)
         .await
         .map(|ws| ws.name.clone())
         .unwrap_or_else(|_| workspace_id.to_string())
@@ -531,11 +539,18 @@ fn workspace_to_view(ws: &domain::workspace::Workspace) -> WorkspaceView {
 
 #[instrument(name = "web.workspaces_page", skip_all)]
 async fn workspaces_page(State(state): State<AppState>, session: Session) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
-    let workspaces = state.app.workspaces().list_all().await.unwrap_or_default();
+    let workspaces = state
+        .app
+        .workspaces()
+        .list_all(&sub)
+        .await
+        .unwrap_or_default();
 
     WorkspaceHubTemplate {
         workspaces: workspaces.iter().map(workspace_to_view).collect(),
@@ -551,11 +566,13 @@ async fn workspaces_page(State(state): State<AppState>, session: Session) -> Res
 
 #[instrument(name = "web.workspace_sidebar_list", skip_all)]
 async fn workspace_sidebar_list(State(state): State<AppState>, session: Session) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return axum::http::StatusCode::UNAUTHORIZED.into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
-    match state.app.workspaces().list_all().await {
+    match state.app.workspaces().list_all(&sub).await {
         Ok(workspaces) => WorkspaceSidebarListTemplate {
             workspaces: workspaces.iter().map(workspace_to_view).collect(),
         }
@@ -592,7 +609,7 @@ async fn workspace_create(
         None => return Redirect::to("/").into_response(),
     };
 
-    let sub = domain::auth::AuthSubject::User(user_id);
+    let sub = AuthSubject::User(user_id);
     let description = form.description.filter(|d| !d.is_empty());
     match state
         .app
@@ -614,17 +631,19 @@ async fn workspace_detail(
     session: Session,
     Path(id): Path<uuid::Uuid>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+    let ws = match state.app.workspaces().find_by_id(&sub, workspace_id).await {
         Ok(ws) => ws,
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agent_views) = workspace_sidebar_context(&sub, &state, workspace_id).await;
 
     WorkspaceDetailTemplate {
         workspace: workspace_to_view(&ws),
@@ -646,7 +665,7 @@ async fn workspace_update(
         None => return Redirect::to("/").into_response(),
     };
 
-    let sub = domain::auth::AuthSubject::User(user_id);
+    let sub = AuthSubject::User(user_id);
     let workspace_id = domain::primitives::WorkspaceId::from(id);
     let description = form.description.filter(|d| !d.is_empty());
     match state
@@ -675,7 +694,7 @@ async fn workspace_delete(
         None => return Redirect::to("/").into_response(),
     };
 
-    let sub = domain::auth::AuthSubject::User(user_id);
+    let sub = AuthSubject::User(user_id);
     let workspace_id = domain::primitives::WorkspaceId::from(id);
     match state.app.workspaces().delete(&sub, workspace_id).await {
         Ok(_) => {
@@ -719,15 +738,17 @@ async fn workspace_secrets_list(
     session: Session,
     Path(id): Path<uuid::Uuid>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return axum::http::StatusCode::UNAUTHORIZED.into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
     match state
         .app
         .workspace_secrets()
-        .list_by_workspace(workspace_id)
+        .list_by_workspace(&sub, workspace_id)
         .await
     {
         Ok(secrets) => WorkspaceSecretsListTemplate {
@@ -755,9 +776,11 @@ async fn workspace_secret_create(
     Path(id): Path<uuid::Uuid>,
     Form(form): Form<CreateSecretForm>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return axum::http::StatusCode::UNAUTHORIZED.into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
     let secret_type: domain::workspace_secret::SecretType = match form.secret_type.parse() {
@@ -768,7 +791,7 @@ async fn workspace_secret_create(
     if let Err(e) = state
         .app
         .workspace_secrets()
-        .create(workspace_id, &form.name, secret_type, &form.value)
+        .create(&sub, workspace_id, &form.name, secret_type, &form.value)
         .await
     {
         tracing::error!(error = %e, "Failed to create workspace secret");
@@ -779,7 +802,7 @@ async fn workspace_secret_create(
     match state
         .app
         .workspace_secrets()
-        .list_by_workspace(workspace_id)
+        .list_by_workspace(&sub, workspace_id)
         .await
     {
         Ok(secrets) => WorkspaceSecretsListTemplate {
@@ -796,14 +819,16 @@ async fn workspace_secret_delete(
     session: Session,
     Path((id, secret_id)): Path<(uuid::Uuid, uuid::Uuid)>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return axum::http::StatusCode::UNAUTHORIZED.into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
     let secret_id = WorkspaceSecretId::from(secret_id);
 
-    if let Err(e) = state.app.workspace_secrets().delete(secret_id).await {
+    if let Err(e) = state.app.workspace_secrets().delete(&sub, secret_id).await {
         tracing::error!(error = %e, "Failed to delete workspace secret");
         return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
     }
@@ -812,7 +837,7 @@ async fn workspace_secret_delete(
     match state
         .app
         .workspace_secrets()
-        .list_by_workspace(workspace_id)
+        .list_by_workspace(&sub, workspace_id)
         .await
     {
         Ok(secrets) => WorkspaceSecretsListTemplate {
@@ -844,22 +869,24 @@ async fn workspace_skills_page(
     session: Session,
     Path(id): Path<uuid::Uuid>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+    let ws = match state.app.workspaces().find_by_id(&sub, workspace_id).await {
         Ok(ws) => ws,
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agent_views) = workspace_sidebar_context(&sub, &state, workspace_id).await;
 
     let skills = state
         .app
         .skills()
-        .list_by_workspace_id(workspace_id)
+        .list_by_workspace_id(&sub, workspace_id)
         .await
         .unwrap_or_default();
 
@@ -878,17 +905,19 @@ async fn workspace_skill_new(
     session: Session,
     Path(id): Path<uuid::Uuid>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+    let ws = match state.app.workspaces().find_by_id(&sub, workspace_id).await {
         Ok(ws) => ws,
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agent_views) = workspace_sidebar_context(&sub, &state, workspace_id).await;
 
     WorkspaceSkillNewTemplate {
         workspace: workspace_to_view(&ws),
@@ -912,9 +941,11 @@ async fn workspace_skill_create(
     Path(id): Path<uuid::Uuid>,
     Form(form): Form<CreateSkillForm>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
     let new_skill = domain::skill::NewSkill::builder()
@@ -925,7 +956,7 @@ async fn workspace_skill_create(
         .build()
         .expect("Could not build new skill");
 
-    if let Err(e) = state.app.skills().create(new_skill).await {
+    if let Err(e) = state.app.skills().create(&sub, new_skill).await {
         tracing::error!(error = %e, "Failed to create skill");
         return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
     }
@@ -939,23 +970,25 @@ async fn workspace_skill_edit(
     session: Session,
     Path((id, skill_id)): Path<(uuid::Uuid, uuid::Uuid)>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+    let ws = match state.app.workspaces().find_by_id(&sub, workspace_id).await {
         Ok(ws) => ws,
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
     let skill_id = SkillId::from(skill_id);
-    let skill = match state.app.skills().find_by_id(skill_id).await {
+    let skill = match state.app.skills().find_by_id(&sub, skill_id).await {
         Ok(s) => s,
         Err(_) => return Redirect::to(&format!("/workspaces/{id}/skills")).into_response(),
     };
 
-    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agent_views) = workspace_sidebar_context(&sub, &state, workspace_id).await;
 
     WorkspaceSkillEditTemplate {
         workspace: workspace_to_view(&ws),
@@ -980,12 +1013,14 @@ async fn workspace_skill_update(
     Path((id, skill_id)): Path<(uuid::Uuid, uuid::Uuid)>,
     Form(form): Form<UpdateSkillForm>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let skill_id = SkillId::from(skill_id);
-    let mut skill = match state.app.skills().find_by_id(skill_id).await {
+    let mut skill = match state.app.skills().find_by_id(&sub, skill_id).await {
         Ok(s) => s,
         Err(_) => return Redirect::to(&format!("/workspaces/{id}/skills")).into_response(),
     };
@@ -994,7 +1029,7 @@ async fn workspace_skill_update(
         .update(Some(form.name), Some(form.description), Some(form.body))
         .did_execute()
     {
-        if let Err(e) = state.app.skills().update(&mut skill).await {
+        if let Err(e) = state.app.skills().update(&sub, &mut skill).await {
             tracing::error!(error = %e, "Failed to update skill");
             return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
         }
@@ -1009,13 +1044,15 @@ async fn workspace_skill_delete(
     session: Session,
     Path((id, skill_id)): Path<(uuid::Uuid, uuid::Uuid)>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let skill_id = SkillId::from(skill_id);
 
-    if let Err(e) = state.app.skills().delete(skill_id).await {
+    if let Err(e) = state.app.skills().delete(&sub, skill_id).await {
         tracing::error!(error = %e, "Failed to delete skill");
         return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
     }
@@ -1081,13 +1118,14 @@ fn sandbox_to_view(s: &domain::sandbox::Sandbox) -> SandboxView {
 /// list underneath. If there's no WorkspaceLead (shouldn't happen after
 /// workspace create, but handle gracefully), `lead_agent` is `None`.
 async fn workspace_sidebar_context(
+    sub: &AuthSubject,
     state: &AppState,
     workspace_id: domain::primitives::WorkspaceId,
 ) -> (Option<AgentView>, Vec<AgentView>) {
     let agents = state
         .app
         .agents()
-        .list_for_workspace(workspace_id)
+        .list_for_workspace(sub, workspace_id)
         .await
         .unwrap_or_default();
 
@@ -1113,22 +1151,24 @@ async fn workspace_sandboxes_page(
     session: Session,
     Path(id): Path<uuid::Uuid>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+    let ws = match state.app.workspaces().find_by_id(&sub, workspace_id).await {
         Ok(ws) => ws,
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agent_views) = workspace_sidebar_context(&sub, &state, workspace_id).await;
 
     let sandboxes = state
         .app
         .sandboxes()
-        .list_for_workspace(workspace_id)
+        .list_for_workspace(&sub, workspace_id)
         .await
         .unwrap_or_default();
 
@@ -1147,17 +1187,19 @@ async fn workspace_sandbox_new(
     session: Session,
     Path(id): Path<uuid::Uuid>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+    let ws = match state.app.workspaces().find_by_id(&sub, workspace_id).await {
         Ok(ws) => ws,
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agent_views) = workspace_sidebar_context(&sub, &state, workspace_id).await;
 
     WorkspaceSandboxNewTemplate {
         workspace: workspace_to_view(&ws),
@@ -1187,9 +1229,11 @@ async fn workspace_sandbox_create(
     Path(id): Path<uuid::Uuid>,
     Form(form): Form<CreateSandboxForm>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
 
@@ -1234,7 +1278,7 @@ async fn workspace_sandbox_create(
     if let Err(e) = state
         .app
         .sandboxes()
-        .create(workspace_id, form.name, specs, mode)
+        .create(&sub, workspace_id, form.name, specs, mode)
         .await
     {
         tracing::error!(error = %e, "Failed to create sandbox");
@@ -1250,23 +1294,25 @@ async fn workspace_sandbox_detail(
     session: Session,
     Path((id, sandbox_id)): Path<(uuid::Uuid, uuid::Uuid)>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+    let ws = match state.app.workspaces().find_by_id(&sub, workspace_id).await {
         Ok(ws) => ws,
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
     let sandbox_id = SandboxId::from(sandbox_id);
-    let sandbox = match state.app.sandboxes().find_by_id(sandbox_id).await {
+    let sandbox = match state.app.sandboxes().find_by_id(&sub, sandbox_id).await {
         Ok(s) => s,
         Err(_) => return Redirect::to(&format!("/workspaces/{id}/sandboxes")).into_response(),
     };
 
-    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agent_views) = workspace_sidebar_context(&sub, &state, workspace_id).await;
 
     WorkspaceSandboxDetailTemplate {
         workspace: workspace_to_view(&ws),
@@ -1283,12 +1329,14 @@ async fn workspace_sandbox_suspend(
     session: Session,
     Path((id, sandbox_id)): Path<(uuid::Uuid, uuid::Uuid)>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let sandbox_id = SandboxId::from(sandbox_id);
-    if let Err(e) = state.app.sandboxes().suspend(sandbox_id).await {
+    if let Err(e) = state.app.sandboxes().suspend(&sub, sandbox_id).await {
         tracing::error!(error = %e, "Failed to suspend sandbox");
         return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
     }
@@ -1302,12 +1350,14 @@ async fn workspace_sandbox_restart(
     session: Session,
     Path((id, sandbox_id)): Path<(uuid::Uuid, uuid::Uuid)>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let sandbox_id = SandboxId::from(sandbox_id);
-    if let Err(e) = state.app.sandboxes().restart(sandbox_id).await {
+    if let Err(e) = state.app.sandboxes().restart(&sub, sandbox_id).await {
         tracing::error!(error = %e, "Failed to restart sandbox");
         return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
     }
@@ -1325,22 +1375,24 @@ async fn workspace_agent_new(
     session: Session,
     Path(id): Path<uuid::Uuid>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+    let ws = match state.app.workspaces().find_by_id(&sub, workspace_id).await {
         Ok(ws) => ws,
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let (lead_agent, agent_views) = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agent_views) = workspace_sidebar_context(&sub, &state, workspace_id).await;
 
     let sandbox_options: Vec<SandboxOptionView> = state
         .app
         .sandboxes()
-        .list_for_workspace(workspace_id)
+        .list_for_workspace(&sub, workspace_id)
         .await
         .unwrap_or_default()
         .iter()
@@ -1377,9 +1429,11 @@ async fn workspace_agent_create(
     Path(id): Path<uuid::Uuid>,
     Form(form): Form<CreateAgentForm>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
 
@@ -1404,6 +1458,7 @@ async fn workspace_agent_create(
         .app
         .agents()
         .create(
+            &sub,
             workspace_id,
             domain::agent::AgentRole::Agent,
             form.name,
@@ -1429,11 +1484,12 @@ fn role_label(role: domain::agent::AgentRole) -> &'static str {
 }
 
 async fn attached_sandbox_view(
+    sub: &AuthSubject,
     state: &AppState,
     attached: Option<(SandboxId, SandboxAgentMode)>,
 ) -> Option<AttachedSandboxView> {
     let (sbx_id, mode) = attached?;
-    let sandbox = state.app.sandboxes().find_by_id(sbx_id).await.ok()?;
+    let sandbox = state.app.sandboxes().find_by_id(sub, sbx_id).await.ok()?;
     Some(AttachedSandboxView {
         id: sandbox.id.to_string(),
         name: sandbox.name.clone(),
@@ -1458,25 +1514,27 @@ async fn workspace_agent_detail(
     Path((id, agent_id)): Path<(uuid::Uuid, uuid::Uuid)>,
     Query(query): Query<AgentDetailQuery>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+    let ws = match state.app.workspaces().find_by_id(&sub, workspace_id).await {
         Ok(ws) => ws,
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
     let agent_id = AgentId::from(agent_id);
-    let agent = match state.app.agents().find_by_id(agent_id).await {
+    let agent = match state.app.agents().find_by_id(&sub, agent_id).await {
         Ok(a) => a,
         Err(_) => return Redirect::to(&format!("/workspaces/{id}")).into_response(),
     };
 
-    let (lead_agent, agents) = workspace_sidebar_context(&state, workspace_id).await;
+    let (lead_agent, agents) = workspace_sidebar_context(&sub, &state, workspace_id).await;
 
-    let attached_view = attached_sandbox_view(&state, agent.attached_sandbox).await;
+    let attached_view = attached_sandbox_view(&sub, &state, agent.attached_sandbox).await;
 
     // Dropdown options are only needed when no sandbox is currently attached.
     let sandbox_options: Vec<SandboxOptionView> = if attached_view.is_some() {
@@ -1485,7 +1543,7 @@ async fn workspace_agent_detail(
         state
             .app
             .sandboxes()
-            .list_for_workspace(workspace_id)
+            .list_for_workspace(&sub, workspace_id)
             .await
             .unwrap_or_default()
             .iter()
@@ -1548,7 +1606,7 @@ async fn workspace_agent_attach_sandbox(
     let Some(user_id) = extract_user_id(&session).await else {
         return Redirect::to("/").into_response();
     };
-    let subject = domain::primitives::AuthSubject::User(user_id);
+    let subject = AuthSubject::User(user_id);
 
     let agent_id = AgentId::from(agent_id);
     let Ok(sandbox_uuid) = form.sandbox_id.parse::<uuid::Uuid>() else {
@@ -1583,11 +1641,11 @@ async fn workspace_agent_detach_sandbox(
     let Some(user_id) = extract_user_id(&session).await else {
         return Redirect::to("/").into_response();
     };
-    let subject = domain::primitives::AuthSubject::User(user_id);
+    let subject = AuthSubject::User(user_id);
 
     let agent_id = AgentId::from(agent_id);
     // The handler needs the sandbox_id; fetch the agent to look it up.
-    let sandbox_id = match state.app.agents().find_by_id(agent_id).await {
+    let sandbox_id = match state.app.agents().find_by_id(&subject, agent_id).await {
         Ok(a) => a.attached_sandbox.map(|(sbx, _)| sbx),
         Err(_) => return Redirect::to(&format!("/workspaces/{id}")).into_response(),
     };
@@ -1625,22 +1683,29 @@ async fn workspace_chat(
     Path(id): Path<uuid::Uuid>,
     Query(query): Query<ChatQuery>,
 ) -> Response {
-    if extract_user_id(&session).await.is_none() {
-        return Redirect::to("/").into_response();
-    }
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let ws = match state.app.workspaces().find_by_id(workspace_id).await {
+    let ws = match state.app.workspaces().find_by_id(&sub, workspace_id).await {
         Ok(ws) => ws,
         Err(_) => return Redirect::to("/workspaces").into_response(),
     };
 
-    let all_workspaces = state.app.workspaces().list_all().await.unwrap_or_default();
+    let all_workspaces = state
+        .app
+        .workspaces()
+        .list_all(&sub)
+        .await
+        .unwrap_or_default();
 
     let agents = state
         .app
         .agents()
-        .list_for_workspace(workspace_id)
+        .list_for_workspace(&sub, workspace_id)
         .await
         .unwrap_or_default();
 
@@ -1803,7 +1868,7 @@ async fn api_agent_secrets(
     let secrets = match state
         .app
         .workspace_secrets()
-        .list_decrypted(workspace_id)
+        .list_decrypted(&auth, workspace_id)
         .await
     {
         Ok(s) => s,


### PR DESCRIPTION
## Summary

- Every public service method now accepts `_sub: &AuthSubject` as its first parameter, establishing a uniform authz boundary across all six services (Sandboxes, Skills, WorkspaceSecrets, Agents, McpCredentials, Workspaces)
- All callsites updated: MCP tools (12 files), web route handlers (~30 handlers), GraphQL resolvers, auth infrastructure, and tests
- Enforcement is intentionally deferred — parameters are `_sub` (unused) — so this is pure plumbing with no behavioral change

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `nix flake check` — all checks pass (includes nextest)
- [ ] Verify web UI login + workspace CRUD still works
- [ ] Verify MCP gateway tool calls still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)