### PR TITLE
feat(drua): add configurable keybinding map with on-screen help

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1327,6 +1327,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
 ]
 
 [[package]]

--- a/drua/Cargo.toml
+++ b/drua/Cargo.toml
@@ -19,3 +19,4 @@ ratatui = { workspace = true }
 crossterm = { workspace = true, features = ["event-stream"] }
 libc = { workspace = true }
 futures = { workspace = true }
+toml = { workspace = true }

--- a/drua/src/commands/dashboard.rs
+++ b/drua/src/commands/dashboard.rs
@@ -16,6 +16,7 @@ use tokio::sync::mpsc;
 use crate::config::Config;
 use crate::graphql::GraphqlClient;
 use crate::tui::chat::{ChatMessage, ChatRole, ContentBlock};
+use crate::tui::keybindings::Keybindings;
 use crate::tui::state::{
     AgentItem, BlockDetail, CellKind, Focus, SandboxInfo, ScreenState, ThreadGridState, ThreadInfo,
     UsageDetail, WorkspaceItem,
@@ -908,7 +909,17 @@ pub async fn run(server: Option<String>) -> Result<()> {
     let (config, client, user_name) = ensure_authenticated(server).await?;
     let workspaces = fetch_workspaces(&client).await?;
 
-    let mut state = ScreenState::new(workspaces, config.server_url.clone(), user_name);
+    let keybindings_path = dirs::home_dir()
+        .map(|h| h.join(".drua").join("keybindings.toml"))
+        .unwrap_or_default();
+    let keybindings = Keybindings::load(&keybindings_path);
+
+    let mut state = ScreenState::new(
+        workspaces,
+        config.server_url.clone(),
+        user_name,
+        keybindings,
+    );
 
     enable_raw_mode()?;
     let mut stdout = io::stdout();

--- a/drua/src/tui/handlers.rs
+++ b/drua/src/tui/handlers.rs
@@ -16,32 +16,36 @@ pub enum Action {
 
 /// Top-level key dispatcher — routes to mode/focus-specific handlers.
 pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
-    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    let kb = &state.keybindings;
 
-    if ctrl {
-        match key.code {
-            KeyCode::Char('c') => return Action::Quit,
-            KeyCode::Char('z') => return Action::Suspend,
-            // Ctrl+O — jump to lead agent chat (global, like command-center)
-            KeyCode::Char('o') => {
-                state.select_lead_and_focus_chat();
-                return Action::None;
-            }
-            // Ctrl+R — refresh workspaces
-            KeyCode::Char('r') => return Action::Refresh,
-            // Ctrl+H / Ctrl+L — focus left / right
-            KeyCode::Char('h') => {
-                state.focus_left();
-                return Action::None;
-            }
-            KeyCode::Char('l') => {
-                state.focus_right();
-                return Action::None;
-            }
-            // Ctrl+T — toggle thread explorer
-            KeyCode::Char('t') => return Action::ToggleThreads,
-            _ => {}
-        }
+    // ── Global bindings (checked first, regardless of mode/focus) ────
+    if kb.global.quit.matches(&key) {
+        return Action::Quit;
+    }
+    if kb.global.suspend.matches(&key) {
+        return Action::Suspend;
+    }
+    if kb.global.focus_lead.matches(&key) {
+        state.select_lead_and_focus_chat();
+        return Action::None;
+    }
+    if kb.global.refresh.matches(&key) {
+        return Action::Refresh;
+    }
+    if kb.global.focus_left.matches(&key) {
+        state.focus_left();
+        return Action::None;
+    }
+    if kb.global.focus_right.matches(&key) {
+        state.focus_right();
+        return Action::None;
+    }
+    if kb.global.toggle_threads.matches(&key) {
+        return Action::ToggleThreads;
+    }
+    if kb.global.show_help.matches(&key) {
+        state.show_help = !state.show_help;
+        return Action::None;
     }
 
     match state.mode {
@@ -58,138 +62,135 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
 
 fn handle_sidebar_key(state: &mut ScreenState, key: KeyEvent) -> Action {
     state.status_message = None;
-    match key.code {
-        KeyCode::Char('q') => Action::Quit,
-        KeyCode::Char('j') | KeyCode::Down => {
-            state.cursor_down();
-            Action::None
-        }
-        KeyCode::Char('k') | KeyCode::Up => {
-            state.cursor_up();
-            Action::None
-        }
-        KeyCode::Enter => {
-            state.select_lead_and_focus_chat();
-            Action::None
-        }
-        KeyCode::Char('n') => {
-            state.enter_create_mode();
-            Action::None
-        }
-        KeyCode::Tab => {
-            state.toggle_focus();
-            Action::None
-        }
-        _ => Action::None,
+    let kb = &state.keybindings.sidebar;
+
+    if kb.quit.matches(&key) {
+        return Action::Quit;
     }
+    if kb.navigate_down.matches(&key) {
+        state.cursor_down();
+        return Action::None;
+    }
+    if kb.navigate_up.matches(&key) {
+        state.cursor_up();
+        return Action::None;
+    }
+    if kb.select.matches(&key) {
+        state.select_lead_and_focus_chat();
+        return Action::None;
+    }
+    if kb.new_workspace.matches(&key) {
+        state.enter_create_mode();
+        return Action::None;
+    }
+    if kb.toggle_focus.matches(&key) {
+        state.toggle_focus();
+        return Action::None;
+    }
+    Action::None
 }
 
 fn handle_agents_key(state: &mut ScreenState, key: KeyEvent) -> Action {
     state.status_message = None;
-    match key.code {
-        KeyCode::Char('j') | KeyCode::Down => {
-            state.agent_cursor_down();
-            Action::None
-        }
-        KeyCode::Char('k') | KeyCode::Up => {
-            state.agent_cursor_up();
-            Action::None
-        }
-        KeyCode::Tab => {
-            state.toggle_focus();
-            Action::None
-        }
-        KeyCode::Esc => {
-            state.focus = Focus::Sidebar;
-            Action::None
-        }
-        KeyCode::Enter => {
-            // Close thread view so chat pane is visible, switch to chat for typing
-            state.thread_view = None;
-            state.focus = Focus::Chat;
-            Action::None
-        }
-        _ => Action::None,
+    let kb = &state.keybindings.agents;
+
+    if kb.navigate_down.matches(&key) {
+        state.agent_cursor_down();
+        return Action::None;
     }
+    if kb.navigate_up.matches(&key) {
+        state.agent_cursor_up();
+        return Action::None;
+    }
+    if kb.toggle_focus.matches(&key) {
+        state.toggle_focus();
+        return Action::None;
+    }
+    if kb.back.matches(&key) {
+        state.focus = Focus::Sidebar;
+        return Action::None;
+    }
+    if kb.open_chat.matches(&key) {
+        // Close thread view so chat pane is visible, switch to chat for typing
+        state.thread_view = None;
+        state.focus = Focus::Chat;
+        return Action::None;
+    }
+    Action::None
 }
 
 fn handle_chat_key(state: &mut ScreenState, key: KeyEvent) -> Action {
-    match key.code {
-        KeyCode::Esc => {
-            state.focus = Focus::Sidebar;
-            Action::None
-        }
-        KeyCode::Tab => {
-            state.toggle_focus();
-            Action::None
-        }
-        KeyCode::Enter => {
-            let input = state.chat_input.trim().to_string();
-            if input.is_empty() {
-                return Action::None;
-            }
-            send_chat_to_selected_agent(state, input)
-        }
-        KeyCode::Up => {
-            state.chat_view.scroll_up();
-            Action::None
-        }
-        KeyCode::Down => {
-            state.chat_view.scroll_down();
-            Action::None
-        }
-        _ => {
-            handle_input_editing(state, &key);
-            Action::None
-        }
+    let kb = &state.keybindings.chat;
+
+    if kb.back.matches(&key) {
+        state.focus = Focus::Sidebar;
+        return Action::None;
     }
+    if kb.toggle_focus.matches(&key) {
+        state.toggle_focus();
+        return Action::None;
+    }
+    if kb.send.matches(&key) {
+        let input = state.chat_input.trim().to_string();
+        if input.is_empty() {
+            return Action::None;
+        }
+        return send_chat_to_selected_agent(state, input);
+    }
+    if kb.scroll_up.matches(&key) {
+        state.chat_view.scroll_up();
+        return Action::None;
+    }
+    if kb.scroll_down.matches(&key) {
+        state.chat_view.scroll_down();
+        return Action::None;
+    }
+
+    // Fall through to text input editing
+    handle_input_editing(state, &key);
+    Action::None
 }
 
 fn handle_threads_key(state: &mut ScreenState, key: KeyEvent) -> Action {
-    match key.code {
-        // ←→ navigate positions (columns)
-        KeyCode::Left | KeyCode::Char('h') => {
-            state.grid_move_left();
-            Action::None
-        }
-        KeyCode::Right | KeyCode::Char('l') => {
-            state.grid_move_right();
-            Action::None
-        }
-        // ↑↓ navigate threads (rows)
-        KeyCode::Up | KeyCode::Char('k') => {
-            state.grid_move_up();
-            Action::None
-        }
-        KeyCode::Down | KeyCode::Char('j') => {
-            state.grid_move_down();
-            Action::None
-        }
-        // g/G — jump to start/end of positions
-        KeyCode::Char('g') => {
-            state.grid_jump_start();
-            Action::None
-        }
-        KeyCode::Char('G') => {
-            state.grid_jump_end();
-            Action::None
-        }
-        // Tab — jump to next unique/summary cell
-        KeyCode::Tab => {
-            state.grid_tab_next();
-            Action::None
-        }
-        // e — export thread to file
-        KeyCode::Char('e') => {
-            state.enter_export_mode();
-            Action::None
-        }
-        KeyCode::Esc => {
-            state.focus = Focus::Sidebar;
-            Action::None
-        }
-        _ => Action::None,
+    let kb = &state.keybindings.threads;
+
+    if kb.navigate_left.matches(&key) {
+        state.grid_move_left();
+        return Action::None;
     }
+    if kb.navigate_right.matches(&key) {
+        state.grid_move_right();
+        return Action::None;
+    }
+    if kb.navigate_up.matches(&key) {
+        state.grid_move_up();
+        return Action::None;
+    }
+    if kb.navigate_down.matches(&key) {
+        state.grid_move_down();
+        return Action::None;
+    }
+    if kb.jump_start.matches(&key) {
+        state.grid_jump_start();
+        return Action::None;
+    }
+    if kb.jump_end.matches(&key) {
+        state.grid_jump_end();
+        return Action::None;
+    }
+    if kb.tab_next.matches(&key) {
+        state.grid_tab_next();
+        return Action::None;
+    }
+    if kb.export.matches(&key) {
+        state.enter_export_mode();
+        return Action::None;
+    }
+    if kb.back.matches(&key) {
+        state.focus = Focus::Sidebar;
+        return Action::None;
+    }
+    Action::None
 }
 
 // ── Shared input editing ────────────────────────────────────────────
@@ -214,34 +215,37 @@ fn handle_input_editing(state: &mut ScreenState, key: &KeyEvent) {
 }
 
 fn handle_create_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    let kb = &state.keybindings.create_workspace;
+
+    if kb.cancel.matches(&key) {
+        state.exit_create_mode();
+        return Action::None;
+    }
+    if kb.switch_field.matches(&key) {
+        state.input_field = (state.input_field + 1) % 2;
+        return Action::None;
+    }
+    if kb.confirm.matches(&key) {
+        if state.input_name.trim().is_empty() {
+            state.status_message = Some("Name is required".to_string());
+            return Action::None;
+        }
+        let name = state.input_name.trim().to_string();
+        let description = state.input_description.trim().to_string();
+        return Action::CreateWorkspace { name, description };
+    }
+
+    // Fall through to character input for the create form
     match key.code {
-        KeyCode::Esc => {
-            state.exit_create_mode();
-            Action::None
-        }
-        KeyCode::Tab | KeyCode::BackTab => {
-            state.input_field = (state.input_field + 1) % 2;
-            Action::None
-        }
         KeyCode::Backspace => {
             state.active_input_mut().pop();
-            Action::None
         }
         KeyCode::Char(c) => {
             state.active_input_mut().push(c);
-            Action::None
         }
-        KeyCode::Enter => {
-            if state.input_name.trim().is_empty() {
-                state.status_message = Some("Name is required".to_string());
-                return Action::None;
-            }
-            let name = state.input_name.trim().to_string();
-            let description = state.input_description.trim().to_string();
-            Action::CreateWorkspace { name, description }
-        }
-        _ => Action::None,
+        _ => {}
     }
+    Action::None
 }
 
 fn handle_export_key(state: &mut ScreenState, key: KeyEvent) -> Action {

--- a/drua/src/tui/keybindings.rs
+++ b/drua/src/tui/keybindings.rs
@@ -1,0 +1,541 @@
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use serde::de::{self, Deserializer, SeqAccess, Visitor};
+use serde::Deserialize;
+use std::fmt;
+use std::path::Path;
+
+/// A single key combination: a key code plus zero or more modifiers.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct KeyCombo {
+    pub code: KeyCode,
+    pub modifiers: KeyModifiers,
+}
+
+impl KeyCombo {
+    fn new(code: KeyCode, modifiers: KeyModifiers) -> Self {
+        Self { code, modifiers }
+    }
+
+    fn matches(&self, key: &KeyEvent) -> bool {
+        if key.code != self.code {
+            return false;
+        }
+        // BackTab is inherently Shift+Tab — crossterm always sets the SHIFT
+        // modifier for it, so ignore SHIFT when matching BackTab.
+        if self.code == KeyCode::BackTab {
+            return key.modifiers & !KeyModifiers::SHIFT == self.modifiers;
+        }
+        key.modifiers == self.modifiers
+    }
+
+    /// Parse a string like `"Ctrl+C"`, `"Enter"`, `"j"` into a KeyCombo.
+    fn parse(s: &str) -> Result<Self, String> {
+        let parts: Vec<&str> = s.split('+').collect();
+        if parts.is_empty() {
+            return Err("empty key string".to_string());
+        }
+
+        let key_str = parts.last().unwrap().trim();
+        let mut modifiers = KeyModifiers::empty();
+
+        for &part in &parts[..parts.len() - 1] {
+            match part.trim().to_lowercase().as_str() {
+                "ctrl" | "control" => modifiers |= KeyModifiers::CONTROL,
+                "shift" => modifiers |= KeyModifiers::SHIFT,
+                "alt" => modifiers |= KeyModifiers::ALT,
+                other => return Err(format!("unknown modifier: {other}")),
+            }
+        }
+
+        let code = parse_key_code(key_str)?;
+        Ok(Self { code, modifiers })
+    }
+}
+
+fn parse_key_code(s: &str) -> Result<KeyCode, String> {
+    match s.to_lowercase().as_str() {
+        "enter" | "return" => Ok(KeyCode::Enter),
+        "esc" | "escape" => Ok(KeyCode::Esc),
+        "tab" => Ok(KeyCode::Tab),
+        "backtab" => Ok(KeyCode::BackTab),
+        "backspace" => Ok(KeyCode::Backspace),
+        "delete" | "del" => Ok(KeyCode::Delete),
+        "up" => Ok(KeyCode::Up),
+        "down" => Ok(KeyCode::Down),
+        "left" => Ok(KeyCode::Left),
+        "right" => Ok(KeyCode::Right),
+        "home" => Ok(KeyCode::Home),
+        "end" => Ok(KeyCode::End),
+        "pageup" => Ok(KeyCode::PageUp),
+        "pagedown" => Ok(KeyCode::PageDown),
+        "space" => Ok(KeyCode::Char(' ')),
+        s if s.len() == 1 => Ok(KeyCode::Char(s.chars().next().unwrap())),
+        other => Err(format!("unknown key: {other}")),
+    }
+}
+
+/// One or more key combos that all trigger the same action.
+#[derive(Clone, Debug)]
+pub struct Binding(Vec<KeyCombo>);
+
+impl Binding {
+    fn single(code: KeyCode, modifiers: KeyModifiers) -> Self {
+        Self(vec![KeyCombo::new(code, modifiers)])
+    }
+
+    fn keys(combos: Vec<KeyCombo>) -> Self {
+        Self(combos)
+    }
+
+    pub fn matches(&self, key: &KeyEvent) -> bool {
+        self.0.iter().any(|combo| combo.matches(key))
+    }
+
+    /// Format all key combos joined with `/`, e.g. "j/Down".
+    pub fn hint_all(&self) -> String {
+        self.0
+            .iter()
+            .map(|c| c.to_string())
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+}
+
+impl fmt::Display for KeyCombo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.code == KeyCode::BackTab {
+            return write!(f, "S-Tab");
+        }
+        if self.modifiers.contains(KeyModifiers::CONTROL) {
+            write!(f, "^")?;
+        }
+        if self.modifiers.contains(KeyModifiers::ALT) {
+            write!(f, "Alt+")?;
+        }
+        if self.modifiers.contains(KeyModifiers::SHIFT) {
+            write!(f, "S-")?;
+        }
+        match self.code {
+            KeyCode::Char(' ') => write!(f, "Space"),
+            KeyCode::Char(c) if self.modifiers.contains(KeyModifiers::CONTROL) => {
+                write!(f, "{}", c.to_ascii_uppercase())
+            }
+            KeyCode::Char(c) => write!(f, "{c}"),
+            KeyCode::Enter => write!(f, "Enter"),
+            KeyCode::Esc => write!(f, "Esc"),
+            KeyCode::Tab => write!(f, "Tab"),
+            KeyCode::Backspace => write!(f, "\u{232b}"),
+            KeyCode::Delete => write!(f, "Del"),
+            KeyCode::Up => write!(f, "Up"),
+            KeyCode::Down => write!(f, "Down"),
+            KeyCode::Left => write!(f, "Left"),
+            KeyCode::Right => write!(f, "Right"),
+            KeyCode::PageUp => write!(f, "PgUp"),
+            KeyCode::PageDown => write!(f, "PgDn"),
+            KeyCode::Home => write!(f, "Home"),
+            KeyCode::End => write!(f, "End"),
+            _ => write!(f, "?"),
+        }
+    }
+}
+
+impl fmt::Display for Binding {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if let Some(combo) = self.0.first() {
+            write!(f, "{combo}")
+        } else {
+            Ok(())
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for Binding {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct BindingVisitor;
+
+        impl<'de> Visitor<'de> for BindingVisitor {
+            type Value = Binding;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a key string or array of key strings")
+            }
+
+            fn visit_str<E: de::Error>(self, v: &str) -> Result<Binding, E> {
+                let combo = KeyCombo::parse(v).map_err(de::Error::custom)?;
+                Ok(Binding(vec![combo]))
+            }
+
+            fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Binding, A::Error> {
+                let mut combos = Vec::new();
+                while let Some(s) = seq.next_element::<String>()? {
+                    combos.push(KeyCombo::parse(&s).map_err(de::Error::custom)?);
+                }
+                if combos.is_empty() {
+                    return Err(de::Error::custom("empty key binding array"));
+                }
+                Ok(Binding(combos))
+            }
+        }
+
+        deserializer.deserialize_any(BindingVisitor)
+    }
+}
+
+// ── Section structs ──────────────────────────────────────────────
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct GlobalBindings {
+    pub quit: Binding,
+    pub suspend: Binding,
+    pub focus_lead: Binding,
+    pub refresh: Binding,
+    pub focus_left: Binding,
+    pub focus_right: Binding,
+    pub toggle_threads: Binding,
+    pub show_help: Binding,
+}
+
+impl Default for GlobalBindings {
+    fn default() -> Self {
+        Self {
+            quit: Binding::single(KeyCode::Char('c'), KeyModifiers::CONTROL),
+            suspend: Binding::single(KeyCode::Char('z'), KeyModifiers::CONTROL),
+            focus_lead: Binding::single(KeyCode::Char('o'), KeyModifiers::CONTROL),
+            refresh: Binding::single(KeyCode::Char('r'), KeyModifiers::CONTROL),
+            focus_left: Binding::single(KeyCode::Char('h'), KeyModifiers::CONTROL),
+            focus_right: Binding::single(KeyCode::Char('l'), KeyModifiers::CONTROL),
+            toggle_threads: Binding::single(KeyCode::Char('t'), KeyModifiers::CONTROL),
+            show_help: Binding::single(KeyCode::Char('?'), KeyModifiers::empty()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct SidebarBindings {
+    pub quit: Binding,
+    pub navigate_down: Binding,
+    pub navigate_up: Binding,
+    pub select: Binding,
+    pub new_workspace: Binding,
+    pub toggle_focus: Binding,
+}
+
+impl Default for SidebarBindings {
+    fn default() -> Self {
+        Self {
+            quit: Binding::single(KeyCode::Char('q'), KeyModifiers::empty()),
+            navigate_down: Binding::keys(vec![
+                KeyCombo::new(KeyCode::Char('j'), KeyModifiers::empty()),
+                KeyCombo::new(KeyCode::Down, KeyModifiers::empty()),
+            ]),
+            navigate_up: Binding::keys(vec![
+                KeyCombo::new(KeyCode::Char('k'), KeyModifiers::empty()),
+                KeyCombo::new(KeyCode::Up, KeyModifiers::empty()),
+            ]),
+            select: Binding::single(KeyCode::Enter, KeyModifiers::empty()),
+            new_workspace: Binding::single(KeyCode::Char('n'), KeyModifiers::empty()),
+            toggle_focus: Binding::single(KeyCode::Tab, KeyModifiers::empty()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct AgentsBindings {
+    pub navigate_down: Binding,
+    pub navigate_up: Binding,
+    pub toggle_focus: Binding,
+    pub back: Binding,
+    pub open_chat: Binding,
+}
+
+impl Default for AgentsBindings {
+    fn default() -> Self {
+        Self {
+            navigate_down: Binding::keys(vec![
+                KeyCombo::new(KeyCode::Char('j'), KeyModifiers::empty()),
+                KeyCombo::new(KeyCode::Down, KeyModifiers::empty()),
+            ]),
+            navigate_up: Binding::keys(vec![
+                KeyCombo::new(KeyCode::Char('k'), KeyModifiers::empty()),
+                KeyCombo::new(KeyCode::Up, KeyModifiers::empty()),
+            ]),
+            toggle_focus: Binding::single(KeyCode::Tab, KeyModifiers::empty()),
+            back: Binding::single(KeyCode::Esc, KeyModifiers::empty()),
+            open_chat: Binding::single(KeyCode::Enter, KeyModifiers::empty()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct ChatBindings {
+    pub back: Binding,
+    pub toggle_focus: Binding,
+    pub send: Binding,
+    pub scroll_up: Binding,
+    pub scroll_down: Binding,
+}
+
+impl Default for ChatBindings {
+    fn default() -> Self {
+        Self {
+            back: Binding::single(KeyCode::Esc, KeyModifiers::empty()),
+            toggle_focus: Binding::single(KeyCode::Tab, KeyModifiers::empty()),
+            send: Binding::single(KeyCode::Enter, KeyModifiers::empty()),
+            scroll_up: Binding::single(KeyCode::Up, KeyModifiers::empty()),
+            scroll_down: Binding::single(KeyCode::Down, KeyModifiers::empty()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct ThreadsBindings {
+    pub navigate_left: Binding,
+    pub navigate_right: Binding,
+    pub navigate_up: Binding,
+    pub navigate_down: Binding,
+    pub jump_start: Binding,
+    pub jump_end: Binding,
+    pub tab_next: Binding,
+    pub export: Binding,
+    pub back: Binding,
+}
+
+impl Default for ThreadsBindings {
+    fn default() -> Self {
+        Self {
+            navigate_left: Binding::keys(vec![
+                KeyCombo::new(KeyCode::Left, KeyModifiers::empty()),
+                KeyCombo::new(KeyCode::Char('h'), KeyModifiers::empty()),
+            ]),
+            navigate_right: Binding::keys(vec![
+                KeyCombo::new(KeyCode::Right, KeyModifiers::empty()),
+                KeyCombo::new(KeyCode::Char('l'), KeyModifiers::empty()),
+            ]),
+            navigate_up: Binding::keys(vec![
+                KeyCombo::new(KeyCode::Up, KeyModifiers::empty()),
+                KeyCombo::new(KeyCode::Char('k'), KeyModifiers::empty()),
+            ]),
+            navigate_down: Binding::keys(vec![
+                KeyCombo::new(KeyCode::Down, KeyModifiers::empty()),
+                KeyCombo::new(KeyCode::Char('j'), KeyModifiers::empty()),
+            ]),
+            jump_start: Binding::single(KeyCode::Char('g'), KeyModifiers::empty()),
+            jump_end: Binding::single(KeyCode::Char('G'), KeyModifiers::SHIFT),
+            tab_next: Binding::single(KeyCode::Tab, KeyModifiers::empty()),
+            export: Binding::single(KeyCode::Char('e'), KeyModifiers::empty()),
+            back: Binding::single(KeyCode::Esc, KeyModifiers::empty()),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+#[serde(default)]
+pub struct CreateWorkspaceBindings {
+    pub cancel: Binding,
+    pub switch_field: Binding,
+    pub confirm: Binding,
+}
+
+impl Default for CreateWorkspaceBindings {
+    fn default() -> Self {
+        Self {
+            cancel: Binding::single(KeyCode::Esc, KeyModifiers::empty()),
+            switch_field: Binding::keys(vec![
+                KeyCombo::new(KeyCode::Tab, KeyModifiers::empty()),
+                KeyCombo::new(KeyCode::BackTab, KeyModifiers::empty()),
+            ]),
+            confirm: Binding::single(KeyCode::Enter, KeyModifiers::empty()),
+        }
+    }
+}
+
+// ── Top-level ────────────────────────────────────────────────────
+
+#[derive(Clone, Debug, Default, Deserialize)]
+#[serde(default)]
+pub struct Keybindings {
+    pub global: GlobalBindings,
+    pub sidebar: SidebarBindings,
+    pub agents: AgentsBindings,
+    pub chat: ChatBindings,
+    pub threads: ThreadsBindings,
+    pub create_workspace: CreateWorkspaceBindings,
+}
+
+impl Keybindings {
+    /// Load keybindings from a TOML file. Falls back to defaults for any
+    /// missing sections or individual bindings.
+    pub fn load(path: &Path) -> Self {
+        match std::fs::read_to_string(path) {
+            Ok(content) => match toml::from_str(&content) {
+                Ok(kb) => kb,
+                Err(e) => {
+                    eprintln!("warning: failed to parse {}: {e}", path.display());
+                    Self::default()
+                }
+            },
+            Err(_) => Self::default(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn press(code: KeyCode, modifiers: KeyModifiers) -> KeyEvent {
+        KeyEvent::new(code, modifiers)
+    }
+
+    #[test]
+    fn parse_simple_char() {
+        let combo = KeyCombo::parse("j").unwrap();
+        assert_eq!(combo.code, KeyCode::Char('j'));
+        assert_eq!(combo.modifiers, KeyModifiers::empty());
+    }
+
+    #[test]
+    fn parse_ctrl_char() {
+        let combo = KeyCombo::parse("Ctrl+c").unwrap();
+        assert_eq!(combo.code, KeyCode::Char('c'));
+        assert_eq!(combo.modifiers, KeyModifiers::CONTROL);
+    }
+
+    #[test]
+    fn parse_special_key() {
+        let combo = KeyCombo::parse("Enter").unwrap();
+        assert_eq!(combo.code, KeyCode::Enter);
+        assert_eq!(combo.modifiers, KeyModifiers::empty());
+    }
+
+    #[test]
+    fn parse_unknown_key_fails() {
+        assert!(KeyCombo::parse("FooBar").is_err());
+    }
+
+    #[test]
+    fn binding_matches_single() {
+        let binding = Binding::single(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert!(binding.matches(&press(KeyCode::Char('c'), KeyModifiers::CONTROL)));
+        assert!(!binding.matches(&press(KeyCode::Char('c'), KeyModifiers::empty())));
+    }
+
+    #[test]
+    fn binding_matches_multi() {
+        let binding = Binding::keys(vec![
+            KeyCombo::new(KeyCode::Char('j'), KeyModifiers::empty()),
+            KeyCombo::new(KeyCode::Down, KeyModifiers::empty()),
+        ]);
+        assert!(binding.matches(&press(KeyCode::Char('j'), KeyModifiers::empty())));
+        assert!(binding.matches(&press(KeyCode::Down, KeyModifiers::empty())));
+        assert!(!binding.matches(&press(KeyCode::Char('k'), KeyModifiers::empty())));
+    }
+
+    #[test]
+    fn deserialize_single_string() {
+        let toml_str = r#"quit = "Ctrl+c""#;
+        #[derive(Deserialize)]
+        struct Test {
+            quit: Binding,
+        }
+        let t: Test = toml::from_str(toml_str).unwrap();
+        assert!(t
+            .quit
+            .matches(&press(KeyCode::Char('c'), KeyModifiers::CONTROL)));
+    }
+
+    #[test]
+    fn deserialize_array() {
+        let toml_str = r#"nav = ["j", "Down"]"#;
+        #[derive(Deserialize)]
+        struct Test {
+            nav: Binding,
+        }
+        let t: Test = toml::from_str(toml_str).unwrap();
+        assert!(t
+            .nav
+            .matches(&press(KeyCode::Char('j'), KeyModifiers::empty())));
+        assert!(t.nav.matches(&press(KeyCode::Down, KeyModifiers::empty())));
+    }
+
+    #[test]
+    fn deserialize_partial_config() {
+        let toml_str = r#"
+[global]
+quit = "q"
+"#;
+        let kb: Keybindings = toml::from_str(toml_str).unwrap();
+        // quit should be overridden
+        assert!(kb
+            .global
+            .quit
+            .matches(&press(KeyCode::Char('q'), KeyModifiers::empty())));
+        // other bindings should be defaults
+        assert!(kb
+            .global
+            .refresh
+            .matches(&press(KeyCode::Char('r'), KeyModifiers::CONTROL)));
+        // other sections should be defaults
+        assert!(kb
+            .sidebar
+            .navigate_down
+            .matches(&press(KeyCode::Char('j'), KeyModifiers::empty())));
+    }
+
+    #[test]
+    fn display_ctrl_char() {
+        let combo = KeyCombo::new(KeyCode::Char('c'), KeyModifiers::CONTROL);
+        assert_eq!(combo.to_string(), "^C");
+    }
+
+    #[test]
+    fn display_plain_char() {
+        let combo = KeyCombo::new(KeyCode::Char('j'), KeyModifiers::empty());
+        assert_eq!(combo.to_string(), "j");
+    }
+
+    #[test]
+    fn hint_all_joins_combos() {
+        let binding = Binding::keys(vec![
+            KeyCombo::new(KeyCode::Char('j'), KeyModifiers::empty()),
+            KeyCombo::new(KeyCode::Down, KeyModifiers::empty()),
+        ]);
+        assert_eq!(binding.hint_all(), "j/Down");
+    }
+
+    #[test]
+    fn default_keybindings_match_original() {
+        let kb = Keybindings::default();
+        // Global
+        assert!(kb
+            .global
+            .quit
+            .matches(&press(KeyCode::Char('c'), KeyModifiers::CONTROL)));
+        assert!(kb
+            .global
+            .suspend
+            .matches(&press(KeyCode::Char('z'), KeyModifiers::CONTROL)));
+        // Sidebar — multiple bindings
+        assert!(kb
+            .sidebar
+            .navigate_down
+            .matches(&press(KeyCode::Char('j'), KeyModifiers::empty())));
+        assert!(kb
+            .sidebar
+            .navigate_down
+            .matches(&press(KeyCode::Down, KeyModifiers::empty())));
+        // Threads — jump_end uses Shift+G
+        assert!(kb
+            .threads
+            .jump_end
+            .matches(&press(KeyCode::Char('G'), KeyModifiers::SHIFT)));
+    }
+}

--- a/drua/src/tui/mod.rs
+++ b/drua/src/tui/mod.rs
@@ -1,4 +1,5 @@
 pub mod chat;
 pub mod handlers;
+pub mod keybindings;
 pub mod state;
 pub mod ui;

--- a/drua/src/tui/state.rs
+++ b/drua/src/tui/state.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use super::chat::{AssistantChat, ChatRole, ContentBlock};
+use super::keybindings::Keybindings;
 
 #[allow(dead_code)]
 pub struct WorkspaceItem {
@@ -253,6 +254,10 @@ pub struct ScreenState {
     pub focus: Focus,
     pub status_message: Option<String>,
 
+    // Keybindings
+    pub keybindings: Keybindings,
+    pub show_help: bool,
+
     // Chat
     pub chat_view: ChatViewState,
     pub chat_input: String,
@@ -275,7 +280,12 @@ pub struct ScreenState {
 }
 
 impl ScreenState {
-    pub fn new(workspaces: Vec<WorkspaceItem>, server_url: String, user_name: String) -> Self {
+    pub fn new(
+        workspaces: Vec<WorkspaceItem>,
+        server_url: String,
+        user_name: String,
+        keybindings: Keybindings,
+    ) -> Self {
         let selected_lead_id = workspaces
             .first()
             .and_then(|ws| ws.lead.as_ref())
@@ -289,6 +299,9 @@ impl ScreenState {
             should_quit: false,
             focus: Focus::default(),
             status_message: None,
+
+            keybindings,
+            show_help: false,
 
             agent_cursor: 0,
 

--- a/drua/src/tui/ui/mod.rs
+++ b/drua/src/tui/ui/mod.rs
@@ -5,12 +5,13 @@ mod sidebar;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
-    style::{Color, Style},
+    style::{Color, Modifier, Style},
     text::{Line, Span},
     widgets::{Block, Borders, Clear, Paragraph},
     Frame,
 };
 
+use super::keybindings::Keybindings;
 use super::state::{Focus, Mode, ScreenState};
 
 pub fn draw(frame: &mut Frame, state: &mut ScreenState) {
@@ -48,6 +49,10 @@ pub fn draw(frame: &mut Frame, state: &mut ScreenState) {
         Mode::ExportThread => draw_export_modal(frame, state),
         Mode::Browse => {}
     }
+
+    if state.show_help {
+        draw_help_overlay(frame, state);
+    }
 }
 
 fn draw_status_bar(frame: &mut Frame, state: &ScreenState, area: Rect) {
@@ -56,6 +61,9 @@ fn draw_status_bar(frame: &mut Frame, state: &ScreenState, area: Rect) {
     } else {
         state.user_name.clone()
     };
+
+    let kb = &state.keybindings;
+    let key = |s: String| Span::styled(s, Style::default().fg(Color::Yellow));
 
     let mut spans = vec![
         Span::styled(" Server: ", Style::default().fg(Color::DarkGray)),
@@ -69,15 +77,72 @@ fn draw_status_bar(frame: &mut Frame, state: &ScreenState, area: Rect) {
         spans.push(Span::styled(msg, Style::default().fg(Color::Green)));
     }
 
-    let keys = match state.focus {
-        Focus::Sidebar => " │ ↑/↓:nav  n:new  r:refresh  Tab:agents  q:quit ",
-        Focus::Agents => " │ ↑/↓:nav  Enter:chat  Tab:chat  Esc:sidebar ",
-        Focus::Chat => " │ Enter:send  Esc:sidebar  ↑/↓:scroll  ^T:threads ",
-        Focus::Threads => {
-            " │ ←→:pos  ↑↓:thread  Tab:next  g/G:jump  e:export  ^T:close  Esc:sidebar "
+    spans.push(Span::styled(" │ ", Style::default().fg(Color::DarkGray)));
+
+    match state.focus {
+        Focus::Sidebar => {
+            spans.extend([
+                key(kb.sidebar.navigate_down.hint_all()),
+                Span::styled(" nav  ", Style::default().fg(Color::DarkGray)),
+                key(kb.sidebar.new_workspace.to_string()),
+                Span::styled(" new  ", Style::default().fg(Color::DarkGray)),
+                key(kb.global.refresh.to_string()),
+                Span::styled(" refresh  ", Style::default().fg(Color::DarkGray)),
+                key(kb.sidebar.toggle_focus.to_string()),
+                Span::styled(" agents  ", Style::default().fg(Color::DarkGray)),
+                key(kb.sidebar.quit.to_string()),
+                Span::styled(" quit  ", Style::default().fg(Color::DarkGray)),
+                key(kb.global.show_help.to_string()),
+                Span::styled(" help", Style::default().fg(Color::DarkGray)),
+            ]);
         }
-    };
-    spans.push(Span::styled(keys, Style::default().fg(Color::DarkGray)));
+        Focus::Agents => {
+            spans.extend([
+                key(kb.agents.navigate_down.hint_all()),
+                Span::styled(" nav  ", Style::default().fg(Color::DarkGray)),
+                key(kb.agents.open_chat.to_string()),
+                Span::styled(" chat  ", Style::default().fg(Color::DarkGray)),
+                key(kb.agents.toggle_focus.to_string()),
+                Span::styled(" cycle  ", Style::default().fg(Color::DarkGray)),
+                key(kb.agents.back.to_string()),
+                Span::styled(" sidebar  ", Style::default().fg(Color::DarkGray)),
+                key(kb.global.show_help.to_string()),
+                Span::styled(" help", Style::default().fg(Color::DarkGray)),
+            ]);
+        }
+        Focus::Chat => {
+            spans.extend([
+                key(kb.chat.send.to_string()),
+                Span::styled(" send  ", Style::default().fg(Color::DarkGray)),
+                key(kb.chat.back.to_string()),
+                Span::styled(" sidebar  ", Style::default().fg(Color::DarkGray)),
+                key(kb.chat.scroll_up.hint_all()),
+                Span::styled(" scroll  ", Style::default().fg(Color::DarkGray)),
+                key(kb.global.toggle_threads.to_string()),
+                Span::styled(" threads  ", Style::default().fg(Color::DarkGray)),
+                key(kb.global.show_help.to_string()),
+                Span::styled(" help", Style::default().fg(Color::DarkGray)),
+            ]);
+        }
+        Focus::Threads => {
+            spans.extend([
+                key(kb.threads.navigate_left.hint_all()),
+                Span::styled(" pos  ", Style::default().fg(Color::DarkGray)),
+                key(kb.threads.navigate_up.hint_all()),
+                Span::styled(" thread  ", Style::default().fg(Color::DarkGray)),
+                key(kb.threads.tab_next.to_string()),
+                Span::styled(" next  ", Style::default().fg(Color::DarkGray)),
+                key(format!("{}/{}", kb.threads.jump_start, kb.threads.jump_end)),
+                Span::styled(" jump  ", Style::default().fg(Color::DarkGray)),
+                key(kb.threads.export.to_string()),
+                Span::styled(" export  ", Style::default().fg(Color::DarkGray)),
+                key(kb.global.toggle_threads.to_string()),
+                Span::styled(" close  ", Style::default().fg(Color::DarkGray)),
+                key(kb.global.show_help.to_string()),
+                Span::styled(" help", Style::default().fg(Color::DarkGray)),
+            ]);
+        }
+    }
 
     let bar = Line::from(spans);
     let paragraph = Paragraph::new(bar);
@@ -85,6 +150,7 @@ fn draw_status_bar(frame: &mut Frame, state: &ScreenState, area: Rect) {
 }
 
 fn draw_create_modal(frame: &mut Frame, state: &ScreenState) {
+    let kb = &state.keybindings.create_workspace;
     let area = centered_rect(52, 10, frame.area());
     frame.render_widget(Clear, area);
 
@@ -107,6 +173,11 @@ fn draw_create_modal(frame: &mut Frame, state: &ScreenState) {
     let cursor_name = if state.input_field == 0 { "▎" } else { "" };
     let cursor_desc = if state.input_field == 1 { "▎" } else { "" };
 
+    let hint = format!(
+        "  {}:switch  {}:create  {}:cancel",
+        kb.switch_field, kb.confirm, kb.cancel
+    );
+
     let lines = vec![
         Line::from(""),
         Line::from(vec![
@@ -123,10 +194,7 @@ fn draw_create_modal(frame: &mut Frame, state: &ScreenState) {
         ]),
         Line::from(""),
         Line::from(""),
-        Line::from(Span::styled(
-            "  Tab:switch  Enter:create  Esc:cancel",
-            Style::default().fg(Color::DarkGray),
-        )),
+        Line::from(Span::styled(hint, Style::default().fg(Color::DarkGray))),
     ];
 
     let paragraph = Paragraph::new(lines).block(block);
@@ -161,6 +229,145 @@ fn draw_export_modal(frame: &mut Frame, state: &ScreenState) {
 
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
+}
+
+fn draw_help_overlay(frame: &mut Frame, state: &ScreenState) {
+    let kb = &state.keybindings;
+    let area = centered_rect(60, 24, frame.area());
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Keybindings ")
+        .border_style(Style::default().fg(Color::Cyan));
+
+    let lines = build_help_lines(kb, &state.focus);
+
+    let paragraph = Paragraph::new(lines).block(block);
+    frame.render_widget(paragraph, area);
+}
+
+fn help_heading(s: &str) -> Line<'static> {
+    Line::from(Span::styled(
+        format!("  {s}"),
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    ))
+}
+
+fn help_entry(key: String, desc: &str) -> Line<'static> {
+    Line::from(vec![
+        Span::styled(format!("    {key:<14}"), Style::default().fg(Color::Yellow)),
+        Span::styled(desc.to_string(), Style::default().fg(Color::White)),
+    ])
+}
+
+fn build_help_lines(kb: &Keybindings, focus: &Focus) -> Vec<Line<'static>> {
+    let mut lines = vec![Line::from("")];
+
+    // Global section
+    lines.push(help_heading("Global"));
+    lines.push(help_entry(kb.global.quit.hint_all(), "Quit"));
+    lines.push(help_entry(kb.global.suspend.hint_all(), "Suspend"));
+    lines.push(help_entry(
+        kb.global.focus_lead.hint_all(),
+        "Focus lead agent",
+    ));
+    lines.push(help_entry(
+        kb.global.refresh.hint_all(),
+        "Refresh workspaces",
+    ));
+    lines.push(help_entry(kb.global.focus_left.hint_all(), "Focus left"));
+    lines.push(help_entry(kb.global.focus_right.hint_all(), "Focus right"));
+    lines.push(help_entry(
+        kb.global.toggle_threads.hint_all(),
+        "Toggle thread view",
+    ));
+    lines.push(help_entry(
+        kb.global.show_help.hint_all(),
+        "Toggle this help",
+    ));
+    lines.push(Line::from(""));
+
+    // Context-specific section
+    match focus {
+        Focus::Sidebar => {
+            lines.push(help_heading("Sidebar"));
+            lines.push(help_entry(
+                kb.sidebar.navigate_down.hint_all(),
+                "Navigate down",
+            ));
+            lines.push(help_entry(kb.sidebar.navigate_up.hint_all(), "Navigate up"));
+            lines.push(help_entry(kb.sidebar.select.hint_all(), "Select workspace"));
+            lines.push(help_entry(
+                kb.sidebar.new_workspace.hint_all(),
+                "New workspace",
+            ));
+            lines.push(help_entry(
+                kb.sidebar.toggle_focus.hint_all(),
+                "Cycle focus",
+            ));
+            lines.push(help_entry(kb.sidebar.quit.hint_all(), "Quit"));
+        }
+        Focus::Agents => {
+            lines.push(help_heading("Agents"));
+            lines.push(help_entry(
+                kb.agents.navigate_down.hint_all(),
+                "Navigate down",
+            ));
+            lines.push(help_entry(kb.agents.navigate_up.hint_all(), "Navigate up"));
+            lines.push(help_entry(kb.agents.open_chat.hint_all(), "Open chat"));
+            lines.push(help_entry(kb.agents.toggle_focus.hint_all(), "Cycle focus"));
+            lines.push(help_entry(kb.agents.back.hint_all(), "Back to sidebar"));
+        }
+        Focus::Chat => {
+            lines.push(help_heading("Chat"));
+            lines.push(help_entry(kb.chat.send.hint_all(), "Send message"));
+            lines.push(help_entry(kb.chat.scroll_up.hint_all(), "Scroll up"));
+            lines.push(help_entry(kb.chat.scroll_down.hint_all(), "Scroll down"));
+            lines.push(help_entry(kb.chat.toggle_focus.hint_all(), "Cycle focus"));
+            lines.push(help_entry(kb.chat.back.hint_all(), "Back to sidebar"));
+            lines.push(Line::from(""));
+            lines.push(help_heading("Input editing"));
+            lines.push(help_entry("^U".to_string(), "Kill to start"));
+            lines.push(help_entry("^W".to_string(), "Kill word"));
+            lines.push(help_entry("^A".to_string(), "Home"));
+            lines.push(help_entry("^E".to_string(), "End"));
+        }
+        Focus::Threads => {
+            lines.push(help_heading("Thread Grid"));
+            lines.push(help_entry(
+                kb.threads.navigate_left.hint_all(),
+                "Move left (pos)",
+            ));
+            lines.push(help_entry(
+                kb.threads.navigate_right.hint_all(),
+                "Move right (pos)",
+            ));
+            lines.push(help_entry(
+                kb.threads.navigate_up.hint_all(),
+                "Move up (thread)",
+            ));
+            lines.push(help_entry(
+                kb.threads.navigate_down.hint_all(),
+                "Move down (thread)",
+            ));
+            lines.push(help_entry(
+                kb.threads.jump_start.hint_all(),
+                "Jump to start",
+            ));
+            lines.push(help_entry(kb.threads.jump_end.hint_all(), "Jump to end"));
+            lines.push(help_entry(
+                kb.threads.tab_next.hint_all(),
+                "Next unique cell",
+            ));
+            lines.push(help_entry(kb.threads.export.hint_all(), "Export thread"));
+            lines.push(help_entry(kb.threads.back.hint_all(), "Back to sidebar"));
+        }
+    }
+
+    lines
 }
 
 fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {


### PR DESCRIPTION
## Summary
- Add a configurable keybinding system to the drua TUI, modeled after command-center's pattern
- Replace all hardcoded key checks in `handlers.rs` with `binding.matches()` lookups against per-context binding structs
- Load user overrides from `~/.drua/keybindings.toml` (partial config supported — missing bindings fall back to defaults)
- Show context-sensitive keybinding hints in the status bar that update based on current focus (Sidebar, Agents, Chat, Threads)
- Add a full keybinding help overlay toggled with `?` key

## Test plan
- [x] `nix flake check` passes (fmt, clippy, nextest)
- [ ] Manual: launch `drua`, verify status bar shows correct hints per focus mode
- [ ] Manual: press `?` to toggle help overlay, verify it shows global + context bindings
- [ ] Manual: create `~/.drua/keybindings.toml` with overrides, verify custom bindings work
- [ ] Manual: verify all existing key behaviors preserved (vim j/k, Ctrl+C quit, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)