### PR TITLE
feat(concourse): add timestamps to build log output

### DIFF
--- a/lib/concourse-client/src/client.rs
+++ b/lib/concourse-client/src/client.rs
@@ -291,7 +291,7 @@ impl ConcourseClient {
 
 /// Format a Unix epoch timestamp as `HH:MM:SS` UTC.
 pub(crate) fn format_epoch(epoch: i64) -> String {
-    let secs = ((epoch % 86400) + 86400) % 86400; // handle negative mod
+    let secs = epoch.rem_euclid(86400);
     let h = secs / 3600;
     let m = (secs % 3600) / 60;
     let s = secs % 60;

--- a/lib/concourse-client/src/client.rs
+++ b/lib/concourse-client/src/client.rs
@@ -289,6 +289,15 @@ impl ConcourseClient {
     }
 }
 
+/// Format a Unix epoch timestamp as `HH:MM:SS` UTC.
+pub(crate) fn format_epoch(epoch: i64) -> String {
+    let secs = ((epoch % 86400) + 86400) % 86400; // handle negative mod
+    let h = secs / 3600;
+    let m = (secs % 3600) / 60;
+    let s = secs % 60;
+    format!("{h:02}:{m:02}:{s:02}")
+}
+
 /// Parse SSE text and extract log lines from event envelopes.
 fn extract_logs_from_sse(body: &str, out: &mut String) {
     for line in body.lines() {
@@ -307,7 +316,21 @@ fn extract_logs_from_sse(body: &str, out: &mut String) {
         }
         if let Some(payload) = envelope.data.get("payload") {
             if let Some(text) = payload.as_str() {
-                out.push_str(text);
+                // Prepend timestamp if available in the event data
+                if let Some(ts) = envelope.data.get("time").and_then(|v| v.as_i64()) {
+                    let stamp = format_epoch(ts);
+                    // Prefix each non-empty line with the timestamp
+                    for (i, line) in text.split('\n').enumerate() {
+                        if i > 0 {
+                            out.push('\n');
+                        }
+                        if !line.is_empty() {
+                            out.push_str(&format!("[{stamp}] {line}"));
+                        }
+                    }
+                } else {
+                    out.push_str(text);
+                }
             }
         }
     }

--- a/lib/concourse-client/src/log_buffer.rs
+++ b/lib/concourse-client/src/log_buffer.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use serde::Serialize;
 use tokio::sync::RwLock;
 
-use crate::client::ConcourseClient;
+use crate::client::{format_epoch, ConcourseClient};
 use crate::error::ConcourseError;
 use crate::types::BuildEventEnvelope;
 
@@ -219,10 +219,18 @@ fn process_envelope(envelope: &BuildEventEnvelope, buf: &mut BuildLogBuffer) {
         "log" => {
             if let Some(payload) = envelope.data.get("payload") {
                 if let Some(text) = payload.as_str() {
+                    let prefix = envelope
+                        .data
+                        .get("time")
+                        .and_then(|v| v.as_i64())
+                        .map(|ts| format!("[{}] ", format_epoch(ts)));
                     // Split multi-line payloads into individual lines
                     for line in text.split('\n') {
                         if !line.is_empty() {
-                            buf.lines.push(line.to_string());
+                            match &prefix {
+                                Some(p) => buf.lines.push(format!("{p}{line}")),
+                                None => buf.lines.push(line.to_string()),
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Summary
- Extract the `time` field from Concourse SSE log events and prefix each log line with `[HH:MM:SS]` UTC
- Applies to both the one-shot `get_build_logs` path (`client.rs`) and the streaming `BuildLogStore` path (`log_buffer.rs`)
- Falls back to no prefix if `time` field is absent

## Test plan
- [ ] Trigger a Concourse build and fetch logs via `concourse_get_build_logs` — verify lines are prefixed with `[HH:MM:SS]`
- [ ] Verify streaming log tailing also includes timestamps
- [ ] Confirm output filtering (grep/tail/head) still works correctly with the prefixed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)