### PR TITLE
feat(agent): system context — sandbox notifications and behavioral guidelines

### DIFF
--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -51,7 +51,6 @@ impl From<u32> for ResetTimeDeltaSeconds {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoleConfig {
     pub model: String,
-    pub system: Vec<llm::prompt::SystemBlock>,
     pub max_tokens: u32,
     /// If set, a new thread is started when a user message arrives more
     /// than this many seconds after the previous user message in the

--- a/core/src/agent/entity.rs
+++ b/core/src/agent/entity.rs
@@ -28,6 +28,7 @@ pub enum AgentEvent {
         agent_role: AgentRole,
         name: String,
         authz_scopes: Vec<AuthScope>,
+        workspace_name: String,
     },
     /// Single delta event for adds and removes — bundles both sides of an
     /// attach/detach into one record. `added` and `removed` carry only the
@@ -53,6 +54,10 @@ pub struct Agent {
     pub workspace_id: WorkspaceId,
     pub agent_role: AgentRole,
     pub name: String,
+    /// Cached workspace display name — set at creation time and never
+    /// updated (if the workspace is renamed, existing agents keep the old
+    /// name until they are recreated).
+    pub workspace_name: String,
     /// Backed by a `HashSet` to enforce no-duplicates at the entity level.
     /// Wire format (`Initialized.authz_scopes`, `AuthScopesUpdated.added/removed`)
     /// stays as `Vec<AuthScope>` for backward-compatible JSON serialization.
@@ -230,12 +235,14 @@ impl TryFromEvents<AgentEvent> for Agent {
                     agent_role,
                     name,
                     authz_scopes,
+                    workspace_name,
                 } => {
                     builder = builder
                         .id(*id)
                         .workspace_id(*workspace_id)
                         .agent_role(*agent_role)
-                        .name(name.clone());
+                        .name(name.clone())
+                        .workspace_name(workspace_name.clone());
                     scopes = authz_scopes.iter().cloned().collect();
                 }
                 AgentEvent::AuthScopesUpdated { added, removed } => {
@@ -274,6 +281,8 @@ pub struct NewAgent {
     #[builder(setter(into))]
     pub(super) name: String,
     pub(super) authz_scopes: Vec<AuthScope>,
+    #[builder(setter(into))]
+    pub(super) workspace_name: String,
 }
 
 impl NewAgent {
@@ -292,6 +301,7 @@ impl IntoEvents<AgentEvent> for NewAgent {
                 agent_role: self.agent_role,
                 name: self.name,
                 authz_scopes: self.authz_scopes,
+                workspace_name: self.workspace_name,
             }],
         )
     }

--- a/core/src/agent/error.rs
+++ b/core/src/agent/error.rs
@@ -1,6 +1,6 @@
 use thiserror::Error;
 
-use crate::primitives::SandboxId;
+use crate::primitives::{SandboxId, WorkspaceId};
 use crate::sandbox::error::SandboxError;
 use crate::skill::SkillError;
 
@@ -37,4 +37,6 @@ pub enum AgentError {
     AlreadyAttachedToSandbox { current: SandboxId },
     #[error("AgentError - workspace lead cannot attach a sandbox")]
     LeadCannotAttachSandbox,
+    #[error("AgentError - no lead agent found in workspace {0}")]
+    NoLeadAgent(WorkspaceId),
 }

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -3,6 +3,7 @@ mod entity;
 pub mod error;
 pub mod repo;
 pub mod session;
+mod system_prompt;
 
 use std::sync::Arc;
 
@@ -81,35 +82,113 @@ impl Agents {
         &self.skills
     }
 
-    #[instrument(name = "domain.agent.create", skip(self, _sub))]
-    pub async fn create(
+    /// Create a workspace lead agent. The workspace name is passed directly
+    /// because it's known at workspace creation time.
+    #[instrument(name = "domain.agent.create_workspace_lead", skip(self))]
+    pub async fn create_workspace_lead(
         &self,
-        _sub: &AuthSubject,
         workspace_id: WorkspaceId,
-        agent_role: AgentRole,
         name: impl Into<String> + std::fmt::Debug,
-        attach_sandbox: Option<(SandboxId, SandboxAgentMode)>,
+        workspace_name: &str,
     ) -> Result<Agent, AgentError> {
         let id = AgentId::new();
         let mut op = self.repo.begin_op().await?;
         let agent = self
-            .create_in_op(&mut op, id, workspace_id, agent_role, name, attach_sandbox)
+            .create_in_op(
+                &mut op,
+                id,
+                workspace_id,
+                AgentRole::WorkspaceLead,
+                name,
+                None,
+                workspace_name,
+            )
             .await?;
         op.commit().await?;
         Ok(agent)
     }
 
-    /// Composable variant of [`Self::create`]. When `attach_sandbox` is
-    /// `Some((sandbox_id, mode))`, the agent is attached to the sandbox as
-    /// part of the same op — the entity-level invariants (workspace match,
-    /// single-writer) are enforced by
-    /// [`crate::sandbox::Sandboxes::attach_to_agent_in_op`] and the
-    /// matching `SandboxRead`/`SandboxWrite` scopes are written via
-    /// [`Agent::sandbox_attached`]. Bypasses the subject-based authz check
-    /// that [`Self::attach_sandbox`] performs — callers of `create_in_op`
-    /// are trusted to have authorized the action upstream.
+    /// Create a regular agent. The workspace name is resolved automatically
+    /// from the existing lead agent in the workspace.
+    #[instrument(name = "domain.agent.create_agent", skip(self))]
+    pub async fn create_agent(
+        &self,
+        workspace_id: WorkspaceId,
+        name: impl Into<String> + std::fmt::Debug,
+        attach_sandbox: Option<(SandboxId, SandboxAgentMode)>,
+    ) -> Result<Agent, AgentError> {
+        let workspace_name = self.resolve_workspace_name(workspace_id).await?;
+        let id = AgentId::new();
+        let mut op = self.repo.begin_op().await?;
+        let agent = self
+            .create_in_op(
+                &mut op,
+                id,
+                workspace_id,
+                AgentRole::Agent,
+                name,
+                attach_sandbox,
+                &workspace_name,
+            )
+            .await?;
+        op.commit().await?;
+        Ok(agent)
+    }
+
+    /// Resolve the workspace display name from the lead agent.
+    async fn resolve_workspace_name(
+        &self,
+        workspace_id: WorkspaceId,
+    ) -> Result<String, AgentError> {
+        let query = es_entity::PaginatedQueryArgs {
+            first: 1,
+            after: None,
+        };
+        let result = self
+            .repo
+            .list_for_workspace_id_by_created_at(
+                workspace_id,
+                query,
+                es_entity::ListDirection::Ascending,
+            )
+            .await?;
+        result
+            .entities
+            .into_iter()
+            .next()
+            .map(|a| a.workspace_name)
+            .ok_or(AgentError::NoLeadAgent(workspace_id))
+    }
+
+    /// Composable variant of [`Self::create_workspace_lead`] — creates a
+    /// lead agent inside an existing op with a pre-determined id.
+    #[instrument(name = "domain.agent.create_workspace_lead_in_op", skip(self, op))]
+    pub async fn create_workspace_lead_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        id: AgentId,
+        workspace_id: WorkspaceId,
+        name: impl Into<String> + std::fmt::Debug,
+        workspace_name: &str,
+    ) -> Result<Agent, AgentError> {
+        self.create_in_op(
+            op,
+            id,
+            workspace_id,
+            AgentRole::WorkspaceLead,
+            name,
+            None,
+            workspace_name,
+        )
+        .await
+    }
+
+    /// Shared inner: creates an agent of any role with all arguments
+    /// explicit. [`Self::create_workspace_lead`] and [`Self::create_agent`]
+    /// delegate here after resolving the workspace name.
+    #[allow(clippy::too_many_arguments)]
     #[instrument(name = "domain.agent.create_in_op", skip(self, op))]
-    pub async fn create_in_op(
+    async fn create_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,
         id: AgentId,
@@ -117,6 +196,7 @@ impl Agents {
         agent_role: AgentRole,
         name: impl Into<String> + std::fmt::Debug,
         attach_sandbox: Option<(SandboxId, SandboxAgentMode)>,
+        workspace_name: &str,
     ) -> Result<Agent, AgentError> {
         let role_config = self
             .config
@@ -133,6 +213,7 @@ impl Agents {
             .agent_role(agent_role)
             .name(name)
             .authz_scopes(authz_scopes)
+            .workspace_name(workspace_name)
             .build()
             .expect("NewAgent build");
 
@@ -147,11 +228,12 @@ impl Agents {
             .top_level_tools(&agent_subject)
             .map(|t| session::message::ToolDefinition::from(llm::prompt::Tool::from(t.as_ref())))
             .collect();
-        let system_blocks: Vec<session::message::SystemBlock> = role_config
-            .system
-            .into_iter()
-            .map(session::message::SystemBlock::from)
-            .collect();
+        let system_blocks = system_prompt::system_blocks_for_role(
+            agent_role,
+            &self.toolsets,
+            &agent_subject,
+            &agent.workspace_name,
+        );
 
         self.sessions
             .create_in_op(
@@ -267,6 +349,21 @@ impl Agents {
             .await?;
 
         op.commit().await?;
+
+        // Notify the agent's session so the LLM knows a sandbox was attached.
+        let sandbox = self.sandboxes.find_by_id(subject, sandbox_id).await?;
+        let workspace_path = self.sandboxes.workspace_path(&sandbox);
+        self.sessions
+            .sandbox_notification(
+                agent_id,
+                sandbox.name,
+                session::message::SandboxOperation::Attach {
+                    mode: format!("{mode:?}").to_lowercase(),
+                    workspace_path,
+                },
+            )
+            .await?;
+
         Ok(agent)
     }
 
@@ -300,6 +397,17 @@ impl Agents {
             .await?;
 
         op.commit().await?;
+
+        // Notify the agent's session so the LLM knows a sandbox was detached.
+        let sandbox = self.sandboxes.find_by_id(subject, sandbox_id).await?;
+        self.sessions
+            .sandbox_notification(
+                agent_id,
+                sandbox.name,
+                session::message::SandboxOperation::Detach,
+            )
+            .await?;
+
         Ok(agent)
     }
 

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -257,8 +257,21 @@ impl Agents {
             if agent.sandbox_attached(sandbox_id, mode)?.did_execute() {
                 self.repo.update_in_op(op, &mut agent).await?;
             }
-            self.sandboxes
+            let sandbox = self
+                .sandboxes
                 .attach_to_agent_in_op(op, workspace_id, sandbox_id, agent.id, mode)
+                .await?;
+
+            self.sessions
+                .sandbox_notification_in_op(
+                    op,
+                    agent.id,
+                    sandbox.name,
+                    session::message::SandboxOperation::Attach {
+                        mode: format!("{mode:?}").to_lowercase(),
+                        mount_path: sandbox.mount_path,
+                    },
+                )
                 .await?;
         }
 

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -343,26 +343,26 @@ impl Agents {
             self.repo.update_in_op(&mut op, &mut agent).await?;
         }
 
-        // Then sandbox side (enforces workspace match and single-writer).
-        self.sandboxes
+        // Sandbox side (enforces workspace match and single-writer).
+        let sandbox = self
+            .sandboxes
             .attach_to_agent_in_op(&mut op, workspace_id, sandbox_id, agent_id, mode)
             .await?;
 
-        op.commit().await?;
-
         // Notify the agent's session so the LLM knows a sandbox was attached.
-        let sandbox = self.sandboxes.find_by_id(subject, sandbox_id).await?;
-        let workspace_path = self.sandboxes.workspace_path(&sandbox);
         self.sessions
-            .sandbox_notification(
+            .sandbox_notification_in_op(
+                &mut op,
                 agent_id,
                 sandbox.name,
                 session::message::SandboxOperation::Attach {
                     mode: format!("{mode:?}").to_lowercase(),
-                    workspace_path,
+                    workspace_path: sandbox.workspace_path,
                 },
             )
             .await?;
+
+        op.commit().await?;
 
         Ok(agent)
     }
@@ -392,21 +392,22 @@ impl Agents {
             self.repo.update_in_op(&mut op, &mut agent).await?;
         }
 
-        self.sandboxes
+        let sandbox = self
+            .sandboxes
             .detach_from_agent_in_op(&mut op, sandbox_id, agent_id)
             .await?;
 
-        op.commit().await?;
-
         // Notify the agent's session so the LLM knows a sandbox was detached.
-        let sandbox = self.sandboxes.find_by_id(subject, sandbox_id).await?;
         self.sessions
-            .sandbox_notification(
+            .sandbox_notification_in_op(
+                &mut op,
                 agent_id,
                 sandbox.name,
                 session::message::SandboxOperation::Detach,
             )
             .await?;
+
+        op.commit().await?;
 
         Ok(agent)
     }

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -357,7 +357,7 @@ impl Agents {
                 sandbox.name,
                 session::message::SandboxOperation::Attach {
                     mode: format!("{mode:?}").to_lowercase(),
-                    workspace_path: sandbox.workspace_path,
+                    mount_path: sandbox.mount_path,
                 },
             )
             .await?;

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -43,6 +43,11 @@ pub enum AgentSessionEvent {
         source: UserMessageSource,
         text: String,
     },
+    SandboxNotificationAdded {
+        target: TargetThread,
+        sandbox_name: String,
+        operation: SandboxOperation,
+    },
     ThreadStarted {
         thread_id: SessionThreadId,
         start_reason: ThreadStartReason,
@@ -113,6 +118,30 @@ impl AgentSession {
             source,
             text: prompt,
         });
+        self.user_message_response(target)
+    }
+
+    pub fn add_sandbox_notification(
+        &mut self,
+        sandbox_name: String,
+        operation: SandboxOperation,
+    ) -> Result<AgentSessionResponse, AgentSessionError> {
+        let target = TargetThread::Main;
+        self.events
+            .push(AgentSessionEvent::SandboxNotificationAdded {
+                target,
+                sandbox_name,
+                operation,
+            });
+        self.user_message_response(target)
+    }
+
+    /// Common post-push response logic shared by [`Self::add_user_input`]
+    /// and [`Self::add_sandbox_notification`].
+    fn user_message_response(
+        &self,
+        target: TargetThread,
+    ) -> Result<AgentSessionResponse, AgentSessionError> {
         let thread_id = match target {
             TargetThread::Main => match self.current_main_thread {
                 Some(id) => id,
@@ -155,7 +184,13 @@ impl AgentSession {
         let total_user_msgs = self
             .events
             .iter_all()
-            .filter(|e| matches!(e, AgentSessionEvent::UserInputAdded { .. }))
+            .filter(|e| {
+                matches!(
+                    e,
+                    AgentSessionEvent::UserInputAdded { .. }
+                        | AgentSessionEvent::SandboxNotificationAdded { .. }
+                )
+            })
             .count();
         let mut user_msg_counter = total_user_msgs;
         let mut pending_indexes = Vec::new();
@@ -165,6 +200,9 @@ impl AgentSession {
                     break;
                 }
                 AgentSessionEvent::UserInputAdded {
+                    target: msg_target, ..
+                }
+                | AgentSessionEvent::SandboxNotificationAdded {
                     target: msg_target, ..
                 } => {
                     user_msg_counter -= 1;
@@ -311,7 +349,8 @@ impl AgentSession {
                 !matches!(e, AgentSessionEvent::PromptSent { thread_id: tid, .. } if *tid == thread_id)
             })
             .any(|e| match e {
-                AgentSessionEvent::UserInputAdded { target, .. } => match target {
+                AgentSessionEvent::UserInputAdded { target, .. }
+                | AgentSessionEvent::SandboxNotificationAdded { target, .. } => match target {
                     TargetThread::Main => self.current_main_thread == Some(thread_id),
                     TargetThread::Id(id) => *id == thread_id,
                 },
@@ -373,7 +412,8 @@ impl AgentSession {
                 AgentSessionEvent::SystemBlocksUpdated { system_blocks } => {
                     materialized.push_system_blocks(system_blocks.iter());
                 }
-                AgentSessionEvent::UserInputAdded { .. } => {
+                AgentSessionEvent::UserInputAdded { .. }
+                | AgentSessionEvent::SandboxNotificationAdded { .. } => {
                     materialized.push_user_message();
                 }
                 AgentSessionEvent::AssistantResponseReceived { content, .. } => {
@@ -404,6 +444,7 @@ impl TryFromEvents<AgentSessionEvent> for AgentSession {
                     builder = builder.current_main_thread(Some(*thread_id));
                 }
                 AgentSessionEvent::UserInputAdded { .. } => {}
+                AgentSessionEvent::SandboxNotificationAdded { .. } => {}
                 AgentSessionEvent::AssistantResponseReceived { .. } => {}
                 AgentSessionEvent::ToolDefsUpdated { .. } => {}
                 AgentSessionEvent::SystemBlocksUpdated { .. } => {}

--- a/core/src/agent/session/message.rs
+++ b/core/src/agent/session/message.rs
@@ -287,10 +287,7 @@ impl From<llm::prompt::SystemBlock> for SystemBlock {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SandboxOperation {
-    Attach {
-        mode: String,
-        workspace_path: String,
-    },
+    Attach { mode: String, mount_path: String },
     Detach,
 }
 
@@ -299,14 +296,11 @@ pub enum SandboxOperation {
 /// agent system prompt.
 pub fn sandbox_notification_text(sandbox_name: &str, op: &SandboxOperation) -> String {
     match op {
-        SandboxOperation::Attach {
-            mode,
-            workspace_path,
-        } => {
+        SandboxOperation::Attach { mode, mount_path } => {
             format!(
                 "<sandbox>\n\
                  Attached sandbox \"{sandbox_name}\" in {mode} mode.\n\
-                 The workspace is mounted at {workspace_path}. \
+                 The workspace is mounted at {mount_path}. \
                  All file operations and command execution are confined to this path — \
                  do not attempt to read, write, or execute anything outside it.\n\
                  </sandbox>"

--- a/core/src/agent/session/message.rs
+++ b/core/src/agent/session/message.rs
@@ -54,6 +54,10 @@ pub enum UserBlock {
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
         is_error: bool,
     },
+    SandboxInfo {
+        sandbox_name: String,
+        sandbox_operation: SandboxOperation,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -187,6 +191,13 @@ impl From<UserBlock> for llm::prompt::UserBlock {
                 is_error,
                 cache_control: None,
             },
+            UserBlock::SandboxInfo {
+                sandbox_name,
+                sandbox_operation,
+            } => llm::prompt::UserBlock::Text {
+                text: sandbox_notification_text(&sandbox_name, &sandbox_operation),
+                cache_control: None,
+            },
         }
     }
 }
@@ -264,6 +275,45 @@ impl From<llm::prompt::SystemBlock> for SystemBlock {
     fn from(b: llm::prompt::SystemBlock) -> Self {
         match b {
             llm::prompt::SystemBlock::Text { text, .. } => SystemBlock::Text { text },
+        }
+    }
+}
+
+// ============================================================================
+// Sandbox notification helpers
+// ============================================================================
+
+/// What happened to a sandbox from the agent's perspective.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SandboxOperation {
+    Attach {
+        mode: String,
+        workspace_path: String,
+    },
+    Detach,
+}
+
+/// Build the XML text injected into the agent's session when a sandbox is
+/// attached or detached. Matches the `<sandbox>` tag format described in the
+/// agent system prompt.
+pub fn sandbox_notification_text(sandbox_name: &str, op: &SandboxOperation) -> String {
+    match op {
+        SandboxOperation::Attach {
+            mode,
+            workspace_path,
+        } => {
+            format!(
+                "<sandbox>\n\
+                 Attached sandbox \"{sandbox_name}\" in {mode} mode.\n\
+                 The workspace is mounted at {workspace_path}. \
+                 All file operations and command execution are confined to this path — \
+                 do not attempt to read, write, or execute anything outside it.\n\
+                 </sandbox>"
+            )
+        }
+        SandboxOperation::Detach => {
+            format!("<sandbox>\nDetached sandbox \"{sandbox_name}\".\n</sandbox>")
         }
     }
 }

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -133,6 +133,19 @@ impl Sessions {
         Ok(result)
     }
 
+    #[instrument(name = "domain.agent_session.sandbox_notification", skip(self))]
+    pub async fn sandbox_notification(
+        &self,
+        agent_id: AgentId,
+        sandbox_name: String,
+        operation: message::SandboxOperation,
+    ) -> Result<AgentSessionResponse, AgentSessionError> {
+        let mut session = self.repo.find_by_agent_id(agent_id).await?;
+        let response = session.add_sandbox_notification(sandbox_name, operation)?;
+        self.repo.update(&mut session).await?;
+        Ok(response)
+    }
+
     #[instrument(name = "domain.agent_session.delete_for_agent_in_op", skip(self, op))]
     pub async fn delete_for_agent_in_op(
         &self,

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -144,7 +144,7 @@ impl Sessions {
         sandbox_name: String,
         operation: message::SandboxOperation,
     ) -> Result<AgentSessionResponse, AgentSessionError> {
-        let mut session = self.repo.find_by_agent_id(agent_id).await?;
+        let mut session = self.repo.find_by_agent_id_in_op(op, agent_id).await?;
         let response = session.add_sandbox_notification(sandbox_name, operation)?;
         self.repo.update_in_op(op, &mut session).await?;
         Ok(response)

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -133,16 +133,20 @@ impl Sessions {
         Ok(result)
     }
 
-    #[instrument(name = "domain.agent_session.sandbox_notification", skip(self))]
-    pub async fn sandbox_notification(
+    #[instrument(
+        name = "domain.agent_session.sandbox_notification_in_op",
+        skip(self, op)
+    )]
+    pub async fn sandbox_notification_in_op(
         &self,
+        op: &mut es_entity::DbOp<'_>,
         agent_id: AgentId,
         sandbox_name: String,
         operation: message::SandboxOperation,
     ) -> Result<AgentSessionResponse, AgentSessionError> {
         let mut session = self.repo.find_by_agent_id(agent_id).await?;
         let response = session.add_sandbox_notification(sandbox_name, operation)?;
-        self.repo.update(&mut session).await?;
+        self.repo.update_in_op(op, &mut session).await?;
         Ok(response)
     }
 

--- a/core/src/agent/session/view.rs
+++ b/core/src/agent/session/view.rs
@@ -261,6 +261,13 @@ impl PromptDefinition {
                 AgentSessionEvent::UserInputAdded { text, .. } => {
                     all_user_texts.push(text.clone());
                 }
+                AgentSessionEvent::SandboxNotificationAdded {
+                    sandbox_name,
+                    operation,
+                    ..
+                } => {
+                    all_user_texts.push(sandbox_notification_text(sandbox_name, operation));
+                }
                 AgentSessionEvent::AssistantResponseReceived { content, .. } => {
                     all_assistant_blocks.extend(content.iter().cloned());
                 }

--- a/core/src/agent/system_prompt.rs
+++ b/core/src/agent/system_prompt.rs
@@ -1,0 +1,188 @@
+use std::sync::Arc;
+
+use crate::primitives::AuthSubject;
+use crate::toolset::ToolSets;
+
+use super::entity::AgentRole;
+use super::session::message::SystemBlock;
+
+/// Identity line shared by every agent role. The workspace name is
+/// interpolated at construction time via [`build_base_block`].
+const BASE_PROMPT_PREFIX: &str = "You are an AI agent operating inside the \
+Galoy Agents platform, in workspace";
+
+/// Behavioral guidelines shared by every agent role. These are
+/// high-ROI directives drawn from Anthropic's official prompting
+/// best-practices and published system-prompt patterns.
+const BEHAVIORAL_GUIDELINES: &str = "\
+<investigate_before_answering>
+Never speculate about sandbox contents you have not read. Always use \
+read, grep, or ls tools before answering questions about code in a \
+sandbox. If you are unsure about something, look it up rather than \
+guessing.
+</investigate_before_answering>
+
+<use_parallel_tool_calls>
+If you intend to call multiple tools and there are no dependencies \
+between the tool calls, make all of the independent tool calls in \
+parallel. For example, when reading several files, read them all at \
+once rather than one at a time.
+</use_parallel_tool_calls>";
+
+/// Role-specific context for the workspace lead.
+const WORKSPACE_LEAD_ROLE: &str = "\
+You are the workspace lead. You coordinate work across the workspace, \
+delegate tasks to other agents, and answer user questions directly. \
+You cannot attach to sandboxes, but you can inspect any sandbox in \
+the workspace using the workspace_inspect_sandbox tool. For code \
+changes and command execution, delegate to other agents.";
+
+/// Role-specific context for a task agent.
+const AGENT_ROLE: &str = "\
+You are a task agent. You start without a sandbox attached. When a \
+sandbox is attached or detached during the conversation, you will \
+receive a <sandbox> message announcing the change and the mode \
+(read or write). When attached in write mode you can run commands \
+and edit files inside the sandbox to complete your assigned tasks. \
+In read-only mode you can browse files but cannot modify them. \
+Focus on completing the specific task you have been given.
+
+<default_to_action>
+Implement changes rather than only suggesting them. Use tools to \
+discover missing details instead of asking for clarification.
+</default_to_action>";
+
+/// Build the system blocks for a given agent role.
+///
+/// Returns four [`SystemBlock`]s:
+/// 1. **Base** — identity line (cacheable).
+/// 2. **Tools** — dynamic list of top-level tools and the progressive
+///    disclosure pattern for upstream toolsets.
+/// 3. **Behavioral** — shared behavioral guidelines (cacheable).
+/// 4. **Role** — role-specific instructions.
+///
+/// Keeping them as separate blocks (rather than one concatenated
+/// string) allows cache-control breakpoints at the LLM layer.
+pub fn system_blocks_for_role(
+    role: AgentRole,
+    toolsets: &Arc<ToolSets>,
+    subject: &AuthSubject,
+    workspace_name: &str,
+) -> Vec<SystemBlock> {
+    let base_text = format!("{BASE_PROMPT_PREFIX} \"{workspace_name}\".");
+    let tools_text = build_tools_section(role, toolsets, subject);
+    let role_text = match role {
+        AgentRole::WorkspaceLead => WORKSPACE_LEAD_ROLE,
+        AgentRole::Agent => AGENT_ROLE,
+    };
+
+    vec![
+        SystemBlock::Text { text: base_text },
+        SystemBlock::Text { text: tools_text },
+        SystemBlock::Text {
+            text: BEHAVIORAL_GUIDELINES.to_string(),
+        },
+        SystemBlock::Text {
+            text: role_text.to_string(),
+        },
+    ]
+}
+
+/// Build the tools-context section. Does NOT re-list top-level tools
+/// (those are already in the prompt's `tools` array with full schemas).
+/// Instead, explains things the model can't infer from the tools array:
+/// sandbox-tool prerequisites (for task agents) and the progressive-
+/// disclosure pattern for upstream toolsets.
+fn build_tools_section(
+    role: AgentRole,
+    toolsets: &Arc<ToolSets>,
+    _subject: &AuthSubject,
+) -> String {
+    let mut section = String::new();
+
+    if matches!(role, AgentRole::Agent) {
+        section.push_str(
+            "Sandbox tools (bash, text_editor, read, ls, grep, glob) \
+             require an attached sandbox.\n",
+        );
+    }
+
+    // Progressive disclosure for upstream/searchable toolsets.
+    let gateway_info = toolsets.mcp_gateway_info();
+    if !gateway_info.is_empty() {
+        section.push_str("\n# Additional tools (progressive disclosure)\n\n");
+        section.push_str(&gateway_info);
+        section.push('\n');
+    }
+
+    section
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workspace_lead_returns_four_blocks() {
+        let toolsets = Arc::new(
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(ToolSets::init(Default::default()))
+                .unwrap(),
+        );
+        let subject = AuthSubject::Anonymous;
+        let blocks =
+            system_blocks_for_role(AgentRole::WorkspaceLead, &toolsets, &subject, "acme-corp");
+        assert_eq!(blocks.len(), 4);
+        match &blocks[0] {
+            SystemBlock::Text { text } => {
+                assert!(text.contains("Galoy Agents platform"));
+                assert!(text.contains("acme-corp"));
+            }
+        }
+        match &blocks[1] {
+            SystemBlock::Text { text } => assert!(text.contains("progressive disclosure")),
+        }
+        match &blocks[2] {
+            SystemBlock::Text { text } => {
+                assert!(text.contains("investigate_before_answering"));
+                assert!(text.contains("use_parallel_tool_calls"));
+            }
+        }
+        match &blocks[3] {
+            SystemBlock::Text { text } => assert!(text.contains("workspace lead")),
+        }
+    }
+
+    #[test]
+    fn agent_returns_four_blocks_with_sandbox_note() {
+        let toolsets = Arc::new(
+            tokio::runtime::Runtime::new()
+                .unwrap()
+                .block_on(ToolSets::init(Default::default()))
+                .unwrap(),
+        );
+        let subject = AuthSubject::Anonymous;
+        let blocks =
+            system_blocks_for_role(AgentRole::Agent, &toolsets, &subject, "test-workspace");
+        assert_eq!(blocks.len(), 4);
+        match &blocks[1] {
+            SystemBlock::Text { text } => {
+                assert!(text.contains("Sandbox tools"));
+                assert!(text.contains("require an attached sandbox"));
+            }
+        }
+        match &blocks[2] {
+            SystemBlock::Text { text } => {
+                assert!(text.contains("investigate_before_answering"));
+                assert!(text.contains("use_parallel_tool_calls"));
+            }
+        }
+        match &blocks[3] {
+            SystemBlock::Text { text } => {
+                assert!(text.contains("task agent"));
+                assert!(text.contains("default_to_action"));
+            }
+        }
+    }
+}

--- a/core/src/sandbox/entity.rs
+++ b/core/src/sandbox/entity.rs
@@ -67,6 +67,8 @@ pub enum SandboxEvent {
         name: String,
         specs: SandboxSpecs,
         mode: SandboxMode,
+        #[serde(default)]
+        workspace_path: String,
     },
     StateChanged {
         state: SandboxState,
@@ -106,6 +108,11 @@ pub struct Sandbox {
     pub name: String,
     pub specs: SandboxSpecs,
     pub mode: SandboxMode,
+    /// Absolute path to the workspace directory inside the sandbox,
+    /// cached at creation time from the admin client. Empty for
+    /// sandboxes created before this field was added.
+    #[builder(default)]
+    pub workspace_path: String,
     #[builder(default = "SandboxState::Provisioning")]
     pub state: SandboxState,
     /// Reason for the most recent failed provisioning step, set by
@@ -345,6 +352,7 @@ impl TryFromEvents<SandboxEvent> for Sandbox {
                     name,
                     specs,
                     mode,
+                    workspace_path,
                 } => {
                     builder = builder
                         .id(*id)
@@ -352,6 +360,7 @@ impl TryFromEvents<SandboxEvent> for Sandbox {
                         .name(name.clone())
                         .specs(specs.clone())
                         .mode(mode.clone())
+                        .workspace_path(workspace_path.clone())
                         .state(SandboxState::Provisioning);
                 }
                 SandboxEvent::StateChanged { state } => {
@@ -402,6 +411,8 @@ pub struct NewSandbox {
     pub(super) name: String,
     pub(super) specs: SandboxSpecs,
     pub(super) mode: SandboxMode,
+    #[builder(default, setter(into))]
+    pub(super) workspace_path: String,
 }
 
 impl NewSandbox {
@@ -422,6 +433,7 @@ impl IntoEvents<SandboxEvent> for NewSandbox {
                 name: self.name,
                 specs: self.specs,
                 mode: self.mode,
+                workspace_path: self.workspace_path,
             }],
         )
     }
@@ -694,6 +706,7 @@ mod tests {
                     name: "test-sandbox".into(),
                     specs: test_specs(),
                     mode: SandboxMode::Scratch,
+                    workspace_path: "/workspace".into(),
                 },
                 SandboxEvent::AgentAttached {
                     agent_id: a,

--- a/core/src/sandbox/entity.rs
+++ b/core/src/sandbox/entity.rs
@@ -67,8 +67,7 @@ pub enum SandboxEvent {
         name: String,
         specs: SandboxSpecs,
         mode: SandboxMode,
-        #[serde(default)]
-        workspace_path: String,
+        mount_path: String,
     },
     StateChanged {
         state: SandboxState,
@@ -112,7 +111,7 @@ pub struct Sandbox {
     /// cached at creation time from the admin client. Empty for
     /// sandboxes created before this field was added.
     #[builder(default)]
-    pub workspace_path: String,
+    pub mount_path: String,
     #[builder(default = "SandboxState::Provisioning")]
     pub state: SandboxState,
     /// Reason for the most recent failed provisioning step, set by
@@ -352,7 +351,7 @@ impl TryFromEvents<SandboxEvent> for Sandbox {
                     name,
                     specs,
                     mode,
-                    workspace_path,
+                    mount_path,
                 } => {
                     builder = builder
                         .id(*id)
@@ -360,7 +359,7 @@ impl TryFromEvents<SandboxEvent> for Sandbox {
                         .name(name.clone())
                         .specs(specs.clone())
                         .mode(mode.clone())
-                        .workspace_path(workspace_path.clone())
+                        .mount_path(mount_path.clone())
                         .state(SandboxState::Provisioning);
                 }
                 SandboxEvent::StateChanged { state } => {
@@ -412,7 +411,7 @@ pub struct NewSandbox {
     pub(super) specs: SandboxSpecs,
     pub(super) mode: SandboxMode,
     #[builder(default, setter(into))]
-    pub(super) workspace_path: String,
+    pub(super) mount_path: String,
 }
 
 impl NewSandbox {
@@ -433,7 +432,7 @@ impl IntoEvents<SandboxEvent> for NewSandbox {
                 name: self.name,
                 specs: self.specs,
                 mode: self.mode,
-                workspace_path: self.workspace_path,
+                mount_path: self.mount_path,
             }],
         )
     }
@@ -706,7 +705,7 @@ mod tests {
                     name: "test-sandbox".into(),
                     specs: test_specs(),
                     mode: SandboxMode::Scratch,
-                    workspace_path: "/workspace".into(),
+                    mount_path: "/workspace".into(),
                 },
                 SandboxEvent::AgentAttached {
                     agent_id: a,

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -313,6 +313,12 @@ impl Sandboxes {
         Ok(())
     }
 
+    /// Return the absolute path to the workspace directory for `sandbox`.
+    /// Delegates to the admin client, which knows the mount layout.
+    pub fn workspace_path(&self, sandbox: &Sandbox) -> String {
+        self.admin.workspace_path(&sandbox.resource_name())
+    }
+
     #[instrument(name = "domain.sandbox.find_by_id", skip(self, _sub))]
     pub async fn find_by_id(
         &self,

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -118,11 +118,15 @@ impl Sandboxes {
         specs: SandboxSpecs,
         mode: SandboxMode,
     ) -> Result<Sandbox, SandboxError> {
+        let id = SandboxId::new();
+        let workspace_path = self.admin.workspace_path(&format!("sb-{id}"));
         let new_sandbox = NewSandbox::builder()
+            .id(id)
             .workspace_id(workspace_id.into())
             .name(name.into())
             .specs(specs)
             .mode(mode)
+            .workspace_path(workspace_path)
             .build()
             .expect("could not build new sandbox");
 
@@ -311,12 +315,6 @@ impl Sandboxes {
         }
         op.commit().await?;
         Ok(())
-    }
-
-    /// Return the absolute path to the workspace directory for `sandbox`.
-    /// Delegates to the admin client, which knows the mount layout.
-    pub fn workspace_path(&self, sandbox: &Sandbox) -> String {
-        self.admin.workspace_path(&sandbox.resource_name())
     }
 
     #[instrument(name = "domain.sandbox.find_by_id", skip(self, _sub))]

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -119,14 +119,14 @@ impl Sandboxes {
         mode: SandboxMode,
     ) -> Result<Sandbox, SandboxError> {
         let id = SandboxId::new();
-        let workspace_path = self.admin.workspace_path(&format!("sb-{id}"));
+        let mount_path = self.admin.mount_path(&format!("sb-{id}"));
         let new_sandbox = NewSandbox::builder()
             .id(id)
             .workspace_id(workspace_id.into())
             .name(name.into())
             .specs(specs)
             .mode(mode)
-            .workspace_path(workspace_path)
+            .mount_path(mount_path)
             .build()
             .expect("could not build new sandbox");
 

--- a/core/src/toolset/top_level/agent.rs
+++ b/core/src/toolset/top_level/agent.rs
@@ -116,7 +116,7 @@ impl TopLevelTool for WorkspaceAgentCreate {
 
         let agent = self
             .agents
-            .create(subject, workspace_id, AgentRole::Agent, &params.name, None)
+            .create_agent(workspace_id, &params.name, None)
             .await
             .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
 
@@ -163,20 +163,14 @@ impl TopLevelTool for AdminAgentCreate {
 
     async fn call(
         &self,
-        subject: &AuthSubject,
+        _subject: &AuthSubject,
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let params: AdminAgentCreateParams = parse_params(arguments)?;
 
         let agent = self
             .agents
-            .create(
-                subject,
-                params.workspace_id,
-                AgentRole::Agent,
-                &params.name,
-                None,
-            )
+            .create_agent(params.workspace_id, &params.name, None)
             .await
             .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
 

--- a/core/src/workspace/mod.rs
+++ b/core/src/workspace/mod.rs
@@ -13,7 +13,7 @@ use entity::*;
 pub use error::*;
 use repo::*;
 
-use crate::agent::{AgentRole, Agents};
+use crate::agent::Agents;
 use crate::primitives::*;
 
 #[derive(Clone)]
@@ -44,14 +44,7 @@ impl Workspaces {
         let workspace = self.repo.create_in_op(&mut op, new_workspace).await?;
 
         self.agents
-            .create_in_op(
-                &mut op,
-                lead_agent_id,
-                workspace_id,
-                AgentRole::WorkspaceLead,
-                "lead",
-                None,
-            )
+            .create_workspace_lead_in_op(&mut op, lead_agent_id, workspace_id, "lead", &name)
             .await?;
 
         op.commit().await?;

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -29,7 +29,6 @@ async fn send_message_round_trip_via_prompt_channel() {
         AgentRole::WorkspaceLead,
         RoleConfig {
             model: "claude-haiku-4-5-20251001".to_string(),
-            system: Vec::new(),
             max_tokens: 1024,
             reset_time_delta_seconds: None,
         },
@@ -59,13 +58,7 @@ async fn send_message_round_trip_via_prompt_channel() {
 
     let sub = AuthSubject::User(UserId::new());
     let agent = agents
-        .create(
-            &sub,
-            WorkspaceId::new(),
-            AgentRole::WorkspaceLead,
-            "lead",
-            None,
-        )
+        .create_workspace_lead(WorkspaceId::new(), "lead", "test-workspace")
         .await
         .expect("create agent");
 
@@ -175,7 +168,6 @@ async fn send_message_dispatches_registered_tool_call() {
         AgentRole::WorkspaceLead,
         RoleConfig {
             model: "claude-haiku-4-5-20251001".to_string(),
-            system: Vec::new(),
             max_tokens: 1024,
             reset_time_delta_seconds: None,
         },
@@ -206,13 +198,7 @@ async fn send_message_dispatches_registered_tool_call() {
 
     let sub = AuthSubject::User(UserId::new());
     let agent = agents
-        .create(
-            &sub,
-            WorkspaceId::new(),
-            AgentRole::WorkspaceLead,
-            "lead",
-            None,
-        )
+        .create_workspace_lead(WorkspaceId::new(), "lead", "test-workspace")
         .await
         .expect("create agent");
 

--- a/drua.yml
+++ b/drua.yml
@@ -14,23 +14,10 @@ agents:
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
       reset_time_delta_seconds: 600
-      system:
-        - type: text
-          text: |
-            You are the workspace lead agent. You coordinate tasks,
-            answer questions, and use the available tools to help the
-            user accomplish their goals. Be concise and action-oriented.
     agent:
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
       reset_time_delta_seconds: 600
-      system:
-        - type: text
-          text: |
-            You are an agent operating inside a Drua workspace.
-            You work on the tasks assigned to you and, when attached to
-            a sandbox, you run commands and edit files inside it. Be
-            concise and action-oriented.
 sandbox:
   # Local mode spawns the sandbox tool server as a child process per sandbox.
   # Each sandbox lives in <local_repo_root>/.sandboxes/<name>/.

--- a/lib/sandbox/src/admin_client/k8s/mod.rs
+++ b/lib/sandbox/src/admin_client/k8s/mod.rs
@@ -572,6 +572,10 @@ impl K8sAdminClient {
     }
 }
 
+/// Default workspace root inside the sandbox container, matching the
+/// `WORKSPACE_ROOT` default in `images/sandbox/server/src/main.rs`.
+const DEFAULT_WORKSPACE_ROOT: &str = "/workspace";
+
 #[async_trait]
 impl AdminClient for K8sAdminClient {
     async fn create_sandbox(
@@ -600,5 +604,12 @@ impl AdminClient for K8sAdminClient {
         timeout: Duration,
     ) -> Result<SandboxView, AdminError> {
         K8sAdminClient::wait_sandbox_ready(self, name, timeout).await
+    }
+
+    fn workspace_path(&self, _name: &str) -> String {
+        self.persistence
+            .as_ref()
+            .map(|p| p.mount_path.clone())
+            .unwrap_or_else(|| DEFAULT_WORKSPACE_ROOT.to_string())
     }
 }

--- a/lib/sandbox/src/admin_client/k8s/mod.rs
+++ b/lib/sandbox/src/admin_client/k8s/mod.rs
@@ -606,7 +606,7 @@ impl AdminClient for K8sAdminClient {
         K8sAdminClient::wait_sandbox_ready(self, name, timeout).await
     }
 
-    fn workspace_path(&self, _name: &str) -> String {
+    fn mount_path(&self, _name: &str) -> String {
         self.persistence
             .as_ref()
             .map(|p| p.mount_path.clone())

--- a/lib/sandbox/src/admin_client/local/mod.rs
+++ b/lib/sandbox/src/admin_client/local/mod.rs
@@ -196,7 +196,7 @@ impl AdminClient for LocalAdminClient {
         self.get_sandbox(name).await
     }
 
-    fn workspace_path(&self, name: &str) -> String {
+    fn mount_path(&self, name: &str) -> String {
         self.sandboxes_root
             .join(name)
             .join("workspace")

--- a/lib/sandbox/src/admin_client/local/mod.rs
+++ b/lib/sandbox/src/admin_client/local/mod.rs
@@ -44,9 +44,12 @@ impl LocalAdminClient {
     /// Create a new client. Sandboxes will be placed under
     /// `<repo_root>/.sandboxes/`.
     pub fn new(config: LocalSandboxConfig, repo_root: impl AsRef<Path>) -> Self {
+        let sandboxes_root = std::fs::canonicalize(repo_root.as_ref())
+            .unwrap_or_else(|_| repo_root.as_ref().to_path_buf())
+            .join(SANDBOXES_DIR_NAME);
         Self {
             config,
-            sandboxes_root: repo_root.as_ref().join(SANDBOXES_DIR_NAME),
+            sandboxes_root,
             ready_timeout: READY_TIMEOUT,
             sandboxes: Arc::new(Mutex::new(HashMap::new())),
         }

--- a/lib/sandbox/src/admin_client/local/mod.rs
+++ b/lib/sandbox/src/admin_client/local/mod.rs
@@ -195,6 +195,14 @@ impl AdminClient for LocalAdminClient {
     ) -> Result<SandboxView, AdminError> {
         self.get_sandbox(name).await
     }
+
+    fn workspace_path(&self, name: &str) -> String {
+        self.sandboxes_root
+            .join(name)
+            .join("workspace")
+            .to_string_lossy()
+            .into_owned()
+    }
 }
 
 /// Allocate a free TCP port by binding to port 0. There's a small race window

--- a/lib/sandbox/src/admin_client/trait.rs
+++ b/lib/sandbox/src/admin_client/trait.rs
@@ -36,4 +36,11 @@ pub trait AdminClient: Send + Sync {
         name: &str,
         timeout: Duration,
     ) -> Result<Sandbox, AdminError>;
+
+    /// Return the absolute path to the workspace directory for `name`.
+    ///
+    /// For the local backend this is
+    /// `<repo_root>/.sandboxes/<name>/workspace`; for k8s it's the
+    /// persistence mount path (typically `/workspace`).
+    fn workspace_path(&self, name: &str) -> String;
 }

--- a/lib/sandbox/src/admin_client/trait.rs
+++ b/lib/sandbox/src/admin_client/trait.rs
@@ -37,10 +37,10 @@ pub trait AdminClient: Send + Sync {
         timeout: Duration,
     ) -> Result<Sandbox, AdminError>;
 
-    /// Return the absolute path to the workspace directory for `name`.
+    /// Return the absolute mount path for the sandbox workspace directory.
     ///
     /// For the local backend this is
     /// `<repo_root>/.sandboxes/<name>/workspace`; for k8s it's the
     /// persistence mount path (typically `/workspace`).
-    fn workspace_path(&self, name: &str) -> String;
+    fn mount_path(&self, name: &str) -> String;
 }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -1423,11 +1423,9 @@ async fn workspace_agent_create(
     Path(id): Path<uuid::Uuid>,
     Form(form): Form<CreateAgentForm>,
 ) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-    let sub = AuthSubject::User(user_id);
+    if extract_user_id(&session).await.is_none() {
+        return Redirect::to("/").into_response();
+    }
 
     let workspace_id = domain::primitives::WorkspaceId::from(id);
 
@@ -1451,13 +1449,7 @@ async fn workspace_agent_create(
     match state
         .app
         .agents()
-        .create(
-            &sub,
-            workspace_id,
-            domain::agent::AgentRole::Agent,
-            form.name,
-            attach,
-        )
+        .create_agent(workspace_id, form.name, attach)
         .await
     {
         Ok(agent) => {


### PR DESCRIPTION
## Summary

- **Sandbox attach/detach notifications**: When a sandbox is attached to or detached from an agent, a `<sandbox>` notification is injected into the agent's LLM session describing what happened, including the workspace mount path and confinement rules
- **Behavioral guidelines**: Added `<investigate_before_answering>`, `<use_parallel_tool_calls>` (shared by all roles), and `<default_to_action>` (task agents only) system prompt blocks based on research into published AI system prompts
- **Workspace path caching**: Sandbox workspace mount path is computed at creation time and cached on the entity, avoiding repeated admin client calls
- **Agent create API split**: Split `Agents::create()` into `create_workspace_lead()` (takes workspace name directly) and `create_agent()` (resolves workspace name from lead automatically), simplifying callers in toolset and web layers
- **Fail-fast notifications**: Sandbox notification failures propagate rather than being swallowed as best-effort
- **Remove backwards-compat defaults**: Drop `#[serde(default)]` and `#[builder(default)]` on agent `workspace_name` (not yet live)

## Test plan

- [ ] `nix develop -c cargo clippy --all-targets -- -D warnings`
- [ ] `nix develop -c sh -c 'git add -A && nix flake check'` (includes nextest)
- [ ] Verify sandbox attach injects `<sandbox>` notification with correct workspace path
- [ ] Verify agent creation via toolset/web no longer requires manual workspace name resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)