### PR TITLE
chore: rename cachix cache to drua-github-actions

### DIFF
--- a/.github/actions/setup-nix/action.yml
+++ b/.github/actions/setup-nix/action.yml
@@ -15,6 +15,6 @@ runs:
     - uses: cachix/cachix-action@v17
       if: inputs.cachix_auth_token != ''
       with:
-        name: galoy-agents-github-action
+        name: drua-github-actions
         authToken: ${{ inputs.cachix_auth_token }}
         skipPush: false


### PR DESCRIPTION
## Summary
- Renames the cachix cache name in the GitHub Actions setup-nix action from `galoy-agents-github-action` to `drua-github-actions`

## Test plan
- [ ] Verify CI workflows still push/pull from cachix correctly with the new cache name

🤖 Generated with [Claude Code](https://claude.com/claude-code)