### PR TITLE
feat(llm): add LlmProvider trait and OpenAI support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,9 +14,14 @@ PG_CON=postgres://user:password@localhost:5432/drua
 # ── Recommended ──────────────────────────────────────────────────────────────
 
 # Anthropic API key for the agent LLM runtime.
-# The server starts without it, but all agent prompts will fail.
+# Required when any role uses `provider: anthropic` (the default).
 # Get one at https://console.anthropic.com/
 ANTHROPIC_API_KEY=
+
+# OpenAI API key for the agent LLM runtime.
+# Required when any role uses `provider: openai`.
+# Get one at https://platform.openai.com/api-keys
+OPENAI_API_KEY=
 
 # ── Optional — OAuth & Access Control ────────────────────────────────────────
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,7 @@ dependencies = [
 name = "anthropic-client"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "futures",
  "llm",
  "reqwest 0.12.28",
@@ -1373,6 +1374,7 @@ dependencies = [
  "http",
  "jsonwebtoken",
  "llm",
+ "openai-client",
  "opentelemetry",
  "opentelemetry-http",
  "pgvector",
@@ -2817,6 +2819,7 @@ checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 name = "llm"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "serde",
  "serde_json",
  "sha2",
@@ -3189,6 +3192,21 @@ name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
+name = "openai-client"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "futures",
+ "llm",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "openssl-probe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "mcp-gateway",
   "lib/sandbox",
   "lib/anthropic-client",
+  "lib/openai-client",
   "lib/llm",
   "web",
   "code-assistant/crates/core",
@@ -45,6 +46,7 @@ sandbox = { path = "lib/sandbox" }
 code-assistant-core = { path = "code-assistant/crates/core" }
 llm = { path = "lib/llm" }
 anthropic-client = { path = "lib/anthropic-client" }
+openai-client = { path = "lib/openai-client" }
 
 # MCP
 rmcp = { version = "1.2", features = ["server", "client", "transport-streamable-http-server", "transport-streamable-http-client", "transport-streamable-http-client-reqwest", "macros"] }

--- a/charts/drua/templates/configmap.yaml
+++ b/charts/drua/templates/configmap.yaml
@@ -26,7 +26,7 @@ data:
         models:
         {{- range .models }}
           - name: {{ .name | quote }}
-            max_tokens: {{ .maxTokens }}
+            max_tokens_per_response: {{ .maxTokensPerResponse }}
             context_window_tokens: {{ .contextWindowTokens }}
         {{- end }}
     {{- end }}

--- a/charts/drua/templates/configmap.yaml
+++ b/charts/drua/templates/configmap.yaml
@@ -35,8 +35,11 @@ data:
       builtin_roles:
         workspace_lead:
           model: {{ .Values.galoyAgents.config.agents.workspaceLead.model | quote }}
-          {{- with .Values.galoyAgents.config.agents.workspaceLead.resetTimeDeltaSeconds }}
-          reset_time_delta_seconds: {{ . }}
+          {{- with .Values.galoyAgents.config.agents.workspaceLead.compaction }}
+          compaction:
+            {{- with .resetTimeDeltaSeconds }}
+            reset_time_delta_seconds: {{ . }}
+            {{- end }}
           {{- end }}
           system:
             - type: text
@@ -45,8 +48,11 @@ data:
         {{- with .Values.galoyAgents.config.agents.agent }}
         agent:
           model: {{ .model | quote }}
-          {{- with .resetTimeDeltaSeconds }}
-          reset_time_delta_seconds: {{ . }}
+          {{- with .compaction }}
+          compaction:
+            {{- with .resetTimeDeltaSeconds }}
+            reset_time_delta_seconds: {{ . }}
+            {{- end }}
           {{- end }}
           system:
             - type: text

--- a/charts/drua/templates/configmap.yaml
+++ b/charts/drua/templates/configmap.yaml
@@ -19,11 +19,22 @@ data:
         - {{ . | quote }}
       {{- end }}
     {{- end }}
+    {{- with .Values.galoyAgents.config.providers }}
+    providers:
+    {{- range . }}
+      - name: {{ .name | quote }}
+        models:
+        {{- range .models }}
+          - name: {{ .name | quote }}
+            max_tokens: {{ .maxTokens }}
+            context_window_tokens: {{ .contextWindowTokens }}
+        {{- end }}
+    {{- end }}
+    {{- end }}
     agents:
       builtin_roles:
         workspace_lead:
           model: {{ .Values.galoyAgents.config.agents.workspaceLead.model | quote }}
-          max_tokens: {{ .Values.galoyAgents.config.agents.workspaceLead.maxTokens }}
           {{- with .Values.galoyAgents.config.agents.workspaceLead.resetTimeDeltaSeconds }}
           reset_time_delta_seconds: {{ . }}
           {{- end }}
@@ -34,7 +45,6 @@ data:
         {{- with .Values.galoyAgents.config.agents.agent }}
         agent:
           model: {{ .model | quote }}
-          max_tokens: {{ .maxTokens }}
           {{- with .resetTimeDeltaSeconds }}
           reset_time_delta_seconds: {{ . }}
           {{- end }}

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -38,7 +38,7 @@ galoyAgents:
       - name: anthropic
         models:
           - name: claude-haiku-4-5-20251001
-            maxTokens: 4096
+            maxTokensPerResponse: 4096
             contextWindowTokens: 200000
     ## Per-role defaults applied when an agent with that role is created.
     ## Both `workspaceLead` and `agent` are REQUIRED — the binary refuses

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -47,17 +47,18 @@ galoyAgents:
     agents:
       workspaceLead:
         model: "claude-haiku-4-5-20251001"
-        ## When a user message arrives more than this many seconds after
-        ## the previous user message in the current thread, the session
-        ## starts a fresh thread. `null` disables the auto-reset.
-        resetTimeDeltaSeconds: 600
+        compaction:
+          ## When a user message arrives more than this many seconds after
+          ## the previous assistant response, start a fresh thread.
+          resetTimeDeltaSeconds: 600
         systemPrompt: |
           You are the lead agent of your workspace. You investigate / coordinate
           and delegate. You answer questions, and use the available tools to help the
           user accomplish their goals. Be concise and action-oriented.
       agent:
         model: "claude-haiku-4-5-20251001"
-        resetTimeDeltaSeconds: 600
+        compaction:
+          resetTimeDeltaSeconds: 600
         systemPrompt: |
           You are an agent operating inside a Galoy Agents workspace.
           You work on the tasks assigned to you and, when attached to

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -32,6 +32,14 @@ galoyAgents:
       githubClientId: ""
       githubRedirectUri: ""
       githubAllowedTeams: []
+    ## LLM providers and their models. Each model declares token limits
+    ## used for compaction and prompt sizing.
+    providers:
+      - name: anthropic
+        models:
+          - name: claude-haiku-4-5-20251001
+            maxTokens: 4096
+            contextWindowTokens: 200000
     ## Per-role defaults applied when an agent with that role is created.
     ## Both `workspaceLead` and `agent` are REQUIRED — the binary refuses
     ## to start if either `agents.builtin_roles.workspace_lead` or
@@ -39,7 +47,6 @@ galoyAgents:
     agents:
       workspaceLead:
         model: "claude-haiku-4-5-20251001"
-        maxTokens: 4096
         ## When a user message arrives more than this many seconds after
         ## the previous user message in the current thread, the session
         ## starts a fresh thread. `null` disables the auto-reset.
@@ -50,7 +57,6 @@ galoyAgents:
           user accomplish their goals. Be concise and action-oriented.
       agent:
         model: "claude-haiku-4-5-20251001"
-        maxTokens: 4096
         resetTimeDeltaSeconds: 600
         systemPrompt: |
           You are an agent operating inside a Galoy Agents workspace.

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -28,33 +28,39 @@ pub struct Config {
     pub github_app: Option<GitHubAppCliConfig>,
     #[serde(skip)]
     pub anthropic_api_key: String,
+    #[serde(skip)]
+    pub openai_api_key: String,
 }
 
 impl Config {
     /// Build a `PromptExecutorConfig` registering every model that the
-    /// configured `agents.builtin_roles` reference, all bound to Anthropic
-    /// using the API key provided via env.
+    /// configured `agents.builtin_roles` reference, each bound to the
+    /// provider specified in its role config.
     pub fn prompt_executor_config(&self) -> PromptExecutorConfig {
-        let mut models: Vec<String> = self
-            .agents
-            .builtin_roles
-            .values()
-            .map(|r| r.model.clone())
-            .collect();
-        models.sort();
-        models.dedup();
-        PromptExecutorConfig {
-            models: models
-                .into_iter()
-                .map(|name| ModelConfig {
-                    name,
-                    provider: Provider::Anthropic {
+        // Collect unique (provider, model) pairs.
+        let mut seen = std::collections::HashSet::new();
+        let mut models = Vec::new();
+
+        for role in self.agents.builtin_roles.values() {
+            let key = (role.provider.clone(), role.model.clone());
+            if seen.insert(key) {
+                let provider = match role.provider.as_str() {
+                    "openai" => Provider::OpenAi {
+                        api_key: self.openai_api_key.clone(),
+                    },
+                    _ => Provider::Anthropic {
                         api_key: self.anthropic_api_key.clone(),
                     },
+                };
+                models.push(ModelConfig {
+                    name: role.model.clone(),
+                    provider,
                     default_max_tokens: None,
-                })
-                .collect(),
+                });
+            }
         }
+
+        PromptExecutorConfig { models }
     }
 }
 
@@ -140,6 +146,7 @@ pub struct EnvSecrets {
     pub github_client_secret: String,
     pub github_allowed_teams: Vec<String>,
     pub anthropic_api_key: String,
+    pub openai_api_key: String,
 }
 
 impl Config {
@@ -175,6 +182,7 @@ impl Config {
         // sneaks in when the key was piped from `echo` or a broken
         // `.env`; both render the key invalid upstream for opaque reasons.
         config.anthropic_api_key = secrets.anthropic_api_key.trim().to_string();
+        config.openai_api_key = secrets.openai_api_key.trim().to_string();
         if !secrets.github_allowed_teams.is_empty() {
             config.oauth.github_allowed_teams = secrets.github_allowed_teams;
         }

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
-use drua_core::agent::AgentsConfig;
+use drua_core::agent::{AgentsConfig, ModelDefaults};
 use drua_core::prompt_executor::{ModelConfig, PromptExecutorConfig, Provider};
 use drua_core::sandbox::SandboxConfig;
 use drua_core::toolset::ToolSetsConfig;
@@ -19,6 +19,8 @@ pub struct Config {
     #[serde(default)]
     pub db: DbConfig,
     #[serde(default)]
+    pub providers: Vec<ProviderConfig>,
+    #[serde(default)]
     pub agents: AgentsConfig,
     #[serde(default)]
     pub toolsets: ToolSetsConfig,
@@ -32,29 +34,45 @@ pub struct Config {
     pub openai_api_key: String,
 }
 
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ProviderConfig {
+    pub name: String,
+    #[serde(default)]
+    pub models: Vec<ProviderModelConfig>,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ProviderModelConfig {
+    pub name: String,
+    pub max_tokens: u32,
+    #[serde(default = "default_context_window")]
+    pub context_window_tokens: u64,
+}
+
+fn default_context_window() -> u64 {
+    200_000
+}
+
 impl Config {
-    /// Build a `PromptExecutorConfig` registering every model that the
-    /// configured `agents.builtin_roles` reference, each bound to the
-    /// provider specified in its role config.
+    /// Build a `PromptExecutorConfig` from the top-level `providers`
+    /// section, binding each model to its provider's API key.
     pub fn prompt_executor_config(&self) -> PromptExecutorConfig {
-        // Collect unique (provider, model) pairs.
-        let mut seen = std::collections::HashSet::new();
         let mut models = Vec::new();
 
-        for role in self.agents.builtin_roles.values() {
-            let key = (role.provider.clone(), role.model.clone());
-            if seen.insert(key) {
-                let provider = match role.provider.as_str() {
-                    "openai" => Provider::OpenAi {
-                        api_key: self.openai_api_key.clone(),
-                    },
-                    _ => Provider::Anthropic {
-                        api_key: self.anthropic_api_key.clone(),
-                    },
-                };
+        for provider_cfg in &self.providers {
+            let provider = match provider_cfg.name.as_str() {
+                "openai" => Provider::OpenAi {
+                    api_key: self.openai_api_key.clone(),
+                },
+                _ => Provider::Anthropic {
+                    api_key: self.anthropic_api_key.clone(),
+                },
+            };
+
+            for model in &provider_cfg.models {
                 models.push(ModelConfig {
-                    name: role.model.clone(),
-                    provider,
+                    name: model.name.clone(),
+                    provider: provider.clone(),
                     default_max_tokens: None,
                 });
             }
@@ -175,6 +193,19 @@ impl Config {
 
         let mut config: Config = serde_yaml::from_value(yaml_value)
             .map_err(|e| anyhow::anyhow!("Invalid config: {e}"))?;
+
+        // Populate agents.models from the top-level providers section.
+        for provider_cfg in &config.providers {
+            for model in &provider_cfg.models {
+                config.agents.models.insert(
+                    model.name.clone(),
+                    ModelDefaults {
+                        max_tokens: model.max_tokens,
+                        context_window_tokens: model.context_window_tokens,
+                    },
+                );
+            }
+        }
 
         config.db.pg_con = secrets.pg_con;
         config.oauth.github_client_secret = secrets.github_client_secret;

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -200,6 +200,7 @@ impl Config {
                 config.agents.models.insert(
                     model.name.clone(),
                     ModelDefaults {
+                        model: model.name.clone(),
                         max_tokens_per_response: model.max_tokens_per_response,
                         context_window_tokens: model.context_window_tokens,
                     },

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -44,7 +44,7 @@ pub struct ProviderConfig {
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct ProviderModelConfig {
     pub name: String,
-    pub max_tokens: u32,
+    pub max_tokens_per_response: u32,
     #[serde(default = "default_context_window")]
     pub context_window_tokens: u64,
 }
@@ -200,7 +200,7 @@ impl Config {
                 config.agents.models.insert(
                     model.name.clone(),
                     ModelDefaults {
-                        max_tokens: model.max_tokens,
+                        max_tokens_per_response: model.max_tokens_per_response,
                         context_window_tokens: model.context_window_tokens,
                     },
                 );

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -29,6 +29,10 @@ struct Cli {
     #[arg(long, env = "ANTHROPIC_API_KEY", default_value = "")]
     anthropic_api_key: String,
 
+    /// OpenAI API key for the light agent runtime.
+    #[arg(long, env = "OPENAI_API_KEY", default_value = "")]
+    openai_api_key: String,
+
     /// Override values in the YAML config file using dot-separated paths.
     /// Example: --set oauth.login=dev
     #[clap(long = "set", value_name = "KEY=VALUE")]
@@ -83,6 +87,7 @@ async fn main() -> anyhow::Result<()> {
             github_client_secret: cli.github_client_secret,
             github_allowed_teams: allowed_teams,
             anthropic_api_key: cli.anthropic_api_key,
+            openai_api_key: cli.openai_api_key,
         },
         &cli.config_overrides,
     )?;

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -12,6 +12,7 @@ graphql = ["es-entity/graphql", "dep:async-graphql"]
 async-graphql = { version = "8.0.0-rc.4", optional = true, default-features = false }
 anthropic-client = { workspace = true }
 code-assistant-core = { workspace = true }
+openai-client = { workspace = true }
 anyhow = { workspace = true }
 async-trait = "0.1"
 base64 = "0.22"

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -61,7 +61,7 @@ pub struct RoleConfig {
 /// Defaults for a model, populated from the top-level `providers` config.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelDefaults {
-    pub max_tokens: u32,
+    pub max_tokens_per_response: u32,
     pub context_window_tokens: u64,
 }
 

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -47,9 +47,16 @@ impl From<u32> for ResetTimeDeltaSeconds {
     }
 }
 
+fn default_provider() -> String {
+    "anthropic".to_string()
+}
+
 /// Per-role defaults applied when an agent with that role is created.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoleConfig {
+    /// LLM provider: `"anthropic"` or `"openai"`.
+    #[serde(default = "default_provider")]
+    pub provider: String,
     pub model: String,
     pub max_tokens: u32,
     /// If set, a new thread is started when a user message arrives more

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -1,10 +1,9 @@
 use std::collections::HashMap;
-use std::time::Duration;
 
-use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use super::error::AgentError;
+use super::session::CompactionConfig;
 use super::AgentRole;
 
 /// Every `AgentRole` variant that must be present in
@@ -13,56 +12,32 @@ use super::AgentRole;
 /// [`AgentsConfig::validate`] will fail fast at startup.
 const REQUIRED_ROLES: &[AgentRole] = &[AgentRole::WorkspaceLead, AgentRole::Agent];
 
-/// Whole-second auto-reset threshold for an `AgentSession`. Wraps a
-/// `u32` count of seconds; the `#[serde(transparent)]` derive lets it
-/// (de)serialize as a bare integer in YAML / JSONB instead of serde's
-/// awkward `{ secs, nanos }` shape for `std::time::Duration`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
-#[serde(transparent)]
-pub struct ResetTimeDeltaSeconds(pub u32);
-
-impl ResetTimeDeltaSeconds {
-    pub fn as_seconds(&self) -> u32 {
-        self.0
-    }
-
-    pub fn as_duration(&self) -> Duration {
-        Duration::from_secs(self.0 as u64)
-    }
-
-    /// True when at least `self` seconds have elapsed between
-    /// `last_user_message_at` and `now`. Negative spans (now < last)
-    /// return `false` — clock skew never triggers a reset.
-    pub fn should_reset(&self, last_user_message_at: DateTime<Utc>, now: DateTime<Utc>) -> bool {
-        now.signed_duration_since(last_user_message_at)
-            .to_std()
-            .map(|elapsed| elapsed > self.as_duration())
-            .unwrap_or(false)
-    }
-}
-
-impl From<u32> for ResetTimeDeltaSeconds {
-    fn from(s: u32) -> Self {
-        Self(s)
-    }
-}
-
 /// Per-role defaults applied when an agent with that role is created.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoleConfig {
     pub model: String,
-    /// If set, a new thread is started when a user message arrives more
-    /// than this many seconds after the previous user message in the
-    /// current thread. `None` disables the auto-reset.
     #[serde(default)]
-    pub reset_time_delta_seconds: Option<ResetTimeDeltaSeconds>,
+    pub compaction: CompactionConfig,
 }
 
-/// Defaults for a model, populated from the top-level `providers` config.
+/// Model-level defaults populated from the top-level `providers` config.
+/// Carries the model name alongside token limits so it can be threaded
+/// through session and thread entities as a single struct.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelDefaults {
+    pub model: String,
     pub max_tokens_per_response: u32,
     pub context_window_tokens: u64,
+}
+
+impl Default for ModelDefaults {
+    fn default() -> Self {
+        Self {
+            model: String::new(),
+            max_tokens_per_response: 4096,
+            context_window_tokens: 200_000,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -47,18 +47,10 @@ impl From<u32> for ResetTimeDeltaSeconds {
     }
 }
 
-fn default_provider() -> String {
-    "anthropic".to_string()
-}
-
 /// Per-role defaults applied when an agent with that role is created.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RoleConfig {
-    /// LLM provider: `"anthropic"` or `"openai"`.
-    #[serde(default = "default_provider")]
-    pub provider: String,
     pub model: String,
-    pub max_tokens: u32,
     /// If set, a new thread is started when a user message arrives more
     /// than this many seconds after the previous user message in the
     /// current thread. `None` disables the auto-reset.
@@ -66,20 +58,35 @@ pub struct RoleConfig {
     pub reset_time_delta_seconds: Option<ResetTimeDeltaSeconds>,
 }
 
+/// Defaults for a model, populated from the top-level `providers` config.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelDefaults {
+    pub max_tokens: u32,
+    pub context_window_tokens: u64,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentsConfig {
     #[serde(default)]
     pub builtin_roles: HashMap<AgentRole, RoleConfig>,
+    /// Populated by the CLI from the `providers:` YAML section.
+    #[serde(default)]
+    pub models: HashMap<String, ModelDefaults>,
 }
 
 impl AgentsConfig {
-    /// Verify that every built-in `AgentRole` has a `RoleConfig`. Called
-    /// from `App::init` so a misconfigured deployment fails loudly at
-    /// startup rather than on the first agent-create.
+    /// Verify that every built-in `AgentRole` has a `RoleConfig` and that
+    /// every referenced model name exists in `self.models`. Called from
+    /// `App::init` so a misconfigured deployment fails loudly at startup.
     pub fn validate(&self) -> Result<(), AgentError> {
         for role in REQUIRED_ROLES {
             if !self.builtin_roles.contains_key(role) {
                 return Err(AgentError::RoleNotConfigured(*role));
+            }
+        }
+        for role_config in self.builtin_roles.values() {
+            if !self.models.contains_key(&role_config.model) {
+                return Err(AgentError::ModelNotConfigured(role_config.model.clone()));
             }
         }
         Ok(())

--- a/core/src/agent/error.rs
+++ b/core/src/agent/error.rs
@@ -30,6 +30,8 @@ pub enum AgentError {
     PromptRequestChannelClosed,
     #[error("AgentError - role not configured: {0:?}")]
     RoleNotConfigured(super::entity::AgentRole),
+    #[error("AgentError - model not configured: {0}")]
+    ModelNotConfigured(String),
     #[error("AgentError - Authorization: {0}")]
     Authorization(#[from] AuthorizationError),
     #[error("AgentError - unauthorized")]

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -44,7 +44,7 @@ use crate::primitives::{
     WorkspaceId,
 };
 use crate::sandbox::{SandboxAgentMode, Sandboxes};
-pub use config::{AgentsConfig, ModelDefaults, ResetTimeDeltaSeconds, RoleConfig};
+pub use config::{AgentsConfig, ModelDefaults, RoleConfig};
 pub use entity::*;
 pub use error::AgentError;
 use repo::AgentRepo;
@@ -256,18 +256,17 @@ impl Agents {
             &agent.workspace_name,
         );
 
+        let session_model_defaults = ModelDefaults {
+            model: role_config.model,
+            ..model_defaults.clone()
+        };
+
         self.sessions
             .create_in_op(
                 op,
                 agent.id,
-                session::ModelSettings {
-                    model: role_config.model,
-                    max_tokens_per_response: model_defaults.max_tokens_per_response,
-                },
-                session::CompactionConfig {
-                    context_window_tokens: model_defaults.context_window_tokens,
-                    ..Default::default()
-                },
+                session_model_defaults,
+                role_config.compaction.clone(),
                 system_blocks,
                 tool_defs,
             )

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -44,7 +44,7 @@ use crate::primitives::{
     WorkspaceId,
 };
 use crate::sandbox::{SandboxAgentMode, Sandboxes};
-pub use config::{AgentsConfig, ResetTimeDeltaSeconds, RoleConfig};
+pub use config::{AgentsConfig, ModelDefaults, ResetTimeDeltaSeconds, RoleConfig};
 pub use entity::*;
 pub use error::AgentError;
 use repo::AgentRepo;
@@ -220,6 +220,12 @@ impl Agents {
             .ok_or(AgentError::RoleNotConfigured(agent_role))?
             .clone();
 
+        let model_defaults = self
+            .config
+            .models
+            .get(&role_config.model)
+            .ok_or_else(|| AgentError::ModelNotConfigured(role_config.model.clone()))?;
+
         let authz_scopes = default_authz_scopes(agent_role, workspace_id);
 
         let new_agent = NewAgent::builder()
@@ -256,7 +262,11 @@ impl Agents {
                 agent.id,
                 session::ModelSettings {
                     model: role_config.model,
-                    max_tokens: role_config.max_tokens,
+                    max_tokens: model_defaults.max_tokens,
+                },
+                session::CompactionConfig {
+                    context_window_tokens: model_defaults.context_window_tokens,
+                    ..Default::default()
                 },
                 system_blocks,
                 tool_defs,

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -262,7 +262,7 @@ impl Agents {
                 agent.id,
                 session::ModelSettings {
                     model: role_config.model,
-                    max_tokens: model_defaults.max_tokens,
+                    max_tokens_per_response: model_defaults.max_tokens_per_response,
                 },
                 session::CompactionConfig {
                     context_window_tokens: model_defaults.context_window_tokens,

--- a/core/src/agent/session/compaction/mod.rs
+++ b/core/src/agent/session/compaction/mod.rs
@@ -113,12 +113,12 @@ pub(super) fn maybe_prune<'a>(
     let system_view = current_prompt_definition.system_view().clone();
     let tool_definitions_view = current_prompt_definition.tool_definitions_view().clone();
     let model = current_prompt_definition.model.clone();
-    let max_tokens = current_prompt_definition.max_tokens;
+    let max_tokens_per_response = current_prompt_definition.max_tokens_per_response;
 
     // Build the PromptDefinition for the compacted thread
     let prompt_definition = PromptDefinition {
         model: model.clone(),
-        max_tokens,
+        max_tokens_per_response,
         system_view: system_view.clone(),
         tool_definitions_view: tool_definitions_view.clone(),
         messages: transformed_messages.clone(),
@@ -130,7 +130,7 @@ pub(super) fn maybe_prune<'a>(
         new_thread_id,
         session_id,
         model,
-        max_tokens,
+        max_tokens_per_response,
         system_view,
         tool_definitions_view,
         transformed_messages,

--- a/core/src/agent/session/compaction/mod.rs
+++ b/core/src/agent/session/compaction/mod.rs
@@ -5,6 +5,10 @@ pub(super) mod trigger;
 use std::collections::HashSet;
 use std::time::Duration;
 
+use es_entity::EntityEvents;
+
+use crate::agent::config::ModelDefaults;
+
 use super::entity::{AgentSessionEvent, ThreadStartReason};
 use super::message::{CompactionMetadata, TargetThread};
 use super::settings::CompactionConfig;
@@ -68,31 +72,48 @@ pub(super) struct CompactionResult {
 /// This function is pure: it reads the event stream and config, builds a
 /// pruning plan, and returns the events + new thread that the caller must
 /// apply to the session entity.
-pub(super) fn maybe_prune<'a>(
-    events: impl DoubleEndedIterator<Item = &'a AgentSessionEvent> + Clone,
+#[allow(clippy::too_many_arguments)]
+pub(super) fn maybe_prune(
+    events: &EntityEvents<AgentSessionEvent>,
     config: &CompactionConfig,
+    model_defaults: &ModelDefaults,
     session_id: super::AgentSessionId,
     current_thread_id: SessionThreadId,
     is_main_thread: bool,
     current_prompt_definition: &PromptDefinition,
-    time_since_last_turn: Duration,
 ) -> Option<CompactionResult> {
-    let last_usage = estimation::last_usage(events.clone(), current_thread_id);
+    let last_usage = estimation::last_usage(events.iter_all(), current_thread_id);
     let estimated_tokens = estimation::estimate_context_tokens(
-        events.clone(),
+        events.iter_all(),
         current_thread_id,
         is_main_thread,
         last_usage,
     );
 
-    let action = config.determine_action(estimated_tokens, time_since_last_turn);
+    let time_since_last_turn = time_since_last_response_on_thread(events, current_thread_id);
+
+    let action = config.determine_action(
+        estimated_tokens,
+        model_defaults.context_window_tokens,
+        time_since_last_turn,
+    );
 
     match action {
         CompactionAction::None => return None,
+        CompactionAction::Orphan => {
+            return build_orphan_result(
+                events.iter_all(),
+                session_id,
+                current_thread_id,
+                is_main_thread,
+                model_defaults,
+                current_prompt_definition,
+            );
+        }
         CompactionAction::PruneOpportunistic | CompactionAction::PruneThenSummarize => {}
     }
 
-    let plan = build_pruning_plan(events, current_thread_id, is_main_thread, config);
+    let plan = build_pruning_plan(events.iter_all(), current_thread_id, is_main_thread, config);
     if plan.is_empty() {
         return None;
     }
@@ -112,13 +133,11 @@ pub(super) fn maybe_prune<'a>(
 
     let system_view = current_prompt_definition.system_view().clone();
     let tool_definitions_view = current_prompt_definition.tool_definitions_view().clone();
-    let model = current_prompt_definition.model.clone();
-    let max_tokens_per_response = current_prompt_definition.max_tokens_per_response;
 
     // Build the PromptDefinition for the compacted thread
     let prompt_definition = PromptDefinition {
-        model: model.clone(),
-        max_tokens_per_response,
+        model: model_defaults.model.clone(),
+        max_tokens_per_response: model_defaults.max_tokens_per_response,
         system_view: system_view.clone(),
         tool_definitions_view: tool_definitions_view.clone(),
         messages: transformed_messages.clone(),
@@ -129,8 +148,7 @@ pub(super) fn maybe_prune<'a>(
     let new_thread = NewSessionThread::compacted(
         new_thread_id,
         session_id,
-        model,
-        max_tokens_per_response,
+        model_defaults.clone(),
         system_view,
         tool_definitions_view,
         transformed_messages,
@@ -178,6 +196,136 @@ pub(super) fn maybe_prune<'a>(
         new_thread_id,
         prompt_definition,
     })
+}
+
+/// Compute duration since the last assistant response on a specific thread.
+/// Falls back to Duration::ZERO when no assistant response has been persisted yet.
+fn time_since_last_response_on_thread(
+    events: &EntityEvents<AgentSessionEvent>,
+    thread_id: SessionThreadId,
+) -> Duration {
+    let last_ts = events
+        .iter_persisted()
+        .rev()
+        .find_map(|pe| match &pe.event {
+            AgentSessionEvent::AssistantResponseReceived { thread_id: tid, .. }
+                if *tid == thread_id =>
+            {
+                Some(pe.recorded_at)
+            }
+            _ => None,
+        });
+    match last_ts {
+        Some(ts) => {
+            let elapsed = chrono::Utc::now() - ts;
+            elapsed.to_std().unwrap_or(Duration::ZERO)
+        }
+        None => Duration::ZERO,
+    }
+}
+
+/// Build an orphan result: a brand-new thread with only the pending user
+/// messages (no conversation carry-over). Used when idle time exceeds the
+/// configured reset threshold.
+fn build_orphan_result<'a>(
+    events: impl DoubleEndedIterator<Item = &'a AgentSessionEvent> + Clone,
+    session_id: super::AgentSessionId,
+    current_thread_id: SessionThreadId,
+    is_main_thread: bool,
+    model_defaults: &ModelDefaults,
+    current_prompt_definition: &PromptDefinition,
+) -> Option<CompactionResult> {
+    let new_thread_id = SessionThreadId::new();
+    let system_view = current_prompt_definition.system_view().clone();
+    let tool_definitions_view = current_prompt_definition.tool_definitions_view().clone();
+
+    // Only carry forward user messages that arrived after the last PromptSent
+    // for this thread — not the entire conversation history.
+    let pending = pending_user_message_indexes(events, current_thread_id, is_main_thread);
+    let user_messages = UserMessagesView { indexes: pending };
+
+    let prompt_definition = PromptDefinition {
+        model: model_defaults.model.clone(),
+        max_tokens_per_response: model_defaults.max_tokens_per_response,
+        system_view: system_view.clone(),
+        tool_definitions_view: tool_definitions_view.clone(),
+        messages: vec![MessageView::User(user_messages.clone())],
+        compaction: None,
+    };
+
+    let session_events = vec![AgentSessionEvent::ThreadStarted {
+        thread_id: new_thread_id,
+        start_reason: ThreadStartReason::Orphan {
+            from_thread: current_thread_id,
+        },
+    }];
+
+    Some(CompactionResult {
+        events: session_events,
+        new_thread: NewSessionThread::orphaned(
+            new_thread_id,
+            session_id,
+            current_thread_id,
+            model_defaults.clone(),
+            system_view,
+            tool_definitions_view,
+            user_messages,
+        ),
+        new_thread_id,
+        prompt_definition,
+    })
+}
+
+/// Collect block indexes for user messages that arrived after the last
+/// `PromptSent` for the given thread. These are the "pending" inputs that
+/// should carry over to an orphan thread.
+fn pending_user_message_indexes<'a>(
+    events: impl DoubleEndedIterator<Item = &'a AgentSessionEvent> + Clone,
+    thread_id: SessionThreadId,
+    is_main_thread: bool,
+) -> Vec<MessageBlockIndex> {
+    // First pass: count total blocks across all events
+    let total_blocks = events.clone().fold(0usize, |acc, e| match e {
+        AgentSessionEvent::UserInputAdded { .. }
+        | AgentSessionEvent::SandboxNotificationAdded { .. } => acc + 1,
+        AgentSessionEvent::AssistantResponseReceived { content, .. } => acc + content.len(),
+        AgentSessionEvent::ToolResultsAdded { results, .. } => acc + results.len(),
+        AgentSessionEvent::ToolResultsMasked { results, .. } => acc + results.len(),
+        _ => acc,
+    });
+
+    // Second pass: scan backwards, collecting indexes until we hit the last
+    // PromptSent for this thread.
+    let mut block_counter = total_blocks;
+    let mut pending = Vec::new();
+    for event in events.rev() {
+        match event {
+            AgentSessionEvent::PromptSent { thread_id: tid, .. } if *tid == thread_id => break,
+            AgentSessionEvent::UserInputAdded { target, .. }
+            | AgentSessionEvent::SandboxNotificationAdded { target, .. } => {
+                block_counter -= 1;
+                let targets_this = match target {
+                    TargetThread::Main => is_main_thread,
+                    TargetThread::Id(id) => *id == thread_id,
+                };
+                if targets_this {
+                    pending.push(MessageBlockIndex::new(block_counter));
+                }
+            }
+            AgentSessionEvent::AssistantResponseReceived { content, .. } => {
+                block_counter -= content.len();
+            }
+            AgentSessionEvent::ToolResultsAdded { results, .. } => {
+                block_counter -= results.len();
+            }
+            AgentSessionEvent::ToolResultsMasked { results, .. } => {
+                block_counter -= results.len();
+            }
+            _ => {}
+        }
+    }
+    pending.reverse();
+    pending
 }
 
 /// Transform message views by applying the pruning plan:

--- a/core/src/agent/session/compaction/prune.rs
+++ b/core/src/agent/session/compaction/prune.rs
@@ -374,9 +374,9 @@ mod tests {
         CompactionConfig {
             enabled: true,
             token_threshold_fraction: 0.6,
-            context_window_tokens: 200_000,
             keep_recent_tool_results: keep_recent,
             cache_ttl_seconds: 300,
+            reset_time_delta_seconds: None,
         }
     }
 

--- a/core/src/agent/session/compaction/trigger.rs
+++ b/core/src/agent/session/compaction/trigger.rs
@@ -2,6 +2,8 @@
 pub enum CompactionAction {
     /// Under threshold, cache hot — do nothing.
     None,
+    /// Idle timeout exceeded — start a brand-new thread.
+    Orphan,
     /// Cache cold, under threshold — prune opportunistically.
     /// Pruning is "free" when the cached prefix has already expired.
     PruneOpportunistic,
@@ -21,18 +23,20 @@ mod tests {
         CompactionConfig {
             enabled: true,
             token_threshold_fraction: 0.6,
-            context_window_tokens: 200_000,
             keep_recent_tool_results: 10,
             cache_ttl_seconds: 300,
+            reset_time_delta_seconds: None,
         }
     }
+
+    const CONTEXT_WINDOW: u64 = 200_000;
 
     #[test]
     fn none_when_disabled() {
         let mut cfg = config();
         cfg.enabled = false;
         assert_eq!(
-            cfg.determine_action(999_999, Duration::from_secs(9999)),
+            cfg.determine_action(999_999, CONTEXT_WINDOW, Duration::from_secs(9999)),
             CompactionAction::None
         );
     }
@@ -42,7 +46,7 @@ mod tests {
         let cfg = config();
         // 60_000 < 120_000 threshold, 60s < 300s cache_ttl
         assert_eq!(
-            cfg.determine_action(60_000, Duration::from_secs(60)),
+            cfg.determine_action(60_000, CONTEXT_WINDOW, Duration::from_secs(60)),
             CompactionAction::None
         );
     }
@@ -52,7 +56,7 @@ mod tests {
         let cfg = config();
         // 60_000 < 120_000, but 600s > 300s cache_ttl
         assert_eq!(
-            cfg.determine_action(60_000, Duration::from_secs(600)),
+            cfg.determine_action(60_000, CONTEXT_WINDOW, Duration::from_secs(600)),
             CompactionAction::PruneOpportunistic
         );
     }
@@ -62,7 +66,7 @@ mod tests {
         let cfg = config();
         // 150_000 > 120_000, 60s < 300s
         assert_eq!(
-            cfg.determine_action(150_000, Duration::from_secs(60)),
+            cfg.determine_action(150_000, CONTEXT_WINDOW, Duration::from_secs(60)),
             CompactionAction::PruneThenSummarize
         );
     }
@@ -72,8 +76,53 @@ mod tests {
         let cfg = config();
         // 150_000 > 120_000, 600s > 300s
         assert_eq!(
-            cfg.determine_action(150_000, Duration::from_secs(600)),
+            cfg.determine_action(150_000, CONTEXT_WINDOW, Duration::from_secs(600)),
             CompactionAction::PruneThenSummarize
+        );
+    }
+
+    #[test]
+    fn orphan_when_reset_threshold_exceeded() {
+        use crate::agent::session::settings::ResetTimeDeltaSeconds;
+
+        let cfg = CompactionConfig {
+            reset_time_delta_seconds: Some(ResetTimeDeltaSeconds(600)),
+            ..config()
+        };
+        // Under token threshold, but idle > 600s → Orphan
+        assert_eq!(
+            cfg.determine_action(60_000, CONTEXT_WINDOW, Duration::from_secs(700)),
+            CompactionAction::Orphan
+        );
+    }
+
+    #[test]
+    fn orphan_overrides_prune_then_summarize() {
+        use crate::agent::session::settings::ResetTimeDeltaSeconds;
+
+        let cfg = CompactionConfig {
+            reset_time_delta_seconds: Some(ResetTimeDeltaSeconds(600)),
+            ..config()
+        };
+        // Over token threshold AND idle > 600s → Orphan (not PruneThenSummarize)
+        assert_eq!(
+            cfg.determine_action(150_000, CONTEXT_WINDOW, Duration::from_secs(700)),
+            CompactionAction::Orphan
+        );
+    }
+
+    #[test]
+    fn no_orphan_when_under_reset_threshold() {
+        use crate::agent::session::settings::ResetTimeDeltaSeconds;
+
+        let cfg = CompactionConfig {
+            reset_time_delta_seconds: Some(ResetTimeDeltaSeconds(600)),
+            ..config()
+        };
+        // Under token threshold AND idle < 600s → None (not Orphan)
+        assert_eq!(
+            cfg.determine_action(60_000, CONTEXT_WINDOW, Duration::from_secs(60)),
+            CompactionAction::None
         );
     }
 }

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -1,10 +1,10 @@
-use std::time::Duration;
-
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
 use crate::primitives::{AgentId, UserMessageSource};
 use es_entity::*;
+
+use crate::agent::config::ModelDefaults;
 
 use super::{
     compaction, error::AgentSessionError, history, message::*, metadata::*, settings::*, thread::*,
@@ -21,6 +21,7 @@ pub enum ThreadStartReason {
     InitialThread,
     ToolDefsUpdated,
     Compaction { from_thread: SessionThreadId },
+    Orphan { from_thread: SessionThreadId },
 }
 
 #[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
@@ -30,10 +31,7 @@ pub enum AgentSessionEvent {
     Initialized {
         id: AgentSessionId,
         agent_id: AgentId,
-        model_settings: ModelSettings,
-        #[serde(default)]
-        thread_simplification_settings: ThreadSimplificationSettings,
-        #[serde(default)]
+        model_defaults: ModelDefaults,
         compaction_config: CompactionConfig,
         system_blocks: Vec<SystemBlock>,
         tool_defs: Vec<ToolDefinition>,
@@ -108,6 +106,9 @@ pub struct AgentSession {
 
     #[builder(default)]
     current_main_thread: Option<SessionThreadId>,
+
+    #[builder(default)]
+    model_defaults: ModelDefaults,
 
     #[builder(default)]
     compaction_config: CompactionConfig,
@@ -429,17 +430,15 @@ impl AgentSession {
         current_thread_id: SessionThreadId,
         current_prompt_def: &PromptDefinition,
     ) -> Option<(SessionThreadId, PromptDefinition)> {
-        let time_since = self.time_since_last_assistant_response();
-
         let is_main_thread = self.current_main_thread == Some(current_thread_id);
         let result = compaction::maybe_prune(
-            self.events.iter_all(),
+            &self.events,
             &self.compaction_config,
+            &self.model_defaults,
             self.id,
             current_thread_id,
             is_main_thread,
             current_prompt_def,
-            time_since,
         )?;
 
         // Apply compaction: push events and add new thread
@@ -452,26 +451,6 @@ impl AgentSession {
         Some((result.new_thread_id, result.prompt_definition))
     }
 
-    /// Compute duration since the last assistant response was persisted.
-    /// Falls back to Duration::ZERO when no assistant response has been persisted yet.
-    fn time_since_last_assistant_response(&self) -> Duration {
-        let last_ts = self
-            .events
-            .iter_persisted()
-            .rev()
-            .find_map(|pe| match &pe.event {
-                AgentSessionEvent::AssistantResponseReceived { .. } => Some(pe.recorded_at),
-                _ => None,
-            });
-        match last_ts {
-            Some(ts) => {
-                let elapsed = chrono::Utc::now() - ts;
-                elapsed.to_std().unwrap_or(Duration::ZERO)
-            }
-            None => Duration::ZERO,
-        }
-    }
-
     fn create_initial_thread(&mut self) -> PromptDefinition {
         let prompt_definition = self.materialize().initial_prompt_definition();
         let thread_id = SessionThreadId::new();
@@ -479,8 +458,7 @@ impl AgentSession {
             .id(thread_id)
             .session_id(self.id)
             .start_reason(ThreadStartReason::InitialThread)
-            .model(prompt_definition.model.clone())
-            .max_tokens_per_response(prompt_definition.max_tokens_per_response)
+            .model_defaults(self.model_defaults.clone())
             .system_view(prompt_definition.system_view().clone())
             .tool_definitions_view(prompt_definition.tool_definitions_view().clone())
             .initial_user_messages(prompt_definition.user_messages_view())
@@ -496,19 +474,15 @@ impl AgentSession {
     }
 
     fn materialize(&self) -> MaterializedSession<'_> {
-        let mut materialized = MaterializedSession::init("", 0);
+        let mut materialized = MaterializedSession::init(&self.model_defaults);
         for event in self.events.iter_all() {
             match event {
                 AgentSessionEvent::Initialized {
-                    model_settings,
                     system_blocks,
                     tool_defs,
                     ..
                 } => {
-                    materialized = MaterializedSession::init(
-                        &model_settings.model,
-                        model_settings.max_tokens_per_response,
-                    );
+                    materialized = MaterializedSession::init(&self.model_defaults);
                     materialized.push_system_blocks(system_blocks.iter());
                     materialized.push_tool_defs(tool_defs.iter());
                 }
@@ -577,12 +551,14 @@ impl TryFromEvents<AgentSessionEvent> for AgentSession {
                 AgentSessionEvent::Initialized {
                     id,
                     agent_id,
+                    model_defaults,
                     compaction_config,
                     ..
                 } => {
                     builder = builder
                         .id(*id)
                         .agent_id(*agent_id)
+                        .model_defaults(model_defaults.clone())
                         .compaction_config(compaction_config.clone());
                 }
                 AgentSessionEvent::ThreadStarted { thread_id, .. } => {
@@ -609,7 +585,7 @@ pub struct NewAgentSession {
     #[builder(setter(into))]
     pub(super) id: AgentSessionId,
     pub(super) agent_id: AgentId,
-    pub(super) model_settings: ModelSettings,
+    pub(super) model_defaults: ModelDefaults,
     #[builder(default)]
     pub(super) compaction_config: CompactionConfig,
     pub(super) system_blocks: Vec<SystemBlock>,
@@ -631,8 +607,7 @@ impl IntoEvents<AgentSessionEvent> for NewAgentSession {
             [AgentSessionEvent::Initialized {
                 id: self.id,
                 agent_id: self.agent_id,
-                model_settings: self.model_settings,
-                thread_simplification_settings: ThreadSimplificationSettings::default(),
+                model_defaults: self.model_defaults,
                 compaction_config: self.compaction_config,
                 system_blocks: self.system_blocks,
                 tool_defs: self.tool_defs,
@@ -651,9 +626,14 @@ mod tests {
     fn new_session() -> AgentSession {
         let new = NewAgentSession::builder()
             .agent_id(AgentId::new())
-            .model_settings(ModelSettings {
+            .model_defaults(ModelDefaults {
                 model: "test-model".into(),
                 max_tokens_per_response: 1024,
+                context_window_tokens: 200_000,
+            })
+            .compaction_config(CompactionConfig {
+                enabled: false,
+                ..Default::default()
             })
             .system_blocks(vec![])
             .tool_defs(vec![])
@@ -1041,16 +1021,17 @@ mod tests {
     fn new_session_with_compaction(keep_recent: usize) -> AgentSession {
         let new = NewAgentSession::builder()
             .agent_id(AgentId::new())
-            .model_settings(ModelSettings {
+            .model_defaults(ModelDefaults {
                 model: "test-model".into(),
                 max_tokens_per_response: 1024,
+                context_window_tokens: 100,
             })
             .compaction_config(CompactionConfig {
                 enabled: true,
                 token_threshold_fraction: 0.0, // always over threshold
-                context_window_tokens: 100,
                 keep_recent_tool_results: keep_recent,
                 cache_ttl_seconds: 0, // cache always cold
+                reset_time_delta_seconds: None,
             })
             .system_blocks(vec![SystemBlock::Text {
                 text: "You are helpful.".into(),

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -480,7 +480,7 @@ impl AgentSession {
             .session_id(self.id)
             .start_reason(ThreadStartReason::InitialThread)
             .model(prompt_definition.model.clone())
-            .max_tokens(prompt_definition.max_tokens)
+            .max_tokens_per_response(prompt_definition.max_tokens_per_response)
             .system_view(prompt_definition.system_view().clone())
             .tool_definitions_view(prompt_definition.tool_definitions_view().clone())
             .initial_user_messages(prompt_definition.user_messages_view())
@@ -505,8 +505,10 @@ impl AgentSession {
                     tool_defs,
                     ..
                 } => {
-                    materialized =
-                        MaterializedSession::init(&model_settings.model, model_settings.max_tokens);
+                    materialized = MaterializedSession::init(
+                        &model_settings.model,
+                        model_settings.max_tokens_per_response,
+                    );
                     materialized.push_system_blocks(system_blocks.iter());
                     materialized.push_tool_defs(tool_defs.iter());
                 }
@@ -651,7 +653,7 @@ mod tests {
             .agent_id(AgentId::new())
             .model_settings(ModelSettings {
                 model: "test-model".into(),
-                max_tokens: 1024,
+                max_tokens_per_response: 1024,
             })
             .system_blocks(vec![])
             .tool_defs(vec![])
@@ -1041,7 +1043,7 @@ mod tests {
             .agent_id(AgentId::new())
             .model_settings(ModelSettings {
                 model: "test-model".into(),
-                max_tokens: 1024,
+                max_tokens_per_response: 1024,
             })
             .compaction_config(CompactionConfig {
                 enabled: true,

--- a/core/src/agent/session/history.rs
+++ b/core/src/agent/session/history.rs
@@ -82,6 +82,7 @@ pub enum ThreadStartReasonKind {
     InitialThread,
     ToolDefsUpdated,
     Compaction,
+    Orphan,
 }
 
 #[derive(Debug, Clone, Serialize)]
@@ -198,6 +199,7 @@ pub(super) fn build_thread_infos<'a>(
                     ThreadStartReason::InitialThread => ThreadStartReasonKind::InitialThread,
                     ThreadStartReason::ToolDefsUpdated => ThreadStartReasonKind::ToolDefsUpdated,
                     ThreadStartReason::Compaction { .. } => ThreadStartReasonKind::Compaction,
+                    ThreadStartReason::Orphan { .. } => ThreadStartReasonKind::Orphan,
                 })
                 .unwrap_or(ThreadStartReasonKind::InitialThread);
             SessionThreadInfo {

--- a/core/src/agent/session/message.rs
+++ b/core/src/agent/session/message.rs
@@ -23,7 +23,7 @@ pub struct CompactionMetadata {
 pub struct Prompt {
     pub target_thread: TargetThread,
     pub model: String,
-    pub max_tokens: u32,
+    pub max_tokens_per_response: u32,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub system: Vec<SystemBlock>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -121,7 +121,7 @@ impl From<Prompt> for llm::Prompt {
     fn from(p: Prompt) -> Self {
         llm::Prompt {
             model: p.model,
-            max_tokens: Some(p.max_tokens),
+            max_tokens: Some(p.max_tokens_per_response),
             system: p
                 .system
                 .into_iter()

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -11,6 +11,7 @@ mod view;
 
 use tracing::instrument;
 
+use crate::agent::config::ModelDefaults;
 use crate::primitives::{AgentId, UserMessageSource};
 pub use entity::*;
 use error::AgentSessionError;
@@ -43,14 +44,14 @@ impl Sessions {
         &self,
         op: &mut es_entity::DbOp<'_>,
         agent_id: AgentId,
-        model_settings: ModelSettings,
+        model_defaults: ModelDefaults,
         compaction_config: CompactionConfig,
         system_blocks: Vec<SystemBlock>,
         tool_defs: Vec<ToolDefinition>,
     ) -> Result<AgentSession, AgentSessionError> {
         let new_session = NewAgentSession::builder()
             .agent_id(agent_id)
-            .model_settings(model_settings)
+            .model_defaults(model_defaults)
             .compaction_config(compaction_config)
             .system_blocks(system_blocks)
             .tool_defs(tool_defs)

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -44,12 +44,14 @@ impl Sessions {
         op: &mut es_entity::DbOp<'_>,
         agent_id: AgentId,
         model_settings: ModelSettings,
+        compaction_config: CompactionConfig,
         system_blocks: Vec<SystemBlock>,
         tool_defs: Vec<ToolDefinition>,
     ) -> Result<AgentSession, AgentSessionError> {
         let new_session = NewAgentSession::builder()
             .agent_id(agent_id)
             .model_settings(model_settings)
+            .compaction_config(compaction_config)
             .system_blocks(system_blocks)
             .tool_defs(tool_defs)
             .build()

--- a/core/src/agent/session/settings.rs
+++ b/core/src/agent/session/settings.rs
@@ -7,7 +7,8 @@ use super::compaction::trigger::CompactionAction;
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ModelSettings {
     pub model: String,
-    pub max_tokens: u32,
+    #[serde(alias = "max_tokens")]
+    pub max_tokens_per_response: u32,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]

--- a/core/src/agent/session/settings.rs
+++ b/core/src/agent/session/settings.rs
@@ -4,16 +4,24 @@ use serde::{Deserialize, Serialize};
 
 use super::compaction::trigger::CompactionAction;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ModelSettings {
-    pub model: String,
-    #[serde(alias = "max_tokens")]
-    pub max_tokens_per_response: u32,
+/// Whole-second auto-reset threshold for an `AgentSession`. Wraps a
+/// `u32` count of seconds; the `#[serde(transparent)]` derive lets it
+/// (de)serialize as a bare integer in YAML / JSONB instead of serde's
+/// awkward `{ secs, nanos }` shape for `std::time::Duration`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ResetTimeDeltaSeconds(pub u32);
+
+impl ResetTimeDeltaSeconds {
+    pub fn as_duration(&self) -> Duration {
+        Duration::from_secs(self.0 as u64)
+    }
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
-pub struct ThreadSimplificationSettings {
-    pub simplify_after_idle_seconds: Option<u32>,
+impl From<u32> for ResetTimeDeltaSeconds {
+    fn from(s: u32) -> Self {
+        Self(s)
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -22,12 +30,14 @@ pub struct CompactionConfig {
     pub enabled: bool,
     /// Token threshold as fraction of context window (e.g. 0.6 = 60%).
     pub token_threshold_fraction: f64,
-    /// Context window size for the model in tokens.
-    pub context_window_tokens: u64,
     /// Number of recent tool results to keep unmasked.
     pub keep_recent_tool_results: usize,
     /// Provider cache TTL in seconds — prune freely after this inactivity period.
     pub cache_ttl_seconds: u64,
+    /// If set, start a fresh thread (orphan) when a user message arrives
+    /// more than this many seconds after the previous assistant response.
+    #[serde(default)]
+    pub reset_time_delta_seconds: Option<ResetTimeDeltaSeconds>,
 }
 
 impl CompactionConfig {
@@ -37,16 +47,27 @@ impl CompactionConfig {
     /// prefix, so we avoid it while the cache is hot (within `cache_ttl`).
     /// Once the cache has expired we prune opportunistically to set up a clean
     /// cacheable prefix for the next burst of turns.
+    ///
+    /// `Orphan` takes priority: if the reset threshold is exceeded the session
+    /// starts a brand-new thread regardless of token counts.
     pub fn determine_action(
         &self,
         estimated_tokens: u64,
+        context_window_tokens: u64,
         time_since_last_turn: Duration,
     ) -> CompactionAction {
         if !self.enabled {
             return CompactionAction::None;
         }
 
-        let threshold = (self.context_window_tokens as f64 * self.token_threshold_fraction) as u64;
+        // Orphan check first — idle timeout overrides everything else
+        if let Some(reset) = &self.reset_time_delta_seconds {
+            if time_since_last_turn > reset.as_duration() {
+                return CompactionAction::Orphan;
+            }
+        }
+
+        let threshold = (context_window_tokens as f64 * self.token_threshold_fraction) as u64;
         let cache_ttl = Duration::from_secs(self.cache_ttl_seconds);
         let cache_cold = time_since_last_turn > cache_ttl;
 
@@ -61,11 +82,11 @@ impl CompactionConfig {
 impl Default for CompactionConfig {
     fn default() -> Self {
         Self {
-            enabled: false,
+            enabled: true,
             token_threshold_fraction: 0.6,
-            context_window_tokens: 200_000,
             keep_recent_tool_results: 10,
             cache_ttl_seconds: 300,
+            reset_time_delta_seconds: None,
         }
     }
 }

--- a/core/src/agent/session/settings.rs
+++ b/core/src/agent/session/settings.rs
@@ -25,6 +25,7 @@ impl From<u32> for ResetTimeDeltaSeconds {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
 pub struct CompactionConfig {
     /// Enable the compaction system.
     pub enabled: bool,

--- a/core/src/agent/session/thread.rs
+++ b/core/src/agent/session/thread.rs
@@ -26,7 +26,8 @@ pub enum SessionThreadEvent {
         session_id: AgentSessionId,
         start_reason: ThreadStartReason,
         model: String,
-        max_tokens: u32,
+        #[serde(alias = "max_tokens")]
+        max_tokens_per_response: u32,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         initial_user_messages: UserMessagesView,
@@ -35,7 +36,8 @@ pub enum SessionThreadEvent {
         id: SessionThreadId,
         session_id: AgentSessionId,
         model: String,
-        max_tokens: u32,
+        #[serde(alias = "max_tokens")]
+        max_tokens_per_response: u32,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         messages: Vec<MessageView>,
@@ -107,7 +109,7 @@ impl SessionThread {
 
     pub fn prompt_definition(&self) -> PromptDefinition {
         let mut model = String::new();
-        let mut max_tokens = 0;
+        let mut max_tokens_per_response = 0;
         let mut system_view = SystemView { indexes: vec![] };
         let mut tool_definitions_view = ToolDefinitionsView { indexes: vec![] };
         let mut messages = Vec::new();
@@ -116,28 +118,28 @@ impl SessionThread {
             match event {
                 SessionThreadEvent::Initialized {
                     model: m,
-                    max_tokens: mt,
+                    max_tokens_per_response: mt,
                     system_view: sv,
                     tool_definitions_view: tdv,
                     initial_user_messages,
                     ..
                 } => {
                     model = m.clone();
-                    max_tokens = *mt;
+                    max_tokens_per_response = *mt;
                     system_view = sv.clone();
                     tool_definitions_view = tdv.clone();
                     messages.push(MessageView::User(initial_user_messages.clone()));
                 }
                 SessionThreadEvent::InitializedFromCompaction {
                     model: m,
-                    max_tokens: mt,
+                    max_tokens_per_response: mt,
                     system_view: sv,
                     tool_definitions_view: tdv,
                     messages: init_messages,
                     ..
                 } => {
                     model = m.clone();
-                    max_tokens = *mt;
+                    max_tokens_per_response = *mt;
                     system_view = sv.clone();
                     tool_definitions_view = tdv.clone();
                     messages.extend(init_messages.iter().cloned());
@@ -167,7 +169,7 @@ impl SessionThread {
 
         PromptDefinition {
             model,
-            max_tokens,
+            max_tokens_per_response,
             system_view,
             tool_definitions_view,
             messages,
@@ -241,7 +243,7 @@ pub struct NewSessionThread {
     pub(super) session_id: AgentSessionId,
     pub(super) start_reason: ThreadStartReason,
     pub(super) model: String,
-    pub(super) max_tokens: u32,
+    pub(super) max_tokens_per_response: u32,
     pub(super) system_view: SystemView,
     pub(super) tool_definitions_view: ToolDefinitionsView,
     init: ThreadInitData,
@@ -265,7 +267,7 @@ impl NewSessionThread {
             session_id: None,
             start_reason: None,
             model: None,
-            max_tokens: None,
+            max_tokens_per_response: None,
             system_view: None,
             tool_definitions_view: None,
             initial_user_messages: None,
@@ -277,7 +279,7 @@ impl NewSessionThread {
         id: SessionThreadId,
         session_id: AgentSessionId,
         model: String,
-        max_tokens: u32,
+        max_tokens_per_response: u32,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         messages: Vec<MessageView>,
@@ -290,7 +292,7 @@ impl NewSessionThread {
                 from_thread: follows_from,
             },
             model,
-            max_tokens,
+            max_tokens_per_response,
             system_view,
             tool_definitions_view,
             init: ThreadInitData::Compacted {
@@ -307,7 +309,7 @@ pub struct NewSessionThreadBuilder {
     session_id: Option<AgentSessionId>,
     start_reason: Option<ThreadStartReason>,
     model: Option<String>,
-    max_tokens: Option<u32>,
+    max_tokens_per_response: Option<u32>,
     system_view: Option<SystemView>,
     tool_definitions_view: Option<ToolDefinitionsView>,
     initial_user_messages: Option<UserMessagesView>,
@@ -334,8 +336,8 @@ impl NewSessionThreadBuilder {
         self
     }
 
-    pub fn max_tokens(mut self, max_tokens: u32) -> Self {
-        self.max_tokens = Some(max_tokens);
+    pub fn max_tokens_per_response(mut self, max_tokens_per_response: u32) -> Self {
+        self.max_tokens_per_response = Some(max_tokens_per_response);
         self
     }
 
@@ -366,9 +368,11 @@ impl NewSessionThreadBuilder {
             model: self.model.ok_or(EntityHydrationError::from(
                 derive_builder::UninitializedFieldError::from("model"),
             ))?,
-            max_tokens: self.max_tokens.ok_or(EntityHydrationError::from(
-                derive_builder::UninitializedFieldError::from("max_tokens"),
-            ))?,
+            max_tokens_per_response: self.max_tokens_per_response.ok_or(
+                EntityHydrationError::from(derive_builder::UninitializedFieldError::from(
+                    "max_tokens_per_response",
+                )),
+            )?,
             system_view: self.system_view.ok_or(EntityHydrationError::from(
                 derive_builder::UninitializedFieldError::from("system_view"),
             ))?,
@@ -398,7 +402,7 @@ impl IntoEvents<SessionThreadEvent> for NewSessionThread {
                 session_id: self.session_id,
                 start_reason: self.start_reason,
                 model: self.model,
-                max_tokens: self.max_tokens,
+                max_tokens_per_response: self.max_tokens_per_response,
                 system_view: self.system_view,
                 tool_definitions_view: self.tool_definitions_view,
                 initial_user_messages,
@@ -410,7 +414,7 @@ impl IntoEvents<SessionThreadEvent> for NewSessionThread {
                 id: self.id,
                 session_id: self.session_id,
                 model: self.model,
-                max_tokens: self.max_tokens,
+                max_tokens_per_response: self.max_tokens_per_response,
                 system_view: self.system_view,
                 tool_definitions_view: self.tool_definitions_view,
                 messages,

--- a/core/src/agent/session/thread.rs
+++ b/core/src/agent/session/thread.rs
@@ -3,6 +3,8 @@ use serde::{Deserialize, Serialize};
 
 use es_entity::*;
 
+use crate::agent::config::ModelDefaults;
+
 use super::entity::ThreadStartReason;
 use super::view::*;
 use super::AgentSessionId;
@@ -25,9 +27,7 @@ pub enum SessionThreadEvent {
         id: SessionThreadId,
         session_id: AgentSessionId,
         start_reason: ThreadStartReason,
-        model: String,
-        #[serde(alias = "max_tokens")]
-        max_tokens_per_response: u32,
+        model_defaults: ModelDefaults,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         initial_user_messages: UserMessagesView,
@@ -35,9 +35,7 @@ pub enum SessionThreadEvent {
     InitializedFromCompaction {
         id: SessionThreadId,
         session_id: AgentSessionId,
-        model: String,
-        #[serde(alias = "max_tokens")]
-        max_tokens_per_response: u32,
+        model_defaults: ModelDefaults,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         messages: Vec<MessageView>,
@@ -117,29 +115,27 @@ impl SessionThread {
         for event in self.events.iter_all() {
             match event {
                 SessionThreadEvent::Initialized {
-                    model: m,
-                    max_tokens_per_response: mt,
+                    model_defaults,
                     system_view: sv,
                     tool_definitions_view: tdv,
                     initial_user_messages,
                     ..
                 } => {
-                    model = m.clone();
-                    max_tokens_per_response = *mt;
+                    model = model_defaults.model.clone();
+                    max_tokens_per_response = model_defaults.max_tokens_per_response;
                     system_view = sv.clone();
                     tool_definitions_view = tdv.clone();
                     messages.push(MessageView::User(initial_user_messages.clone()));
                 }
                 SessionThreadEvent::InitializedFromCompaction {
-                    model: m,
-                    max_tokens_per_response: mt,
+                    model_defaults,
                     system_view: sv,
                     tool_definitions_view: tdv,
                     messages: init_messages,
                     ..
                 } => {
-                    model = m.clone();
-                    max_tokens_per_response = *mt;
+                    model = model_defaults.model.clone();
+                    max_tokens_per_response = model_defaults.max_tokens_per_response;
                     system_view = sv.clone();
                     tool_definitions_view = tdv.clone();
                     messages.extend(init_messages.iter().cloned());
@@ -242,8 +238,7 @@ pub struct NewSessionThread {
     pub(super) id: SessionThreadId,
     pub(super) session_id: AgentSessionId,
     pub(super) start_reason: ThreadStartReason,
-    pub(super) model: String,
-    pub(super) max_tokens_per_response: u32,
+    pub(super) model_defaults: ModelDefaults,
     pub(super) system_view: SystemView,
     pub(super) tool_definitions_view: ToolDefinitionsView,
     init: ThreadInitData,
@@ -266,20 +261,17 @@ impl NewSessionThread {
             id: SessionThreadId::new(),
             session_id: None,
             start_reason: None,
-            model: None,
-            max_tokens_per_response: None,
+            model_defaults: None,
             system_view: None,
             tool_definitions_view: None,
             initial_user_messages: None,
         }
     }
 
-    #[allow(clippy::too_many_arguments)]
     pub fn compacted(
         id: SessionThreadId,
         session_id: AgentSessionId,
-        model: String,
-        max_tokens_per_response: u32,
+        model_defaults: ModelDefaults,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         messages: Vec<MessageView>,
@@ -291,13 +283,36 @@ impl NewSessionThread {
             start_reason: ThreadStartReason::Compaction {
                 from_thread: follows_from,
             },
-            model,
-            max_tokens_per_response,
+            model_defaults,
             system_view,
             tool_definitions_view,
             init: ThreadInitData::Compacted {
                 messages,
                 follows_from,
+            },
+        }
+    }
+
+    /// Create a fresh thread from an orphan action. Carries only the pending
+    /// user messages — no conversation history.
+    pub fn orphaned(
+        id: SessionThreadId,
+        session_id: AgentSessionId,
+        from_thread: SessionThreadId,
+        model_defaults: ModelDefaults,
+        system_view: super::view::SystemView,
+        tool_definitions_view: super::view::ToolDefinitionsView,
+        pending_user_messages: super::view::UserMessagesView,
+    ) -> Self {
+        Self {
+            id,
+            session_id,
+            start_reason: ThreadStartReason::Orphan { from_thread },
+            model_defaults,
+            system_view,
+            tool_definitions_view,
+            init: ThreadInitData::Initial {
+                initial_user_messages: pending_user_messages,
             },
         }
     }
@@ -308,8 +323,7 @@ pub struct NewSessionThreadBuilder {
     id: SessionThreadId,
     session_id: Option<AgentSessionId>,
     start_reason: Option<ThreadStartReason>,
-    model: Option<String>,
-    max_tokens_per_response: Option<u32>,
+    model_defaults: Option<ModelDefaults>,
     system_view: Option<SystemView>,
     tool_definitions_view: Option<ToolDefinitionsView>,
     initial_user_messages: Option<UserMessagesView>,
@@ -331,13 +345,8 @@ impl NewSessionThreadBuilder {
         self
     }
 
-    pub fn model(mut self, model: impl Into<String>) -> Self {
-        self.model = Some(model.into());
-        self
-    }
-
-    pub fn max_tokens_per_response(mut self, max_tokens_per_response: u32) -> Self {
-        self.max_tokens_per_response = Some(max_tokens_per_response);
+    pub fn model_defaults(mut self, model_defaults: ModelDefaults) -> Self {
+        self.model_defaults = Some(model_defaults);
         self
     }
 
@@ -365,14 +374,9 @@ impl NewSessionThreadBuilder {
             start_reason: self.start_reason.ok_or(EntityHydrationError::from(
                 derive_builder::UninitializedFieldError::from("start_reason"),
             ))?,
-            model: self.model.ok_or(EntityHydrationError::from(
-                derive_builder::UninitializedFieldError::from("model"),
+            model_defaults: self.model_defaults.ok_or(EntityHydrationError::from(
+                derive_builder::UninitializedFieldError::from("model_defaults"),
             ))?,
-            max_tokens_per_response: self.max_tokens_per_response.ok_or(
-                EntityHydrationError::from(derive_builder::UninitializedFieldError::from(
-                    "max_tokens_per_response",
-                )),
-            )?,
             system_view: self.system_view.ok_or(EntityHydrationError::from(
                 derive_builder::UninitializedFieldError::from("system_view"),
             ))?,
@@ -401,8 +405,7 @@ impl IntoEvents<SessionThreadEvent> for NewSessionThread {
                 id: self.id,
                 session_id: self.session_id,
                 start_reason: self.start_reason,
-                model: self.model,
-                max_tokens_per_response: self.max_tokens_per_response,
+                model_defaults: self.model_defaults,
                 system_view: self.system_view,
                 tool_definitions_view: self.tool_definitions_view,
                 initial_user_messages,
@@ -413,8 +416,7 @@ impl IntoEvents<SessionThreadEvent> for NewSessionThread {
             } => SessionThreadEvent::InitializedFromCompaction {
                 id: self.id,
                 session_id: self.session_id,
-                model: self.model,
-                max_tokens_per_response: self.max_tokens_per_response,
+                model_defaults: self.model_defaults,
                 system_view: self.system_view,
                 tool_definitions_view: self.tool_definitions_view,
                 messages,

--- a/core/src/agent/session/view.rs
+++ b/core/src/agent/session/view.rs
@@ -65,7 +65,7 @@ pub struct ToolResultsView {
 #[derive(Debug)]
 pub(super) struct MaterializedSession<'a> {
     model: &'a str,
-    max_tokens: u32,
+    max_tokens_per_response: u32,
     system_blocks: Vec<&'a SystemBlock>,
     system_breakpoints: Vec<SystemBlockIndex>,
     tool_defs: Vec<&'a ToolDefinition>,
@@ -77,10 +77,10 @@ pub(super) struct MaterializedSession<'a> {
 }
 
 impl<'a> MaterializedSession<'a> {
-    pub fn init(model: &'a str, max_tokens: u32) -> Self {
+    pub fn init(model: &'a str, max_tokens_per_response: u32) -> Self {
         Self {
             model,
-            max_tokens,
+            max_tokens_per_response,
             system_blocks: Vec::new(),
             system_breakpoints: Vec::new(),
             tool_defs: Vec::new(),
@@ -184,7 +184,7 @@ impl<'a> MaterializedSession<'a> {
         let initial_user_messages = self.all_user_messages();
         PromptDefinition {
             model: self.model.to_string(),
-            max_tokens: self.max_tokens,
+            max_tokens_per_response: self.max_tokens_per_response,
             system_view,
             tool_definitions_view,
             messages: vec![MessageView::User(initial_user_messages)],
@@ -218,7 +218,7 @@ pub enum MessageView {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PromptDefinition {
     pub(super) model: String,
-    pub(super) max_tokens: u32,
+    pub(super) max_tokens_per_response: u32,
     pub(super) system_view: SystemView,
     pub(super) tool_definitions_view: ToolDefinitionsView,
     pub(super) messages: Vec<MessageView>,
@@ -382,7 +382,7 @@ impl PromptDefinition {
         Ok(Prompt {
             target_thread,
             model: self.model,
-            max_tokens: self.max_tokens,
+            max_tokens_per_response: self.max_tokens_per_response,
             system,
             tools,
             messages: merged,

--- a/core/src/agent/session/view.rs
+++ b/core/src/agent/session/view.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 
 use es_entity::EntityEvents;
 
+use crate::agent::config::ModelDefaults;
+
 use super::{entity::AgentSessionEvent, error::AgentSessionError, message::*};
 
 // ============================================================================
@@ -64,8 +66,7 @@ pub struct ToolResultsView {
 
 #[derive(Debug)]
 pub(super) struct MaterializedSession<'a> {
-    model: &'a str,
-    max_tokens_per_response: u32,
+    model_defaults: &'a ModelDefaults,
     system_blocks: Vec<&'a SystemBlock>,
     system_breakpoints: Vec<SystemBlockIndex>,
     tool_defs: Vec<&'a ToolDefinition>,
@@ -77,10 +78,9 @@ pub(super) struct MaterializedSession<'a> {
 }
 
 impl<'a> MaterializedSession<'a> {
-    pub fn init(model: &'a str, max_tokens_per_response: u32) -> Self {
+    pub fn init(model_defaults: &'a ModelDefaults) -> Self {
         Self {
-            model,
-            max_tokens_per_response,
+            model_defaults,
             system_blocks: Vec::new(),
             system_breakpoints: Vec::new(),
             tool_defs: Vec::new(),
@@ -183,8 +183,8 @@ impl<'a> MaterializedSession<'a> {
         let tool_definitions_view = self.tools_since_last_breakpoint();
         let initial_user_messages = self.all_user_messages();
         PromptDefinition {
-            model: self.model.to_string(),
-            max_tokens_per_response: self.max_tokens_per_response,
+            model: self.model_defaults.model.clone(),
+            max_tokens_per_response: self.model_defaults.max_tokens_per_response,
             system_view,
             tool_definitions_view,
             messages: vec![MessageView::User(initial_user_messages)],
@@ -409,6 +409,14 @@ mod tests {
         }
     }
 
+    fn test_model_defaults() -> ModelDefaults {
+        ModelDefaults {
+            model: "test-model".into(),
+            max_tokens_per_response: 8192,
+            context_window_tokens: 200_000,
+        }
+    }
+
     #[test]
     fn tool_defs_breakpoint_returns_latest_batch() {
         let tool_a = tool_def("tool_a");
@@ -416,7 +424,8 @@ mod tests {
         let tool_c = tool_def("tool_c");
         let tool_d = tool_def("tool_d");
 
-        let mut m = MaterializedSession::init("test-model", 8192);
+        let defaults = test_model_defaults();
+        let mut m = MaterializedSession::init(&defaults);
         m.push_tool_defs([&tool_a, &tool_b].into_iter());
         m.push_tool_defs([&tool_c, &tool_d].into_iter());
 
@@ -430,7 +439,8 @@ mod tests {
         let block_b = system_block("Be concise.");
         let block_c = system_block("Use examples.");
 
-        let mut m = MaterializedSession::init("test-model", 8192);
+        let defaults = test_model_defaults();
+        let mut m = MaterializedSession::init(&defaults);
         m.push_system_blocks([&block_a].into_iter());
         m.push_system_blocks([&block_b, &block_c].into_iter());
 

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -6,7 +6,9 @@ use tokio::task::JoinHandle;
 use tracing::instrument;
 
 use anthropic_client::AnthropicClient;
+use llm::provider::LlmProvider;
 use llm::{Prompt, PromptError, PromptRequest, PromptRequestChannel, PromptResponseChannel};
+use openai_client::OpenAiClient;
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PromptExecutorConfig {
@@ -26,6 +28,7 @@ pub struct ModelConfig {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Provider {
     Anthropic { api_key: String },
+    OpenAi { api_key: String },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -47,12 +50,6 @@ impl PromptExecutorConfig {
                     );
                 }
                 Provider::Anthropic { api_key } => {
-                    // Anthropic production keys start with `sk-ant-`. A
-                    // different prefix is usually a paste-swap with some
-                    // other vendor's key (OpenAI, AWS, etc.) and will
-                    // always 401 at the Messages API. Warn loudly and log
-                    // a masked preview so the operator can eyeball the
-                    // value that actually reached the process.
                     let preview = masked_preview(api_key);
                     if !api_key.starts_with("sk-ant-") {
                         tracing::warn!(
@@ -66,6 +63,29 @@ impl PromptExecutorConfig {
                             model = %model.name,
                             key_preview = %preview,
                             "Anthropic credential loaded"
+                        );
+                    }
+                }
+                Provider::OpenAi { api_key } if api_key.is_empty() => {
+                    tracing::warn!(
+                        model = %model.name,
+                        "OpenAI credential is empty — agent prompts will fail until OPENAI_API_KEY is set",
+                    );
+                }
+                Provider::OpenAi { api_key } => {
+                    let preview = masked_preview(api_key);
+                    if !api_key.starts_with("sk-") {
+                        tracing::warn!(
+                            model = %model.name,
+                            key_preview = %preview,
+                            key_len = api_key.len(),
+                            "OpenAI credential does not start with `sk-` — this will most likely 401 at the Chat Completions API",
+                        );
+                    } else {
+                        tracing::info!(
+                            model = %model.name,
+                            key_preview = %preview,
+                            "OpenAI credential loaded"
                         );
                     }
                 }
@@ -173,26 +193,18 @@ impl ExecutorState {
                 if request.prompt.max_tokens.is_none() {
                     request.prompt.max_tokens = model.default_max_tokens;
                 }
-                match model.client {
-                    ProviderClient::Anthropic(client) => {
-                        tokio::spawn(async move {
-                            evaluate_with_anthropic_streaming(
-                                client,
-                                request.prompt,
-                                request.response_channel,
-                            )
-                            .await;
-                        });
-                    }
-                }
+                let client = model.client.clone();
+                tokio::spawn(async move {
+                    evaluate_streaming(client, request.prompt, request.response_channel).await;
+                });
             }
         }
     }
 }
 
 #[instrument(name = "domain.prompt_executor.evaluate_streaming", skip_all)]
-async fn evaluate_with_anthropic_streaming(
-    client: AnthropicClient,
+async fn evaluate_streaming(
+    client: Arc<dyn LlmProvider>,
     prompt: Prompt,
     response: PromptResponseChannel,
 ) {
@@ -208,30 +220,16 @@ async fn evaluate_with_anthropic_streaming(
         return; // caller dropped
     }
 
-    // The anthropic client already converts SSE → StreamDelta internally,
-    // so we just pipe deltas through to the agent loop.
     match client.send_prompt_streaming(&prompt).await {
-        Ok(mut delta_rx) => {
-            while let Some(result) = delta_rx.recv().await {
-                match result {
-                    Ok(delta) => {
-                        if delta_tx.send(Ok(delta)).await.is_err() {
-                            break;
-                        }
-                    }
-                    Err(e) => {
-                        let _ = delta_tx
-                            .send(Err(PromptError::Provider(e.to_string())))
-                            .await;
-                        break;
-                    }
+        Ok(mut provider_rx) => {
+            while let Some(result) = provider_rx.recv().await {
+                if delta_tx.send(result).await.is_err() {
+                    break;
                 }
             }
         }
         Err(e) => {
-            let _ = delta_tx
-                .send(Err(PromptError::Provider(e.to_string())))
-                .await;
+            let _ = delta_tx.send(Err(e)).await;
         }
     }
 }
@@ -240,15 +238,14 @@ async fn evaluate_with_anthropic_streaming(
 struct ResolvedModel {
     name: String,
     default_max_tokens: Option<u32>,
-    client: ProviderClient,
+    client: Arc<dyn LlmProvider>,
 }
 
 impl ResolvedModel {
     fn from_config(config: ModelConfig) -> Self {
-        let client = match config.provider {
-            Provider::Anthropic { api_key } => {
-                ProviderClient::Anthropic(AnthropicClient::new(api_key))
-            }
+        let client: Arc<dyn LlmProvider> = match config.provider {
+            Provider::Anthropic { api_key } => Arc::new(AnthropicClient::new(api_key)),
+            Provider::OpenAi { api_key } => Arc::new(OpenAiClient::new(api_key)),
         };
         Self {
             name: config.name,
@@ -256,9 +253,4 @@ impl ResolvedModel {
             client,
         }
     }
-}
-
-#[derive(Clone)]
-enum ProviderClient {
-    Anthropic(AnthropicClient),
 }

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -30,13 +30,14 @@ async fn send_message_round_trip_via_prompt_channel() {
         AgentRole::WorkspaceLead,
         RoleConfig {
             model: model_name.clone(),
-            reset_time_delta_seconds: None,
+            compaction: Default::default(),
         },
     );
     let mut models = HashMap::new();
     models.insert(
-        model_name,
+        model_name.clone(),
         ModelDefaults {
+            model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
         },
@@ -180,13 +181,14 @@ async fn send_message_dispatches_registered_tool_call() {
         AgentRole::WorkspaceLead,
         RoleConfig {
             model: model_name.clone(),
-            reset_time_delta_seconds: None,
+            compaction: Default::default(),
         },
     );
     let mut models = HashMap::new();
     models.insert(
-        model_name,
+        model_name.clone(),
         ModelDefaults {
+            model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
         },

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use drua_core::agent::{AgentRole, Agents, AgentsConfig, RoleConfig};
+use drua_core::agent::{AgentRole, Agents, AgentsConfig, ModelDefaults, RoleConfig};
 use drua_core::primitives::{AuthSubject, ChatOutputEvent, UserId, WorkspaceId};
 use drua_core::sandbox::{SandboxConfig, Sandboxes};
 use drua_core::toolset::{ToolSets, ToolSetsConfig, ToolSetsError, TopLevelTool};
@@ -24,17 +24,27 @@ async fn send_message_round_trip_via_prompt_channel() {
 
     let (prompt_tx, mut prompt_rx) = mpsc::channel::<PromptRequest>(64);
 
+    let model_name = "claude-haiku-4-5-20251001".to_string();
     let mut builtin_roles = HashMap::new();
     builtin_roles.insert(
         AgentRole::WorkspaceLead,
         RoleConfig {
-            provider: "anthropic".to_string(),
-            model: "claude-haiku-4-5-20251001".to_string(),
-            max_tokens: 1024,
+            model: model_name.clone(),
             reset_time_delta_seconds: None,
         },
     );
-    let config = AgentsConfig { builtin_roles };
+    let mut models = HashMap::new();
+    models.insert(
+        model_name,
+        ModelDefaults {
+            max_tokens: 1024,
+            context_window_tokens: 200_000,
+        },
+    );
+    let config = AgentsConfig {
+        builtin_roles,
+        models,
+    };
 
     let toolsets = Arc::new(
         ToolSets::init(ToolSetsConfig::default())
@@ -164,17 +174,27 @@ async fn send_message_dispatches_registered_tool_call() {
 
     let (prompt_tx, mut prompt_rx) = mpsc::channel::<PromptRequest>(64);
 
+    let model_name = "claude-haiku-4-5-20251001".to_string();
     let mut builtin_roles = HashMap::new();
     builtin_roles.insert(
         AgentRole::WorkspaceLead,
         RoleConfig {
-            provider: "anthropic".to_string(),
-            model: "claude-haiku-4-5-20251001".to_string(),
-            max_tokens: 1024,
+            model: model_name.clone(),
             reset_time_delta_seconds: None,
         },
     );
-    let config = AgentsConfig { builtin_roles };
+    let mut models = HashMap::new();
+    models.insert(
+        model_name,
+        ModelDefaults {
+            max_tokens: 1024,
+            context_window_tokens: 200_000,
+        },
+    );
+    let config = AgentsConfig {
+        builtin_roles,
+        models,
+    };
 
     // Build ToolSets, register the test tool, then share via Arc.
     let toolsets = ToolSets::init(ToolSetsConfig::default())

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -28,6 +28,7 @@ async fn send_message_round_trip_via_prompt_channel() {
     builtin_roles.insert(
         AgentRole::WorkspaceLead,
         RoleConfig {
+            provider: "anthropic".to_string(),
             model: "claude-haiku-4-5-20251001".to_string(),
             max_tokens: 1024,
             reset_time_delta_seconds: None,
@@ -167,6 +168,7 @@ async fn send_message_dispatches_registered_tool_call() {
     builtin_roles.insert(
         AgentRole::WorkspaceLead,
         RoleConfig {
+            provider: "anthropic".to_string(),
             model: "claude-haiku-4-5-20251001".to_string(),
             max_tokens: 1024,
             reset_time_delta_seconds: None,

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -37,7 +37,7 @@ async fn send_message_round_trip_via_prompt_channel() {
     models.insert(
         model_name,
         ModelDefaults {
-            max_tokens: 1024,
+            max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
         },
     );
@@ -187,7 +187,7 @@ async fn send_message_dispatches_registered_tool_call() {
     models.insert(
         model_name,
         ModelDefaults {
-            max_tokens: 1024,
+            max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
         },
     );

--- a/dev/drua.default.yml
+++ b/dev/drua.default.yml
@@ -9,8 +9,10 @@ oauth:
   github_client_id: ''
   github_allowed_teams: []
 db: {}
+providers: []
 agents:
   builtin_roles: {}
+  models: {}
 toolsets:
   mcp_upstreams: []
   concourse:

--- a/drua.yml
+++ b/drua.yml
@@ -19,11 +19,9 @@ agents:
     workspace_lead:
       model: claude-haiku-4-5-20251001
       compaction:
-        reset_time_delta_seconds: 600
+        reset_time_delta_seconds: 18000
     agent:
       model: claude-haiku-4-5-20251001
-      compaction:
-        reset_time_delta_seconds: 600
 sandbox:
   # Local mode spawns the sandbox tool server as a child process per sandbox.
   # Each sandbox lives in <local_repo_root>/.sandboxes/<name>/.

--- a/drua.yml
+++ b/drua.yml
@@ -11,10 +11,12 @@ oauth:
 agents:
   builtin_roles:
     workspace_lead:
+      provider: anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
       reset_time_delta_seconds: 600
     agent:
+      provider: anthropic
       model: claude-haiku-4-5-20251001
       max_tokens: 4096
       reset_time_delta_seconds: 600

--- a/drua.yml
+++ b/drua.yml
@@ -18,10 +18,12 @@ agents:
   builtin_roles:
     workspace_lead:
       model: claude-haiku-4-5-20251001
-      reset_time_delta_seconds: 600
+      compaction:
+        reset_time_delta_seconds: 600
     agent:
       model: claude-haiku-4-5-20251001
-      reset_time_delta_seconds: 600
+      compaction:
+        reset_time_delta_seconds: 600
 sandbox:
   # Local mode spawns the sandbox tool server as a child process per sandbox.
   # Each sandbox lives in <local_repo_root>/.sandboxes/<name>/.

--- a/drua.yml
+++ b/drua.yml
@@ -12,7 +12,7 @@ providers:
   - name: anthropic
     models:
       - name: claude-haiku-4-5-20251001
-        max_tokens: 4096
+        max_tokens_per_response: 4096
         context_window_tokens: 200000
 agents:
   builtin_roles:

--- a/drua.yml
+++ b/drua.yml
@@ -8,17 +8,19 @@ oauth:
   github_client_id: "Ov23li9ZTNnKjiTRwDcb"
   github_redirect_uri: "http://localhost:4200/auth/github/callback"
   github_allowed_teams: []
+providers:
+  - name: anthropic
+    models:
+      - name: claude-haiku-4-5-20251001
+        max_tokens: 4096
+        context_window_tokens: 200000
 agents:
   builtin_roles:
     workspace_lead:
-      provider: anthropic
       model: claude-haiku-4-5-20251001
-      max_tokens: 4096
       reset_time_delta_seconds: 600
     agent:
-      provider: anthropic
       model: claude-haiku-4-5-20251001
-      max_tokens: 4096
       reset_time_delta_seconds: 600
 sandbox:
   # Local mode spawns the sandbox tool server as a child process per sandbox.

--- a/lib/anthropic-client/Cargo.toml
+++ b/lib/anthropic-client/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 
 [dependencies]
+async-trait = "0.1"
 futures = { workspace = true }
 llm = { workspace = true }
 reqwest = { workspace = true, features = ["stream"] }

--- a/lib/anthropic-client/src/lib.rs
+++ b/lib/anthropic-client/src/lib.rs
@@ -10,10 +10,12 @@ mod sse;
 mod stream;
 mod types;
 
+use async_trait::async_trait;
 use thiserror::Error;
 use tracing::instrument;
 
-use llm::{Prompt, PromptResponse};
+use llm::provider::LlmProvider;
+use llm::{Prompt, PromptError, PromptResponse};
 
 use llm::stream::StreamDelta;
 
@@ -184,5 +186,34 @@ impl AnthropicClient {
             .await;
         });
         Ok(rx)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for AnthropicClient {
+    fn name(&self) -> &str {
+        "anthropic"
+    }
+
+    async fn send_prompt_streaming(
+        &self,
+        prompt: &Prompt,
+    ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
+        let rx = AnthropicClient::send_prompt_streaming(self, prompt)
+            .await
+            .map_err(|e| PromptError::Provider(e.to_string()))?;
+
+        // Re-map the error type from AnthropicError to PromptError.
+        let (tx, out_rx) = tokio::sync::mpsc::channel(128);
+        tokio::spawn(async move {
+            let mut rx = rx;
+            while let Some(result) = rx.recv().await {
+                let mapped = result.map_err(|e| PromptError::Provider(e.to_string()));
+                if tx.send(mapped).await.is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(out_rx)
     }
 }

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -1,10 +1,12 @@
 pub mod prompt;
+pub mod provider;
 pub mod request;
 pub mod response;
 pub mod stream;
 pub mod tool;
 
 pub use prompt::Prompt;
+pub use provider::LlmProvider;
 pub use request::{
     PromptError, PromptRequest, PromptRequestChannel, PromptResponseChannel, PromptResult,
     StreamHandle,

--- a/lib/llm/src/provider.rs
+++ b/lib/llm/src/provider.rs
@@ -1,0 +1,39 @@
+//! Provider-agnostic trait for LLM backends.
+//!
+//! Each provider crate (`anthropic-client`, `openai-client`, …) implements
+//! [`LlmProvider`] so that the prompt executor can dispatch to any backend
+//! through a single `Arc<dyn LlmProvider>`.
+
+use async_trait::async_trait;
+use tokio::sync::mpsc;
+
+use crate::stream::StreamDelta;
+use crate::{Prompt, PromptError};
+
+/// Trait implemented by each LLM provider client.
+///
+/// The prompt executor stores providers as `Arc<dyn LlmProvider>` and calls
+/// [`send_prompt_streaming`] without knowing the concrete backend.
+#[async_trait]
+pub trait LlmProvider: Send + Sync {
+    /// Human-readable provider name (e.g. `"anthropic"`, `"openai"`).
+    fn name(&self) -> &str;
+
+    /// Send a prompt and receive streaming deltas via channel.
+    ///
+    /// The returned receiver yields `StreamDelta` events that conform to the
+    /// contract expected by [`crate::stream::StreamAccumulator`]:
+    ///
+    /// 1. `MessageStart` (with input token count)
+    /// 2. One or more content block sequences:
+    ///    `ContentBlockStart` → deltas → `ContentBlockStop`
+    /// 3. `MessageDelta` (with stop reason and output token count)
+    /// 4. `MessageStop`
+    ///
+    /// Providers that don't natively emit this framing (e.g. OpenAI) must
+    /// synthesize the missing events.
+    async fn send_prompt_streaming(
+        &self,
+        prompt: &Prompt,
+    ) -> Result<mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError>;
+}

--- a/lib/openai-client/Cargo.toml
+++ b/lib/openai-client/Cargo.toml
@@ -1,13 +1,15 @@
 [package]
-name = "llm"
+name = "openai-client"
 version.workspace = true
 edition.workspace = true
 
 [dependencies]
 async-trait = "0.1"
+futures = { workspace = true }
+llm = { workspace = true }
+reqwest = { workspace = true, features = ["stream"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
-sha2 = { workspace = true }
 thiserror = { workspace = true }
-tiktoken = { workspace = true }
 tokio = { workspace = true }
+tracing = { workspace = true }

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -1,0 +1,580 @@
+//! Conversion functions between the provider-agnostic `llm` types and the
+//! OpenAI-specific internal types.
+//!
+//! These adapters sit at the boundary of `OpenAiClient`: inbound `Prompt`
+//! values are converted to `OpenAiRequest` for the wire, and streaming
+//! response chunks are converted to `StreamDelta`.
+
+use llm::prompt::{AssistantBlock, Message, SystemBlock, Tool, ToolChoice, ToolResultBlock, UserBlock};
+use llm::stream::{ContentBlockType, StreamDelta};
+use llm::StopReason;
+
+use crate::types::{
+    OpenAiFunction, OpenAiMessage, OpenAiRequest, OpenAiRequestToolCall, OpenAiStreamChunk,
+    OpenAiTool, OpenAiToolChoice, OpenAiToolChoiceFunction, OpenAiToolFunction, StreamOptions,
+};
+
+// ============================================================================
+// Prompt → OpenAiRequest
+// ============================================================================
+
+/// Convert a provider-agnostic `Prompt` into an OpenAI-specific request
+/// body with `stream: true`.
+pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> OpenAiRequest {
+    let mut messages: Vec<OpenAiMessage> = Vec::new();
+
+    // System blocks become system messages (one per block).
+    for block in &prompt.system {
+        match block {
+            SystemBlock::Text { text, .. } => {
+                messages.push(OpenAiMessage {
+                    role: "system",
+                    content: Some(text.clone()),
+                    tool_calls: None,
+                    tool_call_id: None,
+                });
+            }
+        }
+    }
+
+    // Conversation messages.
+    for msg in &prompt.messages {
+        convert_message(msg, &mut messages);
+    }
+
+    let tools = if prompt.tools.is_empty() {
+        None
+    } else {
+        Some(prompt.tools.iter().map(convert_tool).collect())
+    };
+
+    let tool_choice = prompt.tool_choice.as_ref().map(convert_tool_choice);
+
+    OpenAiRequest {
+        model: prompt.model.clone(),
+        messages,
+        max_completion_tokens: prompt.max_tokens,
+        temperature: None,
+        tools,
+        tool_choice,
+        stream: true,
+        stream_options: Some(StreamOptions {
+            include_usage: true,
+        }),
+    }
+}
+
+fn convert_message(message: &Message, out: &mut Vec<OpenAiMessage>) {
+    match message {
+        Message::User { content } => {
+            // Merge consecutive text blocks into a single user message.
+            // Tool results become separate "tool" role messages.
+            let mut text_parts: Vec<String> = Vec::new();
+
+            for block in content {
+                match block {
+                    UserBlock::Text { text, .. } => {
+                        text_parts.push(text.clone());
+                    }
+                    UserBlock::ToolResult {
+                        tool_use_id,
+                        content: result_content,
+                        ..
+                    } => {
+                        // Flush any pending text first.
+                        if !text_parts.is_empty() {
+                            out.push(OpenAiMessage {
+                                role: "user",
+                                content: Some(text_parts.join("\n")),
+                                tool_calls: None,
+                                tool_call_id: None,
+                            });
+                            text_parts.clear();
+                        }
+                        let text = result_content
+                            .iter()
+                            .map(|b| match b {
+                                ToolResultBlock::Text { text } => text.as_str(),
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        out.push(OpenAiMessage {
+                            role: "tool",
+                            content: Some(text),
+                            tool_calls: None,
+                            tool_call_id: Some(tool_use_id.clone()),
+                        });
+                    }
+                }
+            }
+            if !text_parts.is_empty() {
+                out.push(OpenAiMessage {
+                    role: "user",
+                    content: Some(text_parts.join("\n")),
+                    tool_calls: None,
+                    tool_call_id: None,
+                });
+            }
+        }
+        Message::Assistant { content } => {
+            // Group text and tool calls into a single assistant message.
+            let mut text_parts: Vec<String> = Vec::new();
+            let mut tool_calls: Vec<OpenAiRequestToolCall> = Vec::new();
+
+            for block in content {
+                match block {
+                    AssistantBlock::Text { text, .. } => {
+                        text_parts.push(text.clone());
+                    }
+                    AssistantBlock::ToolUse {
+                        id, name, input, ..
+                    } => {
+                        tool_calls.push(OpenAiRequestToolCall {
+                            id: id.clone(),
+                            r#type: "function",
+                            function: OpenAiFunction {
+                                name: name.clone(),
+                                arguments: serde_json::to_string(input).unwrap_or_default(),
+                            },
+                        });
+                    }
+                    AssistantBlock::Thinking { .. } => {
+                        // Anthropic-specific; dropped for OpenAI.
+                    }
+                }
+            }
+
+            let content = if text_parts.is_empty() {
+                None
+            } else {
+                Some(text_parts.join("\n"))
+            };
+
+            let tool_calls_field = if tool_calls.is_empty() {
+                None
+            } else {
+                Some(tool_calls)
+            };
+
+            out.push(OpenAiMessage {
+                role: "assistant",
+                content,
+                tool_calls: tool_calls_field,
+                tool_call_id: None,
+            });
+        }
+    }
+}
+
+fn convert_tool(tool: &Tool) -> OpenAiTool {
+    OpenAiTool {
+        r#type: "function",
+        function: OpenAiToolFunction {
+            name: tool.name.clone(),
+            description: tool.description.clone(),
+            parameters: tool.input_schema.clone(),
+        },
+    }
+}
+
+fn convert_tool_choice(choice: &ToolChoice) -> OpenAiToolChoice {
+    match choice {
+        ToolChoice::Auto => OpenAiToolChoice::String("auto"),
+        ToolChoice::Any => OpenAiToolChoice::String("required"),
+        ToolChoice::None => OpenAiToolChoice::String("none"),
+        ToolChoice::Tool { name } => OpenAiToolChoice::Specific {
+            r#type: "function",
+            function: OpenAiToolChoiceFunction { name: name.clone() },
+        },
+    }
+}
+
+// ============================================================================
+// Streaming chunk → StreamDelta(s)
+// ============================================================================
+
+/// State tracker for synthesizing ContentBlockStart/Stop events that the
+/// StreamAccumulator expects but OpenAI doesn't natively emit.
+pub(crate) struct DeltaSynthesizer {
+    /// Whether we've emitted a ContentBlockStart for the text block.
+    text_block_started: bool,
+    /// Maps tool_call index to the content block index we assigned.
+    /// Tracks which tool call indices we've already emitted ContentBlockStart for.
+    tool_block_indices: Vec<Option<usize>>,
+    /// Next content block index to assign.
+    next_block_index: usize,
+    /// Total open blocks (for emitting ContentBlockStop on finish).
+    open_blocks: usize,
+    /// Input tokens (captured from usage chunk).
+    input_tokens: u32,
+}
+
+impl DeltaSynthesizer {
+    pub fn new() -> Self {
+        Self {
+            text_block_started: false,
+            tool_block_indices: Vec::new(),
+            next_block_index: 0,
+            open_blocks: 0,
+            input_tokens: 0,
+        }
+    }
+
+    /// Process a raw SSE data payload (OpenAI JSON) and emit provider-agnostic
+    /// `StreamDelta`s. Returns `Ok(None)` for the `[DONE]` sentinel.
+    pub fn process_chunk(&mut self, data: &str) -> Result<Vec<StreamDelta>, String> {
+        if data.trim() == "[DONE]" {
+            return Ok(vec![StreamDelta::MessageStop]);
+        }
+
+        let chunk: OpenAiStreamChunk =
+            serde_json::from_str(data).map_err(|e| format!("JSON parse: {e}"))?;
+
+        let mut deltas = Vec::new();
+
+        // Capture usage if present (OpenAI sends it in a separate chunk when
+        // stream_options.include_usage is true).
+        if let Some(usage) = &chunk.usage {
+            self.input_tokens = usage.prompt_tokens;
+            // Emit MessageStart with input tokens.
+            deltas.push(StreamDelta::MessageStart {
+                input_tokens: usage.prompt_tokens,
+            });
+        }
+
+        let Some(choice) = chunk.choices.first() else {
+            return Ok(deltas);
+        };
+
+        if let Some(delta) = &choice.delta {
+            // Handle text content.
+            if let Some(text) = &delta.content {
+                if !text.is_empty() {
+                    if !self.text_block_started {
+                        self.text_block_started = true;
+                        let idx = self.next_block_index;
+                        self.next_block_index += 1;
+                        self.open_blocks += 1;
+                        deltas.push(StreamDelta::ContentBlockStart {
+                            index: idx,
+                            block_type: ContentBlockType::Text,
+                        });
+                    }
+                    // Text block is always index 0 (or the first block index).
+                    let text_idx = if self.text_block_started { 0 } else { 0 };
+                    deltas.push(StreamDelta::TextDelta {
+                        index: text_idx,
+                        text: text.clone(),
+                    });
+                }
+            }
+
+            // Handle tool calls.
+            if let Some(tool_calls) = &delta.tool_calls {
+                for tc in tool_calls {
+                    // Ensure our tracking vec is large enough.
+                    while self.tool_block_indices.len() <= tc.index {
+                        self.tool_block_indices.push(None);
+                    }
+
+                    // First chunk for this tool call — emit ContentBlockStart.
+                    if self.tool_block_indices[tc.index].is_none() {
+                        let block_idx = self.next_block_index;
+                        self.next_block_index += 1;
+                        self.open_blocks += 1;
+                        self.tool_block_indices[tc.index] = Some(block_idx);
+
+                        let id = tc.id.clone().unwrap_or_default();
+                        let name = tc
+                            .function
+                            .as_ref()
+                            .and_then(|f| f.name.clone())
+                            .unwrap_or_default();
+
+                        deltas.push(StreamDelta::ContentBlockStart {
+                            index: block_idx,
+                            block_type: ContentBlockType::ToolUse { id, name },
+                        });
+                    }
+
+                    // Argument deltas.
+                    if let Some(func) = &tc.function {
+                        if let Some(args) = &func.arguments {
+                            if !args.is_empty() {
+                                let block_idx = self.tool_block_indices[tc.index].unwrap();
+                                deltas.push(StreamDelta::InputJsonDelta {
+                                    index: block_idx,
+                                    partial_json: args.clone(),
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Handle finish_reason.
+        if let Some(reason) = &choice.finish_reason {
+            // Close all open blocks.
+            for idx in 0..self.next_block_index {
+                deltas.push(StreamDelta::ContentBlockStop { index: idx });
+            }
+
+            let stop_reason = match reason.as_str() {
+                "stop" => Some(StopReason::EndTurn),
+                "length" => Some(StopReason::MaxTokens),
+                "tool_calls" => Some(StopReason::ToolUse),
+                _ => None,
+            };
+
+            // Output tokens come from the usage chunk. If we haven't seen it
+            // yet (it may arrive after this chunk), use 0 — it will be
+            // populated when the usage chunk arrives.
+            let output_tokens = chunk
+                .usage
+                .as_ref()
+                .map(|u| u.completion_tokens)
+                .unwrap_or(0);
+
+            deltas.push(StreamDelta::MessageDelta {
+                stop_reason,
+                output_tokens,
+            });
+        }
+
+        Ok(deltas)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_prompt() -> llm::Prompt {
+        llm::Prompt {
+            model: "gpt-4o".to_string(),
+            system: vec![SystemBlock::Text {
+                text: "You are a helpful assistant.".to_string(),
+                cache_control: None,
+            }],
+            messages: vec![Message::User {
+                content: vec![UserBlock::Text {
+                    text: "Hello".to_string(),
+                    cache_control: None,
+                }],
+            }],
+            tools: vec![Tool {
+                name: "get_weather".to_string(),
+                description: Some("Get weather".to_string()),
+                input_schema: serde_json::json!({"type": "object", "properties": {"location": {"type": "string"}}}),
+                cache_control: None,
+            }],
+            tool_choice: None,
+            max_tokens: Some(1024),
+        }
+    }
+
+    #[test]
+    fn prompt_to_request_basic() {
+        let prompt = sample_prompt();
+        let req = prompt_to_request(&prompt);
+
+        assert_eq!(req.model, "gpt-4o");
+        assert!(req.stream);
+        assert_eq!(req.messages.len(), 2); // system + user
+        assert_eq!(req.messages[0].role, "system");
+        assert_eq!(req.messages[1].role, "user");
+        assert_eq!(req.max_completion_tokens, Some(1024));
+        assert!(req.tools.is_some());
+        assert_eq!(req.tools.as_ref().unwrap().len(), 1);
+        assert_eq!(req.tools.as_ref().unwrap()[0].function.name, "get_weather");
+    }
+
+    #[test]
+    fn prompt_with_tool_results() {
+        let prompt = llm::Prompt {
+            model: "gpt-4o".to_string(),
+            system: vec![],
+            messages: vec![
+                Message::Assistant {
+                    content: vec![AssistantBlock::ToolUse {
+                        id: "call_123".to_string(),
+                        name: "get_weather".to_string(),
+                        input: serde_json::json!({"location": "NYC"}),
+                        cache_control: None,
+                    }],
+                },
+                Message::User {
+                    content: vec![UserBlock::ToolResult {
+                        tool_use_id: "call_123".to_string(),
+                        content: vec![ToolResultBlock::Text {
+                            text: "72F".to_string(),
+                        }],
+                        is_error: false,
+                        cache_control: None,
+                    }],
+                },
+            ],
+            tools: vec![],
+            tool_choice: None,
+            max_tokens: None,
+        };
+
+        let req = prompt_to_request(&prompt);
+        assert_eq!(req.messages.len(), 2);
+        assert_eq!(req.messages[0].role, "assistant");
+        assert!(req.messages[0].tool_calls.is_some());
+        assert_eq!(req.messages[1].role, "tool");
+        assert_eq!(req.messages[1].tool_call_id.as_deref(), Some("call_123"));
+        assert_eq!(req.messages[1].content.as_deref(), Some("72F"));
+    }
+
+    #[test]
+    fn thinking_blocks_dropped() {
+        let prompt = llm::Prompt {
+            model: "gpt-4o".to_string(),
+            system: vec![],
+            messages: vec![Message::Assistant {
+                content: vec![
+                    AssistantBlock::Thinking {
+                        text: "internal reasoning".to_string(),
+                        signature: Some("sig".to_string()),
+                    },
+                    AssistantBlock::Text {
+                        text: "visible response".to_string(),
+                        cache_control: None,
+                    },
+                ],
+            }],
+            tools: vec![],
+            tool_choice: None,
+            max_tokens: None,
+        };
+
+        let req = prompt_to_request(&prompt);
+        assert_eq!(req.messages.len(), 1);
+        assert_eq!(
+            req.messages[0].content.as_deref(),
+            Some("visible response")
+        );
+        assert!(req.messages[0].tool_calls.is_none());
+    }
+
+    #[test]
+    fn tool_choice_mapping() {
+        assert!(matches!(
+            convert_tool_choice(&ToolChoice::Auto),
+            OpenAiToolChoice::String("auto")
+        ));
+        assert!(matches!(
+            convert_tool_choice(&ToolChoice::Any),
+            OpenAiToolChoice::String("required")
+        ));
+        assert!(matches!(
+            convert_tool_choice(&ToolChoice::None),
+            OpenAiToolChoice::String("none")
+        ));
+        assert!(matches!(
+            convert_tool_choice(&ToolChoice::Tool {
+                name: "foo".to_string()
+            }),
+            OpenAiToolChoice::Specific { .. }
+        ));
+    }
+
+    #[test]
+    fn synthesizer_text_stream() {
+        let mut synth = DeltaSynthesizer::new();
+
+        // First text chunk — should synthesize ContentBlockStart.
+        let deltas = synth
+            .process_chunk(r#"{"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}"#)
+            .unwrap();
+        assert_eq!(deltas.len(), 2); // ContentBlockStart + TextDelta
+        assert!(matches!(
+            &deltas[0],
+            StreamDelta::ContentBlockStart {
+                index: 0,
+                block_type: ContentBlockType::Text
+            }
+        ));
+        assert!(matches!(&deltas[1], StreamDelta::TextDelta { index: 0, text } if text == "Hello"));
+
+        // Second text chunk — no ContentBlockStart.
+        let deltas = synth
+            .process_chunk(r#"{"choices":[{"delta":{"content":" world"},"finish_reason":null}]}"#)
+            .unwrap();
+        assert_eq!(deltas.len(), 1);
+        assert!(matches!(&deltas[0], StreamDelta::TextDelta { index: 0, text } if text == " world"));
+
+        // Finish.
+        let deltas = synth
+            .process_chunk(
+                r#"{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#,
+            )
+            .unwrap();
+        // MessageStart (from usage) + ContentBlockStop + MessageDelta
+        assert!(deltas.iter().any(|d| matches!(d, StreamDelta::MessageStart { input_tokens: 10 })));
+        assert!(deltas.iter().any(|d| matches!(d, StreamDelta::ContentBlockStop { index: 0 })));
+        assert!(deltas.iter().any(|d| matches!(
+            d,
+            StreamDelta::MessageDelta {
+                stop_reason: Some(StopReason::EndTurn),
+                ..
+            }
+        )));
+
+        // DONE sentinel.
+        let deltas = synth.process_chunk("[DONE]").unwrap();
+        assert_eq!(deltas.len(), 1);
+        assert!(matches!(deltas[0], StreamDelta::MessageStop));
+    }
+
+    #[test]
+    fn synthesizer_tool_call_stream() {
+        let mut synth = DeltaSynthesizer::new();
+
+        // Tool call start.
+        let deltas = synth
+            .process_chunk(
+                r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_abc","function":{"name":"get_weather","arguments":""}}]},"finish_reason":null}]}"#,
+            )
+            .unwrap();
+        assert!(deltas.iter().any(|d| matches!(
+            d,
+            StreamDelta::ContentBlockStart {
+                index: 0,
+                block_type: ContentBlockType::ToolUse { .. }
+            }
+        )));
+
+        // Tool call arguments.
+        let deltas = synth
+            .process_chunk(
+                r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"location\":"}}]},"finish_reason":null}]}"#,
+            )
+            .unwrap();
+        assert_eq!(deltas.len(), 1);
+        assert!(matches!(
+            &deltas[0],
+            StreamDelta::InputJsonDelta {
+                index: 0,
+                partial_json
+            } if partial_json == r#"{"location":"#
+        ));
+
+        // Finish with tool_calls reason.
+        let deltas = synth
+            .process_chunk(
+                r#"{"choices":[{"delta":{},"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":20,"completion_tokens":15}}"#,
+            )
+            .unwrap();
+        assert!(deltas.iter().any(|d| matches!(
+            d,
+            StreamDelta::MessageDelta {
+                stop_reason: Some(StopReason::ToolUse),
+                ..
+            }
+        )));
+    }
+}

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -262,10 +262,8 @@ impl DeltaSynthesizer {
                             block_type: ContentBlockType::Text,
                         });
                     }
-                    // Text block is always index 0 (or the first block index).
-                    let text_idx = if self.text_block_started { 0 } else { 0 };
                     deltas.push(StreamDelta::TextDelta {
-                        index: text_idx,
+                        index: 0,
                         text: text.clone(),
                     });
                 }

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -5,7 +5,9 @@
 //! values are converted to `OpenAiRequest` for the wire, and streaming
 //! response chunks are converted to `StreamDelta`.
 
-use llm::prompt::{AssistantBlock, Message, SystemBlock, Tool, ToolChoice, ToolResultBlock, UserBlock};
+use llm::prompt::{
+    AssistantBlock, Message, SystemBlock, Tool, ToolChoice, ToolResultBlock, UserBlock,
+};
 use llm::stream::{ContentBlockType, StreamDelta};
 use llm::StopReason;
 
@@ -453,10 +455,7 @@ mod tests {
 
         let req = prompt_to_request(&prompt);
         assert_eq!(req.messages.len(), 1);
-        assert_eq!(
-            req.messages[0].content.as_deref(),
-            Some("visible response")
-        );
+        assert_eq!(req.messages[0].content.as_deref(), Some("visible response"));
         assert!(req.messages[0].tool_calls.is_none());
     }
 
@@ -505,7 +504,9 @@ mod tests {
             .process_chunk(r#"{"choices":[{"delta":{"content":" world"},"finish_reason":null}]}"#)
             .unwrap();
         assert_eq!(deltas.len(), 1);
-        assert!(matches!(&deltas[0], StreamDelta::TextDelta { index: 0, text } if text == " world"));
+        assert!(
+            matches!(&deltas[0], StreamDelta::TextDelta { index: 0, text } if text == " world")
+        );
 
         // Finish.
         let deltas = synth
@@ -514,8 +515,12 @@ mod tests {
             )
             .unwrap();
         // MessageStart (from usage) + ContentBlockStop + MessageDelta
-        assert!(deltas.iter().any(|d| matches!(d, StreamDelta::MessageStart { input_tokens: 10 })));
-        assert!(deltas.iter().any(|d| matches!(d, StreamDelta::ContentBlockStop { index: 0 })));
+        assert!(deltas
+            .iter()
+            .any(|d| matches!(d, StreamDelta::MessageStart { input_tokens: 10 })));
+        assert!(deltas
+            .iter()
+            .any(|d| matches!(d, StreamDelta::ContentBlockStop { index: 0 })));
         assert!(deltas.iter().any(|d| matches!(
             d,
             StreamDelta::MessageDelta {

--- a/lib/openai-client/src/lib.rs
+++ b/lib/openai-client/src/lib.rs
@@ -1,0 +1,168 @@
+//! OpenAI Chat Completions API client.
+//!
+//! Accepts the provider-agnostic types from `lib/llm` at the public boundary
+//! and uses OpenAI-specific types internally. Streams SSE events and converts
+//! them to the unified `StreamDelta` format that the prompt executor and agent
+//! loop expect.
+
+mod convert;
+mod sse;
+mod types;
+
+use async_trait::async_trait;
+use thiserror::Error;
+use tracing::instrument;
+
+use llm::provider::LlmProvider;
+use llm::stream::StreamDelta;
+use llm::{Prompt, PromptError, PromptResponse};
+
+use crate::convert::{prompt_to_request, DeltaSynthesizer};
+use crate::sse::{parse_sse_stream, SseError};
+
+const DEFAULT_API_URL: &str = "https://api.openai.com/v1/chat/completions";
+
+#[derive(Debug, Error)]
+pub enum OpenAiError {
+    #[error("OpenAiError - HTTP: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("OpenAiError - API: status={status}, message={message}")]
+    Api { status: u16, message: String },
+    #[error("OpenAiError - SSE: {0}")]
+    Sse(String),
+    #[error("OpenAiError - Stream: {0}")]
+    Stream(String),
+}
+
+impl From<SseError> for OpenAiError {
+    fn from(e: SseError) -> Self {
+        match e {
+            SseError::Http(e) => Self::Http(e),
+            SseError::Processing(msg) => Self::Sse(msg),
+        }
+    }
+}
+
+/// OpenAI Chat Completions API client. Converts provider-agnostic `Prompt`
+/// values into OpenAI-specific wire types, streams the SSE response, and
+/// yields `StreamDelta` events.
+#[derive(Clone)]
+pub struct OpenAiClient {
+    http: reqwest::Client,
+    api_key: String,
+    api_url: String,
+}
+
+impl OpenAiClient {
+    pub fn new(api_key: impl Into<String>) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            api_key: api_key.into(),
+            api_url: DEFAULT_API_URL.to_string(),
+        }
+    }
+
+    /// Issue a streaming Chat Completions request and return the
+    /// fully-accumulated assistant reply.
+    #[instrument(name = "openai_client.send_prompt", skip_all)]
+    pub async fn send_prompt(&self, prompt: &Prompt) -> Result<PromptResponse, OpenAiError> {
+        let rx = self.send_prompt_streaming_internal(prompt).await?;
+        let mut rx = rx;
+
+        let mut accumulator = llm::stream::StreamAccumulator::new();
+        while let Some(result) = rx.recv().await {
+            match result {
+                Ok(delta) => accumulator.process(&delta),
+                Err(e) => return Err(OpenAiError::Stream(e.to_string())),
+            }
+        }
+        Ok(accumulator.finish())
+    }
+
+    /// Issue a streaming Chat Completions request, yielding provider-agnostic
+    /// `StreamDelta`s via channel.
+    #[instrument(name = "openai_client.send_prompt_streaming", skip_all)]
+    async fn send_prompt_streaming_internal(
+        &self,
+        prompt: &Prompt,
+    ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, OpenAiError>>, OpenAiError> {
+        let request_body = prompt_to_request(prompt);
+
+        let resp = self
+            .http
+            .post(&self.api_url)
+            .header("Authorization", format!("Bearer {}", self.api_key))
+            .header("content-type", "application/json")
+            .json(&request_body)
+            .send()
+            .await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(OpenAiError::Api {
+                status: status.as_u16(),
+                message,
+            });
+        }
+
+        let byte_stream = resp.bytes_stream();
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<StreamDelta, OpenAiError>>(128);
+
+        tokio::spawn(async move {
+            let tx_ref = &tx;
+            let mut synthesizer = DeltaSynthesizer::new();
+            let synth_ref = &mut synthesizer;
+
+            let _ = parse_sse_stream(byte_stream, |event| {
+                match synth_ref.process_chunk(&event.data) {
+                    Ok(deltas) => {
+                        for delta in deltas {
+                            tx_ref
+                                .try_send(Ok(delta))
+                                .map_err(|e| SseError::Processing(e.to_string()))?;
+                        }
+                        Ok(())
+                    }
+                    Err(e) => {
+                        let _ = tx_ref.try_send(Err(OpenAiError::Stream(e.clone())));
+                        Err(SseError::Processing(e))
+                    }
+                }
+            })
+            .await;
+        });
+
+        Ok(rx)
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OpenAiClient {
+    fn name(&self) -> &str {
+        "openai"
+    }
+
+    async fn send_prompt_streaming(
+        &self,
+        prompt: &Prompt,
+    ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
+        let rx = self
+            .send_prompt_streaming_internal(prompt)
+            .await
+            .map_err(|e| PromptError::Provider(e.to_string()))?;
+
+        // Re-map the error type from OpenAiError to PromptError.
+        let (tx, out_rx) = tokio::sync::mpsc::channel(128);
+        tokio::spawn(async move {
+            let mut rx = rx;
+            while let Some(result) = rx.recv().await {
+                let mapped = result.map_err(|e| PromptError::Provider(e.to_string()));
+                if tx.send(mapped).await.is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(out_rx)
+    }
+}

--- a/lib/openai-client/src/sse.rs
+++ b/lib/openai-client/src/sse.rs
@@ -1,0 +1,131 @@
+//! Lightweight SSE (Server-Sent Events) parser for reqwest byte streams.
+//!
+//! Implements just enough of the SSE protocol to parse OpenAI's streaming
+//! responses. Copied from the anthropic-client crate — the SSE framing is
+//! provider-agnostic; only the JSON payload differs.
+
+use futures::StreamExt;
+
+/// A parsed SSE event with its type and data payload.
+#[derive(Debug, Clone)]
+pub struct SseEvent {
+    /// Event type (from "event:" field, defaults to "message").
+    #[allow(dead_code)]
+    pub event: String,
+    /// Event data (from "data:" field(s), joined with newlines).
+    pub data: String,
+}
+
+/// Parse SSE events from a reqwest response's byte stream.
+///
+/// Collects all SSE events from the stream, calling `handler` for each
+/// complete event.
+pub async fn parse_sse_stream<S, B, F>(mut stream: S, mut handler: F) -> Result<(), SseError>
+where
+    S: futures::Stream<Item = Result<B, reqwest::Error>> + Unpin,
+    B: AsRef<[u8]>,
+    F: FnMut(SseEvent) -> Result<(), SseError>,
+{
+    let mut buffer = String::new();
+
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(SseError::Http)?;
+        buffer.push_str(&String::from_utf8_lossy(chunk.as_ref()));
+
+        // Process all complete events in the buffer.
+        // An event is terminated by a blank line (\n\n or \r\n\r\n).
+        loop {
+            let event_end = find_event_boundary(&buffer);
+            let Some(end_pos) = event_end else {
+                break;
+            };
+
+            let event_text = &buffer[..end_pos.text_end];
+            if let Some(event) = parse_single_event(event_text) {
+                handler(event)?;
+            }
+
+            // Remove the processed event + boundary from buffer
+            buffer.drain(..end_pos.drain_end);
+        }
+    }
+
+    // Process any trailing data in the buffer (stream closed mid-event)
+    if !buffer.trim().is_empty() {
+        if let Some(event) = parse_single_event(&buffer) {
+            handler(event)?;
+        }
+    }
+
+    Ok(())
+}
+
+struct EventBoundary {
+    /// End of the event text (before the blank-line separator).
+    text_end: usize,
+    /// Position to drain up to (past the blank-line separator).
+    drain_end: usize,
+}
+
+/// Find the position of the next event boundary (blank line) in the buffer.
+fn find_event_boundary(buf: &str) -> Option<EventBoundary> {
+    // Look for \n\n (the standard SSE event separator)
+    if let Some(pos) = buf.find("\n\n") {
+        return Some(EventBoundary {
+            text_end: pos,
+            drain_end: pos + 2,
+        });
+    }
+    // Also handle \r\n\r\n
+    if let Some(pos) = buf.find("\r\n\r\n") {
+        return Some(EventBoundary {
+            text_end: pos,
+            drain_end: pos + 4,
+        });
+    }
+    None
+}
+
+/// Parse a single SSE event from its text (lines between blank-line boundaries).
+fn parse_single_event(text: &str) -> Option<SseEvent> {
+    let mut event_type = String::from("message");
+    let mut data_lines: Vec<&str> = Vec::new();
+
+    for line in text.lines() {
+        if line.is_empty() {
+            continue;
+        }
+        if line.starts_with(':') {
+            // Comment line — skip
+            continue;
+        }
+        if let Some((field, value)) = line.split_once(':') {
+            let value = value.strip_prefix(' ').unwrap_or(value);
+            match field {
+                "event" => event_type = value.to_string(),
+                "data" => data_lines.push(value),
+                _ => {} // Ignore unknown fields (id, retry, etc.)
+            }
+        } else if line == "data" {
+            // Field with no colon — treat as field with empty value
+            data_lines.push("");
+        }
+    }
+
+    if data_lines.is_empty() {
+        return None;
+    }
+
+    Some(SseEvent {
+        event: event_type,
+        data: data_lines.join("\n"),
+    })
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SseError {
+    #[error("HTTP stream error: {0}")]
+    Http(reqwest::Error),
+    #[error("Event processing error: {0}")]
+    Processing(String),
+}

--- a/lib/openai-client/src/types.rs
+++ b/lib/openai-client/src/types.rs
@@ -1,0 +1,141 @@
+//! OpenAI Chat Completions API wire types.
+//!
+//! These types model the OpenAI wire format for both requests and streaming
+//! responses. They are used internally by `OpenAiClient` and are NOT exposed
+//! to callers — the public boundary uses the provider-agnostic types from
+//! `lib/llm`.
+
+use serde::{Deserialize, Serialize};
+
+// ============================================================================
+// Request Types
+// ============================================================================
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OpenAiRequest {
+    pub model: String,
+    pub messages: Vec<OpenAiMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_completion_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tools: Option<Vec<OpenAiTool>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_choice: Option<OpenAiToolChoice>,
+    pub stream: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream_options: Option<StreamOptions>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct StreamOptions {
+    pub include_usage: bool,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OpenAiMessage {
+    pub role: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_calls: Option<Vec<OpenAiRequestToolCall>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tool_call_id: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OpenAiRequestToolCall {
+    pub id: String,
+    pub r#type: &'static str,
+    pub function: OpenAiFunction,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OpenAiFunction {
+    pub name: String,
+    pub arguments: String,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OpenAiTool {
+    pub r#type: &'static str,
+    pub function: OpenAiToolFunction,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OpenAiToolFunction {
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub parameters: serde_json::Value,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(untagged)]
+pub(crate) enum OpenAiToolChoice {
+    String(&'static str),
+    Specific {
+        r#type: &'static str,
+        function: OpenAiToolChoiceFunction,
+    },
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct OpenAiToolChoiceFunction {
+    pub name: String,
+}
+
+// ============================================================================
+// Streaming Response Types
+// ============================================================================
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiStreamChunk {
+    #[serde(default)]
+    pub choices: Vec<OpenAiChoice>,
+    #[serde(default)]
+    pub usage: Option<OpenAiUsage>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiChoice {
+    #[serde(default)]
+    pub delta: Option<OpenAiDelta>,
+    #[serde(default)]
+    pub finish_reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiDelta {
+    #[serde(default)]
+    pub content: Option<String>,
+    #[serde(default)]
+    pub tool_calls: Option<Vec<OpenAiToolCallDelta>>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiToolCallDelta {
+    #[serde(default)]
+    pub index: usize,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(default)]
+    pub function: Option<OpenAiFunctionDelta>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiFunctionDelta {
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub arguments: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiUsage {
+    #[serde(default)]
+    pub prompt_tokens: u32,
+    #[serde(default)]
+    pub completion_tokens: u32,
+}

--- a/web/src/graphql/schema.graphql
+++ b/web/src/graphql/schema.graphql
@@ -168,6 +168,7 @@ type ThreadMessageEntry {
 enum ThreadStartReason {
 	COMPACTION
 	INITIAL_THREAD
+	ORPHAN
 	TOOL_DEFS_UPDATED
 }
 

--- a/web/src/graphql/session.rs
+++ b/web/src/graphql/session.rs
@@ -24,6 +24,7 @@ pub enum ThreadStartReason {
     InitialThread,
     ToolDefsUpdated,
     Compaction,
+    Orphan,
 }
 
 // ─── Content blocks (union) ────────────────────────────────────────���─────────
@@ -225,6 +226,7 @@ impl SessionThread {
                     ThreadStartReason::ToolDefsUpdated
                 }
                 history::ThreadStartReasonKind::Compaction => ThreadStartReason::Compaction,
+                history::ThreadStartReasonKind::Orphan => ThreadStartReason::Orphan,
             },
             agent_id,
         }


### PR DESCRIPTION
## Summary

- Introduces an `LlmProvider` trait in `lib/llm/` so the prompt executor dispatches via `Arc<dyn LlmProvider>` — adding a new provider requires only implementing the trait and a factory arm, zero executor changes
- Adds `lib/openai-client/` crate implementing OpenAI Chat Completions API with streaming, tool use, and `StreamDelta` synthesis for the `StreamAccumulator`
- Implements `LlmProvider` for `AnthropicClient` (wraps existing methods)
- Refactors `prompt_executor.rs` from enum-based dispatch to trait-based dispatch
- Adds explicit `provider` field to `RoleConfig` / `drua.yml` (defaults to `"anthropic"`)
- Adds `OPENAI_API_KEY` env var / CLI arg

## Usage

Set `OPENAI_API_KEY` and configure a role in `drua.yml`:
```yaml
agents:
  builtin_roles:
    agent:
      provider: openai
      model: gpt-4o
      max_tokens: 4096
```

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test --lib` — all 243 unit tests pass (including 6 new openai-client tests)
- [ ] Manual: set `OPENAI_API_KEY`, configure `provider: openai` + `model: gpt-4o`, send a message
- [ ] Manual: verify existing Anthropic config still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)