### PR TITLE
refactor: rename remaining galoy-agents infrastructure to drua

### DIFF
--- a/charts/drua/Chart.yaml
+++ b/charts/drua/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: galoy-agents
+name: drua
 description: Helm chart for deploying GaloyMoney/drua
 type: application
 version: 0.1.0-dev

--- a/charts/drua/templates/sandbox-template.yaml
+++ b/charts/drua/templates/sandbox-template.yaml
@@ -65,7 +65,7 @@ spec:
         {{- end }}
         volumeMounts:
         - name: mcp-token
-          mountPath: /var/run/secrets/galoy-agents
+          mountPath: /var/run/secrets/drua
           readOnly: true
         - name: workspace-secrets
           mountPath: /run/secrets
@@ -77,7 +77,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: {{ .Values.sandbox.saTokenAudience | default "galoy-agents-mcp" }}
+              audience: {{ .Values.sandbox.saTokenAudience | default "drua-mcp" }}
               expirationSeconds: 3600
               path: token
       dnsConfig:

--- a/charts/drua/values-minikube.yaml
+++ b/charts/drua/values-minikube.yaml
@@ -1,6 +1,6 @@
 galoyAgents:
   image:
-    repository: us.gcr.io/galoyorg/galoy-agents
+    repository: us.gcr.io/galoyorg/drua
     tag: edge
     digest: ""
   config:
@@ -12,12 +12,12 @@ galoyAgents:
       githubRedirectUri: "http://localhost:5254/auth/callback"
   secrets:
     create: true
-    pgCon: "postgresql://galoy-agents:galoy-agents@galoy-agents-postgresql:5432/galoy-agents"
+    pgCon: "postgresql://drua:drua@drua-postgresql:5432/drua"
     githubClientSecret: "dummy-client-secret"
   codeAssistant:
     indexHash: "825ef7dd2d3b0ae5c61a97f4eb92d09e11c222d452e339d5614edc59c27bfd84"
     modelHash: "5049594d7ce4b8bd3c29c2aa9b7d64575b939e64db935f7922bacee466076696"
-    gcsBucket: galoy-agents-models
+    gcsBucket: drua-models
     initImage: google/cloud-sdk:slim
 postgresql:
   enabled: true
@@ -25,6 +25,6 @@ postgresql:
     tag: latest
   auth:
     enablePostgresUser: false
-    username: galoy-agents
-    password: galoy-agents
-    database: galoy-agents
+    username: drua
+    password: drua
+    database: drua

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -3,7 +3,7 @@ nameOverride: ""
 galoyAgents:
   resources: {}
   tracing:
-    serviceName: galoy-agents-dev
+    serviceName: drua-dev
     otelExporterOtlpEndpoint: "http://localhost:4317"
   server:
     service:
@@ -18,7 +18,7 @@ galoyAgents:
     tls: []
   labels: {}
   image:
-    repository: us.gcr.io/galoyorg/galoy-agents
+    repository: us.gcr.io/galoyorg/drua
     digest: "sha256:69a3157b6ad60c04e5514e1c6fcad69cf234fff2a644b42fc3e1f3df24525fcd"
     tag: edge
   replicas: 1
@@ -53,7 +53,7 @@ galoyAgents:
         maxTokens: 4096
         resetTimeDeltaSeconds: 600
         systemPrompt: |
-          You are an agent operating inside a Galoy Agents workspace.
+          You are an agent operating inside a Drua workspace.
           You work on the tasks assigned to you and, when attached to
           a sandbox, you run commands and edit files inside it. Be
           concise and action-oriented.
@@ -109,7 +109,7 @@ galoyAgents:
   codeAssistant:
     indexHash: "662b885816c34194efddd9be936effb644d20397cafceb041f6d07df1ffc5abc"
     embedderHash: "569359897109da21014e728cd4d618843766f7f5a52f95c0c35e57250c117d06"
-    gcsBucket: galoy-agents-models
+    gcsBucket: drua-models
     gcsCreds: ""
     initImage: google/cloud-sdk:slim
 kubernetes-mcp-server:
@@ -199,7 +199,7 @@ sandbox:
   ## MCP gateway URL for sandbox pods (e.g. "http://drua.drua.svc.cluster.local:5254/mcp")
   mcpGatewayUrl: ""
   ## Audience claim for the projected SA token (must match gateway validation)
-  saTokenAudience: "galoy-agents-mcp"
+  saTokenAudience: "drua-mcp"
   image:
     repository: us.gcr.io/galoyorg/sandbox
     digest: ""
@@ -224,7 +224,7 @@ sandbox:
   ## Example: Override or supplement nix cache config at runtime
   # env:
   # - name: NIX_CONFIG
-  #   value: "extra-substituters = https://galoy-agents.cachix.org\nextra-trusted-public-keys = galoy-agents.cachix.org-1:wGb5wYMLJ3yPYoOvf2O5vt9gEZEJ7hHsqDCNPMELGPY="
+  #   value: "extra-substituters = https://drua.cachix.org\nextra-trusted-public-keys = drua.cachix.org-1:wGb5wYMLJ3yPYoOvf2O5vt9gEZEJ7hHsqDCNPMELGPY="
   persistence:
     mountPath: /workspace
     size: 10Gi
@@ -236,7 +236,7 @@ postgresql:
     tag: 14.5.0-debian-11-r35
   auth:
     enablePostgresUser: false
-    username: galoy-agents
-    password: galoy-agents
-    database: galoy-agents
+    username: drua
+    password: drua
+    database: drua
 resources: {}

--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -16,13 +16,13 @@ variable "anthropic_api_key" {
   default = ""
 }
 locals {
-  cluster_name         = "galoy-agents-cluster"
+  cluster_name         = "drua-cluster"
   cluster_location     = "us-east1-b"
-  gcp_project          = "galoy-agents"
-  namespace            = "galoy-agents"
-  sandbox_namespace    = "galoy-agents-sandboxes"
-  controller_namespace = "galoy-agents-sandbox-controller"
-  vpc_name             = "galoy-agents-vpc"
+  gcp_project          = "drua"
+  namespace            = "drua"
+  sandbox_namespace    = "drua-sandboxes"
+  controller_namespace = "drua-sandbox-controller"
+  vpc_name             = "drua-vpc"
   region               = "us-east1"
 
   github_app_private_key = fileexists("${path.module}/github-app-private-key.pem") ? file("${path.module}/github-app-private-key.pem") : ""
@@ -33,16 +33,16 @@ module "postgresql" {
 
   gcp_project    = local.gcp_project
   vpc_name       = local.vpc_name
-  instance_name  = "galoy-agents"
+  instance_name  = "drua"
   region         = local.region
-  databases      = ["galoy-agents"]
+  databases      = ["drua"]
   destroyable    = true
   highly_available = false
   tier           = "db-f1-micro"
   replication    = false
 }
 
-resource "kubernetes_namespace" "galoy_agents" {
+resource "kubernetes_namespace" "drua" {
   metadata {
     name = local.namespace
   }
@@ -60,14 +60,14 @@ resource "kubernetes_namespace" "sandbox_controller" {
   }
 }
 
-resource "kubernetes_secret" "galoy_agents" {
+resource "kubernetes_secret" "drua" {
   metadata {
-    name      = "galoy-agents"
+    name      = "drua"
     namespace = local.namespace
   }
 
   data = {
-    "pg-con"               = module.postgresql.creds["galoy-agents"].conn
+    "pg-con"               = module.postgresql.creds["drua"].conn
     "github-client-secret" = var.github_client_secret
     "gcs-creds"            = file("${path.module}/gcs-creds.json")
     "concourse-username"   = var.concourse_username
@@ -79,7 +79,7 @@ resource "kubernetes_secret" "galoy_agents" {
     "github-app-private-key" = local.github_app_private_key
   }
 
-  depends_on = [kubernetes_namespace.galoy_agents]
+  depends_on = [kubernetes_namespace.drua]
 }
 
 resource "kubernetes_secret" "sandbox_anthropic" {
@@ -177,15 +177,15 @@ resource "kubectl_manifest" "sandbox_extensions" {
 }
 
 resource "postgresql_extension" "vector" {
-  provider = postgresql.galoy_agents
+  provider = postgresql.drua
   name     = "vector"
-  database = "galoy-agents"
+  database = "drua"
 
   depends_on = [module.postgresql]
 }
 
-resource "helm_release" "galoy_agents" {
-  name      = "galoy-agents"
+resource "helm_release" "drua" {
+  name      = "drua"
   chart     = "${path.module}/chart"
   namespace = local.namespace
 
@@ -193,7 +193,7 @@ resource "helm_release" "galoy_agents" {
     templatefile("${path.module}/prod-values.yml.tmpl", {
       image_digest                = var.image_digest
       sandbox_image_digest        = var.sandbox_image_digest
-      secret_checksum             = sha256(jsonencode(kubernetes_secret.galoy_agents.data))
+      secret_checksum             = sha256(jsonencode(kubernetes_secret.drua.data))
     })
   ]
 
@@ -202,7 +202,7 @@ resource "helm_release" "galoy_agents" {
   timeout           = 900 # 15 minutes
 
   depends_on = [
-    kubernetes_secret.galoy_agents,
+    kubernetes_secret.drua,
     kubernetes_namespace.sandbox,
     google_container_node_pool.gvisor,
     kubectl_manifest.sandbox_controller,
@@ -235,12 +235,12 @@ provider "kubectl" {
 }
 
 provider "postgresql" {
-  alias    = "galoy_agents"
-  host     = module.postgresql.creds["galoy-agents"].host
+  alias    = "drua"
+  host     = module.postgresql.creds["drua"].host
   port     = 5432
   username = module.postgresql.admin-creds.user
   password = module.postgresql.admin-creds.password
-  database = "galoy-agents"
+  database = "drua"
   superuser = false
 }
 

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -61,7 +61,7 @@ galoyAgents:
     tls:
       - hosts:
           - dashboard.agents.galoy.io
-        secretName: galoy-agents-tls
+        secretName: drua-tls
   secrets:
     create: false
   resources:
@@ -71,14 +71,14 @@ galoyAgents:
     limits:
       memory: 512Mi
   tracing:
-    serviceName: galoy-agents
-    otelExporterOtlpEndpoint: "http://opentelemetry-collector.galoy-agents-otel.svc.cluster.local:4317"
+    serviceName: drua
+    otelExporterOtlpEndpoint: "http://opentelemetry-collector.drua-otel.svc.cluster.local:4317"
 
 sandbox:
   enabled: true
   installController: false
-  namespace: galoy-agents-sandboxes
-  controllerNamespace: galoy-agents-sandbox-controller
+  namespace: drua-sandboxes
+  controllerNamespace: drua-sandbox-controller
   createNamespace: false
   templateName: agent-sandbox
   runtimeClassName: gvisor
@@ -91,8 +91,8 @@ sandbox:
     size: 10Gi
     storageClassName: standard-rwo
   anthropicApiKeySecret: anthropic-api-key
-  otelCollectorNamespace: galoy-agents-otel
-  mcpGatewayUrl: "http://galoy-agents.galoy-agents.svc.cluster.local:5254/mcp"
+  otelCollectorNamespace: drua-otel
+  mcpGatewayUrl: "http://drua.drua.svc.cluster.local:5254/mcp"
 
 kubernetes-mcp-server:
   enabled: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,7 +4,7 @@
 #@ )
 
 groups:
-- name: galoy-agents
+- name: drua
   jobs:
   - check-code
   - test-integration
@@ -183,8 +183,8 @@ jobs:
             printf '%s' "$GITHUB_APP_PRIVATE_KEY" | base64 -d > deployment/tf/github-app-private-key.pem
             set -x
             echo "Deployment files prepared"
-  - put: tf-galoy-agents-prod
-    tags: [galoy-agents]
+  - put: tf-drua-prod
+    tags: [drua]
     params:
       env_name: prod
       vars_files: [deployment/tf/terraform.tfvars]
@@ -260,7 +260,7 @@ jobs:
             ln -s "$(pwd)/lana-repo" /tmp/repos/lana-bank
             ln -s "$(pwd)/job-repo" /tmp/repos/job
             ln -s "$(pwd)/obix-repo" /tmp/repos/obix
-            ln -s "$(pwd)/repo" /tmp/repos/galoy-agents
+            ln -s "$(pwd)/repo" /tmp/repos/drua
 
             cd repo
             nix run ./ci#build-code-assistant-index -- /tmp/repos "$(pwd)/../index" "$(pwd)/../embedder" "$(pwd)/../code-assistant-model"
@@ -473,13 +473,13 @@ resources:
     password: #@ data.values.gar_registry_password
     repository: #@ data.values.gar_registry + "/sandbox"
 
-- name: tf-galoy-agents-prod
+- name: tf-drua-prod
   type: terraform
   source:
     backend_type: gcs
     backend_config:
       bucket: #@ data.values.deploy_tf_state_bucket
-      prefix: galoy-agents/prod
+      prefix: drua/prod
       credentials: #@ data.values.deploy_gcp_creds_json
     env:
       GOOGLE_CREDENTIALS: #@ data.values.deploy_gcp_creds_json

--- a/ci/repipe
+++ b/ci/repipe
@@ -8,7 +8,7 @@ if [[ $(which ytt) == "" ]]; then
 fi
 
 target="${FLY_TARGET:-galoy}"
-team=galoy-agents
+team=drua
 
 TMPDIR=""
 TMPDIR=$(mktemp -d -t repipe.XXXXXX)
@@ -18,5 +18,5 @@ ytt -f ci > ${TMPDIR}/pipeline.yml
 
 echo "Updating pipeline @ ${target}"
 
-fly -t ${target} set-pipeline --team=${team} -p galoy-agents-bin -c ${TMPDIR}/pipeline.yml -n
-fly -t ${target} unpause-pipeline --team=${team} -p galoy-agents-bin
+fly -t ${target} set-pipeline --team=${team} -p drua-bin -c ${TMPDIR}/pipeline.yml -n
+fly -t ${target} unpause-pipeline --team=${team} -p drua-bin

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -8,23 +8,23 @@ gar_registry: us.gcr.io/galoyorg
 gar_registry_user: ((gar-creds.username))
 gar_registry_password: ((gar-creds.password))
 
-folder_registry_image: galoy-agents
+folder_registry_image: drua
 
 cala_git_uri: git@github.com:GaloyMoney/cala.git
 lana_git_uri: git@github.com:GaloyMoney/lana-bank.git
 job_git_uri: git@github.com:GaloyMoney/job.git
 obix_git_uri: git@github.com:GaloyMoney/obix.git
 
-gcs_creds_json: ((galoy-agents-gcp-creds.creds_json))
-code_assistant_gcs_bucket: galoy-agents-models
+gcs_creds_json: ((drua-gcp-creds.creds_json))
+code_assistant_gcs_bucket: drua-models
 
-deploy_gcp_creds_json: ((galoy-agents-gcp-creds.creds_json))
-deploy_tf_state_bucket: galoy-agents-tf-state
-deploy_github_client_secret: ((galoy-agents-prod-secrets.github_client_secret))
+deploy_gcp_creds_json: ((drua-gcp-creds.creds_json))
+deploy_tf_state_bucket: drua-tf-state
+deploy_github_client_secret: ((drua-prod-secrets.github_client_secret))
 deploy_concourse_username: ((galoybot-concourse-creds.username))
 deploy_concourse_password: ((galoybot-concourse-creds.password))
 honeycomb_api_key: ((mcp-upstream.honeycomb_api_key))
 github_pat: ((mcp-upstream.github_pat))
 lingo_api_key: ((mcp-upstream.lingo_dev_api_key))
 deploy_anthropic_api_key: ((anthropic-api-key.key))
-deploy_github_app_private_key: ((galoy-agents-prod-secrets.github_app_private_key))
+deploy_github_app_private_key: ((drua-prod-secrets.github_app_private_key))

--- a/infra/chart/drua-values.yml.tmpl
+++ b/infra/chart/drua-values.yml.tmpl
@@ -8,6 +8,6 @@ postgresql:
   image:
     tag: latest
   auth:
-    existingSecret: galoy-agents
+    existingSecret: drua
     secretKeys:
       userPasswordKey: "pg-user-pw"

--- a/infra/chart/main.tf
+++ b/infra/chart/main.tf
@@ -1,17 +1,17 @@
-variable "galoy_agents_namespace" {
-  description = "Namespace for the galoy-agents deployment"
+variable "drua_namespace" {
+  description = "Namespace for the drua deployment"
   type        = string
-  default     = "galoy-agents"
+  default     = "drua"
 }
 
-variable "galoy_agents_image_tag" {
-  description = "Image tag for galoy-agents"
+variable "drua_image_tag" {
+  description = "Image tag for drua"
   type        = string
   default     = "edge"
 }
 
-variable "galoy_agents_secrets" {
-  description = "JSON-encoded secrets for galoy-agents"
+variable "drua_secrets" {
+  description = "JSON-encoded secrets for drua"
   sensitive   = true
   type        = string
   default     = "{}"
@@ -47,26 +47,26 @@ provider "helm" {
 }
 
 locals {
-  secrets = length(var.galoy_agents_secrets) > 2 ? jsondecode(var.galoy_agents_secrets) : {}
+  secrets = length(var.drua_secrets) > 2 ? jsondecode(var.drua_secrets) : {}
 
-  pg_password = try(local.secrets.pg_password, "galoy-agents")
-  pg_con      = try(local.secrets.pg_con, "postgresql://galoy-agents:${local.pg_password}@galoy-agents-postgresql:5432/galoy-agents")
+  pg_password = try(local.secrets.pg_password, "drua")
+  pg_con      = try(local.secrets.pg_con, "postgresql://drua:${local.pg_password}@drua-postgresql:5432/drua")
 
   github_client_id     = try(local.secrets.github_client_id, "dummy-client-id")
   github_client_secret = try(local.secrets.github_client_secret, "dummy-client-secret")
   github_redirect_uri  = try(local.secrets.github_redirect_uri, "http://localhost:5254/auth/callback")
 }
 
-resource "kubernetes_namespace" "galoy_agents" {
+resource "kubernetes_namespace" "drua" {
   metadata {
-    name = var.galoy_agents_namespace
+    name = var.drua_namespace
   }
 }
 
-resource "kubernetes_secret" "galoy_agents" {
+resource "kubernetes_secret" "drua" {
   metadata {
-    name      = "galoy-agents"
-    namespace = kubernetes_namespace.galoy_agents.metadata[0].name
+    name      = "drua"
+    namespace = kubernetes_namespace.drua.metadata[0].name
   }
 
   data = {
@@ -78,18 +78,18 @@ resource "kubernetes_secret" "galoy_agents" {
   }
 }
 
-resource "helm_release" "galoy_agents" {
-  name      = "galoy-agents"
+resource "helm_release" "drua" {
+  name      = "drua"
   chart     = "${path.module}/../../charts/drua"
-  namespace = kubernetes_namespace.galoy_agents.metadata[0].name
+  namespace = kubernetes_namespace.drua.metadata[0].name
 
   values = [
     templatefile("${path.module}/drua-values.yml.tmpl", {
-      image_tag = var.galoy_agents_image_tag
+      image_tag = var.drua_image_tag
     })
   ]
 
-  depends_on = [kubernetes_secret.galoy_agents]
+  depends_on = [kubernetes_secret.drua]
 
   dependency_update = true
   timeout           = 900 # 15 minutes


### PR DESCRIPTION
## Summary
- Rename `charts/galoy-agents/` → `charts/drua/`
- Rename `ci/deploy/galoy-agents/` → `ci/deploy/drua/`
- Rename `infra/chart/galoy-agents-values.yml.tmpl` → `drua-values.yml.tmpl`
- Update all Helm chart values (Chart name, image repo, DB creds, SA token audience, GCS buckets)
- Update Concourse pipeline (paths, resource names, TF state prefix, team/pipeline names)
- Update `ci/values.yml` (git URI, cachix, registry image, secrets refs)
- Update Terraform locals (namespaces, VPC, cluster, DB names) in both `infra/` and `ci/deploy/`
- Update `.github/actions/setup-nix` cachix cache name
- Update benchmark prompt files
- Remove stale `mcp.bak.json`

After this PR, zero `galoy-agents` references remain in the repo.

## ⚠️ DO NOT MERGE without coordinating external resource renames:
1. Create new cachix caches (`drua`, `drua-github-action`)
2. Rename Concourse team and pipeline (`repipe`)
3. Rename GCP project/resources or update Terraform state
4. Rename GCR image repository (`us.gcr.io/galoyorg/galoy-agents` → `drua`)
5. Rename K8s namespaces or migrate Helm release
6. Rename GCS buckets (`galoy-agents-models`, `galoy-agents-tf-state`)
7. Rename Vault/Credhub secrets (`((galoy-agents-*))` → `((drua-*))`)

## Test plan
- [x] `cargo check` passes (no Rust changes in this PR)
- [ ] CI checks pass (will fail on cachix — expected until external resources are renamed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)