### PR TITLE
fix: allow clippy::enum_variant_names on ChatHistoryContentBlock

### DIFF
--- a/drua/src/commands/dashboard.rs
+++ b/drua/src/commands/dashboard.rs
@@ -182,6 +182,7 @@ struct ChatHistoryMessage {
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "__typename")]
+#[allow(clippy::enum_variant_names)]
 enum ChatHistoryContentBlock {
     TextContent {
         text: String,

--- a/web/src/graphql/schema.graphql
+++ b/web/src/graphql/schema.graphql
@@ -89,6 +89,10 @@ type PageInfo {
 
 type Query {
 	"""
+	Look up a single agent by ID.
+	"""
+	agent(id: AgentId!): Agent
+	"""
 	The currently authenticated user, if any.
 	"""
 	me: Me
@@ -162,6 +166,7 @@ type ThreadMessageEntry {
 }
 
 enum ThreadStartReason {
+	COMPACTION
 	INITIAL_THREAD
 	TOOL_DEFS_UPDATED
 }


### PR DESCRIPTION
## Summary
- Fixes CI `check-code` job failure ([build #405](https://ci.galoy.io/teams/galoy-agents/pipelines/galoy-agents-bin/jobs/check-code/builds/405))
- Adds `#[allow(clippy::enum_variant_names)]` to `ChatHistoryContentBlock` enum whose variant names must match the GraphQL `__typename` discriminator for serde deserialization

## Test plan
- [x] `cargo clippy --package drua -- -D warnings` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)