### PR TITLE
fix(toolset): add type-safe params to concourse and code_assistant tools

### DIFF
--- a/core/src/agent/session/compaction/mod.rs
+++ b/core/src/agent/session/compaction/mod.rs
@@ -571,5 +571,4 @@ mod tests {
         let result = transform_message_views(&messages, &plan, &HashMap::new());
         assert!(result.is_empty());
     }
-
 }

--- a/core/src/agent/session/history.rs
+++ b/core/src/agent/session/history.rs
@@ -353,7 +353,9 @@ fn resolve_message_view(
                             SandboxOperation::Detach => SandboxNotificationOp::Detach,
                         },
                     },
-                    _ => panic!("User view index does not point to UserText or SandboxNotification"),
+                    _ => {
+                        panic!("User view index does not point to UserText or SandboxNotification")
+                    }
                 })
                 .collect();
             ThreadMessage {
@@ -376,14 +378,16 @@ fn resolve_message_view(
                 .collect();
             // Look up metadata by the first block index in this assistant turn.
             let usage = block_indexes.first().and_then(|&first_idx| {
-                assistant_metadata.get(&first_idx).map(|meta| ThreadMessageUsage {
-                    model: meta.model.clone(),
-                    input_tokens: meta.usage.input,
-                    output_tokens: meta.usage.output,
-                    cache_read_tokens: meta.usage.cache_read,
-                    total_tokens: meta.usage.total_tokens,
-                    total_cost: meta.cost.total,
-                })
+                assistant_metadata
+                    .get(&first_idx)
+                    .map(|meta| ThreadMessageUsage {
+                        model: meta.model.clone(),
+                        input_tokens: meta.usage.input,
+                        output_tokens: meta.usage.output,
+                        cache_read_tokens: meta.usage.cache_read,
+                        total_tokens: meta.usage.total_tokens,
+                        total_cost: meta.cost.total,
+                    })
             });
             ThreadMessage {
                 role: ChatHistoryRole::Assistant,

--- a/core/src/code_assistant/mod.rs
+++ b/core/src/code_assistant/mod.rs
@@ -19,17 +19,17 @@ use std::time::Instant;
 use logs::CodeAssistantLogs;
 
 /// Parameters for a code search query.
-#[derive(Debug, serde::Deserialize)]
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SearchCodeParams {
-    /// The search query — use a code snippet for best results, not natural language
+    /// The search query. Pass a code snippet for best results — code-as-query gives much better similarity matches than natural language.
     pub query: String,
-    /// Maximum number of results to return (default: 5)
+    /// Maximum number of results to return (default: 5).
     pub limit: Option<u64>,
-    /// Filter results to a specific repository
+    /// Filter results to a specific repository name.
     pub repo: Option<String>,
-    /// Filter results to a specific language (e.g. 'rust', 'bats', 'bash')
+    /// Filter results to a specific language (e.g. 'rust', 'bats', 'bash').
     pub language: Option<String>,
-    /// Filter results to a specific primary label
+    /// Filter results to a specific primary label. Values: entity, entity_command, entity_query, entity_hydration, entity_event, published_event, new_entity, service_method, service, repository, error, authorization, value_object, domain_primitives, api, job, event_handler, type_conversion, test, config, none.
     pub label: Option<String>,
 }
 

--- a/core/src/toolset/searchable/code_assistant.rs
+++ b/core/src/toolset/searchable/code_assistant.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use rmcp::model::{CallToolResult, Content, JsonObject, Tool};
 
@@ -6,6 +6,47 @@ use crate::auth::AuthSubject;
 use crate::code_assistant::{CodeAssistant, SearchCodeParams};
 
 use super::super::{SearchableToolSet, ToolSetEntry, ToolSetsError};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn parse_params<T: serde::de::DeserializeOwned>(
+    arguments: Option<JsonObject>,
+) -> Result<T, ToolSetsError> {
+    let value = serde_json::Value::Object(arguments.unwrap_or_default());
+    serde_json::from_value(value).map_err(|e| ToolSetsError::InvalidArgument(e.to_string()))
+}
+
+fn schema_for<T: schemars::JsonSchema>() -> serde_json::Value {
+    let settings = schemars::gen::SchemaSettings::draft07().with(|s| {
+        s.inline_subschemas = true;
+        s.meta_schema = None;
+    });
+    let generator = settings.into_generator();
+    let schema = generator.into_root_schema_for::<T>();
+    let mut value = serde_json::to_value(schema).expect("schema serialization");
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("title");
+        obj.remove("definitions");
+        obj.insert(
+            "additionalProperties".into(),
+            serde_json::Value::Bool(false),
+        );
+    }
+    value
+}
+
+// ---------------------------------------------------------------------------
+// Schema
+// ---------------------------------------------------------------------------
+
+static SEARCH_CODE_SCHEMA: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<SearchCodeParams>);
+
+// ---------------------------------------------------------------------------
+// Toolset
+// ---------------------------------------------------------------------------
 
 pub struct CodeAssistantToolSet {
     service: Arc<CodeAssistant>,
@@ -31,33 +72,7 @@ impl CodeAssistantToolSet {
                 .into(),
         );
         tool.input_schema = Arc::new(
-            serde_json::from_value(serde_json::json!({
-                "type": "object",
-                "properties": {
-                    "query": {
-                        "type": "string",
-                        "description": "The search query. Pass a code snippet (e.g. the pattern you are about to write) for best results — code-as-query gives much better similarity matches than natural language"
-                    },
-                    "limit": {
-                        "type": "integer",
-                        "description": "Maximum number of results to return (default: 5)"
-                    },
-                    "repo": {
-                        "type": "string",
-                        "description": "Filter results to a specific repository name"
-                    },
-                    "language": {
-                        "type": "string",
-                        "description": "Filter results to a specific language (e.g. 'rust', 'bats', 'bash')"
-                    },
-                    "label": {
-                        "type": "string",
-                        "description": "Filter results to a specific primary label. Values: entity, entity_command, entity_query, entity_hydration, entity_event, published_event, new_entity, service_method, service, repository, error, authorization, value_object, domain_primitives, api, job, event_handler, type_conversion, test, config, none (unlabeled chunks)"
-                    }
-                },
-                "required": ["query"]
-            }))
-            .unwrap_or_default(),
+            serde_json::from_value((*SEARCH_CODE_SCHEMA).clone()).unwrap_or_default(),
         );
 
         let tools = vec![ToolSetEntry {
@@ -96,10 +111,7 @@ impl SearchableToolSet for CodeAssistantToolSet {
     ) -> Result<CallToolResult, ToolSetsError> {
         match tool_name {
             "search_code" => {
-                let params: SearchCodeParams = serde_json::from_value(serde_json::Value::Object(
-                    arguments.unwrap_or_default(),
-                ))
-                .map_err(|e| ToolSetsError::MissingArgument(e.to_string()))?;
+                let params: SearchCodeParams = parse_params(arguments)?;
                 let text = self
                     .service
                     .search(params)

--- a/core/src/toolset/searchable/code_assistant.rs
+++ b/core/src/toolset/searchable/code_assistant.rs
@@ -71,9 +71,8 @@ impl CodeAssistantToolSet {
                 .to_string()
                 .into(),
         );
-        tool.input_schema = Arc::new(
-            serde_json::from_value((*SEARCH_CODE_SCHEMA).clone()).unwrap_or_default(),
-        );
+        tool.input_schema =
+            Arc::new(serde_json::from_value((*SEARCH_CODE_SCHEMA).clone()).unwrap_or_default());
 
         let tools = vec![ToolSetEntry {
             name: "search_code".to_string(),

--- a/core/src/toolset/searchable/concourse.rs
+++ b/core/src/toolset/searchable/concourse.rs
@@ -121,12 +121,10 @@ static EMPTY_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
     })
 });
 
-static PIPELINE_SCHEMA: LazyLock<serde_json::Value> =
-    LazyLock::new(schema_for::<PipelineParams>);
+static PIPELINE_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<PipelineParams>);
 static PIPELINE_JOB_SCHEMA: LazyLock<serde_json::Value> =
     LazyLock::new(schema_for::<PipelineJobParams>);
-static BUILD_ID_SCHEMA: LazyLock<serde_json::Value> =
-    LazyLock::new(schema_for::<BuildIdParams>);
+static BUILD_ID_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<BuildIdParams>);
 static LIST_BUILDS_SCHEMA: LazyLock<serde_json::Value> =
     LazyLock::new(schema_for::<ListBuildsParams>);
 

--- a/core/src/toolset/searchable/concourse.rs
+++ b/core/src/toolset/searchable/concourse.rs
@@ -1,12 +1,138 @@
-use std::sync::Arc;
+use std::sync::{Arc, LazyLock};
 
 use concourse_client::ConcourseClient;
 use rmcp::model::{CallToolResult, Content, JsonObject, Tool};
+use serde::Deserialize;
 
 use crate::auth::AuthSubject;
 
 use super::super::filter::OutputFilter;
 use super::super::{SearchableToolSet, ToolSetEntry, ToolSetsError};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn parse_params<T: serde::de::DeserializeOwned>(
+    arguments: Option<JsonObject>,
+) -> Result<T, ToolSetsError> {
+    let value = serde_json::Value::Object(arguments.unwrap_or_default());
+    serde_json::from_value(value).map_err(|e| ToolSetsError::InvalidArgument(e.to_string()))
+}
+
+fn schema_for<T: schemars::JsonSchema>() -> serde_json::Value {
+    let settings = schemars::gen::SchemaSettings::draft07().with(|s| {
+        s.inline_subschemas = true;
+        s.meta_schema = None;
+    });
+    let generator = settings.into_generator();
+    let schema = generator.into_root_schema_for::<T>();
+    let mut value = serde_json::to_value(schema).expect("schema serialization");
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("title");
+        obj.remove("definitions");
+        obj.insert(
+            "additionalProperties".into(),
+            serde_json::Value::Bool(false),
+        );
+    }
+    value
+}
+
+/// Deserialize an `i64` from either a JSON number or a string like `"20"`.
+fn deserialize_liberal_i64<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<i64, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrInt {
+        Int(i64),
+        Str(String),
+    }
+    match StringOrInt::deserialize(deserializer)? {
+        StringOrInt::Int(v) => Ok(v),
+        StringOrInt::Str(s) => s.parse().map_err(serde::de::Error::custom),
+    }
+}
+
+/// Deserialize an `Option<i64>` from a JSON number, string, or null.
+fn deserialize_option_liberal_i64<'de, D: serde::Deserializer<'de>>(
+    deserializer: D,
+) -> Result<Option<i64>, D::Error> {
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrInt {
+        Int(i64),
+        Str(String),
+    }
+    let opt: Option<StringOrInt> = Option::deserialize(deserializer)?;
+    match opt {
+        None => Ok(None),
+        Some(StringOrInt::Int(v)) => Ok(Some(v)),
+        Some(StringOrInt::Str(s)) => s.parse().map(Some).map_err(serde::de::Error::custom),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Params
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct PipelineParams {
+    /// The pipeline name.
+    pipeline: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct PipelineJobParams {
+    /// The pipeline name.
+    pipeline: String,
+    /// The job name.
+    job: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct BuildIdParams {
+    /// The numeric build ID.
+    #[serde(deserialize_with = "deserialize_liberal_i64")]
+    build_id: i64,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct ListBuildsParams {
+    /// The pipeline name.
+    pipeline: String,
+    /// The job name.
+    job: String,
+    /// Max number of recent builds to return (default: 10).
+    #[serde(default, deserialize_with = "deserialize_option_liberal_i64")]
+    limit: Option<i64>,
+}
+
+// ---------------------------------------------------------------------------
+// Schemas
+// ---------------------------------------------------------------------------
+
+static EMPTY_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
+    serde_json::json!({
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false,
+    })
+});
+
+static PIPELINE_SCHEMA: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<PipelineParams>);
+static PIPELINE_JOB_SCHEMA: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<PipelineJobParams>);
+static BUILD_ID_SCHEMA: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<BuildIdParams>);
+static LIST_BUILDS_SCHEMA: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<ListBuildsParams>);
+
+// ---------------------------------------------------------------------------
+// Toolset
+// ---------------------------------------------------------------------------
 
 pub struct ConcourseToolSet {
     client: Arc<ConcourseClient>,
@@ -19,41 +145,22 @@ impl ConcourseToolSet {
             tool_entry(
                 "list_pipelines",
                 "List all accessible pipelines across all teams. Returns pipeline names, team, paused/archived status.",
-                serde_json::json!({"type": "object", "properties": {}}),
+                (*EMPTY_SCHEMA).clone(),
             ),
             tool_entry(
                 "list_jobs",
                 "List jobs in a Concourse pipeline. Returns job names, paused state, and last build status.",
-                serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "pipeline": {"type": "string", "description": "The pipeline name to list jobs for"}
-                    },
-                    "required": ["pipeline"]
-                }),
+                (*PIPELINE_SCHEMA).clone(),
             ),
             tool_entry(
                 "get_build_status",
                 "Get the latest build status for a specific job in a Concourse pipeline. Returns build ID, status, and timestamps.",
-                serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "pipeline": {"type": "string", "description": "The pipeline name"},
-                        "job": {"type": "string", "description": "The job name"}
-                    },
-                    "required": ["pipeline", "job"]
-                }),
+                (*PIPELINE_JOB_SCHEMA).clone(),
             ),
             tool_entry_with_filter(
                 "get_build_logs",
                 "Get build output/logs for a Concourse build by its numeric build ID. Returns log output as plain text. For in-flight builds, returns partial output — use get_build_status first to check if the build has finished. Output filtering (grep, tail, head) is handled by call_tool's output_filter parameter; default: tail 150 lines.",
-                serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "build_id": {"type": "integer", "description": "The numeric build ID"}
-                    },
-                    "required": ["build_id"]
-                }),
+                (*BUILD_ID_SCHEMA).clone(),
                 Some(OutputFilter {
                     tail: Some(150),
                     ..Default::default()
@@ -62,49 +169,22 @@ impl ConcourseToolSet {
             tool_entry(
                 "trigger_build",
                 "Trigger a new build for a job in a Concourse pipeline. Returns the new build ID and status.",
-                serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "pipeline": {"type": "string", "description": "The pipeline name"},
-                        "job": {"type": "string", "description": "The job name to trigger"}
-                    },
-                    "required": ["pipeline", "job"]
-                }),
+                (*PIPELINE_JOB_SCHEMA).clone(),
             ),
             tool_entry(
                 "get_pipeline_config",
                 "Get the job dependency graph for a Concourse pipeline. Returns each job's resource inputs with trigger and passed constraints, enabling critical path analysis from source to production.",
-                serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "pipeline": {"type": "string", "description": "The pipeline name"}
-                    },
-                    "required": ["pipeline"]
-                }),
+                (*PIPELINE_SCHEMA).clone(),
             ),
             tool_entry(
                 "list_builds_for_job",
                 "List recent builds for a job in a Concourse pipeline. Returns an array of builds (build_id, status, timestamps) ordered most recent first.",
-                serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "pipeline": {"type": "string", "description": "The pipeline name"},
-                        "job": {"type": "string", "description": "The job name"},
-                        "limit": {"type": "integer", "description": "Max number of recent builds to return (default: 10)"}
-                    },
-                    "required": ["pipeline", "job"]
-                }),
+                (*LIST_BUILDS_SCHEMA).clone(),
             ),
             tool_entry(
                 "get_build_resources",
                 "Get the resource versions (e.g. git commit SHA) that were inputs to a Concourse build. Use this to correlate a commit to the builds it triggered.",
-                serde_json::json!({
-                    "type": "object",
-                    "properties": {
-                        "build_id": {"type": "integer", "description": "The numeric build ID"}
-                    },
-                    "required": ["build_id"]
-                }),
+                (*BUILD_ID_SCHEMA).clone(),
             ),
         ];
 
@@ -139,7 +219,6 @@ impl SearchableToolSet for ConcourseToolSet {
         tool_name: &str,
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
-        let args = arguments.unwrap_or_default();
         match tool_name {
             "list_pipelines" => {
                 let pipelines = self.client.list_all_pipelines().await?;
@@ -158,8 +237,8 @@ impl SearchableToolSet for ConcourseToolSet {
                 Ok(text_result(&summary))
             }
             "list_jobs" => {
-                let pipeline = str_arg(&args, "pipeline")?;
-                let jobs = self.client.list_jobs(pipeline).await?;
+                let params: PipelineParams = parse_params(arguments)?;
+                let jobs = self.client.list_jobs(&params.pipeline).await?;
                 let summary: Vec<serde_json::Value> = jobs
                     .iter()
                     .map(|j| {
@@ -181,9 +260,11 @@ impl SearchableToolSet for ConcourseToolSet {
                 Ok(text_result(&summary))
             }
             "get_build_status" => {
-                let pipeline = str_arg(&args, "pipeline")?;
-                let job = str_arg(&args, "job")?;
-                let builds = self.client.list_job_builds(pipeline, job, Some(1)).await?;
+                let params: PipelineJobParams = parse_params(arguments)?;
+                let builds = self
+                    .client
+                    .list_job_builds(&params.pipeline, &params.job, Some(1))
+                    .await?;
                 let Some(latest) = builds.first() else {
                     return Ok(CallToolResult::success(vec![Content::text(
                         "No builds found for this job.",
@@ -203,8 +284,8 @@ impl SearchableToolSet for ConcourseToolSet {
                 )]))
             }
             "get_build_logs" => {
-                let build_id = int_arg(&args, "build_id")?;
-                let logs = self.client.get_build_logs(build_id).await?;
+                let params: BuildIdParams = parse_params(arguments)?;
+                let logs = self.client.get_build_logs(params.build_id).await?;
                 if logs.is_empty() {
                     return Ok(CallToolResult::success(vec![Content::text(
                         "No log output available for this build.",
@@ -213,9 +294,11 @@ impl SearchableToolSet for ConcourseToolSet {
                 Ok(CallToolResult::success(vec![Content::text(logs)]))
             }
             "trigger_build" => {
-                let pipeline = str_arg(&args, "pipeline")?;
-                let job = str_arg(&args, "job")?;
-                let build = self.client.trigger_build(pipeline, job).await?;
+                let params: PipelineJobParams = parse_params(arguments)?;
+                let build = self
+                    .client
+                    .trigger_build(&params.pipeline, &params.job)
+                    .await?;
                 let result = serde_json::json!({
                     "build_id": build.id,
                     "name": build.name,
@@ -228,8 +311,8 @@ impl SearchableToolSet for ConcourseToolSet {
                 )]))
             }
             "get_pipeline_config" => {
-                let pipeline = str_arg(&args, "pipeline")?;
-                let config = self.client.get_pipeline_config(pipeline).await?;
+                let params: PipelineParams = parse_params(arguments)?;
+                let config = self.client.get_pipeline_config(&params.pipeline).await?;
                 let jobs: Vec<serde_json::Value> = config
                     .config
                     .jobs
@@ -243,12 +326,11 @@ impl SearchableToolSet for ConcourseToolSet {
                 Ok(text_result(&jobs))
             }
             "list_builds_for_job" => {
-                let pipeline = str_arg(&args, "pipeline")?;
-                let job = str_arg(&args, "job")?;
-                let limit = args.get("limit").and_then(|v| v.as_i64()).unwrap_or(10) as usize;
+                let params: ListBuildsParams = parse_params(arguments)?;
+                let limit = params.limit.unwrap_or(10) as usize;
                 let builds = self
                     .client
-                    .list_job_builds(pipeline, job, Some(limit))
+                    .list_job_builds(&params.pipeline, &params.job, Some(limit))
                     .await?;
                 let summary: Vec<serde_json::Value> = builds
                     .iter()
@@ -265,8 +347,8 @@ impl SearchableToolSet for ConcourseToolSet {
                 Ok(text_result(&summary))
             }
             "get_build_resources" => {
-                let build_id = int_arg(&args, "build_id")?;
-                let resources = self.client.get_build_resources(build_id).await?;
+                let params: BuildIdParams = parse_params(arguments)?;
+                let resources = self.client.get_build_resources(params.build_id).await?;
                 let inputs: Vec<serde_json::Value> = resources
                     .inputs
                     .iter()
@@ -314,21 +396,6 @@ fn text_result(value: &[serde_json::Value]) -> CallToolResult {
     CallToolResult::success(vec![Content::text(
         serde_json::to_string_pretty(value).unwrap_or_default(),
     )])
-}
-
-fn str_arg<'a>(args: &'a JsonObject, key: &str) -> Result<&'a str, ToolSetsError> {
-    args.get(key)
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| ToolSetsError::MissingArgument(key.to_string()))
-}
-
-fn int_arg(args: &JsonObject, key: &str) -> Result<i64, ToolSetsError> {
-    args.get(key)
-        .and_then(|v| {
-            v.as_i64()
-                .or_else(|| v.as_str().and_then(|s| s.parse().ok()))
-        })
-        .ok_or_else(|| ToolSetsError::MissingArgument(key.to_string()))
 }
 
 fn extract_get_steps(plan: &[serde_json::Value], out: &mut Vec<serde_json::Value>) {

--- a/drua/src/tui/ui/grid.rs
+++ b/drua/src/tui/ui/grid.rs
@@ -45,7 +45,10 @@ fn section_active_columns(
             }
         }
     }
-    active.into_iter().map(|s| s.into_iter().collect()).collect()
+    active
+        .into_iter()
+        .map(|s| s.into_iter().collect())
+        .collect()
 }
 
 pub fn draw_thread_grid(frame: &mut Frame, state: &mut ScreenState, area: Rect) {
@@ -278,7 +281,12 @@ pub fn draw_thread_grid(frame: &mut Frame, state: &mut ScreenState, area: Rect) 
 }
 
 /// Render a non-empty cell symbol + connector into the span list.
-fn render_cell_span(spans: &mut Vec<Span<'static>>, cell: CellKind, is_cursor: bool, conn_str: &str) {
+fn render_cell_span(
+    spans: &mut Vec<Span<'static>>,
+    cell: CellKind,
+    is_cursor: bool,
+    conn_str: &str,
+) {
     let (sym, sym_color, bold) = cell_symbol(cell);
     let sym_style = if is_cursor {
         Style::default().fg(Color::Black).bg(Color::Yellow)
@@ -383,11 +391,7 @@ pub fn draw_position_detail(frame: &mut Frame, state: &ScreenState, area: Rect) 
         if let Some(detail) = grid.details.get(&(grid.cursor_row, grid.cursor_col)) {
             // Show usage summary before content so it's always visible.
             if let Some(ref usage) = detail.usage {
-                let model_short = usage
-                    .model
-                    .rsplit('/')
-                    .next()
-                    .unwrap_or(&usage.model);
+                let model_short = usage.model.rsplit('/').next().unwrap_or(&usage.model);
                 let cost_str = if usage.total_cost > 0.0 {
                     format!(" ${:.4}", usage.total_cost)
                 } else {

--- a/drua/src/tui/ui/mod.rs
+++ b/drua/src/tui/ui/mod.rs
@@ -71,9 +71,7 @@ fn draw_status_bar(frame: &mut Frame, state: &ScreenState, area: Rect) {
         Focus::Sidebar => " │ ↑/↓:nav  n:new  r:refresh  Tab:agents  q:quit ",
         Focus::Agents => " │ ↑/↓:nav  Enter:chat  Tab:chat  Esc:sidebar ",
         Focus::Chat => " │ Enter:send  Esc:sidebar  ↑/↓:scroll  ^T:threads ",
-        Focus::Threads => {
-            " │ ←→:pos  ↑↓:thread  Tab:next  g/G:jump  ^T:close  Esc:sidebar "
-        }
+        Focus::Threads => " │ ←→:pos  ↑↓:thread  Tab:next  g/G:jump  ^T:close  Esc:sidebar ",
     };
     spans.push(Span::styled(keys, Style::default().fg(Color::DarkGray)));
 


### PR DESCRIPTION
## Summary
- Replace raw `serde_json::json!()` schemas and manual `str_arg()`/`int_arg()` extraction in `concourse.rs` with typed param structs (`PipelineParams`, `PipelineJobParams`, `BuildIdParams`, `ListBuildsParams`), `schema_for<T>()`, and `parse_params<T>()`
- Replace hand-written JSON schema in `code_assistant.rs` with `schema_for::<SearchCodeParams>()` — the struct already existed for deserialization but the schema was inconsistent
- Add `schemars::JsonSchema` derive to `SearchCodeParams`
- Matches the pattern used by all other tools (admin, agent, sandbox, log, inspect, read, ls)

## Test plan
- [x] `cargo check -p drua-core` passes
- [x] All 119 existing tests pass (`cargo test -p drua-core`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)