### PR TITLE
Add LLM prompt caching support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3200,6 +3200,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "dirs",
+ "dotenvy",
  "futures",
  "llm",
  "reqwest 0.12.28",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,7 @@ name = "anthropic-client"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "dotenvy",
  "futures",
  "llm",
  "reqwest 0.12.28",

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ These are only needed when running specific integration tests:
 | Variable | Test File | Description |
 |---|---|---|
 | `ANTHROPIC_API_KEY` | `core/tests/prompt_executor.rs` | Anthropic round-trip test. |
+| `ANTHROPIC_API_KEY` + `DRUA_LIVE_CACHE_TESTS=1` | `lib/anthropic-client/tests/live_prompt_caching.rs` | Local-only Anthropic prompt-caching test. Loads `.env` when present and asserts cache creation on the warm request plus cache reads on a warmed follow-up request. |
 | `OPENAI_API_KEY` + `DRUA_LIVE_CACHE_TESTS=1` | `lib/openai-client/tests/live_prompt_caching.rs` | Local-only OpenAI Responses prompt-caching test. Loads `.env` when present and asserts cached prompt tokens are reported on a warmed follow-up request. |
 | `DATABASE_URL` | `core/tests/agent.rs` | Postgres URL for agent integration tests. |
 | `HONEYCOMB_AUTH_HEADER` | `core/tests/toolset.rs` | Auth header for MCP upstream toolset test. |

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ These are only needed when running specific integration tests:
 | Variable | Test File | Description |
 |---|---|---|
 | `ANTHROPIC_API_KEY` | `core/tests/prompt_executor.rs` | Anthropic round-trip test. |
+| `OPENAI_API_KEY` + `DRUA_LIVE_CACHE_TESTS=1` | `lib/openai-client/tests/live_prompt_caching.rs` | Local-only OpenAI Responses prompt-caching test. Loads `.env` when present and asserts cached prompt tokens are reported on a warmed follow-up request. |
 | `DATABASE_URL` | `core/tests/agent.rs` | Postgres URL for agent integration tests. |
 | `HONEYCOMB_AUTH_HEADER` | `core/tests/toolset.rs` | Auth header for MCP upstream toolset test. |
 

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -212,7 +212,7 @@ impl AgentSession {
                 prompt_definition: prompt_definition.clone(),
                 user_messages_view,
             });
-            return prompt_definition.into_prompt(target, &self.events);
+            return self.build_prompt(target, prompt_definition);
         }
         let thread_id = thread_id.unwrap();
 
@@ -312,7 +312,7 @@ impl AgentSession {
             user_messages_view,
         });
 
-        prompt_definition.into_prompt(target, &self.events)
+        self.build_prompt(target, prompt_definition)
     }
 
     pub fn update_tool_definitions(&mut self, tool_defs: Vec<ToolDefinition>) {
@@ -487,6 +487,16 @@ impl AgentSession {
         });
         self.current_main_thread = Some(thread_id);
         prompt_definition
+    }
+
+    fn build_prompt(
+        &self,
+        target: TargetThread,
+        prompt_definition: PromptDefinition,
+    ) -> Result<Prompt, AgentSessionError> {
+        let mut prompt = prompt_definition.into_prompt(target, &self.events)?;
+        prompt.cache_key = Some(format!("agent-session:{}", self.id));
+        Ok(prompt)
     }
 
     fn materialize(&self) -> MaterializedSession<'_> {
@@ -1001,6 +1011,11 @@ mod tests {
             .expect("next_prompt should succeed");
 
         assert_eq!(prompt.model, "test-model");
+        let expected_cache_key = format!("agent-session:{}", session.id);
+        assert_eq!(
+            prompt.cache_key.as_deref(),
+            Some(expected_cache_key.as_str())
+        );
 
         assert_eq!(prompt.system.len(), 1);
         assert!(

--- a/core/src/agent/session/message.rs
+++ b/core/src/agent/session/message.rs
@@ -24,6 +24,8 @@ pub struct Prompt {
     pub target_thread: TargetThread,
     pub model: String,
     pub max_tokens_per_response: u32,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_key: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub system: Vec<SystemBlock>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -122,6 +124,7 @@ impl From<Prompt> for llm::Prompt {
         llm::Prompt {
             model: p.model,
             max_tokens: Some(p.max_tokens_per_response),
+            cache_key: p.cache_key,
             system: p
                 .system
                 .into_iter()

--- a/core/src/agent/session/metadata.rs
+++ b/core/src/agent/session/metadata.rs
@@ -34,8 +34,8 @@ impl From<llm::response::Usage> for AssistantResponseMetadata {
             usage: Usage {
                 input: usage.input_tokens as u64,
                 output: usage.output_tokens as u64,
-                cache_read: 0,
-                cache_write: 0,
+                cache_read: usage.cache_read_input_tokens as u64,
+                cache_write: usage.cache_creation_input_tokens as u64,
                 total_tokens: (usage.input_tokens + usage.output_tokens) as u64,
             },
             cost: Cost::default(),

--- a/core/src/agent/session/view.rs
+++ b/core/src/agent/session/view.rs
@@ -383,6 +383,7 @@ impl PromptDefinition {
             target_thread,
             model: self.model,
             max_tokens_per_response: self.max_tokens_per_response,
+            cache_key: None,
             system,
             tools,
             messages: merged,

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -6,6 +6,7 @@ use tokio::task::JoinHandle;
 use tracing::instrument;
 
 use anthropic_client::AnthropicClient;
+use llm::prompt::CacheTtl;
 use llm::provider::LlmProvider;
 use llm::{Prompt, PromptError, PromptRequest, PromptRequestChannel, PromptResponseChannel};
 use openai_client::{
@@ -234,6 +235,7 @@ impl ExecutorState {
                 if request.prompt.max_tokens.is_none() {
                     request.prompt.max_tokens = model.default_max_tokens;
                 }
+                request.prompt = model.prepare_prompt(request.prompt);
                 let client = model.client.clone();
                 tokio::spawn(async move {
                     evaluate_streaming(client, request.prompt, request.response_channel).await;
@@ -279,27 +281,140 @@ async fn evaluate_streaming(
 struct ResolvedModel {
     name: String,
     default_max_tokens: Option<u32>,
+    provider_kind: ResolvedProviderKind,
     client: Arc<dyn LlmProvider>,
+}
+
+#[derive(Clone, Copy)]
+enum ResolvedProviderKind {
+    Anthropic,
+    OpenAi,
+    OpenAiResponses,
 }
 
 impl ResolvedModel {
     fn from_config(config: ModelConfig) -> Self {
-        let client: Arc<dyn LlmProvider> = match config.provider {
-            Provider::Anthropic { api_key } => Arc::new(AnthropicClient::new(api_key)),
-            Provider::OpenAi { api_key } => Arc::new(OpenAiClient::new(api_key)),
-            Provider::OpenAiResponses { auth } => {
+        let (provider_kind, client): (ResolvedProviderKind, Arc<dyn LlmProvider>) = match config
+            .provider
+        {
+            Provider::Anthropic { api_key } => (
+                ResolvedProviderKind::Anthropic,
+                Arc::new(AnthropicClient::new(api_key)),
+            ),
+            Provider::OpenAi { api_key } => (
+                ResolvedProviderKind::OpenAi,
+                Arc::new(OpenAiClient::new(api_key)),
+            ),
+            Provider::OpenAiResponses { auth } => (
+                ResolvedProviderKind::OpenAiResponses,
                 Arc::new(OpenAiResponsesClient::new(match auth {
                     OpenAiResponsesAuth::ApiKey { api_key } => {
                         ClientOpenAiResponsesAuth::ApiKey { api_key }
                     }
                     OpenAiResponsesAuth::Subscription => ClientOpenAiResponsesAuth::Subscription,
-                }))
-            }
+                })),
+            ),
         };
         Self {
             name: config.name,
             default_max_tokens: config.default_max_tokens,
+            provider_kind,
             client,
+        }
+    }
+
+    fn prepare_prompt(&self, mut prompt: Prompt) -> Prompt {
+        if matches!(self.provider_kind, ResolvedProviderKind::Anthropic) {
+            prompt.enable_anthropic_prompt_caching(Some(CacheTtl::FiveMinutes));
+        }
+        prompt
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use llm::prompt::{AssistantBlock, CacheControl, Message, UserBlock};
+
+    fn sample_prompt() -> Prompt {
+        Prompt {
+            model: "test-model".to_string(),
+            system: Vec::new(),
+            messages: vec![Message::Assistant {
+                content: vec![
+                    AssistantBlock::Thinking {
+                        text: "thinking".to_string(),
+                        signature: None,
+                    },
+                    AssistantBlock::Text {
+                        text: "visible".to_string(),
+                        cache_control: None,
+                    },
+                ],
+            }],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: None,
+            cache_key: Some("agent-session:test".to_string()),
+        }
+    }
+
+    #[test]
+    fn prepare_prompt_marks_anthropic_cache_breakpoint() {
+        let model = ResolvedModel {
+            name: "test-model".to_string(),
+            default_max_tokens: None,
+            provider_kind: ResolvedProviderKind::Anthropic,
+            client: Arc::new(AnthropicClient::new("test")),
+        };
+
+        let prompt = model.prepare_prompt(sample_prompt());
+        match &prompt.messages[0] {
+            Message::Assistant { content } => {
+                assert!(matches!(
+                    &content[1],
+                    AssistantBlock::Text {
+                        cache_control: Some(CacheControl::Ephemeral {
+                            ttl: Some(CacheTtl::FiveMinutes)
+                        }),
+                        ..
+                    }
+                ));
+            }
+            _ => panic!("expected assistant message"),
+        }
+    }
+
+    #[test]
+    fn prepare_prompt_leaves_openai_prompt_unmarked() {
+        let model = ResolvedModel {
+            name: "test-model".to_string(),
+            default_max_tokens: None,
+            provider_kind: ResolvedProviderKind::OpenAi,
+            client: Arc::new(OpenAiClient::new("test")),
+        };
+
+        let prompt = model.prepare_prompt(Prompt {
+            messages: vec![Message::User {
+                content: vec![UserBlock::Text {
+                    text: "hello".to_string(),
+                    cache_control: None,
+                }],
+            }],
+            ..sample_prompt()
+        });
+
+        match &prompt.messages[0] {
+            Message::User { content } => {
+                assert!(matches!(
+                    &content[0],
+                    UserBlock::Text {
+                        cache_control: None,
+                        ..
+                    }
+                ));
+            }
+            _ => panic!("expected user message"),
         }
     }
 }

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -93,6 +93,8 @@ async fn send_message_round_trip_via_prompt_channel() {
             usage: Usage {
                 input_tokens: 5,
                 output_tokens: 3,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
             },
             stop_reason: None,
         })))
@@ -255,6 +257,8 @@ async fn send_message_dispatches_registered_tool_call() {
             usage: Usage {
                 input_tokens: 7,
                 output_tokens: 4,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
             },
             stop_reason: Some(StopReason::ToolUse),
         })))
@@ -276,6 +280,8 @@ async fn send_message_dispatches_registered_tool_call() {
             usage: Usage {
                 input_tokens: 9,
                 output_tokens: 2,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
             },
             stop_reason: None,
         })))

--- a/core/tests/prompt_executor.rs
+++ b/core/tests/prompt_executor.rs
@@ -33,6 +33,7 @@ async fn anthropic_round_trip_via_executor() {
         tools: Vec::new(),
         tool_choice: None,
         max_tokens: None, // executor should fill this in from default_max_tokens
+        cache_key: None,
     };
 
     let (request, response_rx) = PromptRequest::new(prompt);

--- a/lib/anthropic-client/Cargo.toml
+++ b/lib/anthropic-client/Cargo.toml
@@ -13,3 +13,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+dotenvy = "0.15"

--- a/lib/anthropic-client/src/convert.rs
+++ b/lib/anthropic-client/src/convert.rs
@@ -190,8 +190,12 @@ pub(crate) fn accumulated_to_response(acc: AccumulatedResponse) -> PromptRespons
 
     // Truncate u64 → u32 (safe for realistic token counts).
     let usage = Usage {
-        input_tokens: acc.usage.input_tokens as u32,
+        input_tokens: (acc.usage.input_tokens
+            + acc.usage.cache_read_tokens
+            + acc.usage.cache_write_tokens) as u32,
         output_tokens: acc.usage.output_tokens as u32,
+        cache_read_input_tokens: acc.usage.cache_read_tokens as u32,
+        cache_creation_input_tokens: acc.usage.cache_write_tokens as u32,
     };
 
     PromptResponse {
@@ -258,10 +262,28 @@ impl AnthropicDeltaConverter {
 
         Ok(match event {
             AnthropicStreamEvent::MessageStart { message } => {
-                let input_tokens = message.usage.map(|u| u.input as u32).unwrap_or(0);
+                let input_tokens = message
+                    .usage
+                    .as_ref()
+                    .map(|u| {
+                        (u.input + u.cache_read.unwrap_or(0) + u.cache_write.unwrap_or(0)) as u32
+                    })
+                    .unwrap_or(0);
+                let cache_read_input_tokens = message
+                    .usage
+                    .as_ref()
+                    .and_then(|u| u.cache_read)
+                    .unwrap_or(0) as u32;
+                let cache_creation_input_tokens = message
+                    .usage
+                    .as_ref()
+                    .and_then(|u| u.cache_write)
+                    .unwrap_or(0) as u32;
                 vec![StreamDelta::Usage {
                     input_tokens,
                     output_tokens: 0,
+                    cache_read_input_tokens,
+                    cache_creation_input_tokens,
                 }]
             }
             AnthropicStreamEvent::ContentBlockStart {
@@ -323,6 +345,8 @@ impl AnthropicDeltaConverter {
                     deltas.push(StreamDelta::Usage {
                         input_tokens: 0,
                         output_tokens: u.output_tokens as u32,
+                        cache_read_input_tokens: 0,
+                        cache_creation_input_tokens: 0,
                     });
                 }
                 let stop_reason = delta.stop_reason.map(|sr| match sr {

--- a/lib/anthropic-client/tests/live_prompt_caching.rs
+++ b/lib/anthropic-client/tests/live_prompt_caching.rs
@@ -1,0 +1,146 @@
+use std::env;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use anthropic_client::AnthropicClient;
+use llm::prompt::{CacheTtl, Message, SystemBlock, UserBlock};
+use llm::Prompt;
+
+const LIVE_TESTS_ENV: &str = "DRUA_LIVE_CACHE_TESTS";
+const API_KEY_ENV: &str = "ANTHROPIC_API_KEY";
+const MODEL_ENV: &str = "DRUA_ANTHROPIC_CACHE_TEST_MODEL";
+const DEFAULT_MODEL: &str = "claude-haiku-4-5-20251001";
+const MIN_CACHEABLE_TOKENS: usize = 6000;
+
+fn env_flag(name: &str) -> bool {
+    env::var(name).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes"
+        )
+    })
+}
+
+fn maybe_load_dotenv() {
+    let _ = dotenvy::dotenv();
+}
+
+fn unique_nonce() -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{}-{timestamp}", std::process::id())
+}
+
+fn build_prompt(model: &str, system_text: String, user_text: impl Into<String>) -> Prompt {
+    Prompt {
+        model: model.to_string(),
+        messages: vec![Message::User {
+            content: vec![UserBlock::Text {
+                text: user_text.into(),
+                cache_control: None,
+            }],
+        }],
+        system: vec![SystemBlock::Text {
+            text: system_text,
+            cache_control: None,
+        }],
+        tools: Vec::new(),
+        tool_choice: None,
+        max_tokens: Some(64),
+        cache_key: None,
+    }
+}
+
+fn build_large_system_prefix(model: &str, nonce: &str) -> String {
+    let mut prefix = String::new();
+    let mut line = 0usize;
+
+    loop {
+        line += 1;
+        prefix.push_str(
+            format!(
+                "Anthropic prompt cache integration test nonce {nonce} line {line:04}. \
+                 Preserve this exact prefix so prompt caching can reuse the \
+                 same prompt prefix across follow-up requests.\n"
+            )
+            .as_str(),
+        );
+
+        let probe = build_prompt(model, prefix.clone(), "Reply with the word: probe");
+        if probe.estimate_tokens() >= MIN_CACHEABLE_TOKENS {
+            return prefix;
+        }
+    }
+}
+
+#[tokio::test]
+async fn anthropic_reports_cache_write_then_cache_read_on_follow_up_prompt() {
+    maybe_load_dotenv();
+
+    if !env_flag(LIVE_TESTS_ENV) {
+        eprintln!("Set {LIVE_TESTS_ENV}=1 to run live prompt caching tests");
+        return;
+    }
+
+    let Ok(api_key) = env::var(API_KEY_ENV) else {
+        eprintln!("{API_KEY_ENV} not set, skipping live prompt caching test");
+        return;
+    };
+    let model = env::var(MODEL_ENV).unwrap_or_else(|_| DEFAULT_MODEL.to_string());
+
+    let nonce = unique_nonce();
+    let system_text = build_large_system_prefix(&model, &nonce);
+    let client = AnthropicClient::new(api_key);
+
+    let mut warm_prompt = build_prompt(
+        &model,
+        system_text.clone(),
+        "Reply with the single word: seeded",
+    );
+    assert!(
+        warm_prompt.enable_anthropic_prompt_caching(Some(CacheTtl::FiveMinutes)),
+        "expected prompt caching marker to be applied"
+    );
+    let warm_response = client
+        .send_prompt(&warm_prompt)
+        .await
+        .expect("warm request should succeed");
+    assert!(
+        !warm_response.content.is_empty(),
+        "expected content from warm request"
+    );
+    assert!(
+        warm_response.usage.cache_creation_input_tokens > 0,
+        "expected warm request to create a cache entry, got {:?}",
+        warm_response.usage
+    );
+
+    let mut cache_reads = Vec::new();
+    for attempt in 0..3 {
+        let mut prompt = build_prompt(
+            &model,
+            system_text.clone(),
+            format!("Reply with the single word: warmed-{attempt}"),
+        );
+        assert!(
+            prompt.enable_anthropic_prompt_caching(Some(CacheTtl::FiveMinutes)),
+            "expected prompt caching marker to be applied"
+        );
+
+        let response = client
+            .send_prompt(&prompt)
+            .await
+            .expect("follow-up request should succeed");
+        cache_reads.push(response.usage.cache_read_input_tokens);
+        if response.usage.cache_read_input_tokens > 0 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    panic!(
+        "expected cached input tokens on a warmed follow-up prompt, got {:?}",
+        cache_reads
+    );
+}

--- a/lib/anthropic-client/tests/live_prompt_caching.rs
+++ b/lib/anthropic-client/tests/live_prompt_caching.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anthropic_client::AnthropicClient;
-use llm::prompt::{CacheTtl, Message, SystemBlock, UserBlock};
+use llm::prompt::{CacheControl, CacheTtl, Message, SystemBlock, UserBlock};
 use llm::Prompt;
 
 const LIVE_TESTS_ENV: &str = "DRUA_LIVE_CACHE_TESTS";
@@ -52,6 +52,15 @@ fn build_prompt(model: &str, system_text: String, user_text: impl Into<String>) 
     }
 }
 
+fn mark_system_prefix_for_cache(prompt: &mut Prompt) {
+    let Some(SystemBlock::Text { cache_control, .. }) = prompt.system.last_mut() else {
+        panic!("expected a system block to mark for Anthropic prompt caching");
+    };
+    *cache_control = Some(CacheControl::Ephemeral {
+        ttl: Some(CacheTtl::FiveMinutes),
+    });
+}
+
 fn build_large_system_prefix(model: &str, nonce: &str) -> String {
     let mut prefix = String::new();
     let mut line = 0usize;
@@ -98,10 +107,11 @@ async fn anthropic_reports_cache_write_then_cache_read_on_follow_up_prompt() {
         system_text.clone(),
         "Reply with the single word: seeded",
     );
-    assert!(
-        warm_prompt.enable_anthropic_prompt_caching(Some(CacheTtl::FiveMinutes)),
-        "expected prompt caching marker to be applied"
-    );
+    // For this standalone two-request test, cache only the static system
+    // prefix. The generic helper marks the last cacheable block, which is
+    // correct for append-only conversations but would include the varying user
+    // message here and prevent cache hits.
+    mark_system_prefix_for_cache(&mut warm_prompt);
     let warm_response = client
         .send_prompt(&warm_prompt)
         .await
@@ -123,10 +133,7 @@ async fn anthropic_reports_cache_write_then_cache_read_on_follow_up_prompt() {
             system_text.clone(),
             format!("Reply with the single word: warmed-{attempt}"),
         );
-        assert!(
-            prompt.enable_anthropic_prompt_caching(Some(CacheTtl::FiveMinutes)),
-            "expected prompt caching marker to be applied"
-        );
+        mark_system_prefix_for_cache(&mut prompt);
 
         let response = client
             .send_prompt(&prompt)

--- a/lib/llm/src/prompt.rs
+++ b/lib/llm/src/prompt.rs
@@ -13,6 +13,8 @@ pub struct Prompt {
     pub tool_choice: Option<ToolChoice>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cache_key: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -148,7 +150,9 @@ impl Prompt {
     /// primary use-case is cache keys — strings are directly usable in file
     /// names, database columns, and log output without further conversion.
     pub fn hash(&self) -> String {
-        let value = serde_json::to_value(self).expect("Prompt is always serializable");
+        let mut prompt = self.clone();
+        prompt.cache_key = None;
+        let value = serde_json::to_value(prompt).expect("Prompt is always serializable");
         let canonical = canonicalize(&value);
         let bytes = serde_json::to_vec(&canonical).expect("canonical Value is always serializable");
         let digest = Sha256::digest(&bytes);
@@ -229,6 +233,93 @@ impl Prompt {
 
         total
     }
+
+    /// Mark the largest reusable Anthropic prefix with a single explicit cache
+    /// breakpoint. Anthropic automatically checks earlier block boundaries
+    /// before this explicit marker, so append-only chat histories only need the
+    /// final cacheable block marked.
+    pub fn enable_anthropic_prompt_caching(&mut self, ttl: Option<CacheTtl>) -> bool {
+        self.clear_cache_controls();
+        let marker = Some(CacheControl::Ephemeral { ttl });
+
+        for message in self.messages.iter_mut().rev() {
+            match message {
+                Message::User { content } => {
+                    for block in content.iter_mut().rev() {
+                        match block {
+                            UserBlock::Text { cache_control, .. }
+                            | UserBlock::ToolResult { cache_control, .. } => {
+                                *cache_control = marker.clone();
+                                return true;
+                            }
+                        }
+                    }
+                }
+                Message::Assistant { content } => {
+                    for block in content.iter_mut().rev() {
+                        match block {
+                            AssistantBlock::Text { cache_control, .. }
+                            | AssistantBlock::ToolUse { cache_control, .. } => {
+                                *cache_control = marker.clone();
+                                return true;
+                            }
+                            AssistantBlock::Thinking { .. } => {}
+                        }
+                    }
+                }
+            }
+        }
+
+        if let Some(SystemBlock::Text { cache_control, .. }) = self.system.last_mut() {
+            *cache_control = marker.clone();
+            return true;
+        }
+
+        if let Some(tool) = self.tools.last_mut() {
+            tool.cache_control = marker;
+            return true;
+        }
+
+        false
+    }
+
+    fn clear_cache_controls(&mut self) {
+        for block in &mut self.system {
+            match block {
+                SystemBlock::Text { cache_control, .. } => *cache_control = None,
+            }
+        }
+
+        for tool in &mut self.tools {
+            tool.cache_control = None;
+        }
+
+        for message in &mut self.messages {
+            match message {
+                Message::User { content } => {
+                    for block in content {
+                        match block {
+                            UserBlock::Text { cache_control, .. }
+                            | UserBlock::ToolResult { cache_control, .. } => {
+                                *cache_control = None;
+                            }
+                        }
+                    }
+                }
+                Message::Assistant { content } => {
+                    for block in content {
+                        match block {
+                            AssistantBlock::Text { cache_control, .. }
+                            | AssistantBlock::ToolUse { cache_control, .. } => {
+                                *cache_control = None;
+                            }
+                            AssistantBlock::Thinking { .. } => {}
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -262,6 +353,7 @@ mod tests {
             }],
             tool_choice: None,
             max_tokens: Some(1024),
+            cache_key: None,
         }
     }
 
@@ -307,6 +399,7 @@ mod tests {
             tools: vec![],
             tool_choice: None,
             max_tokens: None,
+            cache_key: None,
         };
 
         assert_eq!(make(input_a).hash(), make(input_b).hash());
@@ -331,5 +424,58 @@ mod tests {
         let mut without_tools = sample_prompt("Hi");
         without_tools.tools.clear();
         assert!(with_tools.estimate_tokens() > without_tools.estimate_tokens());
+    }
+
+    #[test]
+    fn hash_ignores_cache_key() {
+        let mut a = sample_prompt("hello");
+        let mut b = sample_prompt("hello");
+        a.cache_key = Some("session-a".to_string());
+        b.cache_key = Some("session-b".to_string());
+
+        assert_eq!(a.hash(), b.hash());
+    }
+
+    #[test]
+    fn enable_anthropic_prompt_caching_marks_last_cacheable_block() {
+        let mut prompt = Prompt {
+            model: "claude-sonnet-4-20250514".to_string(),
+            system: vec![SystemBlock::Text {
+                text: "sys".to_string(),
+                cache_control: None,
+            }],
+            messages: vec![Message::Assistant {
+                content: vec![
+                    AssistantBlock::Thinking {
+                        text: "thinking".to_string(),
+                        signature: None,
+                    },
+                    AssistantBlock::Text {
+                        text: "visible".to_string(),
+                        cache_control: None,
+                    },
+                ],
+            }],
+            tools: Vec::new(),
+            tool_choice: None,
+            max_tokens: None,
+            cache_key: None,
+        };
+
+        assert!(prompt.enable_anthropic_prompt_caching(Some(CacheTtl::FiveMinutes)));
+        match &prompt.messages[0] {
+            Message::Assistant { content } => {
+                assert!(matches!(
+                    &content[1],
+                    AssistantBlock::Text {
+                        cache_control: Some(CacheControl::Ephemeral {
+                            ttl: Some(CacheTtl::FiveMinutes)
+                        }),
+                        ..
+                    }
+                ));
+            }
+            _ => panic!("expected assistant message"),
+        }
     }
 }

--- a/lib/llm/src/prompt.rs
+++ b/lib/llm/src/prompt.rs
@@ -245,26 +245,25 @@ impl Prompt {
         for message in self.messages.iter_mut().rev() {
             match message {
                 Message::User { content } => {
-                    for block in content.iter_mut().rev() {
-                        match block {
-                            UserBlock::Text { cache_control, .. }
-                            | UserBlock::ToolResult { cache_control, .. } => {
-                                *cache_control = marker.clone();
-                                return true;
-                            }
-                        }
+                    if let Some(
+                        UserBlock::Text { cache_control, .. }
+                        | UserBlock::ToolResult { cache_control, .. },
+                    ) = content.last_mut()
+                    {
+                        *cache_control = marker.clone();
+                        return true;
                     }
                 }
                 Message::Assistant { content } => {
-                    for block in content.iter_mut().rev() {
-                        match block {
+                    if let Some(cache_control) =
+                        content.iter_mut().rev().find_map(|block| match block {
                             AssistantBlock::Text { cache_control, .. }
-                            | AssistantBlock::ToolUse { cache_control, .. } => {
-                                *cache_control = marker.clone();
-                                return true;
-                            }
-                            AssistantBlock::Thinking { .. } => {}
-                        }
+                            | AssistantBlock::ToolUse { cache_control, .. } => Some(cache_control),
+                            AssistantBlock::Thinking { .. } => None,
+                        })
+                    {
+                        *cache_control = marker.clone();
+                        return true;
                     }
                 }
             }

--- a/lib/llm/src/response.rs
+++ b/lib/llm/src/response.rs
@@ -15,8 +15,15 @@ pub struct PromptResponse {
 
 #[derive(Debug, Clone, Copy, Default, Serialize, Deserialize)]
 pub struct Usage {
+    /// Total input tokens seen by the model. Providers that expose cache hits
+    /// or cache writes separately should still populate this with the full
+    /// prompt token count so downstream accounting stays consistent.
     pub input_tokens: u32,
     pub output_tokens: u32,
+    #[serde(default)]
+    pub cache_read_input_tokens: u32,
+    #[serde(default)]
+    pub cache_creation_input_tokens: u32,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/lib/llm/src/stream.rs
+++ b/lib/llm/src/stream.rs
@@ -33,6 +33,8 @@ pub enum StreamDelta {
     Usage {
         input_tokens: u32,
         output_tokens: u32,
+        cache_read_input_tokens: u32,
+        cache_creation_input_tokens: u32,
     },
     /// The stream is complete.
     Done { stop_reason: Option<StopReason> },
@@ -117,9 +119,13 @@ impl StreamAccumulator {
             StreamDelta::Usage {
                 input_tokens,
                 output_tokens,
+                cache_read_input_tokens,
+                cache_creation_input_tokens,
             } => {
                 self.usage.input_tokens += *input_tokens;
                 self.usage.output_tokens += *output_tokens;
+                self.usage.cache_read_input_tokens += *cache_read_input_tokens;
+                self.usage.cache_creation_input_tokens += *cache_creation_input_tokens;
             }
             StreamDelta::Done { stop_reason } => {
                 self.stop_reason = *stop_reason;
@@ -196,6 +202,8 @@ mod tests {
         acc.process(&StreamDelta::Usage {
             input_tokens: 10,
             output_tokens: 0,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
         });
         acc.process(&StreamDelta::TextDelta {
             text: "Hello".to_string(),
@@ -206,6 +214,8 @@ mod tests {
         acc.process(&StreamDelta::Usage {
             input_tokens: 0,
             output_tokens: 5,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
         });
         acc.process(&StreamDelta::Done {
             stop_reason: Some(StopReason::EndTurn),
@@ -241,6 +251,8 @@ mod tests {
         acc.process(&StreamDelta::Usage {
             input_tokens: 0,
             output_tokens: 20,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
         });
         acc.process(&StreamDelta::Done {
             stop_reason: Some(StopReason::ToolUse),
@@ -294,6 +306,8 @@ mod tests {
         acc.process(&StreamDelta::Usage {
             input_tokens: 15,
             output_tokens: 0,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
         });
         // Thinking
         acc.process(&StreamDelta::ThinkingDelta {
@@ -315,6 +329,8 @@ mod tests {
         acc.process(&StreamDelta::Usage {
             input_tokens: 0,
             output_tokens: 30,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
         });
         acc.process(&StreamDelta::Done {
             stop_reason: Some(StopReason::ToolUse),
@@ -410,6 +426,8 @@ mod tests {
         acc.process(&StreamDelta::Usage {
             input_tokens: 100,
             output_tokens: 0,
+            cache_read_input_tokens: 80,
+            cache_creation_input_tokens: 20,
         });
         acc.process(&StreamDelta::TextDelta {
             text: "hi".to_string(),
@@ -417,6 +435,8 @@ mod tests {
         acc.process(&StreamDelta::Usage {
             input_tokens: 0,
             output_tokens: 50,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
         });
         acc.process(&StreamDelta::Done {
             stop_reason: Some(StopReason::EndTurn),
@@ -425,5 +445,7 @@ mod tests {
         let resp = acc.finish();
         assert_eq!(resp.usage.input_tokens, 100);
         assert_eq!(resp.usage.output_tokens, 50);
+        assert_eq!(resp.usage.cache_read_input_tokens, 80);
+        assert_eq!(resp.usage.cache_creation_input_tokens, 20);
     }
 }

--- a/lib/openai-client/Cargo.toml
+++ b/lib/openai-client/Cargo.toml
@@ -15,3 +15,6 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+dotenvy = "0.15"

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -55,6 +55,7 @@ pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> OpenAiRequest {
     OpenAiRequest {
         model: prompt.model.clone(),
         messages,
+        prompt_cache_key: prompt.cache_key.clone(),
         max_completion_tokens: prompt.max_tokens,
         temperature: None,
         tools,
@@ -226,9 +227,16 @@ impl DeltaSynthesizer {
         // Usage chunk (OpenAI sends it in a separate chunk when
         // stream_options.include_usage is true).
         if let Some(usage) = &chunk.usage {
+            let cached_tokens = usage
+                .prompt_tokens_details
+                .as_ref()
+                .map(|details| details.cached_tokens)
+                .unwrap_or(0);
             deltas.push(StreamDelta::Usage {
                 input_tokens: usage.prompt_tokens,
                 output_tokens: usage.completion_tokens,
+                cache_read_input_tokens: cached_tokens,
+                cache_creation_input_tokens: 0,
             });
         }
 
@@ -320,6 +328,7 @@ mod tests {
             }],
             tool_choice: None,
             max_tokens: Some(1024),
+            cache_key: None,
         }
     }
 
@@ -334,9 +343,19 @@ mod tests {
         assert_eq!(req.messages[0].role, "system");
         assert_eq!(req.messages[1].role, "user");
         assert_eq!(req.max_completion_tokens, Some(1024));
+        assert!(req.prompt_cache_key.is_none());
         assert!(req.tools.is_some());
         assert_eq!(req.tools.as_ref().unwrap().len(), 1);
         assert_eq!(req.tools.as_ref().unwrap()[0].function.name, "get_weather");
+    }
+
+    #[test]
+    fn prompt_to_request_includes_prompt_cache_key() {
+        let mut prompt = sample_prompt();
+        prompt.cache_key = Some("agent-session:test".to_string());
+
+        let req = prompt_to_request(&prompt);
+        assert_eq!(req.prompt_cache_key.as_deref(), Some("agent-session:test"));
     }
 
     #[test]
@@ -367,6 +386,7 @@ mod tests {
             tools: vec![],
             tool_choice: None,
             max_tokens: None,
+            cache_key: None,
         };
 
         let req = prompt_to_request(&prompt);
@@ -398,6 +418,7 @@ mod tests {
             tools: vec![],
             tool_choice: None,
             max_tokens: None,
+            cache_key: None,
         };
 
         let req = prompt_to_request(&prompt);
@@ -456,7 +477,9 @@ mod tests {
             d,
             StreamDelta::Usage {
                 input_tokens: 10,
-                output_tokens: 5
+                output_tokens: 5,
+                cache_read_input_tokens: 0,
+                cache_creation_input_tokens: 0,
             }
         )));
         assert!(deltas.iter().any(|d| matches!(

--- a/lib/openai-client/src/responses.rs
+++ b/lib/openai-client/src/responses.rs
@@ -221,6 +221,8 @@ struct ResponsesRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     instructions: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    prompt_cache_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     max_output_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     tools: Option<Vec<ResponsesTool>>,
@@ -305,6 +307,7 @@ fn prompt_to_responses_request(prompt: &Prompt, auth: &OpenAiResponsesAuth) -> R
         model: prompt.model.clone(),
         input,
         instructions: (!instructions.is_empty()).then_some(instructions),
+        prompt_cache_key: prompt.cache_key.clone(),
         max_output_tokens: match auth {
             OpenAiResponsesAuth::ApiKey { .. } => {
                 prompt.max_tokens.or(Some(DEFAULT_MAX_OUTPUT_TOKENS))
@@ -441,7 +444,7 @@ struct ResponsesDeltaSynthesizer {
     text: String,
     thinking: String,
     tool_calls: HashMap<String, ToolCallState>,
-    pending_usage: Option<(u32, u32)>,
+    pending_usage: Option<PendingUsage>,
     pending_incomplete_reason: Option<String>,
     saw_tool_call: bool,
     terminal_emitted: bool,
@@ -453,6 +456,13 @@ struct ToolCallState {
     name: String,
     arguments: String,
     started: bool,
+}
+
+#[derive(Debug, Clone, Copy)]
+struct PendingUsage {
+    input_tokens: u32,
+    output_tokens: u32,
+    cached_input_tokens: u32,
 }
 
 impl ResponsesDeltaSynthesizer {
@@ -489,10 +499,15 @@ impl ResponsesDeltaSynthesizer {
             ResponsesResponseEvent::ResponseCompleted { response }
             | ResponsesResponseEvent::ResponseDone { response }
             | ResponsesResponseEvent::ResponseIncomplete { response } => {
-                self.pending_usage = response
-                    .usage
-                    .as_ref()
-                    .map(|usage| (usage.input_tokens, usage.output_tokens));
+                self.pending_usage = response.usage.as_ref().map(|usage| PendingUsage {
+                    input_tokens: usage.input_tokens,
+                    output_tokens: usage.output_tokens,
+                    cached_input_tokens: usage
+                        .input_tokens_details
+                        .as_ref()
+                        .map(|details| details.cached_tokens)
+                        .unwrap_or(0),
+                });
                 self.pending_incomplete_reason = response.incomplete_reason();
                 Ok(Vec::new())
             }
@@ -668,7 +683,12 @@ impl ResponsesDeltaSynthesizer {
             return Ok(Vec::new());
         }
 
-        let Some((input_tokens, output_tokens)) = self.pending_usage else {
+        let Some(PendingUsage {
+            input_tokens,
+            output_tokens,
+            cached_input_tokens,
+        }) = self.pending_usage
+        else {
             return Err("OpenAI Responses stream ended without terminal response".to_string());
         };
 
@@ -677,6 +697,8 @@ impl ResponsesDeltaSynthesizer {
             StreamDelta::Usage {
                 input_tokens,
                 output_tokens,
+                cache_read_input_tokens: cached_input_tokens,
+                cache_creation_input_tokens: 0,
             },
             StreamDelta::Done {
                 stop_reason: Some(self.stop_reason()),
@@ -827,7 +849,15 @@ struct ResponsesUsage {
     #[serde(default)]
     input_tokens: u32,
     #[serde(default)]
+    input_tokens_details: Option<ResponsesInputTokensDetails>,
+    #[serde(default)]
     output_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponsesInputTokensDetails {
+    #[serde(default)]
+    cached_tokens: u32,
 }
 
 #[derive(Debug, Deserialize)]
@@ -943,6 +973,7 @@ mod tests {
             tools: Vec::new(),
             tool_choice: None,
             max_tokens: Some(1234),
+            cache_key: None,
         }
     }
 
@@ -1003,7 +1034,7 @@ mod tests {
             .unwrap()
             .is_empty());
         assert!(synth
-            .process_event(r#"{"type":"response.completed","response":{"incomplete_details":null,"usage":{"input_tokens":1,"output_tokens":1}}}"#)
+            .process_event(r#"{"type":"response.completed","response":{"incomplete_details":null,"usage":{"input_tokens":1,"input_tokens_details":{"cached_tokens":1},"output_tokens":1}}}"#)
             .unwrap()
             .is_empty());
 
@@ -1016,6 +1047,15 @@ mod tests {
         )));
 
         let terminal = synth.process_event("[DONE]").unwrap();
+        assert!(terminal.iter().any(|delta| matches!(
+            delta,
+            StreamDelta::Usage {
+                input_tokens: 1,
+                output_tokens: 1,
+                cache_read_input_tokens: 1,
+                cache_creation_input_tokens: 0,
+            }
+        )));
         assert!(terminal.iter().any(|delta| matches!(
             delta,
             StreamDelta::Done {
@@ -1046,6 +1086,25 @@ mod tests {
         assert!(
             value.get("max_output_tokens").is_none(),
             "subscription endpoint should not receive max_output_tokens"
+        );
+    }
+
+    #[test]
+    fn requests_include_prompt_cache_key_when_present() {
+        let mut prompt = sample_prompt();
+        prompt.cache_key = Some("agent-session:test".to_string());
+
+        let request = prompt_to_responses_request(
+            &prompt,
+            &OpenAiResponsesAuth::ApiKey {
+                api_key: "sk-test".to_string(),
+            },
+        );
+
+        let value = serde_json::to_value(request).expect("request serializes");
+        assert_eq!(
+            value["prompt_cache_key"],
+            serde_json::json!("agent-session:test")
         );
     }
 }

--- a/lib/openai-client/src/types.rs
+++ b/lib/openai-client/src/types.rs
@@ -16,6 +16,8 @@ pub(crate) struct OpenAiRequest {
     pub model: String,
     pub messages: Vec<OpenAiMessage>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt_cache_key: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_completion_tokens: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub temperature: Option<f32>,
@@ -138,4 +140,12 @@ pub(crate) struct OpenAiUsage {
     pub prompt_tokens: u32,
     #[serde(default)]
     pub completion_tokens: u32,
+    #[serde(default)]
+    pub prompt_tokens_details: Option<OpenAiPromptTokensDetails>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiPromptTokensDetails {
+    #[serde(default)]
+    pub cached_tokens: u32,
 }

--- a/lib/openai-client/tests/live_prompt_caching.rs
+++ b/lib/openai-client/tests/live_prompt_caching.rs
@@ -1,0 +1,159 @@
+use std::env;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use llm::prompt::{Message, SystemBlock, UserBlock};
+use llm::provider::LlmProvider;
+use llm::stream::StreamAccumulator;
+use llm::{Prompt, PromptResponse};
+use openai_client::{OpenAiResponsesAuth, OpenAiResponsesClient};
+
+const LIVE_TESTS_ENV: &str = "DRUA_LIVE_CACHE_TESTS";
+const API_KEY_ENV: &str = "OPENAI_API_KEY";
+const MODEL_ENV: &str = "DRUA_OPENAI_CACHE_TEST_MODEL";
+const DEFAULT_MODEL: &str = "gpt-5.4-mini";
+const MIN_CACHEABLE_TOKENS: usize = 1400;
+
+fn env_flag(name: &str) -> bool {
+    env::var(name).is_ok_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes"
+        )
+    })
+}
+
+fn maybe_load_dotenv() {
+    let _ = dotenvy::dotenv();
+}
+
+fn unique_nonce() -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_nanos();
+    format!("{}-{timestamp}", std::process::id())
+}
+
+fn build_prompt(
+    model: &str,
+    cache_key: &str,
+    system_text: String,
+    user_text: impl Into<String>,
+) -> Prompt {
+    Prompt {
+        model: model.to_string(),
+        messages: vec![Message::User {
+            content: vec![UserBlock::Text {
+                text: user_text.into(),
+                cache_control: None,
+            }],
+        }],
+        system: vec![SystemBlock::Text {
+            text: system_text,
+            cache_control: None,
+        }],
+        tools: Vec::new(),
+        tool_choice: None,
+        max_tokens: Some(64),
+        cache_key: Some(cache_key.to_string()),
+    }
+}
+
+fn build_large_system_prefix(model: &str, nonce: &str) -> String {
+    let mut prefix = String::new();
+    let mut line = 0usize;
+
+    loop {
+        line += 1;
+        prefix.push_str(
+            format!(
+                "Prompt cache integration test nonce {nonce} line {line:04}. \
+                 Reuse this exact prefix across requests so the provider can \
+                 skip rebuilding the shared KV state.\n"
+            )
+            .as_str(),
+        );
+
+        let probe = build_prompt(model, "probe", prefix.clone(), "Reply with the word: probe");
+        if probe.estimate_tokens() >= MIN_CACHEABLE_TOKENS {
+            return prefix;
+        }
+    }
+}
+
+async fn send_prompt(
+    client: &OpenAiResponsesClient,
+    prompt: &Prompt,
+) -> Result<PromptResponse, String> {
+    let mut rx = client
+        .send_prompt_streaming(prompt)
+        .await
+        .map_err(|err| err.to_string())?;
+
+    let mut accumulator = StreamAccumulator::new();
+    while let Some(event) = rx.recv().await {
+        let delta = event.map_err(|err| err.to_string())?;
+        accumulator.process(&delta);
+    }
+
+    Ok(accumulator.finish())
+}
+
+#[tokio::test]
+async fn openai_responses_reports_cached_tokens_on_follow_up_prompt() {
+    maybe_load_dotenv();
+
+    if !env_flag(LIVE_TESTS_ENV) {
+        eprintln!("Set {LIVE_TESTS_ENV}=1 to run live prompt caching tests");
+        return;
+    }
+
+    let Ok(api_key) = env::var(API_KEY_ENV) else {
+        eprintln!("{API_KEY_ENV} not set, skipping live prompt caching test");
+        return;
+    };
+    let model = env::var(MODEL_ENV).unwrap_or_else(|_| DEFAULT_MODEL.to_string());
+
+    let nonce = unique_nonce();
+    let cache_key = format!("drua-live-cache-test:{nonce}");
+    let system_text = build_large_system_prefix(&model, &nonce);
+
+    let client = OpenAiResponsesClient::new(OpenAiResponsesAuth::ApiKey { api_key });
+
+    let warm_prompt = build_prompt(
+        &model,
+        &cache_key,
+        system_text.clone(),
+        "Reply with the single word: seeded",
+    );
+    let warm_response = send_prompt(&client, &warm_prompt)
+        .await
+        .expect("warm request should succeed");
+    assert!(
+        !warm_response.content.is_empty(),
+        "expected content from warm request"
+    );
+
+    let mut cache_reads = Vec::new();
+    for attempt in 0..3 {
+        let prompt = build_prompt(
+            &model,
+            &cache_key,
+            system_text.clone(),
+            format!("Reply with the single word: warmed-{attempt}"),
+        );
+        let response = send_prompt(&client, &prompt)
+            .await
+            .expect("follow-up request should succeed");
+        cache_reads.push(response.usage.cache_read_input_tokens);
+        if response.usage.cache_read_input_tokens > 0 {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    panic!(
+        "expected cached input tokens on a warmed follow-up prompt, got {:?}",
+        cache_reads
+    );
+}


### PR DESCRIPTION
## Summary
- add a session-stable prompt cache key so OpenAI follow-up requests can reuse cached prompt prefixes
- mark the last cacheable Anthropic prompt block before dispatch so append-only conversations benefit from provider-side prompt caching
- preserve cached token read/write usage through streaming and response metadata for downstream accounting

## Testing
- cargo test -p llm -p openai-client -p anthropic-client -p drua-core