### PR TITLE
refactor: rename remaining galoy-agents references (cosmetic)

### DIFF
--- a/charts/galoy-agents/Chart.yaml
+++ b/charts/galoy-agents/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: galoy-agents
-description: Helm chart for deploying GaloyMoney/galoy-agents
+description: Helm chart for deploying GaloyMoney/drua
 type: application
 version: 0.1.0-dev
 appVersion: "0.1.0"

--- a/charts/galoy-agents/templates/sandbox-network-policy.yaml
+++ b/charts/galoy-agents/templates/sandbox-network-policy.yaml
@@ -16,7 +16,7 @@ spec:
   policyTypes:
   - Ingress
   - Egress
-  # Ingress: only allow from galoy-agents server (exec proxy)
+  # Ingress: only allow from drua server (exec proxy)
   ingress:
   - from:
     - namespaceSelector:
@@ -40,7 +40,7 @@ spec:
       podSelector:
         matchLabels:
           k8s-app: kube-dns
-  # 2. Dashboard callback — galoy-agents server ClusterIP
+  # 2. Dashboard callback — drua server ClusterIP
   - ports:
     - protocol: TCP
       port: {{ .Values.galoyAgents.server.service.port }}

--- a/charts/galoy-agents/values.yaml
+++ b/charts/galoy-agents/values.yaml
@@ -93,7 +93,7 @@ galoyAgents:
     #   categoryDescription: "AI-powered localization engine management and translation"
     ## GitHub App configuration for token auto-provisioning.
     ## When enabled, sandbox agents receive a `github-token` file secret.
-    ## The PEM private key is read from the main galoy-agents secret (key: github-app-private-key).
+    ## The PEM private key is read from the main drua secret (key: github-app-private-key).
     githubApp:
       enabled: false
       clientId: ""
@@ -196,7 +196,7 @@ sandbox:
   templateName: agent-sandbox
   runtimeClassName: gvisor
   networkPolicyManagement: Managed
-  ## MCP gateway URL for sandbox pods (e.g. "http://galoy-agents.galoy-agents.svc.cluster.local:5254/mcp")
+  ## MCP gateway URL for sandbox pods (e.g. "http://drua.drua.svc.cluster.local:5254/mcp")
   mcpGatewayUrl: ""
   ## Audience claim for the projected SA token (must match gateway validation)
   saTokenAudience: "galoy-agents-mcp"

--- a/ci/config.code-assistant.toml
+++ b/ci/config.code-assistant.toml
@@ -30,6 +30,6 @@ name = "obix"
 url = "unused"
 
 [[repos]]
-name = "galoy-agents"
+name = "drua"
 url = "unused"
 exclude_dirs = ["code-assistant"]

--- a/ci/flake.nix
+++ b/ci/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "galoy-agents CI scripts";
+  description = "drua CI scripts";
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -5,7 +5,7 @@
 //! Each tool keeps its existing `TopLevelTool` implementation unchanged.
 //! The adapter strips the `admin_` prefix from each tool's name to produce
 //! the short catalog name, then the `SearchableToolSet` prefix
-//! (`galoy_agents_`) is added at query time.
+//! (`drua_`) is added at query time.
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -58,7 +58,7 @@ impl AdminToolSet {
 #[async_trait::async_trait]
 impl SearchableToolSet for AdminToolSet {
     fn name(&self) -> &str {
-        "galoy_agents"
+        "drua"
     }
 
     fn category(&self) -> &str {


### PR DESCRIPTION
## Summary
- Rename admin toolset name from `galoy_agents` to `drua` (affects MCP tool prefix)
- Update comments in chart templates and values.yaml
- Update Chart.yaml description
- Update ci/flake.nix description and code-assistant config project name

## What's intentionally left unchanged
- Chart directory name (`charts/galoy-agents/`) — would need Helm release migration
- Helm values keys (`.Values.galoyAgents.*`) — breaking change to all value overrides
- `saTokenAudience: galoy-agents-mcp` — must match binary + existing SA token configs
- SA token mount path `/var/run/secrets/galoy-agents` — used by running sandboxes
- Docker image repo `us.gcr.io/galoyorg/galoy-agents` — external GCR resource
- Cachix cache name — external resource
- Concourse pipeline names — external resource
- PostgreSQL credentials/database name — would need DB migration
- CI pipeline references, Terraform, deploy configs — need coordinated infra changes
- Benchmark prompt files — reference Concourse pipeline name

## Test plan
- [x] `cargo check` passes
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)