### PR TITLE
feat(drua): TUI dashboard agents panel, details pane, and CLI auth fix

### DIFF
--- a/drua/src/commands/dashboard.rs
+++ b/drua/src/commands/dashboard.rs
@@ -426,9 +426,6 @@ async fn run_event_loop(
 ) -> Result<()> {
     let (stream_tx, mut stream_rx) = mpsc::unbounded_channel::<ChatStreamEvent>();
     let mut event_stream = EventStream::new();
-    let mut refresh_interval = tokio::time::interval(Duration::from_secs(30));
-    refresh_interval.tick().await; // consume the immediate first tick
-
     loop {
         terminal.draw(|frame| ui::draw(frame, state))?;
 
@@ -494,11 +491,6 @@ async fn run_event_loop(
             event = stream_rx.recv() => {
                 if let Some(evt) = event {
                     dispatch_stream_event(state, evt);
-                }
-            }
-            _ = refresh_interval.tick() => {
-                if let Ok(workspaces) = fetch_workspaces(client).await {
-                    state.replace_workspaces(workspaces);
                 }
             }
             _ = tokio::time::sleep(timeout) => {}


### PR DESCRIPTION
## Summary
- **CLI auth fix**: Replace MCP credential-based CLI auth with session-based auth so `drua dashboard` resolves as `AuthSubject::User` with full access instead of `ExportedAgent` with empty scopes
- **Agents panel**: Add agents list and agent details pane to the TUI dashboard with sandbox attachment info
- **TUI polish**: Readline shortcuts (Ctrl+W/U/A/E), focus navigation (Ctrl+H/L), prompt prefix showing `[workspace: agent] >`, real terminal cursor, Ctrl+O jump to lead, Ctrl+Z suspend, Ctrl+R refresh

## Test plan
- [ ] `drua dashboard` authenticates via session token (not MCP credential)
- [ ] Workspaces load without `Forbidden` error
- [ ] Agents panel shows agents with lead first
- [ ] Agent details pane shows role and attached sandbox info
- [ ] Readline shortcuts work in chat input
- [ ] Ctrl+H/L navigates focus, Ctrl+O jumps to lead chat, Ctrl+Z suspends

🤖 Generated with [Claude Code](https://claude.com/claude-code)