### PR TITLE
feat(tunnel): deployment-scoped tokens + evict-on-dup registry

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -53,6 +53,11 @@ pub struct App {
     skills: Arc<Skills>,
     sandboxes: Arc<Sandboxes>,
     github_app: Option<Arc<GitHubAppTokenProvider>>,
+    /// Registry of currently-live tunnel connectors, keyed by
+    /// `deployment_id`. Used by the `/tunnel/ws` handler to evict a
+    /// previous tunnel when a new connector registers the same
+    /// `deployment_id`. See [`tunnel::TunnelRegistry`].
+    tunnels: Arc<tunnel::TunnelRegistry>,
     /// Held so the executor's worker task stays alive for the lifetime of
     /// `App`; dropped on shutdown which aborts the task.
     _prompt_executor: Arc<PromptExecutor>,
@@ -208,6 +213,7 @@ impl App {
             skills,
             sandboxes,
             github_app,
+            tunnels: Arc::new(tunnel::TunnelRegistry::new()),
             _prompt_executor: prompt_executor,
         })
     }
@@ -254,6 +260,10 @@ impl App {
 
     pub fn github_app(&self) -> Option<&GitHubAppTokenProvider> {
         self.github_app.as_deref()
+    }
+
+    pub fn tunnels(&self) -> &tunnel::TunnelRegistry {
+        &self.tunnels
     }
 }
 

--- a/core/src/primitives/auth_scope.rs
+++ b/core/src/primitives/auth_scope.rs
@@ -28,6 +28,11 @@ pub enum AuthScope {
     /// Read-only use access — the agent may invoke sandbox tools that
     /// don't modify state. Granted on a `Read` attach.
     SandboxUseReadOnly(SandboxId),
+    /// Authorizes the holder to register a tunnel connector for a specific
+    /// `deployment_id`. The `/tunnel/ws` handler matches this scope against
+    /// the `deployment_id` in the connector's Register frame; a token scoped
+    /// to `Tunnel("galoy-staging")` cannot register as `galoy-production`.
+    Tunnel(String),
     /// Catch-all for scope strings that don't (yet) have a dedicated variant.
     Raw(String),
 }
@@ -43,6 +48,7 @@ impl fmt::Display for AuthScope {
             AuthScope::WorkspaceAdmin(id) => write!(f, "ws:{id}:admin"),
             AuthScope::SandboxUseAll(id) => write!(f, "sandbox:{id}:use_all"),
             AuthScope::SandboxUseReadOnly(id) => write!(f, "sandbox:{id}:use_read_only"),
+            AuthScope::Tunnel(id) => write!(f, "tunnel:{id}"),
             AuthScope::Raw(s) => f.write_str(s),
         }
     }
@@ -75,6 +81,13 @@ impl FromStr for AuthScope {
                 if let Ok(uuid) = uuid_str.parse::<uuid::Uuid>() {
                     return Ok(AuthScope::SandboxUseReadOnly(SandboxId::from(uuid)));
                 }
+            }
+        }
+
+        // Parse "tunnel:{deployment_id}"
+        if let Some(deployment_id) = s.strip_prefix("tunnel:") {
+            if !deployment_id.is_empty() {
+                return Ok(AuthScope::Tunnel(deployment_id.to_owned()));
             }
         }
 
@@ -140,6 +153,7 @@ mod tests {
             AuthScope::WorkspaceAdmin(ws_id),
             AuthScope::SandboxUseAll(sb_id),
             AuthScope::SandboxUseReadOnly(sb_id),
+            AuthScope::Tunnel("galoy-staging".to_owned()),
             AuthScope::Raw("custom:thing".to_owned()),
         ];
 
@@ -210,6 +224,24 @@ mod tests {
     fn from_str_unknown_falls_back_to_raw() {
         let scope: AuthScope = "read".parse().unwrap();
         assert_eq!(scope, AuthScope::Raw("read".to_owned()));
+    }
+
+    #[test]
+    fn tunnel_round_trip() {
+        let scope = AuthScope::Tunnel("galoy-staging".to_owned());
+        assert_eq!(scope.to_string(), "tunnel:galoy-staging");
+        let parsed: AuthScope = "tunnel:galoy-staging".parse().unwrap();
+        assert_eq!(parsed, scope);
+    }
+
+    #[test]
+    fn tunnel_empty_deployment_id_falls_back_to_raw() {
+        // `tunnel:` with no id must not silently become a Tunnel scope —
+        // guards against a malformed token accidentally matching any
+        // deployment. It falls through to Raw, which never matches a
+        // `Tunnel(X)` check via `has_scope`.
+        let scope: AuthScope = "tunnel:".parse().unwrap();
+        assert_eq!(scope, AuthScope::Raw("tunnel:".to_owned()));
     }
 
     /// Eq-based comparison works across all variants.

--- a/core/src/primitives/auth_subject.rs
+++ b/core/src/primitives/auth_subject.rs
@@ -139,6 +139,25 @@ impl AuthSubject {
         })
     }
 
+    /// True when the subject carries an [`AuthScope::Tunnel`] authorizing
+    /// registration of a tunnel connector for `deployment_id`. Session
+    /// `User` subjects bypass this check (they already have effectively
+    /// all scopes); bearer-authenticated subjects must hold the exact
+    /// scope — a token scoped to `galoy-staging` cannot register as
+    /// `galoy-production`.
+    pub fn can_register_tunnel(&self, deployment_id: &str) -> bool {
+        // Short-circuit for session-authenticated humans — session auth
+        // already implies full scopes (see `has_scope`). Also avoids a
+        // `String` allocation on every check when the Tunnel scope is
+        // unused.
+        if matches!(self, AuthSubject::User(_)) {
+            return true;
+        }
+        self.scopes()
+            .iter()
+            .any(|s| matches!(s, AuthScope::Tunnel(id) if id == deployment_id))
+    }
+
     /// Convert the subject into the principal that should be recorded as the
     /// originator of a message. Panics for `Anonymous` (callers must
     /// authenticate before sending messages).
@@ -155,5 +174,80 @@ impl AuthSubject {
             },
             AuthSubject::Anonymous => panic!("Anonymous subject has no message source"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::{AgentId, McpCredsId, UserId};
+    use super::*;
+
+    fn a_user_id() -> UserId {
+        UserId::from(uuid::Uuid::new_v4())
+    }
+
+    fn exported_agent_with(scopes: Vec<AuthScope>) -> AuthSubject {
+        AuthSubject::ExportedAgent(a_user_id(), McpCredsId::from(uuid::Uuid::new_v4()), scopes)
+    }
+
+    fn agent_with(scopes: Vec<AuthScope>) -> AuthSubject {
+        AuthSubject::Agent(
+            WorkspaceId::from(uuid::Uuid::new_v4()),
+            AgentId::from(uuid::Uuid::new_v4()),
+            scopes,
+        )
+    }
+
+    #[test]
+    fn can_register_tunnel_matches_scoped_deployment_id() {
+        let subject = exported_agent_with(vec![AuthScope::Tunnel("galoy-staging".to_owned())]);
+        assert!(subject.can_register_tunnel("galoy-staging"));
+    }
+
+    /// The core auth guarantee: a token scoped to one deployment cannot
+    /// register as another.
+    #[test]
+    fn can_register_tunnel_rejects_different_deployment_id() {
+        let subject = exported_agent_with(vec![AuthScope::Tunnel("galoy-staging".to_owned())]);
+        assert!(!subject.can_register_tunnel("galoy-production"));
+    }
+
+    /// A token without any Tunnel scope cannot register as anything —
+    /// even for a deployment_id that happens to match a Raw scope string.
+    #[test]
+    fn can_register_tunnel_rejects_no_tunnel_scope() {
+        let subject = exported_agent_with(vec![AuthScope::Admin]);
+        assert!(!subject.can_register_tunnel("galoy-staging"));
+
+        let subject_raw = exported_agent_with(vec![AuthScope::Raw("galoy-staging".to_owned())]);
+        assert!(!subject_raw.can_register_tunnel("galoy-staging"));
+    }
+
+    /// Session `User` subjects bypass the check (session auth implies
+    /// all scopes everywhere in the codebase).
+    #[test]
+    fn can_register_tunnel_user_subject_bypasses() {
+        let subject = AuthSubject::User(a_user_id());
+        assert!(subject.can_register_tunnel("anything"));
+        assert!(subject.can_register_tunnel("galoy-production"));
+    }
+
+    /// Anonymous and scope-free Agent subjects cannot register tunnels.
+    #[test]
+    fn can_register_tunnel_rejects_anonymous_and_scopeless() {
+        assert!(!AuthSubject::Anonymous.can_register_tunnel("galoy-staging"));
+        assert!(!agent_with(vec![]).can_register_tunnel("galoy-staging"));
+    }
+
+    /// A subject can hold multiple Tunnel scopes and match any of them.
+    #[test]
+    fn can_register_tunnel_multiple_scopes() {
+        let subject = exported_agent_with(vec![
+            AuthScope::Tunnel("galoy-staging".to_owned()),
+            AuthScope::Tunnel("galoy-qa".to_owned()),
+        ]);
+        assert!(subject.can_register_tunnel("galoy-staging"));
+        assert!(subject.can_register_tunnel("galoy-qa"));
+        assert!(!subject.can_register_tunnel("galoy-production"));
     }
 }

--- a/core/src/tunnel.rs
+++ b/core/src/tunnel.rs
@@ -138,6 +138,103 @@ impl TunnelHandle {
 }
 
 // ---------------------------------------------------------------------------
+// TunnelRegistry — enforces one live tunnel per deployment_id
+// ---------------------------------------------------------------------------
+
+/// Per-live-tunnel entry. The `close_tx` is how the registry signals the
+/// old WS loop to shut down when a new connector takes over the same
+/// `deployment_id`. The `session_id` lets an evicted loop avoid
+/// accidentally removing the *new* entry during its own cleanup.
+struct RegisteredTunnel {
+    session_id: uuid::Uuid,
+    close_tx: mpsc::Sender<()>,
+}
+
+/// Maps `deployment_id` → the currently live tunnel session for that
+/// deployment. At most one entry per `deployment_id` at any time — a
+/// new Register for an already-registered id evicts the previous
+/// connection (closes its WS with a `POLICY` close frame).
+///
+/// This closes gap #2 from drua#127's original "Known security gaps"
+/// list: without the registry, two connectors holding the same
+/// `deployment_id` would race-fight for tool call results via the
+/// shared `TunnelHandle::resolve` pending map. With the registry,
+/// the second connector's registration cleanly replaces the first.
+#[derive(Clone)]
+pub struct TunnelRegistry {
+    inner: Arc<std::sync::Mutex<HashMap<String, RegisteredTunnel>>>,
+}
+
+impl TunnelRegistry {
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(std::sync::Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Claim `deployment_id` for a new session. If an entry already
+    /// exists, its `close_tx` is taken out, the new one inserted under
+    /// the lock, and the old `close_tx` signaled *after* the lock is
+    /// released (await outside the critical section). Returns `true` if
+    /// an existing tunnel was evicted.
+    pub async fn claim(
+        &self,
+        deployment_id: &str,
+        session_id: uuid::Uuid,
+        close_tx: mpsc::Sender<()>,
+    ) -> bool {
+        let evicted = {
+            let mut map = self.inner.lock().expect("tunnel registry lock poisoned");
+            map.insert(
+                deployment_id.to_string(),
+                RegisteredTunnel {
+                    session_id,
+                    close_tx,
+                },
+            )
+        };
+        if let Some(old) = evicted {
+            // Channel capacity is 1; ignore send errors — if the receiver
+            // already dropped, the old loop is already on its way out.
+            let _ = old.close_tx.send(()).await;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Remove the entry for `deployment_id` only if it still belongs to
+    /// `session_id`. Called during cleanup so an evicted loop doesn't
+    /// accidentally remove the *new* tunnel's registry entry.
+    pub fn release(&self, deployment_id: &str, session_id: uuid::Uuid) {
+        let mut map = self.inner.lock().expect("tunnel registry lock poisoned");
+        if let Some(entry) = map.get(deployment_id) {
+            if entry.session_id == session_id {
+                map.remove(deployment_id);
+            }
+        }
+    }
+
+    /// Number of currently-registered deployments. Test/observability helper.
+    pub fn len(&self) -> usize {
+        self.inner
+            .lock()
+            .expect("tunnel registry lock poisoned")
+            .len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl Default for TunnelRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
 // TunnelToolSet — SearchableToolSet backed by a tunnel connection
 // ---------------------------------------------------------------------------
 
@@ -220,5 +317,109 @@ impl SearchableToolSet for TunnelToolSet {
         self.handle
             .call_tool(&self.upstream_name, tool_name, arguments)
             .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A fresh registry starts empty.
+    #[tokio::test]
+    async fn registry_starts_empty() {
+        let registry = TunnelRegistry::new();
+        assert!(registry.is_empty());
+    }
+
+    /// First claim for a deployment_id succeeds without eviction.
+    #[tokio::test]
+    async fn claim_first_does_not_evict() {
+        let registry = TunnelRegistry::new();
+        let (tx, _rx) = mpsc::channel::<()>(1);
+        let evicted = registry
+            .claim("galoy-staging", uuid::Uuid::new_v4(), tx)
+            .await;
+        assert!(!evicted);
+        assert_eq!(registry.len(), 1);
+    }
+
+    /// A second claim for the same deployment_id evicts the first.
+    /// The first session's `close_rx` receives the eviction signal.
+    #[tokio::test]
+    async fn second_claim_evicts_first() {
+        let registry = TunnelRegistry::new();
+
+        let (tx_a, mut rx_a) = mpsc::channel::<()>(1);
+        registry
+            .claim("galoy-staging", uuid::Uuid::new_v4(), tx_a)
+            .await;
+
+        let (tx_b, _rx_b) = mpsc::channel::<()>(1);
+        let evicted = registry
+            .claim("galoy-staging", uuid::Uuid::new_v4(), tx_b)
+            .await;
+
+        assert!(evicted);
+        // Still one entry — the new one replaced the old.
+        assert_eq!(registry.len(), 1);
+        // The evicted session received the close signal.
+        assert!(rx_a.try_recv().is_ok());
+    }
+
+    /// Different deployment_ids coexist without eviction.
+    #[tokio::test]
+    async fn distinct_deployments_coexist() {
+        let registry = TunnelRegistry::new();
+        let (tx_a, _rx_a) = mpsc::channel::<()>(1);
+        let (tx_b, _rx_b) = mpsc::channel::<()>(1);
+
+        assert!(
+            !registry
+                .claim("galoy-staging", uuid::Uuid::new_v4(), tx_a)
+                .await
+        );
+        assert!(
+            !registry
+                .claim("galoy-production", uuid::Uuid::new_v4(), tx_b)
+                .await
+        );
+        assert_eq!(registry.len(), 2);
+    }
+
+    /// `release` with the current session_id removes the entry.
+    #[tokio::test]
+    async fn release_removes_current_entry() {
+        let registry = TunnelRegistry::new();
+        let session = uuid::Uuid::new_v4();
+        let (tx, _rx) = mpsc::channel::<()>(1);
+        registry.claim("galoy-staging", session, tx).await;
+
+        registry.release("galoy-staging", session);
+        assert!(registry.is_empty());
+    }
+
+    /// `release` with a *stale* session_id (e.g. an evicted loop cleaning
+    /// up after the new loop has taken over) must not remove the new
+    /// entry. This is the invariant that keeps eviction safe.
+    #[tokio::test]
+    async fn release_with_stale_session_id_is_noop() {
+        let registry = TunnelRegistry::new();
+
+        let stale_session = uuid::Uuid::new_v4();
+        let (tx_a, _rx_a) = mpsc::channel::<()>(1);
+        registry.claim("galoy-staging", stale_session, tx_a).await;
+
+        let fresh_session = uuid::Uuid::new_v4();
+        let (tx_b, _rx_b) = mpsc::channel::<()>(1);
+        registry.claim("galoy-staging", fresh_session, tx_b).await;
+
+        // Evicted loop calls release with its own (now stale) session id.
+        // Should not affect the fresh entry.
+        registry.release("galoy-staging", stale_session);
+        assert_eq!(registry.len(), 1);
+
+        // Fresh session can still release itself.
+        registry.release("galoy-staging", fresh_session);
+        assert!(registry.is_empty());
     }
 }

--- a/web/src/routes.rs
+++ b/web/src/routes.rs
@@ -168,6 +168,12 @@ pub struct CreateMcpCredsForm {
     name: String,
     #[serde(default)]
     admin: Option<String>,
+    /// When non-empty, the credential receives `AuthScope::Tunnel(<id>)`
+    /// — authorizes the holder to register a tunnel connector for that
+    /// exact `deployment_id` (and only that one). Leave empty for
+    /// regular user tokens.
+    #[serde(default)]
+    tunnel_deployment_id: Option<String>,
 }
 
 fn build_mcp_config(mcp_endpoint: &str, token: &str) -> (String, String) {
@@ -202,11 +208,20 @@ async fn create_mcp_creds(
 
     let (raw_token, token_hash) = generate_token();
 
-    let scopes = if form.admin.as_deref() == Some("true") {
-        vec![domain::primitives::AuthScope::Admin]
-    } else {
-        vec![]
-    };
+    let mut scopes: Vec<domain::primitives::AuthScope> = Vec::new();
+    if form.admin.as_deref() == Some("true") {
+        scopes.push(domain::primitives::AuthScope::Admin);
+    }
+    if let Some(deployment_id) = form
+        .tunnel_deployment_id
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        scopes.push(domain::primitives::AuthScope::Tunnel(
+            deployment_id.to_owned(),
+        ));
+    }
 
     match state
         .app

--- a/web/src/tunnel.rs
+++ b/web/src/tunnel.rs
@@ -43,13 +43,36 @@ pub async fn tunnel_ws_handler(
     ws.on_upgrade(move |socket| handle_tunnel(socket, state, auth))
 }
 
-/// Main tunnel lifecycle: registration → relay loop → cleanup.
-async fn handle_tunnel(mut socket: WebSocket, state: AppState, _auth: AuthSubject) {
+/// Main tunnel lifecycle: registration → scope check → relay loop → cleanup.
+async fn handle_tunnel(mut socket: WebSocket, state: AppState, auth: AuthSubject) {
     // ── 1. Wait for registration ──────────────────────────────────────────
     let (deployment_id, toolset_registrations) = match read_registration(&mut socket).await {
         Some(r) => r,
         None => return,
     };
+
+    // ── 1b. Scope check ───────────────────────────────────────────────────
+    // The caller's bearer token must carry `AuthScope::Tunnel(deployment_id)`
+    // (session `User` subjects bypass — they already have all scopes).
+    // This stops a credential scoped to one deployment from registering
+    // as another: a `Tunnel("galoy-staging")`-scoped token cannot claim
+    // `galoy-production`.
+    if !auth.can_register_tunnel(&deployment_id) {
+        tracing::warn!(
+            deployment_id = %deployment_id,
+            "tunnel registration rejected: caller lacks Tunnel scope for this deployment_id"
+        );
+        let _ = socket
+            .send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                code: axum::extract::ws::close_code::POLICY,
+                reason: format!(
+                    "missing AuthScope::Tunnel({deployment_id}) on caller credentials"
+                )
+                .into(),
+            })))
+            .await;
+        return;
+    }
 
     tracing::info!(
         deployment_id = %deployment_id,
@@ -60,6 +83,22 @@ async fn handle_tunnel(mut socket: WebSocket, state: AppState, _auth: AuthSubjec
     // ── 2. Create channel and handle ──────────────────────────────────────
     let (outbound_tx, mut outbound_rx) = tokio::sync::mpsc::channel::<String>(256);
     let handle = TunnelHandle::new(outbound_tx);
+
+    // ── 2b. Claim deployment_id, evict previous tunnel if any ─────────────
+    // Capacity-1 channel: a single eviction signal is all we ever send.
+    let (close_tx, mut close_rx) = tokio::sync::mpsc::channel::<()>(1);
+    let session_id = uuid::Uuid::new_v4();
+    let evicted = state
+        .app
+        .tunnels()
+        .claim(&deployment_id, session_id, close_tx)
+        .await;
+    if evicted {
+        tracing::warn!(
+            deployment_id = %deployment_id,
+            "evicted previous tunnel with same deployment_id; new connector takes over"
+        );
+    }
 
     // ── 3. Register toolsets ──────────────────────────────────────────────
     let mut registered_names = Vec::new();
@@ -91,6 +130,22 @@ async fn handle_tunnel(mut socket: WebSocket, state: AppState, _auth: AuthSubjec
     // ── 4. Relay loop ─────────────────────────────────────────────────────
     loop {
         tokio::select! {
+            // `biased` so an eviction signal always beats in-flight traffic.
+            biased;
+            // Eviction: another connector claimed the same deployment_id.
+            _ = close_rx.recv() => {
+                tracing::info!(
+                    deployment_id = %deployment_id,
+                    "tunnel evicted by new registration for the same deployment_id; closing"
+                );
+                let _ = socket
+                    .send(Message::Close(Some(axum::extract::ws::CloseFrame {
+                        code: axum::extract::ws::close_code::POLICY,
+                        reason: "evicted by a new tunnel registration for the same deployment_id".into(),
+                    })))
+                    .await;
+                break;
+            }
             // Inbound: messages from the connector (tool results)
             ws_msg = socket.recv() => {
                 match ws_msg {
@@ -128,6 +183,10 @@ async fn handle_tunnel(mut socket: WebSocket, state: AppState, _auth: AuthSubjec
     for name in &registered_names {
         state.app.toolsets().unregister_searchable(name);
     }
+    // `release` is a no-op if we were evicted (the new session owns the
+    // entry now) — the session_id check in `TunnelRegistry::release`
+    // ensures we only remove an entry that's still ours.
+    state.app.tunnels().release(&deployment_id, session_id);
     tracing::info!(
         deployment_id = %deployment_id,
         toolsets = registered_names.len(),

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -18,6 +18,11 @@
       <input type="checkbox" name="admin" value="true">
       Admin scope (grants access to workspace &amp; agent management tools)
     </label>
+    <label>
+      Tunnel deployment ID (optional)
+      <input type="text" name="tunnel_deployment_id" placeholder="galoy-staging">
+      <small>Fill in to mint a token scoped to a single tunnel connector registration. Leave empty for a regular user token.</small>
+    </label>
     <button type="submit">Create Credentials</button>
   </form>
   <div id="creds-result"></div>


### PR DESCRIPTION
Stacked on #127. Closes two of the "Known security gaps" listed in that PR's body.

## Gap #1 — deployment-scoped token binding

Today any valid MCP credential can register as *any* `deployment_id`. A token minted for staging could claim `galoy-production` and receive prod tool calls.

**Fix:**
- New `AuthScope::Tunnel(String)` variant (`primitives/auth_scope.rs`). Round-trips via `Display`/`FromStr` as `tunnel:<deployment_id>`. Empty ids explicitly fall back to `Raw` so malformed strings never silently match.
- `AuthSubject::can_register_tunnel(deployment_id)` — exact-match scope check. Session `User` bypasses (already holds all scopes everywhere else); bearer subjects must carry the exact `Tunnel(<id>)` scope.
- `/tunnel/ws` handler enforces the check right after reading the Register frame. On mismatch → WS close with POLICY frame naming the missing scope.
- **Minting UX**: `mcp-creds` creation form gets an optional `tunnel_deployment_id` field; when set, the credential receives `AuthScope::Tunnel(<id>)`. Existing `admin` checkbox behavior unchanged.

## Gap #2 — duplicate registration protection

Today two connectors holding the same `deployment_id` can hold concurrent live tunnels; their results race-fight through the shared pending map.

**Fix:**
- New `TunnelRegistry` (`core/src/tunnel.rs`) maps `deployment_id` → current session. On a new `claim`, any existing entry is replaced and its `close_tx` signaled. Sessions carry a UUID so an evicted cleanup loop doesn't accidentally remove the *new* entry when it calls `release`.
- Wired as `App.tunnels: Arc<TunnelRegistry>` with `App::tunnels()` accessor.
- Handler flow:
  1. After scope check → `claim` the deployment_id, evicting any previous session
  2. Relay loop gets a `biased` close_rx branch so an eviction signal always beats in-flight traffic
  3. Cleanup calls `release` with the current session_id; the session_id check means an evicted loop can't wipe the new session's entry

**Policy choice: evict the old, don't reject the new.** Handles pod-restart-overlap gracefully (rolling update wouldn't fail until the old pod fully dies), and turns a stolen-token hijack into a visible close-frame on the legitimate connector's side.

## Not addressed (structurally accepted)

From prior discussion on #127:
- Gap #3 (self-reported tool catalog) — we control the connector binary
- Gap #4 (no per-request crypto) — both endpoints are under our control

## Tests

14 new unit tests, full `cargo test --lib -p drua-core` green (94 pass):
- `auth_scope`: round-trip of `Tunnel("galoy-staging")`, empty id falls back to Raw
- `auth_subject::can_register_tunnel`: exact match, cross-deployment rejection, User bypass, Anonymous/scopeless rejection, multi-scope
- `tunnel::registry`: empty start, first claim doesn't evict, second claim evicts and signals close_rx, distinct deployments coexist, release removes current entry, stale session_id release is a no-op

## Review flow

Base is `feat/tunnel-connector` (i.e. #127). Once #127 merges to main this will auto-retarget main (or I'll rebase). Reviewing against #127 is the way to see only my changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)