### PR TITLE
feat(llm): add OpenAI Responses support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,15 @@ PG_CON=postgres://user:password@localhost:5432/drua
 # Get one at https://console.anthropic.com/
 ANTHROPIC_API_KEY=
 
-# OpenAI API key for the agent LLM runtime.
-# Required when any role uses `provider: openai`.
+# OpenAI Platform API key for the agent LLM runtime.
+# Used by `openai` (Chat Completions API) and `openai-responses`
+# (Responses API). `openai-codex` does not use this key.
 # Get one at https://platform.openai.com/api-keys
 OPENAI_API_KEY=
+
+# Optional override for `openai-codex`.
+# If unset, Drua reads the cached Codex/ChatGPT login from ~/.codex/auth.json.
+# OPENAI_CODEX_ACCESS_TOKEN=
 
 # ── Optional — OAuth & Access Control ────────────────────────────────────────
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3198,6 +3198,8 @@ name = "openai-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
+ "dirs",
  "futures",
  "llm",
  "reqwest 0.12.28",

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ direnv allow          # loads the nix devShell + .env
 
 # 2. Copy and fill in secrets
 cp .env.example .env
-$EDITOR .env          # at minimum set ANTHROPIC_API_KEY
+$EDITOR .env          # at minimum set the key/token for the provider you use
 
 # 3. Start everything (Postgres, migrations, server with dev login)
 make start            # full reset + server on :4200
@@ -53,6 +53,8 @@ A complete `.env.example` is provided at the repo root.
 | `PG_CON` | No | `postgres://user:password@localhost:5432/drua` | PostgreSQL connection URL. The Makefile provides this default, which matches the bundled compose stack. |
 | `GITHUB_CLIENT_SECRET` | No | `dev-secret` | GitHub OAuth App client secret (only needed when `oauth.login: github`). |
 | `ANTHROPIC_API_KEY` | No | `""` | Anthropic API key for the agent LLM runtime. Server starts without it but agent prompts will fail. |
+| `OPENAI_API_KEY` | No | `""` | OpenAI Platform API key used by `openai` (Chat Completions API) and `openai-responses` (Responses API). |
+| `OPENAI_CODEX_ACCESS_TOKEN` | No | `""` | Optional override for `openai-codex`. If unset, Drua reads the cached Codex/ChatGPT login from `~/.codex/auth.json`. |
 | `DRUA_CONFIG` | No | `drua.yml` | Path to the YAML config file. |
 | `GITHUB_ALLOWED_TEAMS` | No | `""` (all users) | Comma-separated GitHub teams allowed to log in (`org/team-slug`). |
 | `CONCOURSE_USERNAME` | No | — | Concourse CI basic-auth username (when concourse toolset is enabled). |
@@ -99,6 +101,45 @@ the included `drua.yml` for a complete local-dev example. Key sections:
 | `toolsets.code_assistant` | Path to the code-assistant SQLite DB |
 | `sandbox.backend` | `local` (child process) or `k8s` (namespace + template) |
 | `github_app` | GitHub App client ID and installation ID (private key via env) |
+
+### OpenAI Providers
+
+Drua exposes two OpenAI API protocols, and they are not aliases:
+
+| Provider name | API | Auth | Notes |
+|---|---|---|---|
+| `openai` | Chat Completions API | `OPENAI_API_KEY` | Uses `https://api.openai.com/v1/chat/completions`. |
+| `openai-responses` | Responses API | `OPENAI_API_KEY` | Uses `https://api.openai.com/v1/responses`. |
+| `openai-codex` | Responses API | ChatGPT subscription login | Uses the same Responses protocol as `openai-responses`, but against the ChatGPT/Codex subscription endpoint with credentials from `OPENAI_CODEX_ACCESS_TOKEN` or `~/.codex/auth.json`. |
+
+`openai` and `openai-responses` are different OpenAI APIs with different wire
+formats, streaming events, and tool-calling shapes. Choose the provider name
+that matches the API you want to talk to; switching between them is not just a
+billing or model change.
+
+Example config:
+
+```yaml
+providers:
+  - name: openai
+    models:
+      - name: gpt-4.1-mini
+        max_tokens_per_response: 4096
+        context_window_tokens: 200000
+
+  - name: openai-responses
+    models:
+      - name: gpt-5.4-mini
+        max_tokens_per_response: 4096
+        context_window_tokens: 200000
+
+  # Same Responses API client, but authenticated with a ChatGPT subscription.
+  - name: openai-codex
+    models:
+      - name: gpt-5.4-mini
+        max_tokens_per_response: 4096
+        context_window_tokens: 200000
+```
 
 ## Project Layout
 

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -4,7 +4,9 @@ use anyhow::Context;
 use serde::{Deserialize, Serialize};
 
 use drua_core::agent::{AgentsConfig, ModelDefaults};
-use drua_core::prompt_executor::{ModelConfig, PromptExecutorConfig, Provider};
+use drua_core::prompt_executor::{
+    ModelConfig, OpenAiResponsesAuth, PromptExecutorConfig, Provider,
+};
 use drua_core::sandbox::SandboxConfig;
 use drua_core::toolset::ToolSetsConfig;
 use drua_web::auth::config::{AuthConfig, LoginMethod};
@@ -64,7 +66,14 @@ impl Config {
                 "openai" => Provider::OpenAi {
                     api_key: self.openai_api_key.clone(),
                 },
-                "openai-codex" => Provider::OpenAiCodex,
+                "openai-responses" => Provider::OpenAiResponses {
+                    auth: OpenAiResponsesAuth::ApiKey {
+                        api_key: self.openai_api_key.clone(),
+                    },
+                },
+                "openai-codex" => Provider::OpenAiResponses {
+                    auth: OpenAiResponsesAuth::Subscription,
+                },
                 _ => Provider::Anthropic {
                     api_key: self.anthropic_api_key.clone(),
                 },

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -64,6 +64,7 @@ impl Config {
                 "openai" => Provider::OpenAi {
                     api_key: self.openai_api_key.clone(),
                 },
+                "openai-codex" => Provider::OpenAiCodex,
                 _ => Provider::Anthropic {
                     api_key: self.anthropic_api_key.clone(),
                 },

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -8,7 +8,7 @@ use tracing::instrument;
 use anthropic_client::AnthropicClient;
 use llm::provider::LlmProvider;
 use llm::{Prompt, PromptError, PromptRequest, PromptRequestChannel, PromptResponseChannel};
-use openai_client::OpenAiClient;
+use openai_client::{OpenAiClient, OpenAiCodexClient};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PromptExecutorConfig {
@@ -29,6 +29,7 @@ pub struct ModelConfig {
 pub enum Provider {
     Anthropic { api_key: String },
     OpenAi { api_key: String },
+    OpenAiCodex,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -88,6 +89,12 @@ impl PromptExecutorConfig {
                             "OpenAI credential loaded"
                         );
                     }
+                }
+                Provider::OpenAiCodex => {
+                    tracing::info!(
+                        model = %model.name,
+                        "OpenAI Codex credential will be resolved from OPENAI_CODEX_ACCESS_TOKEN or ~/.codex/auth.json at request time",
+                    );
                 }
             }
         }
@@ -246,6 +253,7 @@ impl ResolvedModel {
         let client: Arc<dyn LlmProvider> = match config.provider {
             Provider::Anthropic { api_key } => Arc::new(AnthropicClient::new(api_key)),
             Provider::OpenAi { api_key } => Arc::new(OpenAiClient::new(api_key)),
+            Provider::OpenAiCodex => Arc::new(OpenAiCodexClient::new()),
         };
         Self {
             name: config.name,

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -8,7 +8,9 @@ use tracing::instrument;
 use anthropic_client::AnthropicClient;
 use llm::provider::LlmProvider;
 use llm::{Prompt, PromptError, PromptRequest, PromptRequestChannel, PromptResponseChannel};
-use openai_client::{OpenAiClient, OpenAiCodexClient};
+use openai_client::{
+    OpenAiClient, OpenAiResponsesAuth as ClientOpenAiResponsesAuth, OpenAiResponsesClient,
+};
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct PromptExecutorConfig {
@@ -29,7 +31,14 @@ pub struct ModelConfig {
 pub enum Provider {
     Anthropic { api_key: String },
     OpenAi { api_key: String },
-    OpenAiCodex,
+    OpenAiResponses { auth: OpenAiResponsesAuth },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum OpenAiResponsesAuth {
+    ApiKey { api_key: String },
+    Subscription,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -90,12 +99,37 @@ impl PromptExecutorConfig {
                         );
                     }
                 }
-                Provider::OpenAiCodex => {
-                    tracing::info!(
-                        model = %model.name,
-                        "OpenAI Codex credential will be resolved from OPENAI_CODEX_ACCESS_TOKEN or ~/.codex/auth.json at request time",
-                    );
-                }
+                Provider::OpenAiResponses { auth } => match auth {
+                    OpenAiResponsesAuth::ApiKey { api_key } if api_key.is_empty() => {
+                        tracing::warn!(
+                            model = %model.name,
+                            "OpenAI Responses credential is empty — agent prompts will fail until OPENAI_API_KEY is set",
+                        );
+                    }
+                    OpenAiResponsesAuth::ApiKey { api_key } => {
+                        let preview = masked_preview(api_key);
+                        if !api_key.starts_with("sk-") {
+                            tracing::warn!(
+                                model = %model.name,
+                                key_preview = %preview,
+                                key_len = api_key.len(),
+                                "OpenAI Responses credential does not start with `sk-` — this will most likely 401 at the Responses API",
+                            );
+                        } else {
+                            tracing::info!(
+                                model = %model.name,
+                                key_preview = %preview,
+                                "OpenAI Responses credential loaded"
+                            );
+                        }
+                    }
+                    OpenAiResponsesAuth::Subscription => {
+                        tracing::info!(
+                            model = %model.name,
+                            "OpenAI subscription credential will be resolved from OPENAI_CODEX_ACCESS_TOKEN or ~/.codex/auth.json at request time",
+                        );
+                    }
+                },
             }
         }
         Ok(())
@@ -253,7 +287,14 @@ impl ResolvedModel {
         let client: Arc<dyn LlmProvider> = match config.provider {
             Provider::Anthropic { api_key } => Arc::new(AnthropicClient::new(api_key)),
             Provider::OpenAi { api_key } => Arc::new(OpenAiClient::new(api_key)),
-            Provider::OpenAiCodex => Arc::new(OpenAiCodexClient::new()),
+            Provider::OpenAiResponses { auth } => {
+                Arc::new(OpenAiResponsesClient::new(match auth {
+                    OpenAiResponsesAuth::ApiKey { api_key } => {
+                        ClientOpenAiResponsesAuth::ApiKey { api_key }
+                    }
+                    OpenAiResponsesAuth::Subscription => ClientOpenAiResponsesAuth::Subscription,
+                }))
+            }
         };
         Self {
             name: config.name,

--- a/drua.yml
+++ b/drua.yml
@@ -9,19 +9,19 @@ oauth:
   github_redirect_uri: "http://localhost:4200/auth/github/callback"
   github_allowed_teams: []
 providers:
-  - name: anthropic
+  - name: openai-codex
     models:
-      - name: claude-haiku-4-5-20251001
+      - name: gpt-5.4-mini
         max_tokens_per_response: 4096
         context_window_tokens: 200000
 agents:
   builtin_roles:
     workspace_lead:
-      model: claude-haiku-4-5-20251001
+      model: gpt-5.4-mini
       compaction:
         reset_time_delta_seconds: 18000
     agent:
-      model: claude-haiku-4-5-20251001
+      model: gpt-5.4-mini
 sandbox:
   # Local mode spawns the sandbox tool server as a child process per sandbox.
   # Each sandbox lives in <local_repo_root>/.sandboxes/<name>/.

--- a/drua.yml
+++ b/drua.yml
@@ -9,6 +9,10 @@ oauth:
   github_redirect_uri: "http://localhost:4200/auth/github/callback"
   github_allowed_teams: []
 providers:
+  # OpenAI provider names are not aliases:
+  # - openai           -> Chat Completions API, uses OPENAI_API_KEY
+  # - openai-responses -> Responses API, uses OPENAI_API_KEY
+  # - openai-codex     -> Responses API over ChatGPT subscription auth
   - name: anthropic
     models:
       - name: claude-haiku-4-5-20251001

--- a/drua.yml
+++ b/drua.yml
@@ -9,19 +9,19 @@ oauth:
   github_redirect_uri: "http://localhost:4200/auth/github/callback"
   github_allowed_teams: []
 providers:
-  - name: openai-codex
+  - name: anthropic
     models:
-      - name: gpt-5.4-mini
+      - name: claude-haiku-4-5-20251001
         max_tokens_per_response: 4096
         context_window_tokens: 200000
 agents:
   builtin_roles:
     workspace_lead:
-      model: gpt-5.4-mini
+      model: claude-haiku-4-5-20251001
       compaction:
         reset_time_delta_seconds: 18000
     agent:
-      model: gpt-5.4-mini
+      model: claude-haiku-4-5-20251001
 sandbox:
   # Local mode spawns the sandbox tool server as a child process per sandbox.
   # Each sandbox lives in <local_repo_root>/.sandboxes/<name>/.

--- a/lib/openai-client/Cargo.toml
+++ b/lib/openai-client/Cargo.toml
@@ -5,6 +5,8 @@ edition.workspace = true
 
 [dependencies]
 async-trait = "0.1"
+base64 = { workspace = true }
+dirs = { workspace = true }
 futures = { workspace = true }
 llm = { workspace = true }
 reqwest = { workspace = true, features = ["stream"] }

--- a/lib/openai-client/src/codex.rs
+++ b/lib/openai-client/src/codex.rs
@@ -1,0 +1,942 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use base64::Engine as _;
+use llm::prompt::{
+    AssistantBlock, Message, SystemBlock, Tool, ToolChoice, ToolResultBlock, UserBlock,
+};
+use llm::provider::LlmProvider;
+use llm::stream::StreamDelta;
+use llm::{Prompt, PromptError};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use tracing::instrument;
+
+use crate::sse::{parse_sse_stream, SseError};
+use crate::OpenAiError;
+
+const DEFAULT_CODEX_API_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
+const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 4096;
+const DEFAULT_REASONING_EFFORT: &str = "low";
+const DEFAULT_TEXT_VERBOSITY: &str = "medium";
+const OPENAI_CODEX_ACCESS_TOKEN_ENV: &str = "OPENAI_CODEX_ACCESS_TOKEN";
+
+#[derive(Clone)]
+pub struct OpenAiCodexClient {
+    http: reqwest::Client,
+    api_url: String,
+}
+
+impl OpenAiCodexClient {
+    pub fn new() -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            api_url: DEFAULT_CODEX_API_URL.to_string(),
+        }
+    }
+
+    #[instrument(name = "openai_codex_client.send_prompt_streaming", skip_all)]
+    async fn send_prompt_streaming_internal(
+        &self,
+        prompt: &Prompt,
+    ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, OpenAiError>>, OpenAiError> {
+        let access_token = resolve_codex_access_token().ok_or(OpenAiError::Api {
+            status: 401,
+            message: format!(
+                "OpenAI Codex credentials not found. Run `codex login` or set {}.",
+                OPENAI_CODEX_ACCESS_TOKEN_ENV
+            ),
+        })?;
+        let account_id = extract_chatgpt_account_id(&access_token).ok_or(OpenAiError::Api {
+            status: 401,
+            message:
+                "OpenAI Codex credential is invalid or expired (missing chatgpt_account_id claim)"
+                    .to_string(),
+        })?;
+
+        let request_body = prompt_to_codex_request(prompt);
+
+        let resp = self
+            .http
+            .post(&self.api_url)
+            .header("Authorization", format!("Bearer {access_token}"))
+            .header("chatgpt-account-id", account_id)
+            .header("OpenAI-Beta", "responses=experimental")
+            .header("originator", "drua")
+            .header("User-Agent", "drua")
+            .header("accept", "text/event-stream")
+            .header("content-type", "application/json")
+            .json(&request_body)
+            .send()
+            .await?;
+
+        let status = resp.status();
+        if !status.is_success() {
+            let message = resp.text().await.unwrap_or_default();
+            return Err(OpenAiError::Api {
+                status: status.as_u16(),
+                message,
+            });
+        }
+
+        let byte_stream = resp.bytes_stream();
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<StreamDelta, OpenAiError>>(128);
+
+        tokio::spawn(async move {
+            let tx_ref = &tx;
+            let mut synthesizer = CodexDeltaSynthesizer::new();
+            let synth_ref = &mut synthesizer;
+
+            let parse_result = parse_sse_stream(byte_stream, |event| {
+                match synth_ref.process_event(&event.data) {
+                    Ok(deltas) => {
+                        for delta in deltas {
+                            tx_ref
+                                .try_send(Ok(delta))
+                                .map_err(|e| SseError::Processing(e.to_string()))?;
+                        }
+                        Ok(())
+                    }
+                    Err(e) => {
+                        let _ = tx_ref.try_send(Err(OpenAiError::Stream(e.clone())));
+                        Err(SseError::Processing(e))
+                    }
+                }
+            })
+            .await;
+
+            if let Ok(deltas) = synth_ref.finish_stream() {
+                for delta in deltas {
+                    if tx_ref.try_send(Ok(delta)).is_err() {
+                        return;
+                    }
+                }
+            }
+
+            if let Err(e) = parse_result {
+                let _ = tx_ref.try_send(Err(OpenAiError::from(e)));
+            }
+        });
+
+        Ok(rx)
+    }
+}
+
+impl Default for OpenAiCodexClient {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl LlmProvider for OpenAiCodexClient {
+    fn name(&self) -> &str {
+        "openai-codex"
+    }
+
+    async fn send_prompt_streaming(
+        &self,
+        prompt: &Prompt,
+    ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
+        let rx = self
+            .send_prompt_streaming_internal(prompt)
+            .await
+            .map_err(|e| PromptError::Provider(e.to_string()))?;
+
+        let (tx, out_rx) = tokio::sync::mpsc::channel(128);
+        tokio::spawn(async move {
+            let mut rx = rx;
+            while let Some(result) = rx.recv().await {
+                let mapped = result.map_err(|e| PromptError::Provider(e.to_string()));
+                if tx.send(mapped).await.is_err() {
+                    break;
+                }
+            }
+        });
+        Ok(out_rx)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CodexRequest {
+    model: String,
+    input: Vec<CodexInputItem>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    instructions: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    max_output_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tools: Option<Vec<CodexTool>>,
+    tool_choice: Value,
+    parallel_tool_calls: bool,
+    stream: bool,
+    store: bool,
+    text: CodexTextConfig,
+    include: Vec<&'static str>,
+    reasoning: CodexReasoningConfig,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum CodexInputItem {
+    Message {
+        role: String,
+        content: Vec<CodexMessageContent>,
+    },
+    FunctionCall {
+        call_id: String,
+        name: String,
+        arguments: String,
+    },
+    FunctionCallOutput {
+        call_id: String,
+        output: String,
+    },
+}
+
+#[derive(Debug, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum CodexMessageContent {
+    InputText { text: String },
+    OutputText { text: String },
+}
+
+#[derive(Debug, Serialize)]
+struct CodexTool {
+    #[serde(rename = "type")]
+    kind: &'static str,
+    name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    description: Option<String>,
+    parameters: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct CodexTextConfig {
+    verbosity: &'static str,
+}
+
+#[derive(Debug, Serialize)]
+struct CodexReasoningConfig {
+    effort: &'static str,
+    summary: &'static str,
+}
+
+fn prompt_to_codex_request(prompt: &Prompt) -> CodexRequest {
+    let mut input = Vec::new();
+
+    for message in &prompt.messages {
+        convert_message(message, &mut input);
+    }
+
+    let tools = if prompt.tools.is_empty() {
+        None
+    } else {
+        Some(prompt.tools.iter().map(convert_tool).collect())
+    };
+
+    let instructions = prompt
+        .system
+        .iter()
+        .map(|block| match block {
+            SystemBlock::Text { text, .. } => text.as_str(),
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    CodexRequest {
+        model: prompt.model.clone(),
+        input,
+        instructions: (!instructions.is_empty()).then_some(instructions),
+        max_output_tokens: prompt.max_tokens.or(Some(DEFAULT_MAX_OUTPUT_TOKENS)),
+        tools,
+        tool_choice: convert_tool_choice(prompt.tool_choice.as_ref()),
+        parallel_tool_calls: true,
+        stream: true,
+        store: false,
+        text: CodexTextConfig {
+            verbosity: DEFAULT_TEXT_VERBOSITY,
+        },
+        include: vec!["reasoning.encrypted_content"],
+        reasoning: CodexReasoningConfig {
+            effort: DEFAULT_REASONING_EFFORT,
+            summary: "auto",
+        },
+    }
+}
+
+fn convert_message(message: &Message, out: &mut Vec<CodexInputItem>) {
+    match message {
+        Message::User { content } => {
+            let mut text_parts = Vec::new();
+
+            for block in content {
+                match block {
+                    UserBlock::Text { text, .. } => text_parts.push(text.clone()),
+                    UserBlock::ToolResult {
+                        tool_use_id,
+                        content,
+                        is_error,
+                        ..
+                    } => {
+                        if !text_parts.is_empty() {
+                            out.push(CodexInputItem::Message {
+                                role: "user".to_string(),
+                                content: vec![CodexMessageContent::InputText {
+                                    text: text_parts.join("\n"),
+                                }],
+                            });
+                            text_parts.clear();
+                        }
+
+                        let output = content
+                            .iter()
+                            .map(|block| match block {
+                                ToolResultBlock::Text { text } => text.as_str(),
+                            })
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        let output = if *is_error {
+                            format!("ERROR: {output}")
+                        } else {
+                            output
+                        };
+
+                        out.push(CodexInputItem::FunctionCallOutput {
+                            call_id: tool_use_id.clone(),
+                            output,
+                        });
+                    }
+                }
+            }
+
+            if !text_parts.is_empty() {
+                out.push(CodexInputItem::Message {
+                    role: "user".to_string(),
+                    content: vec![CodexMessageContent::InputText {
+                        text: text_parts.join("\n"),
+                    }],
+                });
+            }
+        }
+        Message::Assistant { content } => {
+            let mut text_parts = Vec::new();
+            let mut tool_calls = Vec::new();
+
+            for block in content {
+                match block {
+                    AssistantBlock::Text { text, .. } => text_parts.push(text.clone()),
+                    AssistantBlock::ToolUse {
+                        id, name, input, ..
+                    } => {
+                        tool_calls.push(CodexInputItem::FunctionCall {
+                            call_id: id.clone(),
+                            name: name.clone(),
+                            arguments: serde_json::to_string(input).unwrap_or_default(),
+                        });
+                    }
+                    AssistantBlock::Thinking { .. } => {}
+                }
+            }
+
+            if !text_parts.is_empty() {
+                out.push(CodexInputItem::Message {
+                    role: "assistant".to_string(),
+                    content: vec![CodexMessageContent::OutputText {
+                        text: text_parts.join("\n"),
+                    }],
+                });
+            }
+
+            out.extend(tool_calls);
+        }
+    }
+}
+
+fn convert_tool(tool: &Tool) -> CodexTool {
+    CodexTool {
+        kind: "function",
+        name: tool.name.clone(),
+        description: tool.description.clone(),
+        parameters: tool.input_schema.clone(),
+    }
+}
+
+fn convert_tool_choice(choice: Option<&ToolChoice>) -> Value {
+    match choice {
+        Some(ToolChoice::Auto) | None => Value::String("auto".to_string()),
+        Some(ToolChoice::Any) => Value::String("required".to_string()),
+        Some(ToolChoice::None) => Value::String("none".to_string()),
+        Some(ToolChoice::Tool { name }) => serde_json::json!({
+            "type": "function",
+            "name": name,
+        }),
+    }
+}
+
+#[derive(Default)]
+struct CodexDeltaSynthesizer {
+    text: String,
+    thinking: String,
+    tool_calls: HashMap<String, ToolCallState>,
+    pending_usage: Option<(u32, u32)>,
+    pending_incomplete_reason: Option<String>,
+    saw_tool_call: bool,
+    terminal_emitted: bool,
+}
+
+#[derive(Default)]
+struct ToolCallState {
+    call_id: String,
+    name: String,
+    arguments: String,
+    started: bool,
+}
+
+impl CodexDeltaSynthesizer {
+    fn new() -> Self {
+        Self::default()
+    }
+
+    fn process_event(&mut self, data: &str) -> Result<Vec<StreamDelta>, String> {
+        if data.trim() == "[DONE]" {
+            return self.drain_terminal();
+        }
+
+        let event: CodexResponseEvent =
+            serde_json::from_str(data).map_err(|e| format!("JSON parse: {e}"))?;
+
+        match event {
+            CodexResponseEvent::OutputTextDelta { delta, .. } => Ok(self.append_text_delta(&delta)),
+            CodexResponseEvent::OutputTextDone { text, .. } => Ok(self.reconcile_text(&text)),
+            CodexResponseEvent::ReasoningTextDelta { delta, .. }
+            | CodexResponseEvent::ReasoningSummaryTextDelta { delta, .. } => {
+                Ok(self.append_thinking_delta(&delta))
+            }
+            CodexResponseEvent::ReasoningTextDone { text, .. }
+            | CodexResponseEvent::ReasoningSummaryTextDone { text, .. } => {
+                Ok(self.reconcile_thinking(&text))
+            }
+            CodexResponseEvent::OutputItemAdded { item }
+            | CodexResponseEvent::OutputItemDone { item } => self.process_output_item(item),
+            CodexResponseEvent::FunctionCallArgumentsDelta { item_id, delta } => {
+                Ok(self.append_tool_args(&item_id, &delta))
+            }
+            CodexResponseEvent::ResponseCompleted { response }
+            | CodexResponseEvent::ResponseDone { response }
+            | CodexResponseEvent::ResponseIncomplete { response } => {
+                self.pending_usage = response
+                    .usage
+                    .as_ref()
+                    .map(|usage| (usage.input_tokens, usage.output_tokens));
+                self.pending_incomplete_reason = response.incomplete_reason();
+                Ok(Vec::new())
+            }
+            CodexResponseEvent::ResponseFailed { response } => Err(response.error_message()),
+            CodexResponseEvent::Error { error } => Err(error.message),
+            CodexResponseEvent::Other => Ok(Vec::new()),
+        }
+    }
+
+    fn finish_stream(&mut self) -> Result<Vec<StreamDelta>, String> {
+        self.drain_terminal()
+    }
+
+    fn append_text_delta(&mut self, delta: &str) -> Vec<StreamDelta> {
+        if delta.is_empty() {
+            return Vec::new();
+        }
+        self.text.push_str(delta);
+        vec![StreamDelta::TextDelta {
+            text: delta.to_string(),
+        }]
+    }
+
+    fn reconcile_text(&mut self, full_text: &str) -> Vec<StreamDelta> {
+        if full_text.is_empty() || full_text == self.text {
+            return Vec::new();
+        }
+        if let Some(suffix) = full_text.strip_prefix(&self.text) {
+            return self.append_text_delta(suffix);
+        }
+        if self.text.is_empty() {
+            return self.append_text_delta(full_text);
+        }
+        Vec::new()
+    }
+
+    fn append_thinking_delta(&mut self, delta: &str) -> Vec<StreamDelta> {
+        if delta.is_empty() {
+            return Vec::new();
+        }
+        self.thinking.push_str(delta);
+        vec![StreamDelta::ThinkingDelta {
+            text: delta.to_string(),
+        }]
+    }
+
+    fn reconcile_thinking(&mut self, full_text: &str) -> Vec<StreamDelta> {
+        if full_text.is_empty() || full_text == self.thinking {
+            return Vec::new();
+        }
+        if let Some(suffix) = full_text.strip_prefix(&self.thinking) {
+            return self.append_thinking_delta(suffix);
+        }
+        if self.thinking.is_empty() {
+            return self.append_thinking_delta(full_text);
+        }
+        Vec::new()
+    }
+
+    fn process_output_item(&mut self, item: CodexOutputItem) -> Result<Vec<StreamDelta>, String> {
+        if item.kind != "function_call" {
+            return Ok(Vec::new());
+        }
+
+        let item_id = item
+            .id
+            .unwrap_or_else(|| item.call_id.clone().unwrap_or_default());
+        let call_id = item.call_id.unwrap_or_else(|| item_id.clone());
+        let name = item.name.unwrap_or_default();
+        let mut deltas = self.ensure_tool_started(&item_id, &call_id, &name);
+
+        if let Some(arguments) = item.arguments {
+            let suffix = self.reconcile_tool_args(&item_id, &arguments)?;
+            deltas.extend(suffix);
+        }
+
+        Ok(deltas)
+    }
+
+    fn ensure_tool_started(
+        &mut self,
+        item_id: &str,
+        call_id: &str,
+        name: &str,
+    ) -> Vec<StreamDelta> {
+        let state = self.tool_calls.entry(item_id.to_string()).or_default();
+        if state.call_id.is_empty() {
+            state.call_id = call_id.to_string();
+        }
+        if state.name.is_empty() {
+            state.name = name.to_string();
+        }
+
+        if state.started {
+            return Vec::new();
+        }
+
+        state.started = true;
+        self.saw_tool_call = true;
+
+        let mut deltas = vec![StreamDelta::ToolCallStart {
+            id: state.call_id.clone(),
+            name: state.name.clone(),
+        }];
+        if !state.arguments.is_empty() {
+            deltas.push(StreamDelta::ToolCallDelta {
+                id: state.call_id.clone(),
+                partial_json: state.arguments.clone(),
+            });
+        }
+        deltas
+    }
+
+    fn append_tool_args(&mut self, item_id: &str, delta: &str) -> Vec<StreamDelta> {
+        if delta.is_empty() {
+            return Vec::new();
+        }
+        let state = self.tool_calls.entry(item_id.to_string()).or_default();
+        state.arguments.push_str(delta);
+        if state.started {
+            vec![StreamDelta::ToolCallDelta {
+                id: state.call_id.clone(),
+                partial_json: delta.to_string(),
+            }]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn reconcile_tool_args(
+        &mut self,
+        item_id: &str,
+        arguments: &str,
+    ) -> Result<Vec<StreamDelta>, String> {
+        let state = self
+            .tool_calls
+            .get_mut(item_id)
+            .ok_or_else(|| "tool call state missing".to_string())?;
+
+        if arguments.is_empty() || arguments == state.arguments {
+            return Ok(Vec::new());
+        }
+
+        if let Some(suffix) = arguments.strip_prefix(&state.arguments) {
+            state.arguments.push_str(suffix);
+            if state.started && !suffix.is_empty() {
+                return Ok(vec![StreamDelta::ToolCallDelta {
+                    id: state.call_id.clone(),
+                    partial_json: suffix.to_string(),
+                }]);
+            }
+            return Ok(Vec::new());
+        }
+
+        if state.arguments.is_empty() {
+            state.arguments = arguments.to_string();
+            if state.started {
+                return Ok(vec![StreamDelta::ToolCallDelta {
+                    id: state.call_id.clone(),
+                    partial_json: arguments.to_string(),
+                }]);
+            }
+        }
+
+        Ok(Vec::new())
+    }
+
+    fn drain_terminal(&mut self) -> Result<Vec<StreamDelta>, String> {
+        if self.terminal_emitted {
+            return Ok(Vec::new());
+        }
+
+        let Some((input_tokens, output_tokens)) = self.pending_usage else {
+            return Err("OpenAI Codex stream ended without terminal response".to_string());
+        };
+
+        self.terminal_emitted = true;
+        Ok(vec![
+            StreamDelta::Usage {
+                input_tokens,
+                output_tokens,
+            },
+            StreamDelta::Done {
+                stop_reason: Some(self.stop_reason()),
+            },
+        ])
+    }
+
+    fn stop_reason(&self) -> llm::StopReason {
+        if self.saw_tool_call {
+            return llm::StopReason::ToolUse;
+        }
+
+        let Some(reason) = self.pending_incomplete_reason.as_ref() else {
+            return llm::StopReason::EndTurn;
+        };
+
+        let lower = reason.to_ascii_lowercase();
+        if lower.contains("max_output") || lower.contains("length") {
+            llm::StopReason::MaxTokens
+        } else if lower.contains("tool") {
+            llm::StopReason::ToolUse
+        } else {
+            llm::StopReason::EndTurn
+        }
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type")]
+enum CodexResponseEvent {
+    #[serde(rename = "response.output_text.delta")]
+    OutputTextDelta {
+        #[serde(default)]
+        delta: String,
+        #[serde(default)]
+        item_id: String,
+        #[serde(default)]
+        content_index: u32,
+    },
+    #[serde(rename = "response.output_text.done")]
+    OutputTextDone {
+        #[serde(default)]
+        text: String,
+        #[serde(default)]
+        item_id: String,
+        #[serde(default)]
+        content_index: u32,
+    },
+    #[serde(rename = "response.output_item.added")]
+    OutputItemAdded { item: CodexOutputItem },
+    #[serde(rename = "response.output_item.done")]
+    OutputItemDone { item: CodexOutputItem },
+    #[serde(rename = "response.function_call_arguments.delta")]
+    FunctionCallArgumentsDelta {
+        item_id: String,
+        #[serde(default)]
+        delta: String,
+    },
+    #[serde(rename = "response.reasoning_text.delta")]
+    ReasoningTextDelta {
+        #[serde(default)]
+        delta: String,
+        #[serde(default)]
+        item_id: String,
+        #[serde(default)]
+        content_index: u32,
+    },
+    #[serde(rename = "response.reasoning_text.done")]
+    ReasoningTextDone {
+        #[serde(default)]
+        text: String,
+        #[serde(default)]
+        item_id: String,
+        #[serde(default)]
+        content_index: u32,
+    },
+    #[serde(rename = "response.reasoning_summary_text.delta")]
+    ReasoningSummaryTextDelta {
+        #[serde(default)]
+        delta: String,
+        #[serde(default)]
+        item_id: String,
+        #[serde(default)]
+        summary_index: u32,
+    },
+    #[serde(rename = "response.reasoning_summary_text.done")]
+    ReasoningSummaryTextDone {
+        #[serde(default)]
+        text: String,
+        #[serde(default)]
+        item_id: String,
+        #[serde(default)]
+        summary_index: u32,
+    },
+    #[serde(rename = "response.completed")]
+    ResponseCompleted { response: CodexDonePayload },
+    #[serde(rename = "response.done")]
+    ResponseDone { response: CodexDonePayload },
+    #[serde(rename = "response.incomplete")]
+    ResponseIncomplete { response: CodexDonePayload },
+    #[serde(rename = "response.failed")]
+    ResponseFailed { response: CodexFailedPayload },
+    #[serde(rename = "error")]
+    Error { error: CodexErrorPayload },
+    #[serde(other)]
+    Other,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexOutputItem {
+    #[serde(rename = "type")]
+    kind: String,
+    #[serde(default)]
+    id: Option<String>,
+    #[serde(default)]
+    call_id: Option<String>,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    arguments: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexDonePayload {
+    #[serde(default)]
+    incomplete_details: Option<CodexIncompleteDetails>,
+    #[serde(default)]
+    usage: Option<CodexUsage>,
+}
+
+impl CodexDonePayload {
+    fn incomplete_reason(&self) -> Option<String> {
+        self.incomplete_details
+            .as_ref()
+            .and_then(|details| details.reason.clone())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexIncompleteDetails {
+    #[serde(default)]
+    reason: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexUsage {
+    #[serde(default)]
+    input_tokens: u32,
+    #[serde(default)]
+    output_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexFailedPayload {
+    #[serde(default)]
+    error: Option<CodexErrorPayload>,
+}
+
+impl CodexFailedPayload {
+    fn error_message(&self) -> String {
+        self.error
+            .as_ref()
+            .map(|error| error.message.clone())
+            .unwrap_or_else(|| "OpenAI Codex request failed".to_string())
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct CodexErrorPayload {
+    #[serde(default)]
+    message: String,
+}
+
+fn resolve_codex_access_token() -> Option<String> {
+    std::env::var(OPENAI_CODEX_ACCESS_TOKEN_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+        .or_else(read_cached_codex_access_token)
+}
+
+fn read_cached_codex_access_token() -> Option<String> {
+    let home = dirs::home_dir()?;
+    let candidates = [
+        home.join(".codex").join("auth.json"),
+        home.join(".config").join("codex").join("auth.json"),
+    ];
+
+    for path in candidates {
+        if let Ok(content) = std::fs::read_to_string(&path) {
+            if let Ok(value) = serde_json::from_str::<Value>(&content) {
+                if let Some(token) = codex_access_token_from_value(&value) {
+                    return Some(token);
+                }
+            }
+        }
+    }
+
+    None
+}
+
+fn codex_access_token_from_value(value: &Value) -> Option<String> {
+    let candidates = [
+        value
+            .get("tokens")
+            .and_then(|tokens| tokens.get("access_token"))
+            .and_then(Value::as_str),
+        value
+            .get("tokens")
+            .and_then(|tokens| tokens.get("accessToken"))
+            .and_then(Value::as_str),
+        value.get("access_token").and_then(Value::as_str),
+        value.get("accessToken").and_then(Value::as_str),
+        value.get("token").and_then(Value::as_str),
+    ];
+
+    candidates
+        .into_iter()
+        .flatten()
+        .map(str::trim)
+        .find(|token| !token.is_empty() && !token.starts_with("sk-"))
+        .map(ToString::to_string)
+}
+
+fn extract_chatgpt_account_id(token: &str) -> Option<String> {
+    let mut parts = token.split('.');
+    let _header = parts.next()?;
+    let payload = parts.next()?;
+    let _signature = parts.next()?;
+    if parts.next().is_some() {
+        return None;
+    }
+
+    let decoded = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(payload)
+        .or_else(|_| base64::engine::general_purpose::URL_SAFE.decode(payload))
+        .ok()?;
+    let payload_json: Value = serde_json::from_slice(&decoded).ok()?;
+    payload_json
+        .get("https://api.openai.com/auth")
+        .and_then(|auth| auth.get("chatgpt_account_id"))
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(ToString::to_string)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn build_test_jwt(account_id: &str) -> String {
+        let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+            .encode(r#"{"alg":"none","typ":"JWT"}"#);
+        let payload = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(
+            serde_json::json!({
+                "https://api.openai.com/auth": {
+                    "chatgpt_account_id": account_id
+                }
+            })
+            .to_string(),
+        );
+        format!("{header}.{payload}.sig")
+    }
+
+    #[test]
+    fn extracts_chatgpt_account_id_from_token() {
+        let token = build_test_jwt("acct_123");
+        assert_eq!(
+            extract_chatgpt_account_id(&token).as_deref(),
+            Some("acct_123")
+        );
+    }
+
+    #[test]
+    fn extracts_codex_access_token_from_cached_auth() {
+        let value = serde_json::json!({
+            "tokens": {
+                "access_token": "eyJhbGciOiJub25lIn0.payload.sig"
+            }
+        });
+
+        assert_eq!(
+            codex_access_token_from_value(&value).as_deref(),
+            Some("eyJhbGciOiJub25lIn0.payload.sig")
+        );
+    }
+
+    #[test]
+    fn ignores_api_keys_in_cached_auth() {
+        let value = serde_json::json!({
+            "tokens": {
+                "access_token": "sk-test-key"
+            }
+        });
+
+        assert!(codex_access_token_from_value(&value).is_none());
+    }
+
+    #[test]
+    fn terminal_done_waits_for_late_tool_calls() {
+        let mut synth = CodexDeltaSynthesizer::new();
+
+        assert!(synth
+            .process_event(r#"{"type":"response.function_call_arguments.delta","item_id":"fc_5","delta":"{\"text\":\"late tool\"}"}"#)
+            .unwrap()
+            .is_empty());
+        assert!(synth
+            .process_event(r#"{"type":"response.completed","response":{"incomplete_details":null,"usage":{"input_tokens":1,"output_tokens":1}}}"#)
+            .unwrap()
+            .is_empty());
+
+        let tool_start = synth
+            .process_event(r#"{"type":"response.output_item.done","item":{"type":"function_call","id":"fc_5","call_id":"call_5","name":"echo","arguments":""}}"#)
+            .unwrap();
+        assert!(tool_start.iter().any(|delta| matches!(
+            delta,
+            StreamDelta::ToolCallStart { id, name } if id == "call_5" && name == "echo"
+        )));
+
+        let terminal = synth.process_event("[DONE]").unwrap();
+        assert!(terminal.iter().any(|delta| matches!(
+            delta,
+            StreamDelta::Done {
+                stop_reason: Some(llm::StopReason::ToolUse)
+            }
+        )));
+    }
+}

--- a/lib/openai-client/src/lib.rs
+++ b/lib/openai-client/src/lib.rs
@@ -21,23 +21,23 @@ use llm::{Prompt, PromptError, PromptResponse};
 use crate::convert::{prompt_to_request, DeltaSynthesizer};
 use crate::sse::{parse_sse_stream, SseError};
 
-pub use responses::{OpenAiResponsesAuth, OpenAiResponsesClient};
+pub use responses::{OpenAiResponsesAuth, OpenAiResponsesClient, OpenAiResponsesError};
 
 const DEFAULT_API_URL: &str = "https://api.openai.com/v1/chat/completions";
 
 #[derive(Debug, Error)]
-pub enum OpenAiError {
-    #[error("OpenAiError - HTTP: {0}")]
+pub enum OpenAiChatCompletionsError {
+    #[error("OpenAiChatCompletionsError - HTTP: {0}")]
     Http(#[from] reqwest::Error),
-    #[error("OpenAiError - API: status={status}, message={message}")]
+    #[error("OpenAiChatCompletionsError - API: status={status}, message={message}")]
     Api { status: u16, message: String },
-    #[error("OpenAiError - SSE: {0}")]
+    #[error("OpenAiChatCompletionsError - SSE: {0}")]
     Sse(String),
-    #[error("OpenAiError - Stream: {0}")]
+    #[error("OpenAiChatCompletionsError - Stream: {0}")]
     Stream(String),
 }
 
-impl From<SseError> for OpenAiError {
+impl From<SseError> for OpenAiChatCompletionsError {
     fn from(e: SseError) -> Self {
         match e {
             SseError::Http(e) => Self::Http(e),
@@ -68,7 +68,10 @@ impl OpenAiClient {
     /// Issue a streaming Chat Completions request and return the
     /// fully-accumulated assistant reply.
     #[instrument(name = "openai_client.send_prompt", skip_all)]
-    pub async fn send_prompt(&self, prompt: &Prompt) -> Result<PromptResponse, OpenAiError> {
+    pub async fn send_prompt(
+        &self,
+        prompt: &Prompt,
+    ) -> Result<PromptResponse, OpenAiChatCompletionsError> {
         let rx = self.send_prompt_streaming_internal(prompt).await?;
         let mut rx = rx;
 
@@ -76,7 +79,7 @@ impl OpenAiClient {
         while let Some(result) = rx.recv().await {
             match result {
                 Ok(delta) => accumulator.process(&delta),
-                Err(e) => return Err(OpenAiError::Stream(e.to_string())),
+                Err(e) => return Err(OpenAiChatCompletionsError::Stream(e.to_string())),
             }
         }
         Ok(accumulator.finish())
@@ -88,7 +91,10 @@ impl OpenAiClient {
     async fn send_prompt_streaming_internal(
         &self,
         prompt: &Prompt,
-    ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, OpenAiError>>, OpenAiError> {
+    ) -> Result<
+        tokio::sync::mpsc::Receiver<Result<StreamDelta, OpenAiChatCompletionsError>>,
+        OpenAiChatCompletionsError,
+    > {
         let request_body = prompt_to_request(prompt);
 
         let resp = self
@@ -103,14 +109,15 @@ impl OpenAiClient {
         let status = resp.status();
         if !status.is_success() {
             let message = resp.text().await.unwrap_or_default();
-            return Err(OpenAiError::Api {
+            return Err(OpenAiChatCompletionsError::Api {
                 status: status.as_u16(),
                 message,
             });
         }
 
         let byte_stream = resp.bytes_stream();
-        let (tx, rx) = tokio::sync::mpsc::channel::<Result<StreamDelta, OpenAiError>>(128);
+        let (tx, rx) =
+            tokio::sync::mpsc::channel::<Result<StreamDelta, OpenAiChatCompletionsError>>(128);
 
         tokio::spawn(async move {
             let tx_ref = &tx;
@@ -128,7 +135,7 @@ impl OpenAiClient {
                         Ok(())
                     }
                     Err(e) => {
-                        let _ = tx_ref.try_send(Err(OpenAiError::Stream(e.clone())));
+                        let _ = tx_ref.try_send(Err(OpenAiChatCompletionsError::Stream(e.clone())));
                         Err(SseError::Processing(e))
                     }
                 }
@@ -155,7 +162,7 @@ impl LlmProvider for OpenAiClient {
             .await
             .map_err(|e| PromptError::Provider(e.to_string()))?;
 
-        // Re-map the error type from OpenAiError to PromptError.
+        // Re-map the error type from OpenAiChatCompletionsError to PromptError.
         let (tx, out_rx) = tokio::sync::mpsc::channel(128);
         tokio::spawn(async move {
             let mut rx = rx;

--- a/lib/openai-client/src/lib.rs
+++ b/lib/openai-client/src/lib.rs
@@ -5,6 +5,7 @@
 //! them to the unified `StreamDelta` format that the prompt executor and agent
 //! loop expect.
 
+mod codex;
 mod convert;
 mod sse;
 mod types;
@@ -19,6 +20,8 @@ use llm::{Prompt, PromptError, PromptResponse};
 
 use crate::convert::{prompt_to_request, DeltaSynthesizer};
 use crate::sse::{parse_sse_stream, SseError};
+
+pub use codex::OpenAiCodexClient;
 
 const DEFAULT_API_URL: &str = "https://api.openai.com/v1/chat/completions";
 

--- a/lib/openai-client/src/lib.rs
+++ b/lib/openai-client/src/lib.rs
@@ -5,8 +5,8 @@
 //! them to the unified `StreamDelta` format that the prompt executor and agent
 //! loop expect.
 
-mod codex;
 mod convert;
+mod responses;
 mod sse;
 mod types;
 
@@ -21,7 +21,7 @@ use llm::{Prompt, PromptError, PromptResponse};
 use crate::convert::{prompt_to_request, DeltaSynthesizer};
 use crate::sse::{parse_sse_stream, SseError};
 
-pub use codex::OpenAiCodexClient;
+pub use responses::{OpenAiResponsesAuth, OpenAiResponsesClient};
 
 const DEFAULT_API_URL: &str = "https://api.openai.com/v1/chat/completions";
 

--- a/lib/openai-client/src/responses.rs
+++ b/lib/openai-client/src/responses.rs
@@ -10,10 +10,10 @@ use llm::stream::StreamDelta;
 use llm::{Prompt, PromptError};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use thiserror::Error;
 use tracing::instrument;
 
 use crate::sse::{parse_sse_stream, SseError};
-use crate::OpenAiError;
 
 const DEFAULT_RESPONSES_API_URL: &str = "https://api.openai.com/v1/responses";
 const DEFAULT_SUBSCRIPTION_API_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
@@ -27,6 +27,27 @@ const OPENAI_RESPONSES_SUBSCRIPTION_TOKEN_ENV: &str = "OPENAI_CODEX_ACCESS_TOKEN
 pub enum OpenAiResponsesAuth {
     ApiKey { api_key: String },
     Subscription,
+}
+
+#[derive(Debug, Error)]
+pub enum OpenAiResponsesError {
+    #[error("OpenAiResponsesError - HTTP: {0}")]
+    Http(#[from] reqwest::Error),
+    #[error("OpenAiResponsesError - API: status={status}, message={message}")]
+    Api { status: u16, message: String },
+    #[error("OpenAiResponsesError - SSE: {0}")]
+    Sse(String),
+    #[error("OpenAiResponsesError - Stream: {0}")]
+    Stream(String),
+}
+
+impl From<SseError> for OpenAiResponsesError {
+    fn from(e: SseError) -> Self {
+        match e {
+            SseError::Http(e) => Self::Http(e),
+            SseError::Processing(msg) => Self::Sse(msg),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -64,8 +85,11 @@ impl OpenAiResponsesClient {
     async fn send_prompt_streaming_internal(
         &self,
         prompt: &Prompt,
-    ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, OpenAiError>>, OpenAiError> {
-        let request_body = prompt_to_responses_request(prompt);
+    ) -> Result<
+        tokio::sync::mpsc::Receiver<Result<StreamDelta, OpenAiResponsesError>>,
+        OpenAiResponsesError,
+    > {
+        let request_body = prompt_to_responses_request(prompt, &self.auth);
         let mut request = self
             .http
             .post(&self.api_url)
@@ -77,18 +101,21 @@ impl OpenAiResponsesClient {
                 request = request.header("Authorization", format!("Bearer {api_key}"));
             }
             OpenAiResponsesAuth::Subscription => {
-                let access_token = resolve_subscription_access_token().ok_or(OpenAiError::Api {
-                    status: 401,
-                    message: format!(
+                let access_token =
+                    resolve_subscription_access_token().ok_or(OpenAiResponsesError::Api {
+                        status: 401,
+                        message: format!(
                         "OpenAI subscription credentials not found. Run `codex login` or set {}.",
                         OPENAI_RESPONSES_SUBSCRIPTION_TOKEN_ENV
                     ),
-                })?;
-                let account_id =
-                    extract_chatgpt_account_id(&access_token).ok_or(OpenAiError::Api {
-                        status: 401,
-                        message: "OpenAI subscription credential is invalid or expired (missing chatgpt_account_id claim)".to_string(),
                     })?;
+                let account_id =
+                    extract_chatgpt_account_id(&access_token).ok_or(
+                        OpenAiResponsesError::Api {
+                            status: 401,
+                            message: "OpenAI subscription credential is invalid or expired (missing chatgpt_account_id claim)".to_string(),
+                        },
+                    )?;
                 request = request
                     .header("Authorization", format!("Bearer {access_token}"))
                     .header("chatgpt-account-id", account_id)
@@ -103,14 +130,14 @@ impl OpenAiResponsesClient {
         let status = resp.status();
         if !status.is_success() {
             let message = resp.text().await.unwrap_or_default();
-            return Err(OpenAiError::Api {
+            return Err(OpenAiResponsesError::Api {
                 status: status.as_u16(),
                 message,
             });
         }
 
         let byte_stream = resp.bytes_stream();
-        let (tx, rx) = tokio::sync::mpsc::channel::<Result<StreamDelta, OpenAiError>>(128);
+        let (tx, rx) = tokio::sync::mpsc::channel::<Result<StreamDelta, OpenAiResponsesError>>(128);
 
         tokio::spawn(async move {
             let tx_ref = &tx;
@@ -128,7 +155,7 @@ impl OpenAiResponsesClient {
                         Ok(())
                     }
                     Err(e) => {
-                        let _ = tx_ref.try_send(Err(OpenAiError::Stream(e.clone())));
+                        let _ = tx_ref.try_send(Err(OpenAiResponsesError::Stream(e.clone())));
                         Err(SseError::Processing(e))
                     }
                 }
@@ -144,7 +171,7 @@ impl OpenAiResponsesClient {
             }
 
             if let Err(e) = parse_result {
-                let _ = tx_ref.try_send(Err(OpenAiError::from(e)));
+                let _ = tx_ref.try_send(Err(OpenAiResponsesError::from(e)));
             }
         });
 
@@ -252,7 +279,7 @@ struct ResponsesReasoningConfig {
     summary: &'static str,
 }
 
-fn prompt_to_responses_request(prompt: &Prompt) -> ResponsesRequest {
+fn prompt_to_responses_request(prompt: &Prompt, auth: &OpenAiResponsesAuth) -> ResponsesRequest {
     let mut input = Vec::new();
 
     for message in &prompt.messages {
@@ -278,7 +305,12 @@ fn prompt_to_responses_request(prompt: &Prompt) -> ResponsesRequest {
         model: prompt.model.clone(),
         input,
         instructions: (!instructions.is_empty()).then_some(instructions),
-        max_output_tokens: prompt.max_tokens.or(Some(DEFAULT_MAX_OUTPUT_TOKENS)),
+        max_output_tokens: match auth {
+            OpenAiResponsesAuth::ApiKey { .. } => {
+                prompt.max_tokens.or(Some(DEFAULT_MAX_OUTPUT_TOKENS))
+            }
+            OpenAiResponsesAuth::Subscription => None,
+        },
         tools,
         tool_choice: convert_tool_choice(prompt.tool_choice.as_ref()),
         parallel_tool_calls: true,
@@ -896,6 +928,23 @@ fn extract_chatgpt_account_id(token: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use llm::prompt::{Message, UserBlock};
+
+    fn sample_prompt() -> Prompt {
+        Prompt {
+            model: "gpt-5.4-mini".to_string(),
+            messages: vec![Message::User {
+                content: vec![UserBlock::Text {
+                    text: "hello".to_string(),
+                    cache_control: None,
+                }],
+            }],
+            system: Vec::new(),
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: Some(1234),
+        }
+    }
 
     fn build_test_jwt(account_id: &str) -> String {
         let header = base64::engine::general_purpose::URL_SAFE_NO_PAD
@@ -973,5 +1022,30 @@ mod tests {
                 stop_reason: Some(llm::StopReason::ToolUse)
             }
         )));
+    }
+
+    #[test]
+    fn api_key_requests_include_max_output_tokens() {
+        let request = prompt_to_responses_request(
+            &sample_prompt(),
+            &OpenAiResponsesAuth::ApiKey {
+                api_key: "sk-test".to_string(),
+            },
+        );
+
+        let value = serde_json::to_value(request).expect("request serializes");
+        assert_eq!(value["max_output_tokens"], serde_json::json!(1234));
+    }
+
+    #[test]
+    fn subscription_requests_omit_max_output_tokens() {
+        let request =
+            prompt_to_responses_request(&sample_prompt(), &OpenAiResponsesAuth::Subscription);
+
+        let value = serde_json::to_value(request).expect("request serializes");
+        assert!(
+            value.get("max_output_tokens").is_none(),
+            "subscription endpoint should not receive max_output_tokens"
+        );
     }
 }

--- a/lib/openai-client/src/responses.rs
+++ b/lib/openai-client/src/responses.rs
@@ -15,60 +15,90 @@ use tracing::instrument;
 use crate::sse::{parse_sse_stream, SseError};
 use crate::OpenAiError;
 
-const DEFAULT_CODEX_API_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
+const DEFAULT_RESPONSES_API_URL: &str = "https://api.openai.com/v1/responses";
+const DEFAULT_SUBSCRIPTION_API_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
 const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 4096;
 const DEFAULT_REASONING_EFFORT: &str = "low";
 const DEFAULT_TEXT_VERBOSITY: &str = "medium";
-const OPENAI_CODEX_ACCESS_TOKEN_ENV: &str = "OPENAI_CODEX_ACCESS_TOKEN";
+const OPENAI_RESPONSES_SUBSCRIPTION_TOKEN_ENV: &str = "OPENAI_CODEX_ACCESS_TOKEN";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum OpenAiResponsesAuth {
+    ApiKey { api_key: String },
+    Subscription,
+}
 
 #[derive(Clone)]
-pub struct OpenAiCodexClient {
+pub struct OpenAiResponsesClient {
     http: reqwest::Client,
+    auth: OpenAiResponsesAuth,
     api_url: String,
 }
 
-impl OpenAiCodexClient {
-    pub fn new() -> Self {
+impl OpenAiResponsesClient {
+    pub fn new(auth: OpenAiResponsesAuth) -> Self {
+        let api_url = match &auth {
+            OpenAiResponsesAuth::ApiKey { .. } => DEFAULT_RESPONSES_API_URL.to_string(),
+            OpenAiResponsesAuth::Subscription => DEFAULT_SUBSCRIPTION_API_URL.to_string(),
+        };
+
         Self {
             http: reqwest::Client::new(),
-            api_url: DEFAULT_CODEX_API_URL.to_string(),
+            auth,
+            api_url,
         }
     }
 
-    #[instrument(name = "openai_codex_client.send_prompt_streaming", skip_all)]
+    pub fn with_api_key(api_key: impl Into<String>) -> Self {
+        Self::new(OpenAiResponsesAuth::ApiKey {
+            api_key: api_key.into(),
+        })
+    }
+
+    pub fn with_subscription() -> Self {
+        Self::new(OpenAiResponsesAuth::Subscription)
+    }
+
+    #[instrument(name = "openai_responses_client.send_prompt_streaming", skip_all)]
     async fn send_prompt_streaming_internal(
         &self,
         prompt: &Prompt,
     ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, OpenAiError>>, OpenAiError> {
-        let access_token = resolve_codex_access_token().ok_or(OpenAiError::Api {
-            status: 401,
-            message: format!(
-                "OpenAI Codex credentials not found. Run `codex login` or set {}.",
-                OPENAI_CODEX_ACCESS_TOKEN_ENV
-            ),
-        })?;
-        let account_id = extract_chatgpt_account_id(&access_token).ok_or(OpenAiError::Api {
-            status: 401,
-            message:
-                "OpenAI Codex credential is invalid or expired (missing chatgpt_account_id claim)"
-                    .to_string(),
-        })?;
-
-        let request_body = prompt_to_codex_request(prompt);
-
-        let resp = self
+        let request_body = prompt_to_responses_request(prompt);
+        let mut request = self
             .http
             .post(&self.api_url)
-            .header("Authorization", format!("Bearer {access_token}"))
-            .header("chatgpt-account-id", account_id)
-            .header("OpenAI-Beta", "responses=experimental")
-            .header("originator", "drua")
-            .header("User-Agent", "drua")
             .header("accept", "text/event-stream")
-            .header("content-type", "application/json")
-            .json(&request_body)
-            .send()
-            .await?;
+            .header("content-type", "application/json");
+
+        match &self.auth {
+            OpenAiResponsesAuth::ApiKey { api_key } => {
+                request = request.header("Authorization", format!("Bearer {api_key}"));
+            }
+            OpenAiResponsesAuth::Subscription => {
+                let access_token = resolve_subscription_access_token().ok_or(OpenAiError::Api {
+                    status: 401,
+                    message: format!(
+                        "OpenAI subscription credentials not found. Run `codex login` or set {}.",
+                        OPENAI_RESPONSES_SUBSCRIPTION_TOKEN_ENV
+                    ),
+                })?;
+                let account_id =
+                    extract_chatgpt_account_id(&access_token).ok_or(OpenAiError::Api {
+                        status: 401,
+                        message: "OpenAI subscription credential is invalid or expired (missing chatgpt_account_id claim)".to_string(),
+                    })?;
+                request = request
+                    .header("Authorization", format!("Bearer {access_token}"))
+                    .header("chatgpt-account-id", account_id)
+                    .header("OpenAI-Beta", "responses=experimental")
+                    .header("originator", "drua")
+                    .header("User-Agent", "drua");
+            }
+        }
+
+        let resp = request.json(&request_body).send().await?;
 
         let status = resp.status();
         if !status.is_success() {
@@ -84,7 +114,7 @@ impl OpenAiCodexClient {
 
         tokio::spawn(async move {
             let tx_ref = &tx;
-            let mut synthesizer = CodexDeltaSynthesizer::new();
+            let mut synthesizer = ResponsesDeltaSynthesizer::new();
             let synth_ref = &mut synthesizer;
 
             let parse_result = parse_sse_stream(byte_stream, |event| {
@@ -122,16 +152,16 @@ impl OpenAiCodexClient {
     }
 }
 
-impl Default for OpenAiCodexClient {
+impl Default for OpenAiResponsesClient {
     fn default() -> Self {
-        Self::new()
+        Self::with_subscription()
     }
 }
 
 #[async_trait]
-impl LlmProvider for OpenAiCodexClient {
+impl LlmProvider for OpenAiResponsesClient {
     fn name(&self) -> &str {
-        "openai-codex"
+        "openai-responses"
     }
 
     async fn send_prompt_streaming(
@@ -158,30 +188,30 @@ impl LlmProvider for OpenAiCodexClient {
 }
 
 #[derive(Debug, Serialize)]
-struct CodexRequest {
+struct ResponsesRequest {
     model: String,
-    input: Vec<CodexInputItem>,
+    input: Vec<ResponsesInputItem>,
     #[serde(skip_serializing_if = "Option::is_none")]
     instructions: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     max_output_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    tools: Option<Vec<CodexTool>>,
+    tools: Option<Vec<ResponsesTool>>,
     tool_choice: Value,
     parallel_tool_calls: bool,
     stream: bool,
     store: bool,
-    text: CodexTextConfig,
+    text: ResponsesTextConfig,
     include: Vec<&'static str>,
-    reasoning: CodexReasoningConfig,
+    reasoning: ResponsesReasoningConfig,
 }
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-enum CodexInputItem {
+enum ResponsesInputItem {
     Message {
         role: String,
-        content: Vec<CodexMessageContent>,
+        content: Vec<ResponsesMessageContent>,
     },
     FunctionCall {
         call_id: String,
@@ -196,13 +226,13 @@ enum CodexInputItem {
 
 #[derive(Debug, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
-enum CodexMessageContent {
+enum ResponsesMessageContent {
     InputText { text: String },
     OutputText { text: String },
 }
 
 #[derive(Debug, Serialize)]
-struct CodexTool {
+struct ResponsesTool {
     #[serde(rename = "type")]
     kind: &'static str,
     name: String,
@@ -212,17 +242,17 @@ struct CodexTool {
 }
 
 #[derive(Debug, Serialize)]
-struct CodexTextConfig {
+struct ResponsesTextConfig {
     verbosity: &'static str,
 }
 
 #[derive(Debug, Serialize)]
-struct CodexReasoningConfig {
+struct ResponsesReasoningConfig {
     effort: &'static str,
     summary: &'static str,
 }
 
-fn prompt_to_codex_request(prompt: &Prompt) -> CodexRequest {
+fn prompt_to_responses_request(prompt: &Prompt) -> ResponsesRequest {
     let mut input = Vec::new();
 
     for message in &prompt.messages {
@@ -244,7 +274,7 @@ fn prompt_to_codex_request(prompt: &Prompt) -> CodexRequest {
         .collect::<Vec<_>>()
         .join("\n");
 
-    CodexRequest {
+    ResponsesRequest {
         model: prompt.model.clone(),
         input,
         instructions: (!instructions.is_empty()).then_some(instructions),
@@ -254,18 +284,18 @@ fn prompt_to_codex_request(prompt: &Prompt) -> CodexRequest {
         parallel_tool_calls: true,
         stream: true,
         store: false,
-        text: CodexTextConfig {
+        text: ResponsesTextConfig {
             verbosity: DEFAULT_TEXT_VERBOSITY,
         },
         include: vec!["reasoning.encrypted_content"],
-        reasoning: CodexReasoningConfig {
+        reasoning: ResponsesReasoningConfig {
             effort: DEFAULT_REASONING_EFFORT,
             summary: "auto",
         },
     }
 }
 
-fn convert_message(message: &Message, out: &mut Vec<CodexInputItem>) {
+fn convert_message(message: &Message, out: &mut Vec<ResponsesInputItem>) {
     match message {
         Message::User { content } => {
             let mut text_parts = Vec::new();
@@ -280,9 +310,9 @@ fn convert_message(message: &Message, out: &mut Vec<CodexInputItem>) {
                         ..
                     } => {
                         if !text_parts.is_empty() {
-                            out.push(CodexInputItem::Message {
+                            out.push(ResponsesInputItem::Message {
                                 role: "user".to_string(),
-                                content: vec![CodexMessageContent::InputText {
+                                content: vec![ResponsesMessageContent::InputText {
                                     text: text_parts.join("\n"),
                                 }],
                             });
@@ -302,7 +332,7 @@ fn convert_message(message: &Message, out: &mut Vec<CodexInputItem>) {
                             output
                         };
 
-                        out.push(CodexInputItem::FunctionCallOutput {
+                        out.push(ResponsesInputItem::FunctionCallOutput {
                             call_id: tool_use_id.clone(),
                             output,
                         });
@@ -311,9 +341,9 @@ fn convert_message(message: &Message, out: &mut Vec<CodexInputItem>) {
             }
 
             if !text_parts.is_empty() {
-                out.push(CodexInputItem::Message {
+                out.push(ResponsesInputItem::Message {
                     role: "user".to_string(),
-                    content: vec![CodexMessageContent::InputText {
+                    content: vec![ResponsesMessageContent::InputText {
                         text: text_parts.join("\n"),
                     }],
                 });
@@ -329,7 +359,7 @@ fn convert_message(message: &Message, out: &mut Vec<CodexInputItem>) {
                     AssistantBlock::ToolUse {
                         id, name, input, ..
                     } => {
-                        tool_calls.push(CodexInputItem::FunctionCall {
+                        tool_calls.push(ResponsesInputItem::FunctionCall {
                             call_id: id.clone(),
                             name: name.clone(),
                             arguments: serde_json::to_string(input).unwrap_or_default(),
@@ -340,9 +370,9 @@ fn convert_message(message: &Message, out: &mut Vec<CodexInputItem>) {
             }
 
             if !text_parts.is_empty() {
-                out.push(CodexInputItem::Message {
+                out.push(ResponsesInputItem::Message {
                     role: "assistant".to_string(),
-                    content: vec![CodexMessageContent::OutputText {
+                    content: vec![ResponsesMessageContent::OutputText {
                         text: text_parts.join("\n"),
                     }],
                 });
@@ -353,8 +383,8 @@ fn convert_message(message: &Message, out: &mut Vec<CodexInputItem>) {
     }
 }
 
-fn convert_tool(tool: &Tool) -> CodexTool {
-    CodexTool {
+fn convert_tool(tool: &Tool) -> ResponsesTool {
+    ResponsesTool {
         kind: "function",
         name: tool.name.clone(),
         description: tool.description.clone(),
@@ -375,7 +405,7 @@ fn convert_tool_choice(choice: Option<&ToolChoice>) -> Value {
 }
 
 #[derive(Default)]
-struct CodexDeltaSynthesizer {
+struct ResponsesDeltaSynthesizer {
     text: String,
     thinking: String,
     tool_calls: HashMap<String, ToolCallState>,
@@ -393,7 +423,7 @@ struct ToolCallState {
     started: bool,
 }
 
-impl CodexDeltaSynthesizer {
+impl ResponsesDeltaSynthesizer {
     fn new() -> Self {
         Self::default()
     }
@@ -403,28 +433,30 @@ impl CodexDeltaSynthesizer {
             return self.drain_terminal();
         }
 
-        let event: CodexResponseEvent =
+        let event: ResponsesResponseEvent =
             serde_json::from_str(data).map_err(|e| format!("JSON parse: {e}"))?;
 
         match event {
-            CodexResponseEvent::OutputTextDelta { delta, .. } => Ok(self.append_text_delta(&delta)),
-            CodexResponseEvent::OutputTextDone { text, .. } => Ok(self.reconcile_text(&text)),
-            CodexResponseEvent::ReasoningTextDelta { delta, .. }
-            | CodexResponseEvent::ReasoningSummaryTextDelta { delta, .. } => {
+            ResponsesResponseEvent::OutputTextDelta { delta, .. } => {
+                Ok(self.append_text_delta(&delta))
+            }
+            ResponsesResponseEvent::OutputTextDone { text, .. } => Ok(self.reconcile_text(&text)),
+            ResponsesResponseEvent::ReasoningTextDelta { delta, .. }
+            | ResponsesResponseEvent::ReasoningSummaryTextDelta { delta, .. } => {
                 Ok(self.append_thinking_delta(&delta))
             }
-            CodexResponseEvent::ReasoningTextDone { text, .. }
-            | CodexResponseEvent::ReasoningSummaryTextDone { text, .. } => {
+            ResponsesResponseEvent::ReasoningTextDone { text, .. }
+            | ResponsesResponseEvent::ReasoningSummaryTextDone { text, .. } => {
                 Ok(self.reconcile_thinking(&text))
             }
-            CodexResponseEvent::OutputItemAdded { item }
-            | CodexResponseEvent::OutputItemDone { item } => self.process_output_item(item),
-            CodexResponseEvent::FunctionCallArgumentsDelta { item_id, delta } => {
+            ResponsesResponseEvent::OutputItemAdded { item }
+            | ResponsesResponseEvent::OutputItemDone { item } => self.process_output_item(item),
+            ResponsesResponseEvent::FunctionCallArgumentsDelta { item_id, delta } => {
                 Ok(self.append_tool_args(&item_id, &delta))
             }
-            CodexResponseEvent::ResponseCompleted { response }
-            | CodexResponseEvent::ResponseDone { response }
-            | CodexResponseEvent::ResponseIncomplete { response } => {
+            ResponsesResponseEvent::ResponseCompleted { response }
+            | ResponsesResponseEvent::ResponseDone { response }
+            | ResponsesResponseEvent::ResponseIncomplete { response } => {
                 self.pending_usage = response
                     .usage
                     .as_ref()
@@ -432,9 +464,9 @@ impl CodexDeltaSynthesizer {
                 self.pending_incomplete_reason = response.incomplete_reason();
                 Ok(Vec::new())
             }
-            CodexResponseEvent::ResponseFailed { response } => Err(response.error_message()),
-            CodexResponseEvent::Error { error } => Err(error.message),
-            CodexResponseEvent::Other => Ok(Vec::new()),
+            ResponsesResponseEvent::ResponseFailed { response } => Err(response.error_message()),
+            ResponsesResponseEvent::Error { error } => Err(error.message),
+            ResponsesResponseEvent::Other => Ok(Vec::new()),
         }
     }
 
@@ -488,7 +520,10 @@ impl CodexDeltaSynthesizer {
         Vec::new()
     }
 
-    fn process_output_item(&mut self, item: CodexOutputItem) -> Result<Vec<StreamDelta>, String> {
+    fn process_output_item(
+        &mut self,
+        item: ResponsesOutputItem,
+    ) -> Result<Vec<StreamDelta>, String> {
         if item.kind != "function_call" {
             return Ok(Vec::new());
         }
@@ -602,7 +637,7 @@ impl CodexDeltaSynthesizer {
         }
 
         let Some((input_tokens, output_tokens)) = self.pending_usage else {
-            return Err("OpenAI Codex stream ended without terminal response".to_string());
+            return Err("OpenAI Responses stream ended without terminal response".to_string());
         };
 
         self.terminal_emitted = true;
@@ -640,7 +675,7 @@ impl CodexDeltaSynthesizer {
 #[allow(dead_code)]
 #[derive(Debug, Deserialize)]
 #[serde(tag = "type")]
-enum CodexResponseEvent {
+enum ResponsesResponseEvent {
     #[serde(rename = "response.output_text.delta")]
     OutputTextDelta {
         #[serde(default)]
@@ -660,9 +695,9 @@ enum CodexResponseEvent {
         content_index: u32,
     },
     #[serde(rename = "response.output_item.added")]
-    OutputItemAdded { item: CodexOutputItem },
+    OutputItemAdded { item: ResponsesOutputItem },
     #[serde(rename = "response.output_item.done")]
-    OutputItemDone { item: CodexOutputItem },
+    OutputItemDone { item: ResponsesOutputItem },
     #[serde(rename = "response.function_call_arguments.delta")]
     FunctionCallArgumentsDelta {
         item_id: String,
@@ -706,21 +741,21 @@ enum CodexResponseEvent {
         summary_index: u32,
     },
     #[serde(rename = "response.completed")]
-    ResponseCompleted { response: CodexDonePayload },
+    ResponseCompleted { response: ResponsesDonePayload },
     #[serde(rename = "response.done")]
-    ResponseDone { response: CodexDonePayload },
+    ResponseDone { response: ResponsesDonePayload },
     #[serde(rename = "response.incomplete")]
-    ResponseIncomplete { response: CodexDonePayload },
+    ResponseIncomplete { response: ResponsesDonePayload },
     #[serde(rename = "response.failed")]
-    ResponseFailed { response: CodexFailedPayload },
+    ResponseFailed { response: ResponsesFailedPayload },
     #[serde(rename = "error")]
-    Error { error: CodexErrorPayload },
+    Error { error: ResponsesErrorPayload },
     #[serde(other)]
     Other,
 }
 
 #[derive(Debug, Deserialize)]
-struct CodexOutputItem {
+struct ResponsesOutputItem {
     #[serde(rename = "type")]
     kind: String,
     #[serde(default)]
@@ -734,14 +769,14 @@ struct CodexOutputItem {
 }
 
 #[derive(Debug, Deserialize)]
-struct CodexDonePayload {
+struct ResponsesDonePayload {
     #[serde(default)]
-    incomplete_details: Option<CodexIncompleteDetails>,
+    incomplete_details: Option<ResponsesIncompleteDetails>,
     #[serde(default)]
-    usage: Option<CodexUsage>,
+    usage: Option<ResponsesUsage>,
 }
 
-impl CodexDonePayload {
+impl ResponsesDonePayload {
     fn incomplete_reason(&self) -> Option<String> {
         self.incomplete_details
             .as_ref()
@@ -750,13 +785,13 @@ impl CodexDonePayload {
 }
 
 #[derive(Debug, Deserialize)]
-struct CodexIncompleteDetails {
+struct ResponsesIncompleteDetails {
     #[serde(default)]
     reason: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
-struct CodexUsage {
+struct ResponsesUsage {
     #[serde(default)]
     input_tokens: u32,
     #[serde(default)]
@@ -764,35 +799,35 @@ struct CodexUsage {
 }
 
 #[derive(Debug, Deserialize)]
-struct CodexFailedPayload {
+struct ResponsesFailedPayload {
     #[serde(default)]
-    error: Option<CodexErrorPayload>,
+    error: Option<ResponsesErrorPayload>,
 }
 
-impl CodexFailedPayload {
+impl ResponsesFailedPayload {
     fn error_message(&self) -> String {
         self.error
             .as_ref()
             .map(|error| error.message.clone())
-            .unwrap_or_else(|| "OpenAI Codex request failed".to_string())
+            .unwrap_or_else(|| "OpenAI Responses request failed".to_string())
     }
 }
 
 #[derive(Debug, Deserialize)]
-struct CodexErrorPayload {
+struct ResponsesErrorPayload {
     #[serde(default)]
     message: String,
 }
 
-fn resolve_codex_access_token() -> Option<String> {
-    std::env::var(OPENAI_CODEX_ACCESS_TOKEN_ENV)
+fn resolve_subscription_access_token() -> Option<String> {
+    std::env::var(OPENAI_RESPONSES_SUBSCRIPTION_TOKEN_ENV)
         .ok()
         .map(|value| value.trim().to_string())
         .filter(|value| !value.is_empty())
-        .or_else(read_cached_codex_access_token)
+        .or_else(read_cached_subscription_access_token)
 }
 
-fn read_cached_codex_access_token() -> Option<String> {
+fn read_cached_subscription_access_token() -> Option<String> {
     let home = dirs::home_dir()?;
     let candidates = [
         home.join(".codex").join("auth.json"),
@@ -802,7 +837,7 @@ fn read_cached_codex_access_token() -> Option<String> {
     for path in candidates {
         if let Ok(content) = std::fs::read_to_string(&path) {
             if let Ok(value) = serde_json::from_str::<Value>(&content) {
-                if let Some(token) = codex_access_token_from_value(&value) {
+                if let Some(token) = subscription_access_token_from_value(&value) {
                     return Some(token);
                 }
             }
@@ -812,7 +847,7 @@ fn read_cached_codex_access_token() -> Option<String> {
     None
 }
 
-fn codex_access_token_from_value(value: &Value) -> Option<String> {
+fn subscription_access_token_from_value(value: &Value) -> Option<String> {
     let candidates = [
         value
             .get("tokens")
@@ -886,7 +921,7 @@ mod tests {
     }
 
     #[test]
-    fn extracts_codex_access_token_from_cached_auth() {
+    fn extracts_subscription_access_token_from_cached_auth() {
         let value = serde_json::json!({
             "tokens": {
                 "access_token": "eyJhbGciOiJub25lIn0.payload.sig"
@@ -894,7 +929,7 @@ mod tests {
         });
 
         assert_eq!(
-            codex_access_token_from_value(&value).as_deref(),
+            subscription_access_token_from_value(&value).as_deref(),
             Some("eyJhbGciOiJub25lIn0.payload.sig")
         );
     }
@@ -907,12 +942,12 @@ mod tests {
             }
         });
 
-        assert!(codex_access_token_from_value(&value).is_none());
+        assert!(subscription_access_token_from_value(&value).is_none());
     }
 
     #[test]
     fn terminal_done_waits_for_late_tool_calls() {
-        let mut synth = CodexDeltaSynthesizer::new();
+        let mut synth = ResponsesDeltaSynthesizer::new();
 
         assert!(synth
             .process_event(r#"{"type":"response.function_call_arguments.delta","item_id":"fc_5","delta":"{\"text\":\"late tool\"}"}"#)


### PR DESCRIPTION
## Summary
- add an OpenAI Responses client module alongside the existing Chat Completions client inside `openai-client`, sharing the same HTTP, SSE, and error infrastructure
- support both API-key Responses auth (`openai-responses`) and ChatGPT subscription auth (`openai-codex`) by varying auth and endpoint selection inside the same client
- keep the sample `drua.yml` on the existing Anthropic default

## Testing
- `nix develop -c cargo check -p drua-cli`
- `nix develop -c cargo test -p openai-client responses -- --nocapture`
- `yq . drua.yml >/dev/null`