### PR TITLE
refactor(session): move cache_ttl_seconds to model/provider config

### DIFF
--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -49,10 +49,18 @@ pub struct ProviderModelConfig {
     pub max_tokens_per_response: u32,
     #[serde(default = "default_context_window")]
     pub context_window_tokens: u64,
+    /// Provider prompt-cache TTL in seconds. Defaults to 300 (Anthropic).
+    /// Set to 0 for providers without prompt caching.
+    #[serde(default = "default_cache_ttl")]
+    pub cache_ttl_seconds: u64,
 }
 
 fn default_context_window() -> u64 {
     200_000
+}
+
+fn default_cache_ttl() -> u64 {
+    300
 }
 
 impl Config {
@@ -213,6 +221,7 @@ impl Config {
                         model: model.name.clone(),
                         max_tokens_per_response: model.max_tokens_per_response,
                         context_window_tokens: model.context_window_tokens,
+                        cache_ttl_seconds: model.cache_ttl_seconds,
                     },
                 );
             }

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -30,12 +30,7 @@ pub struct ModelDefaults {
     pub context_window_tokens: u64,
     /// Provider prompt-cache TTL in seconds. Anthropic ≈ 300 s; providers
     /// without caching should set this to 0.
-    #[serde(default = "default_cache_ttl_seconds")]
     pub cache_ttl_seconds: u64,
-}
-
-fn default_cache_ttl_seconds() -> u64 {
-    300
 }
 
 impl Default for ModelDefaults {
@@ -44,7 +39,7 @@ impl Default for ModelDefaults {
             model: String::new(),
             max_tokens_per_response: 4096,
             context_window_tokens: 200_000,
-            cache_ttl_seconds: default_cache_ttl_seconds(),
+            cache_ttl_seconds: 300,
         }
     }
 }

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -28,6 +28,14 @@ pub struct ModelDefaults {
     pub model: String,
     pub max_tokens_per_response: u32,
     pub context_window_tokens: u64,
+    /// Provider prompt-cache TTL in seconds. Anthropic ≈ 300 s; providers
+    /// without caching should set this to 0.
+    #[serde(default = "default_cache_ttl_seconds")]
+    pub cache_ttl_seconds: u64,
+}
+
+fn default_cache_ttl_seconds() -> u64 {
+    300
 }
 
 impl Default for ModelDefaults {
@@ -36,6 +44,7 @@ impl Default for ModelDefaults {
             model: String::new(),
             max_tokens_per_response: 4096,
             context_window_tokens: 200_000,
+            cache_ttl_seconds: default_cache_ttl_seconds(),
         }
     }
 }

--- a/core/src/agent/session/compaction/mod.rs
+++ b/core/src/agent/session/compaction/mod.rs
@@ -95,6 +95,7 @@ pub(super) fn maybe_prune(
     let action = config.determine_action(
         estimated_tokens,
         model_defaults.context_window_tokens,
+        model_defaults.cache_ttl_seconds,
         time_since_last_turn,
     );
 

--- a/core/src/agent/session/compaction/prune.rs
+++ b/core/src/agent/session/compaction/prune.rs
@@ -395,7 +395,6 @@ mod tests {
             enabled: true,
             token_threshold_fraction: 0.6,
             keep_recent_tool_results: keep_recent,
-            cache_ttl_seconds: 300,
             reset_time_delta_seconds: None,
         }
     }

--- a/core/src/agent/session/compaction/trigger.rs
+++ b/core/src/agent/session/compaction/trigger.rs
@@ -24,19 +24,24 @@ mod tests {
             enabled: true,
             token_threshold_fraction: 0.6,
             keep_recent_tool_results: 10,
-            cache_ttl_seconds: 300,
             reset_time_delta_seconds: None,
         }
     }
 
     const CONTEXT_WINDOW: u64 = 200_000;
+    const CACHE_TTL: u64 = 300;
 
     #[test]
     fn none_when_disabled() {
         let mut cfg = config();
         cfg.enabled = false;
         assert_eq!(
-            cfg.determine_action(999_999, CONTEXT_WINDOW, Duration::from_secs(9999)),
+            cfg.determine_action(
+                999_999,
+                CONTEXT_WINDOW,
+                CACHE_TTL,
+                Duration::from_secs(9999)
+            ),
             CompactionAction::None
         );
     }
@@ -46,7 +51,7 @@ mod tests {
         let cfg = config();
         // 60_000 < 120_000 threshold, 60s < 300s cache_ttl
         assert_eq!(
-            cfg.determine_action(60_000, CONTEXT_WINDOW, Duration::from_secs(60)),
+            cfg.determine_action(60_000, CONTEXT_WINDOW, CACHE_TTL, Duration::from_secs(60)),
             CompactionAction::None
         );
     }
@@ -56,7 +61,7 @@ mod tests {
         let cfg = config();
         // 60_000 < 120_000, but 600s > 300s cache_ttl
         assert_eq!(
-            cfg.determine_action(60_000, CONTEXT_WINDOW, Duration::from_secs(600)),
+            cfg.determine_action(60_000, CONTEXT_WINDOW, CACHE_TTL, Duration::from_secs(600)),
             CompactionAction::PruneOpportunistic
         );
     }
@@ -66,7 +71,7 @@ mod tests {
         let cfg = config();
         // 150_000 > 120_000, 60s < 300s
         assert_eq!(
-            cfg.determine_action(150_000, CONTEXT_WINDOW, Duration::from_secs(60)),
+            cfg.determine_action(150_000, CONTEXT_WINDOW, CACHE_TTL, Duration::from_secs(60)),
             CompactionAction::PruneThenSummarize
         );
     }
@@ -76,7 +81,7 @@ mod tests {
         let cfg = config();
         // 150_000 > 120_000, 600s > 300s
         assert_eq!(
-            cfg.determine_action(150_000, CONTEXT_WINDOW, Duration::from_secs(600)),
+            cfg.determine_action(150_000, CONTEXT_WINDOW, CACHE_TTL, Duration::from_secs(600)),
             CompactionAction::PruneThenSummarize
         );
     }
@@ -91,7 +96,7 @@ mod tests {
         };
         // Under token threshold, but idle > 600s → Orphan
         assert_eq!(
-            cfg.determine_action(60_000, CONTEXT_WINDOW, Duration::from_secs(700)),
+            cfg.determine_action(60_000, CONTEXT_WINDOW, CACHE_TTL, Duration::from_secs(700)),
             CompactionAction::Orphan
         );
     }
@@ -106,7 +111,7 @@ mod tests {
         };
         // Over token threshold AND idle > 600s → Orphan (not PruneThenSummarize)
         assert_eq!(
-            cfg.determine_action(150_000, CONTEXT_WINDOW, Duration::from_secs(700)),
+            cfg.determine_action(150_000, CONTEXT_WINDOW, CACHE_TTL, Duration::from_secs(700)),
             CompactionAction::Orphan
         );
     }
@@ -121,7 +126,7 @@ mod tests {
         };
         // Under token threshold AND idle < 600s → None (not Orphan)
         assert_eq!(
-            cfg.determine_action(60_000, CONTEXT_WINDOW, Duration::from_secs(60)),
+            cfg.determine_action(60_000, CONTEXT_WINDOW, CACHE_TTL, Duration::from_secs(60)),
             CompactionAction::None
         );
     }

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -681,6 +681,7 @@ mod tests {
                 model: "test-model".into(),
                 max_tokens_per_response: 1024,
                 context_window_tokens: 200_000,
+                ..Default::default()
             })
             .compaction_config(CompactionConfig {
                 enabled: false,
@@ -1081,12 +1082,12 @@ mod tests {
                 model: "test-model".into(),
                 max_tokens_per_response: 1024,
                 context_window_tokens: 100,
+                cache_ttl_seconds: 0, // cache always cold
             })
             .compaction_config(CompactionConfig {
                 enabled: true,
                 token_threshold_fraction: 0.0, // always over threshold
                 keep_recent_tool_results: keep_recent,
-                cache_ttl_seconds: 0, // cache always cold
                 reset_time_delta_seconds: None,
             })
             .system_blocks(vec![SystemBlock::Text {

--- a/core/src/agent/session/settings.rs
+++ b/core/src/agent/session/settings.rs
@@ -33,8 +33,6 @@ pub struct CompactionConfig {
     pub token_threshold_fraction: f64,
     /// Number of recent tool results to keep unmasked.
     pub keep_recent_tool_results: usize,
-    /// Provider cache TTL in seconds — prune freely after this inactivity period.
-    pub cache_ttl_seconds: u64,
     /// If set, start a fresh thread (orphan) when a user message arrives
     /// more than this many seconds after the previous assistant response.
     #[serde(default)]
@@ -51,10 +49,14 @@ impl CompactionConfig {
     ///
     /// `Orphan` takes priority: if the reset threshold is exceeded the session
     /// starts a brand-new thread regardless of token counts.
+    ///
+    /// `cache_ttl_seconds` is the provider's prompt-cache TTL sourced from
+    /// [`ModelDefaults`](crate::agent::config::ModelDefaults).
     pub fn determine_action(
         &self,
         estimated_tokens: u64,
         context_window_tokens: u64,
+        cache_ttl_seconds: u64,
         time_since_last_turn: Duration,
     ) -> CompactionAction {
         if !self.enabled {
@@ -69,7 +71,7 @@ impl CompactionConfig {
         }
 
         let threshold = (context_window_tokens as f64 * self.token_threshold_fraction) as u64;
-        let cache_ttl = Duration::from_secs(self.cache_ttl_seconds);
+        let cache_ttl = Duration::from_secs(cache_ttl_seconds);
         let cache_cold = time_since_last_turn > cache_ttl;
 
         match (estimated_tokens > threshold, cache_cold) {
@@ -86,7 +88,6 @@ impl Default for CompactionConfig {
             enabled: true,
             token_threshold_fraction: 0.6,
             keep_recent_tool_results: 10,
-            cache_ttl_seconds: 300,
             reset_time_delta_seconds: None,
         }
     }

--- a/core/src/agent/session/view.rs
+++ b/core/src/agent/session/view.rs
@@ -415,6 +415,7 @@ mod tests {
             model: "test-model".into(),
             max_tokens_per_response: 8192,
             context_window_tokens: 200_000,
+            ..Default::default()
         }
     }
 

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -40,6 +40,7 @@ async fn send_message_round_trip_via_prompt_channel() {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
+            ..Default::default()
         },
     );
     let config = AgentsConfig {
@@ -193,6 +194,7 @@ async fn send_message_dispatches_registered_tool_call() {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
+            ..Default::default()
         },
     );
     let config = AgentsConfig {


### PR DESCRIPTION
## Summary
- **Moves `cache_ttl_seconds`** from `CompactionConfig` to `ModelDefaults` (core) and `ProviderModelConfig` (CLI)
- Cache TTL is a provider/model property (Anthropic ≈ 300s, OpenAI may differ, some providers have none) — it was incorrectly nested under compaction config
- `determine_action()` now takes `cache_ttl_seconds` as an explicit parameter, mirroring how `context_window_tokens` already flows from `ModelDefaults`
- Backward compatible: old persisted events deserialize cleanly via serde defaults

## Changes
| File | What changed |
|------|-------------|
| `core/src/agent/config.rs` | Added `cache_ttl_seconds: u64` to `ModelDefaults` (default 300) |
| `cli/src/config.rs` | Added `cache_ttl_seconds: u64` to `ProviderModelConfig`, wired through to `ModelDefaults` |
| `core/src/agent/session/settings.rs` | Removed `cache_ttl_seconds` from `CompactionConfig`, added it as param to `determine_action()` |
| `core/src/agent/session/compaction/mod.rs` | Pass `model_defaults.cache_ttl_seconds` to `determine_action()` |
| Tests (trigger, prune, entity, view, agent) | Updated struct literals and test helpers |

## Test plan
- [x] `nix flake check` passes (fmt + clippy + nextest + schema + config checks)
- [ ] Verify YAML config with explicit `cache_ttl_seconds` on a provider model parses correctly
- [ ] Verify old persisted sessions (with `cache_ttl_seconds` in CompactionConfig JSONB) still load

🤖 Generated with [Claude Code](https://claude.com/claude-code)