### PR TITLE
feat(drua): positionally-aligned thread grid explorer

### DIFF
--- a/drua/src/commands/dashboard.rs
+++ b/drua/src/commands/dashboard.rs
@@ -1,3 +1,4 @@
+use std::collections::{BTreeSet, HashMap};
 use std::io;
 use std::time::Duration;
 
@@ -15,7 +16,10 @@ use tokio::sync::mpsc;
 use crate::config::Config;
 use crate::graphql::GraphqlClient;
 use crate::tui::chat::{ChatMessage, ChatRole, ContentBlock};
-use crate::tui::state::{AgentItem, SandboxInfo, ScreenState, WorkspaceItem};
+use crate::tui::state::{
+    AgentItem, BlockDetail, CellKind, Focus, SandboxInfo, ScreenState, ThreadGridState, ThreadInfo,
+    WorkspaceItem,
+};
 use crate::tui::{handlers, ui};
 
 // ---------------------------------------------------------------------------
@@ -233,6 +237,70 @@ impl ChatHistoryContentBlock {
 }
 
 // ---------------------------------------------------------------------------
+// Threads (GQL)
+// ---------------------------------------------------------------------------
+
+const THREADS_QUERY: &str = r#"
+    query Threads($agentId: AgentId!) {
+        agent(id: $agentId) {
+            session {
+                threads {
+                    id
+                    isCurrent
+                    nextTurn
+                    startReason
+                    messages {
+                        role
+                        blockIndexes
+                        content {
+                            __typename
+                            ... on TextContent { text }
+                            ... on ToolUseContent { name }
+                            ... on ThinkingContent { text }
+                            ... on ToolResultContent { toolUseId content isError }
+                            ... on SandboxNotificationContent { sandboxName operation }
+                        }
+                    }
+                }
+            }
+        }
+    }
+"#;
+
+#[derive(Debug, Deserialize)]
+struct ThreadsResponse {
+    agent: Option<ThreadsAgent>,
+}
+
+#[derive(Debug, Deserialize)]
+struct ThreadsAgent {
+    session: ThreadsSession,
+}
+
+#[derive(Debug, Deserialize)]
+struct ThreadsSession {
+    threads: Vec<ThreadNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ThreadNode {
+    id: String,
+    is_current: bool,
+    next_turn: String,
+    start_reason: String,
+    messages: Vec<ThreadMessageNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ThreadMessageNode {
+    role: String,
+    block_indexes: Vec<i32>,
+    content: Vec<ChatHistoryContentBlock>,
+}
+
+// ---------------------------------------------------------------------------
 // Chat streaming
 // ---------------------------------------------------------------------------
 
@@ -244,6 +312,8 @@ enum ChatStreamEvent {
     Done,
     /// Pre-fetched chat history for an agent (agent_id, messages).
     HistoryLoaded(String, Vec<ChatMessage>),
+    /// Thread grid data loaded for an agent (agent_id, grid_state).
+    ThreadsLoaded(String, ThreadGridState),
 }
 
 fn spawn_chat_stream(
@@ -496,6 +566,156 @@ fn spawn_chat_history_fetch(
     });
 }
 
+async fn fetch_threads(client: &GraphqlClient, agent_id: &str) -> Result<ThreadGridState> {
+    let resp: ThreadsResponse = client
+        .query(THREADS_QUERY, serde_json::json!({ "agentId": agent_id }))
+        .await?;
+
+    let thread_nodes = resp
+        .agent
+        .map(|a| a.session.threads)
+        .unwrap_or_default();
+
+    Ok(build_thread_grid(thread_nodes))
+}
+
+/// Build a positionally-aligned grid from raw thread data.
+///
+/// Columns = unique block indexes (sorted). Rows = threads.
+/// First thread to reference a block index "owns" it (Unique).
+/// Subsequent threads referencing the same index get Shared.
+/// Unique blocks in COMPACTION threads are marked Summary.
+fn build_thread_grid(thread_nodes: Vec<ThreadNode>) -> ThreadGridState {
+    // 1. Collect all unique block indexes and determine ownership.
+    let mut all_positions = BTreeSet::new();
+    let mut owner: HashMap<i32, usize> = HashMap::new();
+
+    for (thread_idx, node) in thread_nodes.iter().enumerate() {
+        for msg in &node.messages {
+            for &bi in &msg.block_indexes {
+                all_positions.insert(bi);
+                owner.entry(bi).or_insert(thread_idx);
+            }
+        }
+    }
+
+    let positions: Vec<i32> = all_positions.into_iter().collect();
+    let pos_map: HashMap<i32, usize> = positions
+        .iter()
+        .enumerate()
+        .map(|(i, &pos)| (pos, i))
+        .collect();
+
+    let num_positions = positions.len();
+    let num_threads = thread_nodes.len();
+
+    // 2. Build grid and details (consuming thread_nodes).
+    let mut grid: Vec<Vec<CellKind>> = vec![vec![CellKind::Empty; num_positions]; num_threads];
+    let mut details: HashMap<(usize, usize), BlockDetail> = HashMap::new();
+    let mut thread_infos = Vec::new();
+
+    for (thread_idx, node) in thread_nodes.into_iter().enumerate() {
+        let is_compaction = node.start_reason == "COMPACTION";
+        let msg_count = node.messages.len();
+
+        thread_infos.push(ThreadInfo {
+            id: node.id,
+            is_current: node.is_current,
+            next_turn: node.next_turn,
+            start_reason: node.start_reason,
+            message_count: msg_count,
+        });
+
+        for msg in node.messages {
+            let role = match msg.role.as_str() {
+                "USER" => ChatRole::User,
+                _ => ChatRole::Assistant,
+            };
+
+            for (content_block, bi) in msg.content.into_iter().zip(msg.block_indexes.into_iter()) {
+                let pos_idx = match pos_map.get(&bi) {
+                    Some(&idx) => idx,
+                    None => continue,
+                };
+
+                let content = content_block.into_content_block();
+                let type_char = content_type_char(&content, role);
+                let is_owner = owner.get(&bi) == Some(&thread_idx);
+
+                let cell = if is_owner {
+                    if is_compaction {
+                        CellKind::Summary(type_char)
+                    } else {
+                        CellKind::Unique(type_char)
+                    }
+                } else {
+                    CellKind::Shared
+                };
+
+                grid[thread_idx][pos_idx] = cell;
+                details.insert((thread_idx, pos_idx), BlockDetail { role, content });
+            }
+        }
+    }
+
+    // Initial cursor: current thread, first unique/summary block.
+    let current_thread_idx = thread_infos
+        .iter()
+        .position(|t| t.is_current)
+        .unwrap_or(0);
+    let initial_col = grid
+        .get(current_thread_idx)
+        .and_then(|row| {
+            row.iter()
+                .position(|c| matches!(c, CellKind::Unique(_) | CellKind::Summary(_)))
+        })
+        .unwrap_or(0);
+
+    ThreadGridState {
+        threads: thread_infos,
+        positions,
+        grid,
+        details,
+        cursor_col: initial_col,
+        cursor_row: current_thread_idx,
+        scroll_col: 0,
+        visible_cols: 0,
+    }
+}
+
+fn content_type_char(content: &ContentBlock, role: ChatRole) -> char {
+    match content {
+        ContentBlock::Text(_) => match role {
+            ChatRole::User => 'U',
+            ChatRole::Assistant | ChatRole::System => 'A',
+        },
+        ContentBlock::ToolUse(_) => 'T',
+        ContentBlock::Thinking(_) => 'A', // assistant reasoning
+        ContentBlock::ToolResult(_) => 'R',
+    }
+}
+
+fn spawn_threads_fetch(
+    base_url: String,
+    token: String,
+    agent_id: String,
+    tx: mpsc::UnboundedSender<ChatStreamEvent>,
+) {
+    tokio::spawn(async move {
+        let client = GraphqlClient::new(&base_url, &token);
+        match fetch_threads(&client, &agent_id).await {
+            Ok(grid) => {
+                let _ = tx.send(ChatStreamEvent::ThreadsLoaded(agent_id, grid));
+            }
+            Err(e) => {
+                let _ = tx.send(ChatStreamEvent::Error(format!(
+                    "Failed to load threads: {e}"
+                )));
+            }
+        }
+    });
+}
+
 // ---------------------------------------------------------------------------
 // Dispatch stream events → AssistantChat
 // ---------------------------------------------------------------------------
@@ -525,6 +745,13 @@ fn dispatch_stream_event(state: &mut ScreenState, evt: ChatStreamEvent) {
             if state.selected_agent_id().as_deref() == Some(agent_id.as_str()) {
                 state.chat_view.assistant.load_history(messages);
                 state.chat_view.reset_scroll();
+            }
+        }
+        ChatStreamEvent::ThreadsLoaded(agent_id, grid) => {
+            if state.selected_agent_id().as_deref() == Some(agent_id.as_str()) {
+                state.status_message = None;
+                state.thread_view = Some(grid);
+                state.focus = Focus::Threads;
             }
         }
     }
@@ -644,6 +871,23 @@ async fn run_event_loop(
                                     prompt,
                                     stream_tx.clone(),
                                 );
+                            }
+                            handlers::Action::ToggleThreads => {
+                                if state.thread_view.is_some() {
+                                    // Close thread view → reload flat history
+                                    state.thread_view = None;
+                                    state.focus = Focus::Chat;
+                                    state.loaded_agent_id = None; // triggers reactive reload below
+                                } else if let Some(agent_id) = state.selected_agent_id() {
+                                    // Open thread view → fetch threads
+                                    state.status_message = Some("Loading threads…".to_string());
+                                    spawn_threads_fetch(
+                                        config.server_url.clone(),
+                                        config.auth_token.clone(),
+                                        agent_id,
+                                        stream_tx.clone(),
+                                    );
+                                }
                             }
                             handlers::Action::None => {}
                         }

--- a/drua/src/commands/dashboard.rs
+++ b/drua/src/commands/dashboard.rs
@@ -571,10 +571,7 @@ async fn fetch_threads(client: &GraphqlClient, agent_id: &str) -> Result<ThreadG
         .query(THREADS_QUERY, serde_json::json!({ "agentId": agent_id }))
         .await?;
 
-    let thread_nodes = resp
-        .agent
-        .map(|a| a.session.threads)
-        .unwrap_or_default();
+    let thread_nodes = resp.agent.map(|a| a.session.threads).unwrap_or_default();
 
     Ok(build_thread_grid(thread_nodes))
 }
@@ -659,10 +656,7 @@ fn build_thread_grid(thread_nodes: Vec<ThreadNode>) -> ThreadGridState {
     }
 
     // Initial cursor: current thread, first unique/summary block.
-    let current_thread_idx = thread_infos
-        .iter()
-        .position(|t| t.is_current)
-        .unwrap_or(0);
+    let current_thread_idx = thread_infos.iter().position(|t| t.is_current).unwrap_or(0);
     let initial_col = grid
         .get(current_thread_idx)
         .and_then(|row| {

--- a/drua/src/commands/dashboard.rs
+++ b/drua/src/commands/dashboard.rs
@@ -186,6 +186,7 @@ struct ChatHistoryMessage {
 
 #[derive(Debug, Deserialize)]
 #[serde(tag = "__typename")]
+#[allow(clippy::enum_variant_names)]
 enum ChatHistoryContentBlock {
     TextContent {
         text: String,
@@ -629,7 +630,7 @@ fn build_thread_grid(thread_nodes: Vec<ThreadNode>) -> ThreadGridState {
                 _ => ChatRole::Assistant,
             };
 
-            for (content_block, bi) in msg.content.into_iter().zip(msg.block_indexes.into_iter()) {
+            for (content_block, bi) in msg.content.into_iter().zip(msg.block_indexes) {
                 let pos_idx = match pos_map.get(&bi) {
                     Some(&idx) => idx,
                     None => continue,

--- a/drua/src/tui/chat.rs
+++ b/drua/src/tui/chat.rs
@@ -1,4 +1,5 @@
 /// Structured chat content: interleaved text and tool-use blocks.
+#[derive(Clone)]
 pub enum ContentBlock {
     Text(String),
     ToolUse(String),
@@ -13,6 +14,7 @@ pub enum ChatRole {
     System,
 }
 
+#[derive(Clone)]
 pub struct ChatMessage {
     pub role: ChatRole,
     pub blocks: Vec<ContentBlock>,

--- a/drua/src/tui/handlers.rs
+++ b/drua/src/tui/handlers.rs
@@ -10,6 +10,7 @@ pub enum Action {
     Refresh,
     CreateWorkspace { name: String, description: String },
     SendChat { agent_id: String, prompt: String },
+    ToggleThreads,
 }
 
 /// Top-level key dispatcher — routes to mode/focus-specific handlers.
@@ -36,6 +37,8 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
                 state.focus_right();
                 return Action::None;
             }
+            // Ctrl+T — toggle thread explorer
+            KeyCode::Char('t') => return Action::ToggleThreads,
             _ => {}
         }
     }
@@ -45,6 +48,7 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
             Focus::Sidebar => handle_sidebar_key(state, key),
             Focus::Agents => handle_agents_key(state, key),
             Focus::Chat => handle_chat_key(state, key),
+            Focus::Threads => handle_threads_key(state, key),
         },
         Mode::CreateWorkspace => handle_create_key(state, key),
     }
@@ -139,6 +143,48 @@ fn handle_chat_key(state: &mut ScreenState, key: KeyEvent) -> Action {
             handle_input_editing(state, &key);
             Action::None
         }
+    }
+}
+
+fn handle_threads_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        // ←→ navigate positions (columns)
+        KeyCode::Left | KeyCode::Char('h') => {
+            state.grid_move_left();
+            Action::None
+        }
+        KeyCode::Right | KeyCode::Char('l') => {
+            state.grid_move_right();
+            Action::None
+        }
+        // ↑↓ navigate threads (rows)
+        KeyCode::Up | KeyCode::Char('k') => {
+            state.grid_move_up();
+            Action::None
+        }
+        KeyCode::Down | KeyCode::Char('j') => {
+            state.grid_move_down();
+            Action::None
+        }
+        // g/G — jump to start/end of positions
+        KeyCode::Char('g') => {
+            state.grid_jump_start();
+            Action::None
+        }
+        KeyCode::Char('G') => {
+            state.grid_jump_end();
+            Action::None
+        }
+        // Tab — jump to next unique/summary cell
+        KeyCode::Tab => {
+            state.grid_tab_next();
+            Action::None
+        }
+        KeyCode::Esc => {
+            state.focus = Focus::Sidebar;
+            Action::None
+        }
+        _ => Action::None,
     }
 }
 

--- a/drua/src/tui/state.rs
+++ b/drua/src/tui/state.rs
@@ -1,4 +1,6 @@
-use super::chat::AssistantChat;
+use std::collections::HashMap;
+
+use super::chat::{AssistantChat, ChatRole, ContentBlock};
 
 #[allow(dead_code)]
 pub struct WorkspaceItem {
@@ -36,6 +38,7 @@ pub enum Focus {
     Sidebar,
     Agents,
     Chat,
+    Threads,
 }
 
 /// Scroll and viewport state for the chat message area.
@@ -67,6 +70,73 @@ impl ChatViewState {
     }
 }
 
+// ── Thread explorer types (positionally-aligned grid) ─────────────────
+
+#[allow(dead_code)]
+pub struct ThreadInfo {
+    pub id: String,
+    pub is_current: bool,
+    pub next_turn: String,
+    pub start_reason: String,
+    pub message_count: usize,
+}
+
+/// Classification of a cell in the thread × position grid.
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub enum CellKind {
+    /// Unique content block owned by this thread. Char = type: U/A/T/R.
+    Unique(char),
+    /// Shared reference — another thread already has this block.
+    Shared,
+    /// Summary block (unique content in a COMPACTION thread).
+    Summary(char),
+    /// Empty — this thread doesn't reference this position.
+    Empty,
+}
+
+/// Content detail for a single block at a (thread, position).
+pub struct BlockDetail {
+    pub role: ChatRole,
+    pub content: ContentBlock,
+}
+
+/// Positionally-aligned thread grid state.
+pub struct ThreadGridState {
+    /// Thread metadata.
+    pub threads: Vec<ThreadInfo>,
+    /// All unique block-index positions (sorted) across all threads.
+    pub positions: Vec<i32>,
+    /// Grid cells: `grid[thread_idx][position_idx]`.
+    pub grid: Vec<Vec<CellKind>>,
+    /// Content at each `(thread_idx, position_idx)` — only for non-empty cells.
+    pub details: HashMap<(usize, usize), BlockDetail>,
+    /// Cursor column (position index).
+    pub cursor_col: usize,
+    /// Cursor row (thread index).
+    pub cursor_row: usize,
+    /// Horizontal scroll offset (in columns).
+    pub scroll_col: usize,
+    /// Number of visible columns (updated from render path).
+    pub visible_cols: usize,
+}
+
+impl ThreadGridState {
+    pub fn ensure_cursor_visible(&mut self) {
+        if self.visible_cols == 0 {
+            return;
+        }
+        if self.cursor_col < self.scroll_col {
+            self.scroll_col = self.cursor_col;
+        } else if self.cursor_col >= self.scroll_col + self.visible_cols {
+            self.scroll_col = self.cursor_col.saturating_sub(self.visible_cols) + 1;
+        }
+    }
+
+    pub fn update_visible_cols(&mut self, cols: usize) {
+        self.visible_cols = cols;
+    }
+}
+
 /// Top-level TUI state — replaces the old flat `App` struct.
 pub struct ScreenState {
     // Workspace browsing
@@ -91,6 +161,9 @@ pub struct ScreenState {
     /// The agent whose history is currently loaded in the chat view.
     /// When this differs from `selected_agent_id()`, the event loop fetches fresh history.
     pub loaded_agent_id: Option<String>,
+
+    // Thread explorer (positionally-aligned grid)
+    pub thread_view: Option<ThreadGridState>,
 
     // Create workspace modal
     pub mode: Mode,
@@ -121,6 +194,8 @@ impl ScreenState {
             chat_input: String::new(),
             input_cursor: 0,
             loaded_agent_id: None,
+
+            thread_view: None,
 
             mode: Mode::default(),
             input_name: String::new(),
@@ -215,6 +290,7 @@ impl ScreenState {
             Focus::Sidebar => Focus::Chat,
             Focus::Chat => Focus::Agents,
             Focus::Agents => Focus::Sidebar,
+            Focus::Threads => Focus::Sidebar,
         };
     }
 
@@ -223,6 +299,7 @@ impl ScreenState {
             Focus::Sidebar => Focus::Agents,
             Focus::Chat => Focus::Sidebar,
             Focus::Agents => Focus::Chat,
+            Focus::Threads => Focus::Sidebar,
         };
     }
 
@@ -231,6 +308,7 @@ impl ScreenState {
             Focus::Sidebar => Focus::Chat,
             Focus::Chat => Focus::Agents,
             Focus::Agents => Focus::Sidebar,
+            Focus::Threads => Focus::Agents,
         };
     }
 
@@ -312,6 +390,85 @@ impl ScreenState {
         self.input_cursor = 0;
     }
 
+    // ── Thread grid navigation ────────────────────────────────────
+
+    pub fn grid_move_right(&mut self) {
+        if let Some(ref mut g) = self.thread_view {
+            if !g.positions.is_empty() && g.cursor_col < g.positions.len() - 1 {
+                g.cursor_col += 1;
+                g.ensure_cursor_visible();
+            }
+        }
+    }
+
+    pub fn grid_move_left(&mut self) {
+        if let Some(ref mut g) = self.thread_view {
+            if g.cursor_col > 0 {
+                g.cursor_col -= 1;
+                g.ensure_cursor_visible();
+            }
+        }
+    }
+
+    pub fn grid_move_down(&mut self) {
+        if let Some(ref mut g) = self.thread_view {
+            if !g.threads.is_empty() && g.cursor_row < g.threads.len() - 1 {
+                g.cursor_row += 1;
+            }
+        }
+    }
+
+    pub fn grid_move_up(&mut self) {
+        if let Some(ref mut g) = self.thread_view {
+            if g.cursor_row > 0 {
+                g.cursor_row -= 1;
+            }
+        }
+    }
+
+    pub fn grid_jump_start(&mut self) {
+        if let Some(ref mut g) = self.thread_view {
+            g.cursor_col = 0;
+            g.scroll_col = 0;
+        }
+    }
+
+    pub fn grid_jump_end(&mut self) {
+        if let Some(ref mut g) = self.thread_view {
+            if !g.positions.is_empty() {
+                g.cursor_col = g.positions.len() - 1;
+                g.ensure_cursor_visible();
+            }
+        }
+    }
+
+    /// Jump to the next unique/summary cell on the current row (wraps).
+    pub fn grid_tab_next(&mut self) {
+        if let Some(ref mut g) = self.thread_view {
+            let row = g.cursor_row;
+            if row >= g.grid.len() {
+                return;
+            }
+            let cols = g.grid[row].len();
+            // Search forward
+            for col in (g.cursor_col + 1)..cols {
+                if matches!(g.grid[row][col], CellKind::Unique(_) | CellKind::Summary(_)) {
+                    g.cursor_col = col;
+                    g.ensure_cursor_visible();
+                    return;
+                }
+            }
+            // Wrap around
+            for col in 0..g.cursor_col {
+                if matches!(g.grid[row][col], CellKind::Unique(_) | CellKind::Summary(_)) {
+                    g.cursor_col = col;
+                    g.ensure_cursor_visible();
+                    return;
+                }
+            }
+        }
+    }
+
     fn sync_lead_and_clear_chat(&mut self) {
         self.selected_lead_id = self
             .selected_workspace()
@@ -319,6 +476,7 @@ impl ScreenState {
             .map(|l| l.id.clone());
         self.agent_cursor = 0;
         self.loaded_agent_id = None;
+        self.thread_view = None;
         self.chat_view.assistant.clear();
         self.input_clear();
         self.chat_view.reset_scroll();

--- a/drua/src/tui/ui.rs
+++ b/drua/src/tui/ui.rs
@@ -7,7 +7,7 @@ use ratatui::{
 };
 
 use super::chat::{ChatMessage, ChatRole, ContentBlock};
-use super::state::{Focus, Mode, ScreenState};
+use super::state::{CellKind, Focus, Mode, ScreenState};
 
 pub fn draw(frame: &mut Frame, state: &mut ScreenState) {
     let chunks = Layout::default()
@@ -226,22 +226,33 @@ fn draw_agent_details(frame: &mut Frame, state: &ScreenState, area: Rect) {
 }
 
 fn draw_chat_pane(frame: &mut Frame, state: &mut ScreenState, area: Rect) {
-    let chat_layout = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Min(1), Constraint::Length(3)])
-        .split(area);
+    if state.thread_view.is_some() {
+        // Thread grid mode: grid (top 50%) + position detail (bottom 50%).
+        // Replaces the entire center panel — no chat input.
+        let layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(area);
 
-    let messages_area = chat_layout[0];
-    let input_area = chat_layout[1];
+        draw_thread_grid(frame, state, layout[0]);
+        draw_position_detail(frame, state, layout[1]);
+    } else {
+        // Normal mode: messages + input
+        let chat_layout = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Min(1), Constraint::Length(3)])
+            .split(area);
 
-    // Record viewport height so scroll_up/scroll_down can do half-page jumps.
-    // Subtract 2 for the border lines.
-    state
-        .chat_view
-        .update_viewport_height(messages_area.height.saturating_sub(2));
+        let messages_area = chat_layout[0];
+        let input_area = chat_layout[1];
 
-    draw_chat_messages(frame, state, messages_area);
-    draw_chat_input(frame, state, input_area);
+        state
+            .chat_view
+            .update_viewport_height(messages_area.height.saturating_sub(2));
+
+        draw_chat_messages(frame, state, messages_area);
+        draw_chat_input(frame, state, input_area);
+    }
 }
 
 fn draw_chat_messages(frame: &mut Frame, state: &ScreenState, area: Rect) {
@@ -295,10 +306,28 @@ fn draw_chat_messages(frame: &mut Frame, state: &ScreenState, area: Rect) {
         )));
     }
 
+    // Auto-scroll: chat_scroll is "lines from bottom".
+    // 0 = pinned to bottom, >0 = scrolled up into history.
+    let viewport = area.height.saturating_sub(2);
+    let available_width = area.width.saturating_sub(2) as usize;
+    let wrapped_lines: u16 = lines
+        .iter()
+        .map(|line| {
+            let len: usize = line.spans.iter().map(|s| s.content.len()).sum();
+            if len == 0 || available_width == 0 {
+                1
+            } else {
+                ((len + available_width - 1) / available_width).max(1) as u16
+            }
+        })
+        .sum();
+    let max_scroll = wrapped_lines.saturating_sub(viewport);
+    let scroll_offset = max_scroll.saturating_sub(state.chat_view.chat_scroll);
+
     let paragraph = Paragraph::new(lines)
         .block(block)
         .wrap(Wrap { trim: false })
-        .scroll((state.chat_view.chat_scroll, 0));
+        .scroll((scroll_offset, 0));
 
     frame.render_widget(paragraph, area);
 }
@@ -384,6 +413,327 @@ fn format_chat_message(msg: &ChatMessage) -> Vec<Line<'static>> {
     }
 }
 
+fn draw_thread_grid(frame: &mut Frame, state: &mut ScreenState, area: Rect) {
+    let border_color = if state.focus == Focus::Threads {
+        Color::Yellow
+    } else {
+        Color::Cyan
+    };
+
+    let grid = match state.thread_view.as_mut() {
+        Some(g) => g,
+        None => return,
+    };
+
+    let title = format!(
+        " Thread Grid — pos {}/{} thread {}/{} ",
+        if grid.positions.is_empty() {
+            0
+        } else {
+            grid.cursor_col + 1
+        },
+        grid.positions.len(),
+        if grid.threads.is_empty() {
+            0
+        } else {
+            grid.cursor_row + 1
+        },
+        grid.threads.len(),
+    );
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(Style::default().fg(border_color));
+
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    if inner.height == 0 || inner.width == 0 || grid.threads.is_empty() {
+        return;
+    }
+
+    let label_width: usize = 12;
+    let cell_width: usize = 4;
+    let grid_px = inner.width as usize - label_width.min(inner.width as usize);
+    let visible_cols = if cell_width > 0 {
+        grid_px / cell_width
+    } else {
+        0
+    };
+
+    grid.update_visible_cols(visible_cols);
+    grid.ensure_cursor_visible();
+
+    // Vertical scrolling
+    let max_rows = inner.height as usize;
+    let start_row = if grid.cursor_row >= max_rows {
+        grid.cursor_row - max_rows + 1
+    } else {
+        0
+    };
+    let end_row = (start_row + max_rows).min(grid.threads.len());
+
+    let start_col = grid.scroll_col;
+    let end_col = (grid.scroll_col + visible_cols).min(grid.positions.len());
+
+    for (display_row, row_idx) in (start_row..end_row).enumerate() {
+        let thread = &grid.threads[row_idx];
+        let y = inner.y + display_row as u16;
+        if y >= inner.y + inner.height {
+            break;
+        }
+
+        // Thread label
+        let reason = match thread.start_reason.as_str() {
+            "INITIAL_THREAD" => "Init",
+            "TOOL_DEFS_UPDATED" => "TDef",
+            "COMPACTION" => "Comp",
+            other => {
+                if other.len() > 4 {
+                    &other[..4]
+                } else {
+                    other
+                }
+            }
+        };
+        let label = if thread.is_current {
+            format!("{:>2}.{} *", row_idx + 1, reason)
+        } else {
+            format!("{:>2}.{}", row_idx + 1, reason)
+        };
+        let label_style = if row_idx == grid.cursor_row {
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default().fg(Color::DarkGray)
+        };
+        let label_span = Span::styled(
+            format!("{:<width$}", label, width = label_width),
+            label_style,
+        );
+
+        // Compute non-empty columns for this row (full row, not just visible)
+        let row_cells = &grid.grid[row_idx];
+        let non_empty: Vec<usize> = row_cells
+            .iter()
+            .enumerate()
+            .filter(|(_, c)| !matches!(c, CellKind::Empty))
+            .map(|(i, _)| i)
+            .collect();
+        let first_ne = non_empty.first().copied();
+        let last_ne = non_empty.last().copied();
+
+        let mut spans = vec![label_span];
+
+        for col in start_col..end_col {
+            let cell = row_cells.get(col).copied().unwrap_or(CellKind::Empty);
+            let is_cursor = row_idx == grid.cursor_row && col == grid.cursor_col;
+
+            // Is this empty cell between two non-empty cells? (connector pass-through)
+            let is_between = matches!(cell, CellKind::Empty)
+                && matches!((first_ne, last_ne), (Some(f), Some(l)) if f < col && col < l);
+            // Does this cell connect rightward?
+            let has_rightward =
+                !matches!(cell, CellKind::Empty) && last_ne.map(|l| col < l).unwrap_or(false);
+
+            let (text, base_color) = if is_between {
+                ("────".to_string(), Color::DarkGray)
+            } else {
+                match cell {
+                    CellKind::Empty => ("    ".to_string(), Color::DarkGray),
+                    CellKind::Unique(c) => {
+                        let conn = if has_rightward { "───" } else { "   " };
+                        let color = match c {
+                            'U' => Color::Cyan,
+                            'A' => Color::White,
+                            'T' => Color::Yellow,
+                            'R' => Color::Gray,
+                            _ => Color::White,
+                        };
+                        (format!("{c}{conn}"), color)
+                    }
+                    CellKind::Summary(_) => {
+                        let conn = if has_rightward { "───" } else { "   " };
+                        (format!("*{conn}"), Color::Magenta)
+                    }
+                    CellKind::Shared => {
+                        let conn = if has_rightward { "───" } else { "   " };
+                        (format!("·{conn}"), Color::DarkGray)
+                    }
+                }
+            };
+
+            let style = if is_cursor {
+                Style::default().fg(Color::Black).bg(Color::Yellow)
+            } else {
+                Style::default().fg(base_color)
+            };
+
+            spans.push(Span::styled(text, style));
+        }
+
+        let line = Line::from(spans);
+        let line_area = Rect::new(inner.x, y, inner.width, 1);
+        frame.render_widget(Paragraph::new(line), line_area);
+    }
+}
+
+fn draw_position_detail(frame: &mut Frame, state: &ScreenState, area: Rect) {
+    let border_color = if state.focus == Focus::Threads {
+        Color::Yellow
+    } else {
+        Color::Cyan
+    };
+
+    let grid = match state.thread_view.as_ref() {
+        Some(g) => g,
+        None => {
+            let block = Block::default()
+                .borders(Borders::ALL)
+                .title(" Position Detail ")
+                .border_style(Style::default().fg(border_color));
+            frame.render_widget(
+                Paragraph::new(Line::from(Span::styled(
+                    "No thread data",
+                    Style::default().fg(Color::DarkGray),
+                )))
+                .block(block),
+                area,
+            );
+            return;
+        }
+    };
+
+    let pos = grid.positions.get(grid.cursor_col);
+    let title = match pos {
+        Some(p) => format!(
+            " Position {}/{} (block #{}) ",
+            grid.cursor_col + 1,
+            grid.positions.len(),
+            p
+        ),
+        None => " Position Detail ".to_string(),
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(title)
+        .border_style(Style::default().fg(border_color));
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    for (thread_idx, thread) in grid.threads.iter().enumerate() {
+        let cell = grid
+            .grid
+            .get(thread_idx)
+            .and_then(|row| row.get(grid.cursor_col))
+            .copied()
+            .unwrap_or(CellKind::Empty);
+
+        if matches!(cell, CellKind::Empty) {
+            continue;
+        }
+
+        let reason = match thread.start_reason.as_str() {
+            "INITIAL_THREAD" => "Init",
+            "TOOL_DEFS_UPDATED" => "TDef",
+            "COMPACTION" => "Comp",
+            other => other,
+        };
+        let thread_label = format!("{}. {}", thread_idx + 1, reason);
+        let is_selected_row = thread_idx == grid.cursor_row;
+
+        let header_style = if is_selected_row {
+            Style::default()
+                .fg(Color::Yellow)
+                .add_modifier(Modifier::BOLD)
+        } else {
+            Style::default()
+                .fg(Color::Cyan)
+                .add_modifier(Modifier::BOLD)
+        };
+
+        let cell_label = match cell {
+            CellKind::Unique(c) => format!(" [{c}]"),
+            CellKind::Shared => " [·]".to_string(),
+            CellKind::Summary(_) => " [*]".to_string(),
+            CellKind::Empty => unreachable!(),
+        };
+
+        lines.push(Line::from(vec![
+            Span::styled(format!(" {thread_label}"), header_style),
+            Span::styled(cell_label, Style::default().fg(Color::DarkGray)),
+        ]));
+
+        if let Some(detail) = grid.details.get(&(thread_idx, grid.cursor_col)) {
+            let content_lines = format_block_detail(&detail.content, detail.role);
+            lines.extend(content_lines);
+        }
+
+        lines.push(Line::from("")); // spacer
+    }
+
+    if lines.is_empty() {
+        lines.push(Line::from(Span::styled(
+            " No content at this position",
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    let paragraph = Paragraph::new(lines)
+        .block(block)
+        .wrap(Wrap { trim: false });
+    frame.render_widget(paragraph, area);
+}
+
+/// Format a single content block for the position detail pane.
+fn format_block_detail(content: &ContentBlock, role: ChatRole) -> Vec<Line<'static>> {
+    let role_color = match role {
+        ChatRole::User => Color::Cyan,
+        ChatRole::Assistant => Color::White,
+        ChatRole::System => Color::DarkGray,
+    };
+
+    match content {
+        ContentBlock::Text(text) => text
+            .lines()
+            .map(|l| {
+                Line::from(Span::styled(
+                    format!("   {l}"),
+                    Style::default().fg(role_color),
+                ))
+            })
+            .collect(),
+        ContentBlock::ToolUse(name) => {
+            vec![Line::from(Span::styled(
+                format!("   [{name}]"),
+                Style::default().fg(Color::Yellow),
+            ))]
+        }
+        ContentBlock::Thinking(text) => {
+            let preview = if text.len() > 120 {
+                format!("   💭 {}…", &text[..120])
+            } else {
+                format!("   💭 {text}")
+            };
+            vec![Line::from(Span::styled(
+                preview,
+                Style::default()
+                    .fg(Color::DarkGray)
+                    .add_modifier(Modifier::ITALIC),
+            ))]
+        }
+        ContentBlock::ToolResult(summary) => {
+            vec![Line::from(Span::styled(
+                format!("   ↳ {summary}"),
+                Style::default().fg(Color::DarkGray),
+            ))]
+        }
+    }
+}
+
 fn draw_chat_input(frame: &mut Frame, state: &ScreenState, area: Rect) {
     let focused = state.focus == Focus::Chat;
     let border_color = if focused { Color::Yellow } else { Color::Cyan };
@@ -443,7 +793,8 @@ fn draw_status_bar(frame: &mut Frame, state: &ScreenState, area: Rect) {
     let keys = match state.focus {
         Focus::Sidebar => " │ ↑/↓:nav  n:new  r:refresh  Tab:agents  q:quit ",
         Focus::Agents => " │ ↑/↓:nav  Enter:chat  Tab:chat  Esc:sidebar ",
-        Focus::Chat => " │ Enter:send  Esc:sidebar  ↑/↓:scroll ",
+        Focus::Chat => " │ Enter:send  Esc:sidebar  ↑/↓:scroll  ^T:threads ",
+        Focus::Threads => " │ ←→:pos  ↑↓:thread  Tab:next  g/G:jump  ^T:close  Esc:sidebar ",
     };
     spans.push(Span::styled(keys, Style::default().fg(Color::DarkGray)));
 

--- a/drua/src/tui/ui.rs
+++ b/drua/src/tui/ui.rs
@@ -317,7 +317,7 @@ fn draw_chat_messages(frame: &mut Frame, state: &ScreenState, area: Rect) {
             if len == 0 || available_width == 0 {
                 1
             } else {
-                ((len + available_width - 1) / available_width).max(1) as u16
+                len.div_ceil(available_width).max(1) as u16
             }
         })
         .sum();
@@ -456,11 +456,7 @@ fn draw_thread_grid(frame: &mut Frame, state: &mut ScreenState, area: Rect) {
     let label_width: usize = 12;
     let cell_width: usize = 4;
     let grid_px = inner.width as usize - label_width.min(inner.width as usize);
-    let visible_cols = if cell_width > 0 {
-        grid_px / cell_width
-    } else {
-        0
-    };
+    let visible_cols = grid_px.checked_div(cell_width).unwrap_or(0);
 
     grid.update_visible_cols(visible_cols);
     grid.ensure_cursor_visible();


### PR DESCRIPTION
## Summary
- Replace tree-based thread explorer with a positionally-aligned grid view (Ctrl+T to toggle)
- Grid columns = global block positions (from `blockIndexes`), rows = threads
- Symbols: `U`/`A`/`T`/`R` (unique by content type), `·` (shared), `*` (summary/compaction), `───` connectors
- Detail pane below grid shows all threads' content at the selected column position
- Fix pre-existing chat auto-scroll bug (chat now pins to bottom during streaming)

## Files changed
- `drua/src/tui/state.rs` — `CellKind`, `BlockDetail`, `ThreadGridState` types + grid cursor navigation
- `drua/src/commands/dashboard.rs` — `build_thread_grid()` using `blockIndexes` for cross-thread alignment
- `drua/src/tui/handlers.rs` — Grid navigation: ←→ pos, ↑↓ thread, Tab next unique, g/G jump, Esc close
- `drua/src/tui/ui.rs` — `draw_thread_grid()` + `draw_position_detail()` rendering
- `drua/src/tui/chat.rs` — Added `Clone` derives for content types

## Test plan
- [x] `cargo check` — clean compile (full workspace)
- [x] `cargo test -p drua-core -- session` — 31/31 tests pass
- [ ] Manual: `drua dashboard` → navigate to workspace → Ctrl+T to open grid → ←→↑↓ navigation → Ctrl+T to close

🤖 Generated with [Claude Code](https://claude.com/claude-code)