### PR TITLE
ci(concourse): remove retry on bats test job

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -69,7 +69,6 @@ jobs:
     trigger: true
   - task: bats-e2e
     privileged: true
-    attempts: 2
     config:
       platform: linux
       image_resource: #@ nix_flake_image_config()


### PR DESCRIPTION
## Summary
- Remove `attempts: 2` from the bats e2e test task — tests should pass reliably without retries.

## Test plan
- [ ] Verify CI pipeline still runs the bats test job correctly without retry

🤖 Generated with [Claude Code](https://claude.com/claude-code)