### PR TITLE
refactor(llm): make StreamDelta provider-neutral

### DIFF
--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -777,19 +777,18 @@ async fn consume_stream(
 }
 
 fn delta_to_chat_event(delta: &llm::stream::StreamDelta) -> Option<ChatOutputEvent> {
-    use llm::stream::{ContentBlockType, StreamDelta};
+    use llm::stream::StreamDelta;
     match delta {
-        StreamDelta::TextDelta { text, .. } => {
+        StreamDelta::TextDelta { text } => {
             Some(ChatOutputEvent::TextDelta { text: text.clone() })
         }
-        StreamDelta::ThinkingDelta { text, .. } => {
+        StreamDelta::ThinkingDelta { text } => {
             Some(ChatOutputEvent::ThinkingDelta { text: text.clone() })
         }
-        StreamDelta::ContentBlockStart {
-            block_type: ContentBlockType::ToolUse { name, .. },
-            ..
-        } => Some(ChatOutputEvent::ToolCallStart { name: name.clone() }),
-        StreamDelta::InputJsonDelta { partial_json, .. } => {
+        StreamDelta::ToolCallStart { name, .. } => {
+            Some(ChatOutputEvent::ToolCallStart { name: name.clone() })
+        }
+        StreamDelta::ToolCallDelta { partial_json, .. } => {
             Some(ChatOutputEvent::ToolCallInputDelta {
                 partial_json: partial_json.clone(),
             })

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -779,9 +779,7 @@ async fn consume_stream(
 fn delta_to_chat_event(delta: &llm::stream::StreamDelta) -> Option<ChatOutputEvent> {
     use llm::stream::StreamDelta;
     match delta {
-        StreamDelta::TextDelta { text } => {
-            Some(ChatOutputEvent::TextDelta { text: text.clone() })
-        }
+        StreamDelta::TextDelta { text } => Some(ChatOutputEvent::TextDelta { text: text.clone() }),
         StreamDelta::ThinkingDelta { text } => {
             Some(ChatOutputEvent::ThinkingDelta { text: text.clone() })
         }

--- a/lib/anthropic-client/src/convert.rs
+++ b/lib/anthropic-client/src/convert.rs
@@ -11,7 +11,7 @@ use llm::prompt::{
 };
 use llm::{PromptResponse, StopReason, Usage};
 
-use llm::stream::{ContentBlockType, StreamDelta};
+use llm::stream::StreamDelta;
 
 use crate::stream::{AccumulatedBlock, AccumulatedResponse, AccumulatedStopReason};
 use crate::types::{
@@ -228,84 +228,121 @@ fn convert_accumulated_block(block: AccumulatedBlock) -> AssistantBlock {
 }
 
 // ============================================================================
-// SSE JSON → StreamDelta
+// SSE JSON → StreamDelta (stateful converter)
 // ============================================================================
 
-/// Parse a raw SSE data payload (Anthropic JSON) into a provider-agnostic
-/// [`StreamDelta`]. Returns `Ok(None)` for events that have no meaningful
-/// delta (e.g. `Ping`).
-pub(crate) fn sse_data_to_delta(data: &str) -> Result<Option<StreamDelta>, String> {
-    let event: AnthropicStreamEvent =
-        serde_json::from_str(data).map_err(|e| format!("JSON parse: {e}"))?;
-    Ok(match event {
-        AnthropicStreamEvent::MessageStart { message } => {
-            let input_tokens = message.usage.map(|u| u.input as u32).unwrap_or(0);
-            Some(StreamDelta::MessageStart { input_tokens })
-        }
-        AnthropicStreamEvent::ContentBlockStart {
-            index,
-            content_block,
-        } => {
-            let block_type = match content_block {
-                AnthropicContentBlock::Text => ContentBlockType::Text,
-                AnthropicContentBlock::ToolUse { id, name } => ContentBlockType::ToolUse {
-                    id: id.unwrap_or_default(),
-                    name: name.unwrap_or_default(),
-                },
-                AnthropicContentBlock::Thinking => ContentBlockType::Thinking,
-            };
-            Some(StreamDelta::ContentBlockStart {
-                index: index as usize,
-                block_type,
-            })
-        }
-        AnthropicStreamEvent::ContentBlockDelta { index, delta } => {
-            let idx = index as usize;
-            match delta {
-                AnthropicDelta::TextDelta { text } => text.map(|t| StreamDelta::TextDelta {
-                    index: idx,
-                    text: t,
-                }),
-                AnthropicDelta::ThinkingDelta { thinking } => {
-                    thinking.map(|t| StreamDelta::ThinkingDelta {
-                        index: idx,
-                        text: t,
-                    })
+/// Tracks Anthropic content-block indices so that index-only deltas
+/// (e.g. `InputJsonDelta`) can be mapped to the tool call ID that was
+/// announced in the preceding `ContentBlockStart`.
+pub(crate) struct AnthropicDeltaConverter {
+    blocks: Vec<BlockInfo>,
+}
+
+enum BlockInfo {
+    Text,
+    Thinking,
+    ToolUse { id: String },
+}
+
+impl AnthropicDeltaConverter {
+    pub fn new() -> Self {
+        Self { blocks: Vec::new() }
+    }
+
+    /// Process a raw SSE data payload and return zero or more provider-agnostic
+    /// [`StreamDelta`]s. Returns an empty vec for events with no meaningful
+    /// delta (e.g. `Ping`, `ContentBlockStop`, `MessageStop`).
+    pub fn process_event(&mut self, data: &str) -> Result<Vec<StreamDelta>, String> {
+        let event: AnthropicStreamEvent =
+            serde_json::from_str(data).map_err(|e| format!("JSON parse: {e}"))?;
+
+        Ok(match event {
+            AnthropicStreamEvent::MessageStart { message } => {
+                let input_tokens = message.usage.map(|u| u.input as u32).unwrap_or(0);
+                vec![StreamDelta::Usage {
+                    input_tokens,
+                    output_tokens: 0,
+                }]
+            }
+            AnthropicStreamEvent::ContentBlockStart {
+                index,
+                content_block,
+            } => {
+                let idx = index as usize;
+                // Grow the blocks vec to accommodate this index.
+                while self.blocks.len() <= idx {
+                    self.blocks.push(BlockInfo::Text);
                 }
-                AnthropicDelta::InputJsonDelta { partial_json } => {
-                    partial_json.map(|j| StreamDelta::InputJsonDelta {
-                        index: idx,
-                        partial_json: j,
-                    })
-                }
-                AnthropicDelta::SignatureDelta { signature } => {
-                    signature.map(|s| StreamDelta::SignatureDelta {
-                        index: idx,
-                        signature: s,
-                    })
+                match content_block {
+                    AnthropicContentBlock::Text => {
+                        self.blocks[idx] = BlockInfo::Text;
+                        vec![]
+                    }
+                    AnthropicContentBlock::Thinking => {
+                        self.blocks[idx] = BlockInfo::Thinking;
+                        vec![]
+                    }
+                    AnthropicContentBlock::ToolUse { id, name } => {
+                        let id = id.unwrap_or_default();
+                        let name = name.unwrap_or_default();
+                        self.blocks[idx] = BlockInfo::ToolUse { id: id.clone() };
+                        vec![StreamDelta::ToolCallStart { id, name }]
+                    }
                 }
             }
-        }
-        AnthropicStreamEvent::ContentBlockStop { index } => Some(StreamDelta::ContentBlockStop {
-            index: index as usize,
-        }),
-        AnthropicStreamEvent::MessageDelta { delta, usage } => {
-            let stop_reason = delta.stop_reason.map(|sr| match sr {
-                AnthropicStopReason::EndTurn => StopReason::EndTurn,
-                AnthropicStopReason::MaxTokens => StopReason::MaxTokens,
-                AnthropicStopReason::ToolUse => StopReason::ToolUse,
-                AnthropicStopReason::StopSequence => StopReason::StopSequence,
-            });
-            let output_tokens = usage.map(|u| u.output_tokens as u32).unwrap_or(0);
-            Some(StreamDelta::MessageDelta {
-                stop_reason,
-                output_tokens,
-            })
-        }
-        AnthropicStreamEvent::MessageStop => Some(StreamDelta::MessageStop),
-        AnthropicStreamEvent::Error { error } => Some(StreamDelta::Error {
-            message: error.message,
-        }),
-        AnthropicStreamEvent::Ping => None,
-    })
+            AnthropicStreamEvent::ContentBlockDelta { index, delta } => {
+                let idx = index as usize;
+                match delta {
+                    AnthropicDelta::TextDelta { text } => text
+                        .map(|t| vec![StreamDelta::TextDelta { text: t }])
+                        .unwrap_or_default(),
+                    AnthropicDelta::ThinkingDelta { thinking } => thinking
+                        .map(|t| vec![StreamDelta::ThinkingDelta { text: t }])
+                        .unwrap_or_default(),
+                    AnthropicDelta::InputJsonDelta { partial_json } => {
+                        partial_json
+                            .map(|j| {
+                                let id = match self.blocks.get(idx) {
+                                    Some(BlockInfo::ToolUse { id }) => id.clone(),
+                                    _ => String::new(),
+                                };
+                                vec![StreamDelta::ToolCallDelta {
+                                    id,
+                                    partial_json: j,
+                                }]
+                            })
+                            .unwrap_or_default()
+                    }
+                    AnthropicDelta::SignatureDelta { signature } => signature
+                        .map(|s| vec![StreamDelta::ThinkingSignature { signature: s }])
+                        .unwrap_or_default(),
+                }
+            }
+            AnthropicStreamEvent::ContentBlockStop { .. } => vec![],
+            AnthropicStreamEvent::MessageDelta { delta, usage } => {
+                let mut deltas = Vec::new();
+                if let Some(u) = usage {
+                    deltas.push(StreamDelta::Usage {
+                        input_tokens: 0,
+                        output_tokens: u.output_tokens as u32,
+                    });
+                }
+                let stop_reason = delta.stop_reason.map(|sr| match sr {
+                    AnthropicStopReason::EndTurn => StopReason::EndTurn,
+                    AnthropicStopReason::MaxTokens => StopReason::MaxTokens,
+                    AnthropicStopReason::ToolUse => StopReason::ToolUse,
+                    AnthropicStopReason::StopSequence => StopReason::StopSequence,
+                });
+                deltas.push(StreamDelta::Done { stop_reason });
+                deltas
+            }
+            AnthropicStreamEvent::MessageStop => vec![],
+            AnthropicStreamEvent::Error { error } => {
+                vec![StreamDelta::Error {
+                    message: error.message,
+                }]
+            }
+            AnthropicStreamEvent::Ping => vec![],
+        })
+    }
 }

--- a/lib/anthropic-client/src/convert.rs
+++ b/lib/anthropic-client/src/convert.rs
@@ -299,20 +299,18 @@ impl AnthropicDeltaConverter {
                     AnthropicDelta::ThinkingDelta { thinking } => thinking
                         .map(|t| vec![StreamDelta::ThinkingDelta { text: t }])
                         .unwrap_or_default(),
-                    AnthropicDelta::InputJsonDelta { partial_json } => {
-                        partial_json
-                            .map(|j| {
-                                let id = match self.blocks.get(idx) {
-                                    Some(BlockInfo::ToolUse { id }) => id.clone(),
-                                    _ => String::new(),
-                                };
-                                vec![StreamDelta::ToolCallDelta {
-                                    id,
-                                    partial_json: j,
-                                }]
-                            })
-                            .unwrap_or_default()
-                    }
+                    AnthropicDelta::InputJsonDelta { partial_json } => partial_json
+                        .map(|j| {
+                            let id = match self.blocks.get(idx) {
+                                Some(BlockInfo::ToolUse { id }) => id.clone(),
+                                _ => String::new(),
+                            };
+                            vec![StreamDelta::ToolCallDelta {
+                                id,
+                                partial_json: j,
+                            }]
+                        })
+                        .unwrap_or_default(),
                     AnthropicDelta::SignatureDelta { signature } => signature
                         .map(|s| vec![StreamDelta::ThinkingSignature { signature: s }])
                         .unwrap_or_default(),

--- a/lib/anthropic-client/src/lib.rs
+++ b/lib/anthropic-client/src/lib.rs
@@ -19,7 +19,7 @@ use llm::{Prompt, PromptError, PromptResponse};
 
 use llm::stream::StreamDelta;
 
-use crate::convert::{accumulated_to_response, prompt_to_request, sse_data_to_delta};
+use crate::convert::{accumulated_to_response, prompt_to_request, AnthropicDeltaConverter};
 use crate::sse::{parse_sse_stream, SseError};
 use crate::stream::StreamAccumulator;
 
@@ -168,15 +168,21 @@ impl AnthropicClient {
         let (tx, rx) = tokio::sync::mpsc::channel::<Result<StreamDelta, AnthropicError>>(128);
         tokio::spawn(async move {
             let tx_ref = &tx;
+            let mut converter = AnthropicDeltaConverter::new();
+            let converter_ref = &mut converter;
             let _ = parse_sse_stream(byte_stream, |event| {
                 if event.event == "ping" {
                     return Ok(());
                 }
-                match sse_data_to_delta(&event.data) {
-                    Ok(Some(delta)) => tx_ref
-                        .try_send(Ok(delta))
-                        .map_err(|e| SseError::Processing(e.to_string())),
-                    Ok(None) => Ok(()),
+                match converter_ref.process_event(&event.data) {
+                    Ok(deltas) => {
+                        for delta in deltas {
+                            tx_ref
+                                .try_send(Ok(delta))
+                                .map_err(|e| SseError::Processing(e.to_string()))?;
+                        }
+                        Ok(())
+                    }
                     Err(e) => {
                         let _ = tx_ref.try_send(Err(AnthropicError::Stream(e.clone())));
                         Err(SseError::Processing(e))

--- a/lib/llm/src/provider.rs
+++ b/lib/llm/src/provider.rs
@@ -21,17 +21,16 @@ pub trait LlmProvider: Send + Sync {
 
     /// Send a prompt and receive streaming deltas via channel.
     ///
-    /// The returned receiver yields `StreamDelta` events that conform to the
-    /// contract expected by [`crate::stream::StreamAccumulator`]:
+    /// Events may arrive in any order, but the typical sequence is:
     ///
-    /// 1. `MessageStart` (with input token count)
-    /// 2. One or more content block sequences:
-    ///    `ContentBlockStart` → deltas → `ContentBlockStop`
-    /// 3. `MessageDelta` (with stop reason and output token count)
-    /// 4. `MessageStop`
+    /// 1. Content deltas (`TextDelta`, `ThinkingDelta`, `ToolCallStart` /
+    ///    `ToolCallDelta`)
+    /// 2. `Usage` (token counts — may arrive before, during, or after content;
+    ///    accumulated additively)
+    /// 3. `Done` (with stop reason)
     ///
-    /// Providers that don't natively emit this framing (e.g. OpenAI) must
-    /// synthesize the missing events.
+    /// Providers need not synthesize lifecycle events — only emit the
+    /// content and metadata events that map naturally to their wire format.
     async fn send_prompt_streaming(
         &self,
         prompt: &Prompt,

--- a/lib/llm/src/stream.rs
+++ b/lib/llm/src/stream.rs
@@ -30,7 +30,10 @@ pub enum StreamDelta {
     ThinkingSignature { signature: String },
     /// Token usage statistics. Accumulated additively — providers may emit
     /// this more than once (e.g. input tokens early, output tokens late).
-    Usage { input_tokens: u32, output_tokens: u32 },
+    Usage {
+        input_tokens: u32,
+        output_tokens: u32,
+    },
     /// The stream is complete.
     Done { stop_reason: Option<StopReason> },
     /// An error occurred mid-stream.

--- a/lib/llm/src/stream.rs
+++ b/lib/llm/src/stream.rs
@@ -5,80 +5,70 @@
 //! feeds them into a [`StreamAccumulator`] that builds the final
 //! [`PromptResponse`] once the stream completes.
 
+use std::collections::HashMap;
+
 use crate::prompt::AssistantBlock;
 use crate::{PromptResponse, StopReason, Usage};
 
 /// Provider-agnostic streaming delta. Forwarded to UI and fed to accumulator.
+///
+/// Providers emit only the events that map naturally to their wire format —
+/// no lifecycle framing (start/stop) is required. The [`StreamAccumulator`]
+/// infers block boundaries from the content deltas.
 #[derive(Debug, Clone)]
 pub enum StreamDelta {
-    MessageStart {
-        input_tokens: u32,
-    },
-    ContentBlockStart {
-        index: usize,
-        block_type: ContentBlockType,
-    },
-    TextDelta {
-        index: usize,
-        text: String,
-    },
-    ThinkingDelta {
-        index: usize,
-        text: String,
-    },
-    InputJsonDelta {
-        index: usize,
-        partial_json: String,
-    },
-    SignatureDelta {
-        index: usize,
-        signature: String,
-    },
-    ContentBlockStop {
-        index: usize,
-    },
-    MessageDelta {
-        stop_reason: Option<StopReason>,
-        output_tokens: u32,
-    },
-    MessageStop,
-    Error {
-        message: String,
-    },
-}
-
-#[derive(Debug, Clone)]
-pub enum ContentBlockType {
-    Text,
-    ToolUse { id: String, name: String },
-    Thinking,
+    /// A chunk of assistant text content.
+    TextDelta { text: String },
+    /// A chunk of thinking / reasoning content.
+    ThinkingDelta { text: String },
+    /// Start of a new tool call. Must precede any [`ToolCallDelta`] for
+    /// the same `id`.
+    ToolCallStart { id: String, name: String },
+    /// A chunk of JSON arguments for a tool call identified by `id`.
+    ToolCallDelta { id: String, partial_json: String },
+    /// Signature for the current thinking block.
+    ThinkingSignature { signature: String },
+    /// Token usage statistics. Accumulated additively — providers may emit
+    /// this more than once (e.g. input tokens early, output tokens late).
+    Usage { input_tokens: u32, output_tokens: u32 },
+    /// The stream is complete.
+    Done { stop_reason: Option<StopReason> },
+    /// An error occurred mid-stream.
+    Error { message: String },
 }
 
 /// Accumulates [`StreamDelta`] events into a complete [`PromptResponse`].
+///
+/// Block boundaries are inferred from the deltas themselves — no explicit
+/// start/stop events are required from providers.
 pub struct StreamAccumulator {
-    blocks: Vec<BlockBuilder>,
+    thinking: Option<ThinkingBuilder>,
+    text: Option<String>,
+    tool_calls: Vec<ToolCallBuilder>,
+    tool_call_index: HashMap<String, usize>,
     usage: Usage,
     stop_reason: Option<StopReason>,
     done: bool,
 }
 
-enum BlockBuilder {
-    Text(String),
-    Thinking {
-        text: String,
-        signature: Option<String>,
-    },
-    ToolUse {
-        id: String,
-        name: String,
-        json_buf: String,
-    },
+struct ThinkingBuilder {
+    text: String,
+    signature: Option<String>,
+}
+
+struct ToolCallBuilder {
+    id: String,
+    name: String,
+    json_buf: String,
 }
 
 impl StreamAccumulator {
     pub fn new() -> Self {
         Self {
-            blocks: Vec::new(),
+            thinking: None,
+            text: None,
+            tool_calls: Vec::new(),
+            tool_call_index: HashMap::new(),
             usage: Usage::default(),
             stop_reason: None,
             done: false,
@@ -90,67 +80,46 @@ impl StreamAccumulator {
     /// separately.
     pub fn process(&mut self, delta: &StreamDelta) {
         match delta {
-            StreamDelta::MessageStart { input_tokens } => {
-                self.usage.input_tokens = *input_tokens;
+            StreamDelta::TextDelta { text } => {
+                self.text.get_or_insert_with(String::new).push_str(text);
             }
-            StreamDelta::ContentBlockStart { block_type, .. } => match block_type {
-                ContentBlockType::Text => self.blocks.push(BlockBuilder::Text(String::new())),
-                ContentBlockType::ToolUse { id, name } => {
-                    self.blocks.push(BlockBuilder::ToolUse {
-                        id: id.clone(),
-                        name: name.clone(),
-                        json_buf: String::new(),
-                    });
-                }
-                ContentBlockType::Thinking => {
-                    self.blocks.push(BlockBuilder::Thinking {
+            StreamDelta::ThinkingDelta { text } => {
+                self.thinking
+                    .get_or_insert_with(|| ThinkingBuilder {
                         text: String::new(),
                         signature: None,
-                    });
-                }
-            },
-            StreamDelta::TextDelta { index, text } => {
-                if let Some(BlockBuilder::Text(ref mut t)) = self.blocks.get_mut(*index) {
-                    t.push_str(text);
+                    })
+                    .text
+                    .push_str(text);
+            }
+            StreamDelta::ToolCallStart { id, name } => {
+                let idx = self.tool_calls.len();
+                self.tool_calls.push(ToolCallBuilder {
+                    id: id.clone(),
+                    name: name.clone(),
+                    json_buf: String::new(),
+                });
+                self.tool_call_index.insert(id.clone(), idx);
+            }
+            StreamDelta::ToolCallDelta { id, partial_json } => {
+                if let Some(&idx) = self.tool_call_index.get(id) {
+                    self.tool_calls[idx].json_buf.push_str(partial_json);
                 }
             }
-            StreamDelta::ThinkingDelta { index, text } => {
-                if let Some(BlockBuilder::Thinking {
-                    text: ref mut t, ..
-                }) = self.blocks.get_mut(*index)
-                {
-                    t.push_str(text);
+            StreamDelta::ThinkingSignature { signature } => {
+                if let Some(ref mut t) = self.thinking {
+                    t.signature = Some(signature.clone());
                 }
             }
-            StreamDelta::InputJsonDelta {
-                index,
-                partial_json,
-            } => {
-                if let Some(BlockBuilder::ToolUse {
-                    ref mut json_buf, ..
-                }) = self.blocks.get_mut(*index)
-                {
-                    json_buf.push_str(partial_json);
-                }
-            }
-            StreamDelta::SignatureDelta { index, signature } => {
-                if let Some(BlockBuilder::Thinking {
-                    signature: ref mut s,
-                    ..
-                }) = self.blocks.get_mut(*index)
-                {
-                    *s = Some(signature.clone());
-                }
-            }
-            StreamDelta::ContentBlockStop { .. } => { /* blocks finalized in finish() */ }
-            StreamDelta::MessageDelta {
-                stop_reason,
+            StreamDelta::Usage {
+                input_tokens,
                 output_tokens,
             } => {
-                self.stop_reason = *stop_reason;
-                self.usage.output_tokens = *output_tokens;
+                self.usage.input_tokens += *input_tokens;
+                self.usage.output_tokens += *output_tokens;
             }
-            StreamDelta::MessageStop => {
+            StreamDelta::Done { stop_reason } => {
+                self.stop_reason = *stop_reason;
                 self.done = true;
             }
             StreamDelta::Error { .. } => {
@@ -163,29 +132,34 @@ impl StreamAccumulator {
         self.done
     }
 
+    /// Produce the final response. Blocks are ordered: thinking, text, tool calls.
     pub fn finish(self) -> PromptResponse {
-        let content = self
-            .blocks
-            .into_iter()
-            .map(|b| match b {
-                BlockBuilder::Text(text) => AssistantBlock::Text {
-                    text,
-                    cache_control: None,
-                },
-                BlockBuilder::Thinking { text, signature } => {
-                    AssistantBlock::Thinking { text, signature }
-                }
-                BlockBuilder::ToolUse { id, name, json_buf } => {
-                    let input = serde_json::from_str(&json_buf).unwrap_or(serde_json::Value::Null);
-                    AssistantBlock::ToolUse {
-                        id,
-                        name,
-                        input,
-                        cache_control: None,
-                    }
-                }
-            })
-            .collect();
+        let mut content = Vec::new();
+
+        if let Some(t) = self.thinking {
+            content.push(AssistantBlock::Thinking {
+                text: t.text,
+                signature: t.signature,
+            });
+        }
+
+        if let Some(text) = self.text {
+            content.push(AssistantBlock::Text {
+                text,
+                cache_control: None,
+            });
+        }
+
+        for tc in self.tool_calls {
+            let input = serde_json::from_str(&tc.json_buf).unwrap_or(serde_json::Value::Null);
+            content.push(AssistantBlock::ToolUse {
+                id: tc.id,
+                name: tc.name,
+                input,
+                cache_control: None,
+            });
+        }
+
         PromptResponse {
             content,
             usage: self.usage,
@@ -207,25 +181,23 @@ mod tests {
     #[test]
     fn accumulates_text_only() {
         let mut acc = StreamAccumulator::new();
-        acc.process(&StreamDelta::MessageStart { input_tokens: 10 });
-        acc.process(&StreamDelta::ContentBlockStart {
-            index: 0,
-            block_type: ContentBlockType::Text,
+        acc.process(&StreamDelta::Usage {
+            input_tokens: 10,
+            output_tokens: 0,
         });
         acc.process(&StreamDelta::TextDelta {
-            index: 0,
             text: "Hello".to_string(),
         });
         acc.process(&StreamDelta::TextDelta {
-            index: 0,
             text: " world".to_string(),
         });
-        acc.process(&StreamDelta::ContentBlockStop { index: 0 });
-        acc.process(&StreamDelta::MessageDelta {
-            stop_reason: Some(StopReason::EndTurn),
+        acc.process(&StreamDelta::Usage {
+            input_tokens: 0,
             output_tokens: 5,
         });
-        acc.process(&StreamDelta::MessageStop);
+        acc.process(&StreamDelta::Done {
+            stop_reason: Some(StopReason::EndTurn),
+        });
 
         assert!(acc.is_done());
         let resp = acc.finish();
@@ -242,28 +214,25 @@ mod tests {
     #[test]
     fn accumulates_tool_use() {
         let mut acc = StreamAccumulator::new();
-        acc.process(&StreamDelta::MessageStart { input_tokens: 0 });
-        acc.process(&StreamDelta::ContentBlockStart {
-            index: 0,
-            block_type: ContentBlockType::ToolUse {
-                id: "tu_1".to_string(),
-                name: "get_weather".to_string(),
-            },
+        acc.process(&StreamDelta::ToolCallStart {
+            id: "tu_1".to_string(),
+            name: "get_weather".to_string(),
         });
-        acc.process(&StreamDelta::InputJsonDelta {
-            index: 0,
+        acc.process(&StreamDelta::ToolCallDelta {
+            id: "tu_1".to_string(),
             partial_json: r#"{"loc"#.to_string(),
         });
-        acc.process(&StreamDelta::InputJsonDelta {
-            index: 0,
+        acc.process(&StreamDelta::ToolCallDelta {
+            id: "tu_1".to_string(),
             partial_json: r#"ation":"NYC"}"#.to_string(),
         });
-        acc.process(&StreamDelta::ContentBlockStop { index: 0 });
-        acc.process(&StreamDelta::MessageDelta {
-            stop_reason: Some(StopReason::ToolUse),
+        acc.process(&StreamDelta::Usage {
+            input_tokens: 0,
             output_tokens: 20,
         });
-        acc.process(&StreamDelta::MessageStop);
+        acc.process(&StreamDelta::Done {
+            stop_reason: Some(StopReason::ToolUse),
+        });
 
         let resp = acc.finish();
         assert_eq!(resp.content.len(), 1);
@@ -283,29 +252,18 @@ mod tests {
     #[test]
     fn accumulates_thinking() {
         let mut acc = StreamAccumulator::new();
-        acc.process(&StreamDelta::MessageStart { input_tokens: 5 });
-        acc.process(&StreamDelta::ContentBlockStart {
-            index: 0,
-            block_type: ContentBlockType::Thinking,
-        });
         acc.process(&StreamDelta::ThinkingDelta {
-            index: 0,
             text: "Let me think".to_string(),
         });
         acc.process(&StreamDelta::ThinkingDelta {
-            index: 0,
             text: " about this.".to_string(),
         });
-        acc.process(&StreamDelta::SignatureDelta {
-            index: 0,
+        acc.process(&StreamDelta::ThinkingSignature {
             signature: "sig123".to_string(),
         });
-        acc.process(&StreamDelta::ContentBlockStop { index: 0 });
-        acc.process(&StreamDelta::MessageDelta {
+        acc.process(&StreamDelta::Done {
             stop_reason: Some(StopReason::EndTurn),
-            output_tokens: 8,
         });
-        acc.process(&StreamDelta::MessageStop);
 
         let resp = acc.finish();
         assert_eq!(resp.content.len(), 1);
@@ -321,48 +279,38 @@ mod tests {
     #[test]
     fn accumulates_mixed_multi_block() {
         let mut acc = StreamAccumulator::new();
-        acc.process(&StreamDelta::MessageStart { input_tokens: 15 });
-        // Block 0: Thinking
-        acc.process(&StreamDelta::ContentBlockStart {
-            index: 0,
-            block_type: ContentBlockType::Thinking,
+        acc.process(&StreamDelta::Usage {
+            input_tokens: 15,
+            output_tokens: 0,
         });
+        // Thinking
         acc.process(&StreamDelta::ThinkingDelta {
-            index: 0,
             text: "hmm".to_string(),
         });
-        acc.process(&StreamDelta::ContentBlockStop { index: 0 });
-        // Block 1: Text
-        acc.process(&StreamDelta::ContentBlockStart {
-            index: 1,
-            block_type: ContentBlockType::Text,
-        });
+        // Text
         acc.process(&StreamDelta::TextDelta {
-            index: 1,
             text: "Hello".to_string(),
         });
-        acc.process(&StreamDelta::ContentBlockStop { index: 1 });
-        // Block 2: Tool use
-        acc.process(&StreamDelta::ContentBlockStart {
-            index: 2,
-            block_type: ContentBlockType::ToolUse {
-                id: "tu_2".to_string(),
-                name: "calc".to_string(),
-            },
+        // Tool use
+        acc.process(&StreamDelta::ToolCallStart {
+            id: "tu_2".to_string(),
+            name: "calc".to_string(),
         });
-        acc.process(&StreamDelta::InputJsonDelta {
-            index: 2,
+        acc.process(&StreamDelta::ToolCallDelta {
+            id: "tu_2".to_string(),
             partial_json: r#"{"x":1}"#.to_string(),
         });
-        acc.process(&StreamDelta::ContentBlockStop { index: 2 });
-        acc.process(&StreamDelta::MessageDelta {
-            stop_reason: Some(StopReason::ToolUse),
+        acc.process(&StreamDelta::Usage {
+            input_tokens: 0,
             output_tokens: 30,
         });
-        acc.process(&StreamDelta::MessageStop);
+        acc.process(&StreamDelta::Done {
+            stop_reason: Some(StopReason::ToolUse),
+        });
 
         let resp = acc.finish();
         assert_eq!(resp.content.len(), 3);
+        // Order: thinking, text, tool calls
         assert!(matches!(&resp.content[0], AssistantBlock::Thinking { .. }));
         assert!(matches!(&resp.content[1], AssistantBlock::Text { .. }));
         assert!(matches!(&resp.content[2], AssistantBlock::ToolUse { .. }));
@@ -371,13 +319,7 @@ mod tests {
     #[test]
     fn error_mid_stream_marks_done() {
         let mut acc = StreamAccumulator::new();
-        acc.process(&StreamDelta::MessageStart { input_tokens: 5 });
-        acc.process(&StreamDelta::ContentBlockStart {
-            index: 0,
-            block_type: ContentBlockType::Text,
-        });
         acc.process(&StreamDelta::TextDelta {
-            index: 0,
             text: "partial".to_string(),
         });
         acc.process(&StreamDelta::Error {
@@ -391,5 +333,85 @@ mod tests {
             AssistantBlock::Text { text, .. } => assert_eq!(text, "partial"),
             _ => panic!("expected text block"),
         }
+    }
+
+    #[test]
+    fn interleaved_tool_calls() {
+        let mut acc = StreamAccumulator::new();
+        acc.process(&StreamDelta::ToolCallStart {
+            id: "call_a".to_string(),
+            name: "search".to_string(),
+        });
+        acc.process(&StreamDelta::ToolCallStart {
+            id: "call_b".to_string(),
+            name: "fetch".to_string(),
+        });
+        // Interleaved deltas
+        acc.process(&StreamDelta::ToolCallDelta {
+            id: "call_a".to_string(),
+            partial_json: r#"{"q":"#.to_string(),
+        });
+        acc.process(&StreamDelta::ToolCallDelta {
+            id: "call_b".to_string(),
+            partial_json: r#"{"url":"#.to_string(),
+        });
+        acc.process(&StreamDelta::ToolCallDelta {
+            id: "call_a".to_string(),
+            partial_json: r#""rust"}"#.to_string(),
+        });
+        acc.process(&StreamDelta::ToolCallDelta {
+            id: "call_b".to_string(),
+            partial_json: r#""https://example.com"}"#.to_string(),
+        });
+        acc.process(&StreamDelta::Done {
+            stop_reason: Some(StopReason::ToolUse),
+        });
+
+        let resp = acc.finish();
+        assert_eq!(resp.content.len(), 2);
+        match &resp.content[0] {
+            AssistantBlock::ToolUse {
+                id, name, input, ..
+            } => {
+                assert_eq!(id, "call_a");
+                assert_eq!(name, "search");
+                assert_eq!(input, &serde_json::json!({"q": "rust"}));
+            }
+            _ => panic!("expected tool use block"),
+        }
+        match &resp.content[1] {
+            AssistantBlock::ToolUse {
+                id, name, input, ..
+            } => {
+                assert_eq!(id, "call_b");
+                assert_eq!(name, "fetch");
+                assert_eq!(input, &serde_json::json!({"url": "https://example.com"}));
+            }
+            _ => panic!("expected tool use block"),
+        }
+    }
+
+    #[test]
+    fn additive_usage_accumulation() {
+        let mut acc = StreamAccumulator::new();
+        // Anthropic pattern: input tokens early, output tokens late
+        acc.process(&StreamDelta::Usage {
+            input_tokens: 100,
+            output_tokens: 0,
+        });
+        acc.process(&StreamDelta::TextDelta {
+            text: "hi".to_string(),
+        });
+        acc.process(&StreamDelta::Usage {
+            input_tokens: 0,
+            output_tokens: 50,
+        });
+        acc.process(&StreamDelta::Done {
+            stop_reason: Some(StopReason::EndTurn),
+        });
+
+        let resp = acc.finish();
+        assert_eq!(resp.usage.input_tokens, 100);
+        assert_eq!(resp.usage.output_tokens, 50);
     }
 }

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -452,9 +452,13 @@ mod tests {
                 r#"{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#,
             )
             .unwrap();
-        assert!(deltas
-            .iter()
-            .any(|d| matches!(d, StreamDelta::Usage { input_tokens: 10, output_tokens: 5 })));
+        assert!(deltas.iter().any(|d| matches!(
+            d,
+            StreamDelta::Usage {
+                input_tokens: 10,
+                output_tokens: 5
+            }
+        )));
         assert!(deltas.iter().any(|d| matches!(
             d,
             StreamDelta::Done {
@@ -520,8 +524,12 @@ mod tests {
                 r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"search","arguments":""}},{"index":1,"id":"call_2","function":{"name":"fetch","arguments":""}}]},"finish_reason":null}]}"#,
             )
             .unwrap();
-        assert!(deltas.iter().any(|d| matches!(d, StreamDelta::ToolCallStart { id, .. } if id == "call_1")));
-        assert!(deltas.iter().any(|d| matches!(d, StreamDelta::ToolCallStart { id, .. } if id == "call_2")));
+        assert!(deltas
+            .iter()
+            .any(|d| matches!(d, StreamDelta::ToolCallStart { id, .. } if id == "call_1")));
+        assert!(deltas
+            .iter()
+            .any(|d| matches!(d, StreamDelta::ToolCallStart { id, .. } if id == "call_2")));
 
         // Interleaved argument deltas.
         let deltas = synth

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -8,7 +8,7 @@
 use llm::prompt::{
     AssistantBlock, Message, SystemBlock, Tool, ToolChoice, ToolResultBlock, UserBlock,
 };
-use llm::stream::{ContentBlockType, StreamDelta};
+use llm::stream::StreamDelta;
 use llm::StopReason;
 
 use crate::types::{
@@ -195,38 +195,27 @@ fn convert_tool_choice(choice: &ToolChoice) -> OpenAiToolChoice {
 // Streaming chunk → StreamDelta(s)
 // ============================================================================
 
-/// State tracker for synthesizing ContentBlockStart/Stop events that the
-/// StreamAccumulator expects but OpenAI doesn't natively emit.
+/// Converts OpenAI streaming chunks into provider-agnostic [`StreamDelta`]s.
+///
+/// Only tracks tool call IDs so that subsequent argument deltas can reference
+/// the correct tool call.
 pub(crate) struct DeltaSynthesizer {
-    /// Whether we've emitted a ContentBlockStart for the text block.
-    text_block_started: bool,
-    /// Maps tool_call index to the content block index we assigned.
-    /// Tracks which tool call indices we've already emitted ContentBlockStart for.
-    tool_block_indices: Vec<Option<usize>>,
-    /// Next content block index to assign.
-    next_block_index: usize,
-    /// Total open blocks (for emitting ContentBlockStop on finish).
-    open_blocks: usize,
-    /// Input tokens (captured from usage chunk).
-    input_tokens: u32,
+    /// Maps OpenAI tool_call index to the tool call ID.
+    tool_ids: Vec<Option<String>>,
 }
 
 impl DeltaSynthesizer {
     pub fn new() -> Self {
         Self {
-            text_block_started: false,
-            tool_block_indices: Vec::new(),
-            next_block_index: 0,
-            open_blocks: 0,
-            input_tokens: 0,
+            tool_ids: Vec::new(),
         }
     }
 
     /// Process a raw SSE data payload (OpenAI JSON) and emit provider-agnostic
-    /// `StreamDelta`s. Returns `Ok(None)` for the `[DONE]` sentinel.
+    /// `StreamDelta`s.
     pub fn process_chunk(&mut self, data: &str) -> Result<Vec<StreamDelta>, String> {
         if data.trim() == "[DONE]" {
-            return Ok(vec![StreamDelta::MessageStop]);
+            return Ok(vec![]);
         }
 
         let chunk: OpenAiStreamChunk =
@@ -234,13 +223,12 @@ impl DeltaSynthesizer {
 
         let mut deltas = Vec::new();
 
-        // Capture usage if present (OpenAI sends it in a separate chunk when
+        // Usage chunk (OpenAI sends it in a separate chunk when
         // stream_options.include_usage is true).
         if let Some(usage) = &chunk.usage {
-            self.input_tokens = usage.prompt_tokens;
-            // Emit MessageStart with input tokens.
-            deltas.push(StreamDelta::MessageStart {
+            deltas.push(StreamDelta::Usage {
                 input_tokens: usage.prompt_tokens,
+                output_tokens: usage.completion_tokens,
             });
         }
 
@@ -249,61 +237,40 @@ impl DeltaSynthesizer {
         };
 
         if let Some(delta) = &choice.delta {
-            // Handle text content.
+            // Text content.
             if let Some(text) = &delta.content {
                 if !text.is_empty() {
-                    if !self.text_block_started {
-                        self.text_block_started = true;
-                        let idx = self.next_block_index;
-                        self.next_block_index += 1;
-                        self.open_blocks += 1;
-                        deltas.push(StreamDelta::ContentBlockStart {
-                            index: idx,
-                            block_type: ContentBlockType::Text,
-                        });
-                    }
-                    deltas.push(StreamDelta::TextDelta {
-                        index: 0,
-                        text: text.clone(),
-                    });
+                    deltas.push(StreamDelta::TextDelta { text: text.clone() });
                 }
             }
 
-            // Handle tool calls.
+            // Tool calls.
             if let Some(tool_calls) = &delta.tool_calls {
                 for tc in tool_calls {
-                    // Ensure our tracking vec is large enough.
-                    while self.tool_block_indices.len() <= tc.index {
-                        self.tool_block_indices.push(None);
+                    // Grow tracking vec.
+                    while self.tool_ids.len() <= tc.index {
+                        self.tool_ids.push(None);
                     }
 
-                    // First chunk for this tool call — emit ContentBlockStart.
-                    if self.tool_block_indices[tc.index].is_none() {
-                        let block_idx = self.next_block_index;
-                        self.next_block_index += 1;
-                        self.open_blocks += 1;
-                        self.tool_block_indices[tc.index] = Some(block_idx);
-
+                    // First chunk for this tool call — emit ToolCallStart.
+                    if self.tool_ids[tc.index].is_none() {
                         let id = tc.id.clone().unwrap_or_default();
                         let name = tc
                             .function
                             .as_ref()
                             .and_then(|f| f.name.clone())
                             .unwrap_or_default();
-
-                        deltas.push(StreamDelta::ContentBlockStart {
-                            index: block_idx,
-                            block_type: ContentBlockType::ToolUse { id, name },
-                        });
+                        self.tool_ids[tc.index] = Some(id.clone());
+                        deltas.push(StreamDelta::ToolCallStart { id, name });
                     }
 
                     // Argument deltas.
                     if let Some(func) = &tc.function {
                         if let Some(args) = &func.arguments {
                             if !args.is_empty() {
-                                let block_idx = self.tool_block_indices[tc.index].unwrap();
-                                deltas.push(StreamDelta::InputJsonDelta {
-                                    index: block_idx,
+                                let id = self.tool_ids[tc.index].clone().unwrap_or_default();
+                                deltas.push(StreamDelta::ToolCallDelta {
+                                    id,
                                     partial_json: args.clone(),
                                 });
                             }
@@ -313,33 +280,15 @@ impl DeltaSynthesizer {
             }
         }
 
-        // Handle finish_reason.
+        // Handle finish_reason — emit Done.
         if let Some(reason) = &choice.finish_reason {
-            // Close all open blocks.
-            for idx in 0..self.next_block_index {
-                deltas.push(StreamDelta::ContentBlockStop { index: idx });
-            }
-
             let stop_reason = match reason.as_str() {
                 "stop" => Some(StopReason::EndTurn),
                 "length" => Some(StopReason::MaxTokens),
                 "tool_calls" => Some(StopReason::ToolUse),
                 _ => None,
             };
-
-            // Output tokens come from the usage chunk. If we haven't seen it
-            // yet (it may arrive after this chunk), use 0 — it will be
-            // populated when the usage chunk arrives.
-            let output_tokens = chunk
-                .usage
-                .as_ref()
-                .map(|u| u.completion_tokens)
-                .unwrap_or(0);
-
-            deltas.push(StreamDelta::MessageDelta {
-                stop_reason,
-                output_tokens,
-            });
+            deltas.push(StreamDelta::Done { stop_reason });
         }
 
         Ok(deltas)
@@ -483,54 +432,39 @@ mod tests {
     fn synthesizer_text_stream() {
         let mut synth = DeltaSynthesizer::new();
 
-        // First text chunk — should synthesize ContentBlockStart.
+        // First text chunk.
         let deltas = synth
             .process_chunk(r#"{"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}"#)
             .unwrap();
-        assert_eq!(deltas.len(), 2); // ContentBlockStart + TextDelta
-        assert!(matches!(
-            &deltas[0],
-            StreamDelta::ContentBlockStart {
-                index: 0,
-                block_type: ContentBlockType::Text
-            }
-        ));
-        assert!(matches!(&deltas[1], StreamDelta::TextDelta { index: 0, text } if text == "Hello"));
+        assert_eq!(deltas.len(), 1);
+        assert!(matches!(&deltas[0], StreamDelta::TextDelta { text } if text == "Hello"));
 
-        // Second text chunk — no ContentBlockStart.
+        // Second text chunk.
         let deltas = synth
             .process_chunk(r#"{"choices":[{"delta":{"content":" world"},"finish_reason":null}]}"#)
             .unwrap();
         assert_eq!(deltas.len(), 1);
-        assert!(
-            matches!(&deltas[0], StreamDelta::TextDelta { index: 0, text } if text == " world")
-        );
+        assert!(matches!(&deltas[0], StreamDelta::TextDelta { text } if text == " world"));
 
-        // Finish.
+        // Finish with usage.
         let deltas = synth
             .process_chunk(
                 r#"{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5}}"#,
             )
             .unwrap();
-        // MessageStart (from usage) + ContentBlockStop + MessageDelta
         assert!(deltas
             .iter()
-            .any(|d| matches!(d, StreamDelta::MessageStart { input_tokens: 10 })));
-        assert!(deltas
-            .iter()
-            .any(|d| matches!(d, StreamDelta::ContentBlockStop { index: 0 })));
+            .any(|d| matches!(d, StreamDelta::Usage { input_tokens: 10, output_tokens: 5 })));
         assert!(deltas.iter().any(|d| matches!(
             d,
-            StreamDelta::MessageDelta {
+            StreamDelta::Done {
                 stop_reason: Some(StopReason::EndTurn),
-                ..
             }
         )));
 
-        // DONE sentinel.
+        // DONE sentinel — no deltas.
         let deltas = synth.process_chunk("[DONE]").unwrap();
-        assert_eq!(deltas.len(), 1);
-        assert!(matches!(deltas[0], StreamDelta::MessageStop));
+        assert!(deltas.is_empty());
     }
 
     #[test]
@@ -545,10 +479,8 @@ mod tests {
             .unwrap();
         assert!(deltas.iter().any(|d| matches!(
             d,
-            StreamDelta::ContentBlockStart {
-                index: 0,
-                block_type: ContentBlockType::ToolUse { .. }
-            }
+            StreamDelta::ToolCallStart { id, name }
+            if id == "call_abc" && name == "get_weather"
         )));
 
         // Tool call arguments.
@@ -560,10 +492,8 @@ mod tests {
         assert_eq!(deltas.len(), 1);
         assert!(matches!(
             &deltas[0],
-            StreamDelta::InputJsonDelta {
-                index: 0,
-                partial_json
-            } if partial_json == r#"{"location":"#
+            StreamDelta::ToolCallDelta { id, partial_json }
+            if id == "call_abc" && partial_json == r#"{"location":"#
         ));
 
         // Finish with tool_calls reason.
@@ -574,10 +504,38 @@ mod tests {
             .unwrap();
         assert!(deltas.iter().any(|d| matches!(
             d,
-            StreamDelta::MessageDelta {
+            StreamDelta::Done {
                 stop_reason: Some(StopReason::ToolUse),
-                ..
             }
         )));
+    }
+
+    #[test]
+    fn synthesizer_interleaved_tool_calls() {
+        let mut synth = DeltaSynthesizer::new();
+
+        // Two tool calls start in the same chunk.
+        let deltas = synth
+            .process_chunk(
+                r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_1","function":{"name":"search","arguments":""}},{"index":1,"id":"call_2","function":{"name":"fetch","arguments":""}}]},"finish_reason":null}]}"#,
+            )
+            .unwrap();
+        assert!(deltas.iter().any(|d| matches!(d, StreamDelta::ToolCallStart { id, .. } if id == "call_1")));
+        assert!(deltas.iter().any(|d| matches!(d, StreamDelta::ToolCallStart { id, .. } if id == "call_2")));
+
+        // Interleaved argument deltas.
+        let deltas = synth
+            .process_chunk(
+                r#"{"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\"q\":\"rust\"}"}}]},"finish_reason":null}]}"#,
+            )
+            .unwrap();
+        assert!(matches!(&deltas[0], StreamDelta::ToolCallDelta { id, .. } if id == "call_1"));
+
+        let deltas = synth
+            .process_chunk(
+                r#"{"choices":[{"delta":{"tool_calls":[{"index":1,"function":{"arguments":"{\"url\":\"https://example.com\"}"}}]},"finish_reason":null}]}"#,
+            )
+            .unwrap();
+        assert!(matches!(&deltas[0], StreamDelta::ToolCallDelta { id, .. } if id == "call_2"));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to #165 — makes the `StreamDelta` streaming protocol genuinely provider-neutral instead of mirroring Anthropic's SSE lifecycle.

- **Remove Anthropic-shaped lifecycle events**: `MessageStart`/`MessageStop`, `ContentBlockStart`/`ContentBlockStop`, `ContentBlockType`, and all `index` fields
- **Replace with content-oriented variants**: `ToolCallStart`/`ToolCallDelta` (identified by tool call ID), standalone `Usage` (additive accumulation), `Done` (replaces MessageDelta+MessageStop)
- **StreamAccumulator now infers block boundaries** from content deltas instead of requiring explicit start/stop events from providers
- **Anthropic converter** (`sse_data_to_delta` → stateful `AnthropicDeltaConverter`) tracks index-to-tool-call-ID mapping
- **OpenAI DeltaSynthesizer** simplified from 5 state fields to 1 — no longer synthesizes fake lifecycle events

## Test plan

- [x] `cargo build` — all crates compile cleanly
- [x] `cargo test --lib` — all 256 unit tests pass (including new interleaved tool call and additive usage tests)
- [ ] Manual: verify Anthropic streaming works unchanged
- [ ] Manual: verify OpenAI streaming works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)