### PR TITLE
ci(concourse): replace Cachix with local nix binary cache

### DIFF
--- a/ci/fragments.lib.yml
+++ b/ci/fragments.lib.yml
@@ -1,6 +1,6 @@
 #@ load("@ytt:data", "data")
 
-#@ def nix_flake_cachix_image_config():
+#@ def nix_flake_image_config():
 type: registry-image
 source:
   repository: ghcr.io/nix-community/docker-nixpkgs/cachix-flakes

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -377,12 +377,6 @@ resource_types:
     repository: frodenas/gcs-resource
 
 resources:
-#@ repo_source = {
-#@   "uri": data.values.git_uri,
-#@   "branch": data.values.git_branch,
-#@   "private_key": data.values.github_private_key,
-#@ }
-
 - name: repo
   type: git
   source:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,6 +1,6 @@
 #@ load("@ytt:data", "data")
 #@ load("fragments.lib.yml",
-#@   "nix_flake_cachix_image_config",
+#@   "nix_flake_image_config",
 #@ )
 
 groups:
@@ -25,21 +25,19 @@ jobs:
   - task: nix-flake-check
     config:
       platform: linux
-      image_resource: #@ nix_flake_cachix_image_config()
+      image_resource: #@ nix_flake_image_config()
       inputs:
       - name: repo
-      params:
-        CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
-        CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
+      caches:
+      - path: /nix-cache
       run:
-        path: sh
+        path: repo/ci/tasks/with-nix-cache.sh
         args:
+          - sh
           - -exc
           - |
-            set -euo pipefail
             cd repo
-            cachix use $CACHIX_CACHE_NAME
-            cachix watch-exec $CACHIX_CACHE_NAME -- nix flake check
+            nix flake check
 
 - name: test-integration
   serial: true
@@ -50,22 +48,19 @@ jobs:
     privileged: true
     config:
       platform: linux
-      image_resource: #@ nix_flake_cachix_image_config()
+      image_resource: #@ nix_flake_image_config()
       inputs:
       - name: repo
-      params:
-        CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
-        CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
+      caches:
+      - path: /nix-cache
       run:
-        path: sh
+        path: repo/ci/tasks/with-nix-cache.sh
         args:
+          - sh
           - -exc
           - |
-            set -euo pipefail
             cd repo
-            cachix use $CACHIX_CACHE_NAME
-            cachix watch-exec $CACHIX_CACHE_NAME -- \
-              nix run .#integration-tests
+            nix run .#integration-tests
 
 - name: test-bats
   serial: true
@@ -77,21 +72,19 @@ jobs:
     attempts: 2
     config:
       platform: linux
-      image_resource: #@ nix_flake_cachix_image_config()
+      image_resource: #@ nix_flake_image_config()
       inputs:
       - name: repo
-      params:
-        CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
-        CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
+      caches:
+      - path: /nix-cache
       run:
-        path: sh
+        path: repo/ci/tasks/with-nix-cache.sh
         args:
+          - sh
           - -exc
           - |
-            set -euo pipefail
             cd repo
-            cachix use $CACHIX_CACHE_NAME
-            cachix watch-exec $CACHIX_CACHE_NAME -- nix run .#bats
+            nix run .#bats
 
 - name: build-edge-image
   serial: true
@@ -102,23 +95,21 @@ jobs:
   - task: build-image
     config:
       platform: linux
-      image_resource: #@ nix_flake_cachix_image_config()
+      image_resource: #@ nix_flake_image_config()
       inputs:
       - name: repo
       outputs:
       - name: image
-      params:
-        CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
-        CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
+      caches:
+      - path: /nix-cache
       run:
-        path: sh
+        path: repo/ci/tasks/with-nix-cache.sh
         args:
+          - sh
           - -exc
           - |
-            set -euo pipefail
             cd repo
-            cachix use $CACHIX_CACHE_NAME
-            cachix watch-exec $CACHIX_CACHE_NAME -- nix build .#docker-image
+            nix build .#docker-image
             gunzip -c result > ../image/image.tar
   - put: edge-image
     params:
@@ -145,7 +136,7 @@ jobs:
   - task: prepare-deployment
     config:
       platform: linux
-      image_resource: #@ nix_flake_cachix_image_config()
+      image_resource: #@ nix_flake_image_config()
       inputs:
       - name: deploy-config
         path: repo
@@ -210,24 +201,21 @@ jobs:
   - task: train-and-export
     config:
       platform: linux
-      image_resource: #@ nix_flake_cachix_image_config()
+      image_resource: #@ nix_flake_image_config()
       inputs:
       - name: repo
       outputs:
       - name: model
-      params:
-        CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
-        CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
+      caches:
+      - path: /nix-cache
       run:
-        path: sh
+        path: repo/ci/tasks/with-nix-cache.sh
         args:
+          - sh
           - -exc
           - |
-            set -euo pipefail
-            cachix use $CACHIX_CACHE_NAME
-
             cd repo
-            cachix watch-exec $CACHIX_CACHE_NAME -- nix run ./ci#train-classifier -- "$(pwd)/../model"
+            nix run ./ci#train-classifier -- "$(pwd)/../model"
   - put: code-assistant-model
     params:
       file: model/*.tar.gz
@@ -249,7 +237,7 @@ jobs:
   - task: build-index
     config:
       platform: linux
-      image_resource: #@ nix_flake_cachix_image_config()
+      image_resource: #@ nix_flake_image_config()
       inputs:
       - name: repo
       - name: cala-repo
@@ -260,17 +248,14 @@ jobs:
       outputs:
       - name: index
       - name: embedder
-      params:
-        CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
-        CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
+      caches:
+      - path: /nix-cache
       run:
-        path: sh
+        path: repo/ci/tasks/with-nix-cache.sh
         args:
+          - sh
           - -exc
           - |
-            set -euo pipefail
-            cachix use $CACHIX_CACHE_NAME
-
             mkdir -p /tmp/repos
             ln -s "$(pwd)/cala-repo" /tmp/repos/cala
             ln -s "$(pwd)/lana-repo" /tmp/repos/lana-bank
@@ -279,8 +264,7 @@ jobs:
             ln -s "$(pwd)/repo" /tmp/repos/galoy-agents
 
             cd repo
-            cachix watch-exec $CACHIX_CACHE_NAME -- \
-              nix run ./ci#build-code-assistant-index -- /tmp/repos "$(pwd)/../index" "$(pwd)/../embedder" "$(pwd)/../code-assistant-model"
+            nix run ./ci#build-code-assistant-index -- /tmp/repos "$(pwd)/../index" "$(pwd)/../embedder" "$(pwd)/../code-assistant-model"
   - put: code-assistant-index
     params:
       file: index/*.tar.gz
@@ -290,39 +274,34 @@ jobs:
   - task: commit-index-hash
     config:
       platform: linux
-      image_resource: #@ nix_flake_cachix_image_config()
+      image_resource: #@ nix_flake_image_config()
       inputs:
       - name: repo
       - name: index
       - name: embedder
       outputs:
       - name: repo-updated
-      params:
-        CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
-        CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
+      caches:
+      - path: /nix-cache
       run:
-        path: sh
+        path: repo/ci/tasks/with-nix-cache.sh
         args:
+          - sh
           - -exc
           - |
-            set -euo pipefail
-            cachix use $CACHIX_CACHE_NAME
-
             INDEX_HASH=$(basename "$(ls index/*.tar.gz)" .tar.gz)
             EMBEDDER_HASH=$(basename "$(ls embedder/*.tar.gz)" .tar.gz)
 
             cp -a repo/. repo-updated/
             cd repo-updated
-            cachix watch-exec $CACHIX_CACHE_NAME -- \
-              nix run ./ci#commit-hash -- "$(pwd)" \
-                charts/galoy-agents/values.yaml \
-                "galoyAgents.codeAssistant.indexHash" \
-                "$INDEX_HASH"
-            cachix watch-exec $CACHIX_CACHE_NAME -- \
-              nix run ./ci#commit-hash -- "$(pwd)" \
-                charts/galoy-agents/values.yaml \
-                "galoyAgents.codeAssistant.embedderHash" \
-                "$EMBEDDER_HASH"
+            nix run ./ci#commit-hash -- "$(pwd)" \
+              charts/galoy-agents/values.yaml \
+              "galoyAgents.codeAssistant.indexHash" \
+              "$INDEX_HASH"
+            nix run ./ci#commit-hash -- "$(pwd)" \
+              charts/galoy-agents/values.yaml \
+              "galoyAgents.codeAssistant.embedderHash" \
+              "$EMBEDDER_HASH"
   - put: repo-chart-values
     params:
       repository: repo-updated
@@ -336,23 +315,20 @@ jobs:
   - task: sandbox-integration-test
     config:
       platform: linux
-      image_resource: #@ nix_flake_cachix_image_config()
+      image_resource: #@ nix_flake_image_config()
       inputs:
       - name: repo-sandbox
         path: repo
-      params:
-        CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
-        CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
+      caches:
+      - path: /nix-cache
       run:
-        path: sh
+        path: repo/ci/tasks/with-nix-cache.sh
         args:
+          - sh
           - -exc
           - |
-            set -euo pipefail
             cd repo
-            cachix use $CACHIX_CACHE_NAME
-            cachix watch-exec $CACHIX_CACHE_NAME -- \
-              nix run .#sandbox-bats
+            nix run .#sandbox-bats
 
 - name: build-sandbox-image
   serial: true
@@ -363,24 +339,22 @@ jobs:
   - task: build-image
     config:
       platform: linux
-      image_resource: #@ nix_flake_cachix_image_config()
+      image_resource: #@ nix_flake_image_config()
       inputs:
       - name: repo-sandbox
         path: repo
       outputs:
       - name: image
-      params:
-        CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
-        CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
+      caches:
+      - path: /nix-cache
       run:
-        path: sh
+        path: repo/ci/tasks/with-nix-cache.sh
         args:
+          - sh
           - -exc
           - |
-            set -euo pipefail
             cd repo
-            cachix use $CACHIX_CACHE_NAME
-            cachix watch-exec $CACHIX_CACHE_NAME -- nix build .#sandbox-image
+            nix build .#sandbox-image
             gunzip -c result > ../image/image.tar
   - put: sandbox-edge-image
     params:

--- a/ci/tasks/with-nix-cache.sh
+++ b/ci/tasks/with-nix-cache.sh
@@ -1,0 +1,86 @@
+#!/bin/sh
+set -eu
+
+# Wrapper that adds a persistent local Nix binary cache.
+# Concourse task caches persist /nix-cache between runs of the same task step.
+# On the first run the cache is empty; on subsequent runs Nix finds most store
+# paths locally and skips downloading them from cache.nixos.org.
+
+# Maximum cache size in bytes (25 GB). When exceeded after saving,
+# the oldest .narinfo / .nar files are removed until size drops below.
+CACHE_MAX_BYTES=$((25 * 1024 * 1024 * 1024))
+
+setup_nix_cache() {
+  mkdir -p /nix-cache
+  if [ -f /nix-cache/nix-cache-info ]; then
+    cache_size=$(du -sh /nix-cache 2>/dev/null | cut -f1)
+    echo "nix-cache: local cache found (${cache_size}), restoring"
+    # Modify nix.conf for tools that read it directly
+    echo "extra-substituters = file:///nix-cache" >> /etc/nix/nix.conf
+    echo "require-sigs = false" >> /etc/nix/nix.conf
+
+    # Export NIX_CONFIG so the running nix-daemon picks up changes.
+    # The daemon loads nix.conf at startup (before this wrapper runs),
+    # so modifying the file alone is not enough. NIX_CONFIG is read by
+    # nix commands at invocation time and supplements the daemon config.
+    export NIX_CONFIG="${NIX_CONFIG:+$NIX_CONFIG
+}extra-substituters = file:///nix-cache
+require-sigs = false"
+  else
+    echo "nix-cache: no local cache found (cold start)"
+  fi
+}
+
+# Remove oldest files until cache is under CACHE_MAX_BYTES.
+prune_nix_cache() {
+  echo "nix-cache: calculating cache size..."
+  current_bytes=$(du -sb /nix-cache 2>/dev/null | cut -f1)
+  echo "nix-cache: cache size is $((current_bytes / 1024 / 1024)) MB"
+
+  if [ "$current_bytes" -le "$CACHE_MAX_BYTES" ]; then
+    echo "nix-cache: under limit ($((CACHE_MAX_BYTES / 1024 / 1024 / 1024)) GB), no pruning needed"
+    return
+  fi
+
+  echo "nix-cache: over limit, pruning to ~25 GB..."
+
+  # Delete oldest files first (both .narinfo and .nar) until under budget.
+  # Re-check size every 50 deletions to avoid running du on every iteration.
+  count=0
+  ls -tr /nix-cache/*.narinfo /nix-cache/nar/* > /tmp/files-to-prune.txt 2>/dev/null || true
+
+  while read -r file; do
+    echo "nix-cache: removing $file"
+    rm -f "$file"
+
+    count=$((count + 1))
+    if [ $((count % 50)) -eq 0 ]; then
+      echo "nix-cache: deleted $count files so far, recalculating size..."
+      current_bytes=$(du -sb /nix-cache 2>/dev/null | cut -f1)
+      echo "nix-cache: cache size is $((current_bytes / 1024 / 1024)) MB"
+      if [ "$current_bytes" -le "$CACHE_MAX_BYTES" ]; then
+        break
+      fi
+    fi
+  done < /tmp/files-to-prune.txt
+  rm -f /tmp/files-to-prune.txt
+
+  echo "nix-cache: pruning done, removed $count files, final size: $((current_bytes / 1024 / 1024)) MB"
+}
+
+save_nix_cache() {
+  # Always save -- nix copy skips paths already present in the destination,
+  # so this is cheap on warm runs but ensures newly-built derivations
+  # (updated deps, new flake inputs) are cached for next time.
+  echo "nix-cache: saving new store paths to local cache..."
+  nix copy --to 'file:///nix-cache?compression=none' --all 2>/dev/null || true
+  prune_nix_cache
+  echo "nix-cache: done saving to local cache"
+}
+
+echo "=== with-nix-cache: start $(date -u +%H:%M:%S) ==="
+setup_nix_cache
+trap save_nix_cache EXIT
+echo "=== with-nix-cache: setup done $(date -u +%H:%M:%S), running task ==="
+
+"$@"

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -8,9 +8,6 @@ gar_registry: us.gcr.io/galoyorg
 gar_registry_user: ((gar-creds.username))
 gar_registry_password: ((gar-creds.password))
 
-cachix_auth_token: ((cachix-token.token))
-cachix_cache_name: galoy-agents
-
 folder_registry_image: galoy-agents
 
 cala_git_uri: git@github.com:GaloyMoney/cala.git


### PR DESCRIPTION
## Summary
- Replace Cachix with a local `/nix-cache` file-based binary cache using Concourse's `caches:` directive
- Add `ci/tasks/with-nix-cache.sh` wrapper script (same approach as lana-bank) that configures the cache as a nix substituter, runs the task, then saves new store paths on exit
- Remove `cachix_auth_token` / `cachix_cache_name` from pipeline values — no more Cachix token dependency for Concourse

## Test plan
- [ ] Verify `repipe` applies the updated pipeline successfully
- [ ] Run a cold CI build and confirm `with-nix-cache.sh` reports "cold start"
- [ ] Run a second build and confirm cache hits from `/nix-cache`

🤖 Generated with [Claude Code](https://claude.com/claude-code)