### PR TITLE
feat: add configurable base_url for LLM providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,42 @@ providers:
         context_window_tokens: 200000
 ```
 
+### Custom / Alternative Providers
+
+Any provider entry supports an optional `base_url` field to point at an
+OpenAI-compatible or Anthropic-compatible endpoint — for example OpenRouter,
+a local Llama server, vLLM, or any proxy.
+
+The client appends the standard API path (`/v1/messages` for Anthropic,
+`/v1/chat/completions` for `openai`, `/v1/responses` for `openai-responses`),
+so `base_url` should be the scheme + host + any path prefix, without the
+trailing API path.
+
+```yaml
+providers:
+  # Route Anthropic-protocol models through OpenRouter
+  - name: anthropic
+    base_url: https://openrouter.ai/api
+    models:
+      - name: claude-haiku-4-5-20251001
+        max_tokens_per_response: 4096
+
+  # Use a local Llama server via the OpenAI Chat Completions protocol
+  - name: openai
+    base_url: http://localhost:8080
+    models:
+      - name: llama-3-8b
+        max_tokens_per_response: 4096
+        context_window_tokens: 128000
+        cache_ttl_seconds: 0
+```
+
+When `base_url` is set, API-key prefix validation (`sk-ant-`, `sk-`) is
+skipped, since alternative providers use different credential formats.
+Set the corresponding API key env var (`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`)
+to whatever the target endpoint expects — or leave it empty if the endpoint
+requires no authentication.
+
 ## Project Layout
 
 ```

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -327,32 +327,31 @@ enum ResolvedProviderKind {
 
 impl ResolvedModel {
     fn from_config(config: ModelConfig) -> Self {
-        let (provider_kind, client): (ResolvedProviderKind, Arc<dyn LlmProvider>) = match config
-            .provider
-        {
-            Provider::Anthropic { api_key, base_url } => (
-                ResolvedProviderKind::Anthropic,
-                Arc::new(AnthropicClient::new(api_key).with_base_url(base_url)),
-            ),
-            Provider::OpenAi { api_key, base_url } => (
-                ResolvedProviderKind::OpenAi,
-                Arc::new(OpenAiClient::new(api_key).with_base_url(base_url)),
-            ),
-            Provider::OpenAiResponses { auth, base_url } => (
-                ResolvedProviderKind::OpenAiResponses,
-                Arc::new(
-                    OpenAiResponsesClient::new(match auth {
-                        OpenAiResponsesAuth::ApiKey { api_key } => {
-                            ClientOpenAiResponsesAuth::ApiKey { api_key }
-                        }
-                        OpenAiResponsesAuth::Subscription => {
-                            ClientOpenAiResponsesAuth::Subscription
-                        }
-                    })
-                    .with_base_url(base_url),
+        let (provider_kind, client): (ResolvedProviderKind, Arc<dyn LlmProvider>) =
+            match config.provider {
+                Provider::Anthropic { api_key, base_url } => (
+                    ResolvedProviderKind::Anthropic,
+                    Arc::new(AnthropicClient::new(api_key).with_base_url(base_url)),
                 ),
-            ),
-        };
+                Provider::OpenAi { api_key, base_url } => (
+                    ResolvedProviderKind::OpenAi,
+                    Arc::new(OpenAiClient::new(api_key).with_base_url(base_url)),
+                ),
+                Provider::OpenAiResponses { auth, base_url } => (
+                    ResolvedProviderKind::OpenAiResponses,
+                    Arc::new(
+                        OpenAiResponsesClient::new(match auth {
+                            OpenAiResponsesAuth::ApiKey { api_key } => {
+                                ClientOpenAiResponsesAuth::ApiKey { api_key }
+                            }
+                            OpenAiResponsesAuth::Subscription => {
+                                ClientOpenAiResponsesAuth::Subscription
+                            }
+                        })
+                        .with_base_url(base_url),
+                    ),
+                ),
+            };
         Self {
             name: config.name,
             default_max_tokens: config.default_max_tokens,

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -30,9 +30,21 @@ pub struct ModelConfig {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum Provider {
-    Anthropic { api_key: String },
-    OpenAi { api_key: String },
-    OpenAiResponses { auth: OpenAiResponsesAuth },
+    Anthropic {
+        api_key: String,
+        #[serde(default)]
+        base_url: Option<String>,
+    },
+    OpenAi {
+        api_key: String,
+        #[serde(default)]
+        base_url: Option<String>,
+    },
+    OpenAiResponses {
+        auth: OpenAiResponsesAuth,
+        #[serde(default)]
+        base_url: Option<String>,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -54,15 +66,22 @@ impl PromptExecutorConfig {
     pub fn validate(&self) -> Result<(), PromptExecutorConfigError> {
         for model in &self.models {
             match &model.provider {
-                Provider::Anthropic { api_key } if api_key.is_empty() => {
+                Provider::Anthropic { api_key, .. } if api_key.is_empty() => {
                     tracing::warn!(
                         model = %model.name,
                         "Anthropic credential is empty — agent prompts will fail until ANTHROPIC_API_KEY is set",
                     );
                 }
-                Provider::Anthropic { api_key } => {
+                Provider::Anthropic { api_key, base_url } => {
                     let preview = masked_preview(api_key);
-                    if !api_key.starts_with("sk-ant-") {
+                    if base_url.is_some() {
+                        tracing::info!(
+                            model = %model.name,
+                            key_preview = %preview,
+                            base_url = %base_url.as_deref().unwrap_or("default"),
+                            "Anthropic credential loaded (custom endpoint — key prefix validation skipped)"
+                        );
+                    } else if !api_key.starts_with("sk-ant-") {
                         tracing::warn!(
                             model = %model.name,
                             key_preview = %preview,
@@ -77,15 +96,22 @@ impl PromptExecutorConfig {
                         );
                     }
                 }
-                Provider::OpenAi { api_key } if api_key.is_empty() => {
+                Provider::OpenAi { api_key, .. } if api_key.is_empty() => {
                     tracing::warn!(
                         model = %model.name,
                         "OpenAI credential is empty — agent prompts will fail until OPENAI_API_KEY is set",
                     );
                 }
-                Provider::OpenAi { api_key } => {
+                Provider::OpenAi { api_key, base_url } => {
                     let preview = masked_preview(api_key);
-                    if !api_key.starts_with("sk-") {
+                    if base_url.is_some() {
+                        tracing::info!(
+                            model = %model.name,
+                            key_preview = %preview,
+                            base_url = %base_url.as_deref().unwrap_or("default"),
+                            "OpenAI credential loaded (custom endpoint — key prefix validation skipped)"
+                        );
+                    } else if !api_key.starts_with("sk-") {
                         tracing::warn!(
                             model = %model.name,
                             key_preview = %preview,
@@ -100,7 +126,7 @@ impl PromptExecutorConfig {
                         );
                     }
                 }
-                Provider::OpenAiResponses { auth } => match auth {
+                Provider::OpenAiResponses { auth, base_url } => match auth {
                     OpenAiResponsesAuth::ApiKey { api_key } if api_key.is_empty() => {
                         tracing::warn!(
                             model = %model.name,
@@ -109,7 +135,14 @@ impl PromptExecutorConfig {
                     }
                     OpenAiResponsesAuth::ApiKey { api_key } => {
                         let preview = masked_preview(api_key);
-                        if !api_key.starts_with("sk-") {
+                        if base_url.is_some() {
+                            tracing::info!(
+                                model = %model.name,
+                                key_preview = %preview,
+                                base_url = %base_url.as_deref().unwrap_or("default"),
+                                "OpenAI Responses credential loaded (custom endpoint — key prefix validation skipped)"
+                            );
+                        } else if !api_key.starts_with("sk-") {
                             tracing::warn!(
                                 model = %model.name,
                                 key_preview = %preview,
@@ -297,22 +330,27 @@ impl ResolvedModel {
         let (provider_kind, client): (ResolvedProviderKind, Arc<dyn LlmProvider>) = match config
             .provider
         {
-            Provider::Anthropic { api_key } => (
+            Provider::Anthropic { api_key, base_url } => (
                 ResolvedProviderKind::Anthropic,
-                Arc::new(AnthropicClient::new(api_key)),
+                Arc::new(AnthropicClient::new(api_key).with_base_url(base_url)),
             ),
-            Provider::OpenAi { api_key } => (
+            Provider::OpenAi { api_key, base_url } => (
                 ResolvedProviderKind::OpenAi,
-                Arc::new(OpenAiClient::new(api_key)),
+                Arc::new(OpenAiClient::new(api_key).with_base_url(base_url)),
             ),
-            Provider::OpenAiResponses { auth } => (
+            Provider::OpenAiResponses { auth, base_url } => (
                 ResolvedProviderKind::OpenAiResponses,
-                Arc::new(OpenAiResponsesClient::new(match auth {
-                    OpenAiResponsesAuth::ApiKey { api_key } => {
-                        ClientOpenAiResponsesAuth::ApiKey { api_key }
-                    }
-                    OpenAiResponsesAuth::Subscription => ClientOpenAiResponsesAuth::Subscription,
-                })),
+                Arc::new(
+                    OpenAiResponsesClient::new(match auth {
+                        OpenAiResponsesAuth::ApiKey { api_key } => {
+                            ClientOpenAiResponsesAuth::ApiKey { api_key }
+                        }
+                        OpenAiResponsesAuth::Subscription => {
+                            ClientOpenAiResponsesAuth::Subscription
+                        }
+                    })
+                    .with_base_url(base_url),
+                ),
             ),
         };
         Self {

--- a/core/tests/prompt_executor.rs
+++ b/core/tests/prompt_executor.rs
@@ -14,7 +14,10 @@ async fn anthropic_round_trip_via_executor() {
     let config = PromptExecutorConfig {
         models: vec![ModelConfig {
             name: MODEL.to_string(),
-            provider: Provider::Anthropic { api_key, base_url: None },
+            provider: Provider::Anthropic {
+                api_key,
+                base_url: None,
+            },
             default_max_tokens: Some(64),
         }],
     };

--- a/core/tests/prompt_executor.rs
+++ b/core/tests/prompt_executor.rs
@@ -14,7 +14,7 @@ async fn anthropic_round_trip_via_executor() {
     let config = PromptExecutorConfig {
         models: vec![ModelConfig {
             name: MODEL.to_string(),
-            provider: Provider::Anthropic { api_key },
+            provider: Provider::Anthropic { api_key, base_url: None },
             default_max_tokens: Some(64),
         }],
     };

--- a/lib/anthropic-client/src/lib.rs
+++ b/lib/anthropic-client/src/lib.rs
@@ -23,7 +23,8 @@ use crate::convert::{accumulated_to_response, prompt_to_request, AnthropicDeltaC
 use crate::sse::{parse_sse_stream, SseError};
 use crate::stream::StreamAccumulator;
 
-const API_URL: &str = "https://api.anthropic.com/v1/messages";
+const DEFAULT_BASE_URL: &str = "https://api.anthropic.com";
+const API_PATH: &str = "/v1/messages";
 const API_VERSION: &str = "2023-06-01";
 
 #[derive(Debug, Error)]
@@ -57,6 +58,7 @@ impl From<SseError> for AnthropicError {
 pub struct AnthropicClient {
     http: reqwest::Client,
     api_key: String,
+    api_url: String,
 }
 
 impl AnthropicClient {
@@ -64,7 +66,16 @@ impl AnthropicClient {
         Self {
             http: reqwest::Client::new(),
             api_key: api_key.into(),
+            api_url: format!("{DEFAULT_BASE_URL}{API_PATH}"),
         }
+    }
+
+    pub fn with_base_url(mut self, base_url: Option<String>) -> Self {
+        if let Some(base) = base_url {
+            let base = base.trim_end_matches('/');
+            self.api_url = format!("{base}{API_PATH}");
+        }
+        self
     }
 
     /// Issue a streaming Messages API request and return the fully-accumulated
@@ -80,7 +91,7 @@ impl AnthropicClient {
 
         let resp = self
             .http
-            .post(API_URL)
+            .post(&self.api_url)
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", API_VERSION)
             .header("accept", "text/event-stream")
@@ -146,7 +157,7 @@ impl AnthropicClient {
 
         let resp = self
             .http
-            .post(API_URL)
+            .post(&self.api_url)
             .header("x-api-key", &self.api_key)
             .header("anthropic-version", API_VERSION)
             .header("accept", "text/event-stream")

--- a/lib/openai-client/src/lib.rs
+++ b/lib/openai-client/src/lib.rs
@@ -24,6 +24,7 @@ use crate::sse::{parse_sse_stream, SseError};
 pub use responses::{OpenAiResponsesAuth, OpenAiResponsesClient, OpenAiResponsesError};
 
 const DEFAULT_API_URL: &str = "https://api.openai.com/v1/chat/completions";
+const API_PATH: &str = "/v1/chat/completions";
 
 #[derive(Debug, Error)]
 pub enum OpenAiChatCompletionsError {
@@ -63,6 +64,14 @@ impl OpenAiClient {
             api_key: api_key.into(),
             api_url: DEFAULT_API_URL.to_string(),
         }
+    }
+
+    pub fn with_base_url(mut self, base_url: Option<String>) -> Self {
+        if let Some(base) = base_url {
+            let base = base.trim_end_matches('/');
+            self.api_url = format!("{base}{API_PATH}");
+        }
+        self
     }
 
     /// Issue a streaming Chat Completions request and return the

--- a/lib/openai-client/src/responses.rs
+++ b/lib/openai-client/src/responses.rs
@@ -17,6 +17,8 @@ use crate::sse::{parse_sse_stream, SseError};
 
 const DEFAULT_RESPONSES_API_URL: &str = "https://api.openai.com/v1/responses";
 const DEFAULT_SUBSCRIPTION_API_URL: &str = "https://chatgpt.com/backend-api/codex/responses";
+const RESPONSES_API_PATH: &str = "/v1/responses";
+const SUBSCRIPTION_API_PATH: &str = "/backend-api/codex/responses";
 const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 4096;
 const DEFAULT_REASONING_EFFORT: &str = "low";
 const DEFAULT_TEXT_VERBOSITY: &str = "medium";
@@ -79,6 +81,18 @@ impl OpenAiResponsesClient {
 
     pub fn with_subscription() -> Self {
         Self::new(OpenAiResponsesAuth::Subscription)
+    }
+
+    pub fn with_base_url(mut self, base_url: Option<String>) -> Self {
+        if let Some(base) = base_url {
+            let base = base.trim_end_matches('/');
+            let path = match &self.auth {
+                OpenAiResponsesAuth::ApiKey { .. } => RESPONSES_API_PATH,
+                OpenAiResponsesAuth::Subscription => SUBSCRIPTION_API_PATH,
+            };
+            self.api_url = format!("{base}{path}");
+        }
+        self
     }
 
     #[instrument(name = "openai_responses_client.send_prompt_streaming", skip_all)]

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -40,6 +40,8 @@ pub struct Config {
 pub struct ProviderConfig {
     pub name: String,
     #[serde(default)]
+    pub base_url: Option<String>,
+    #[serde(default)]
     pub models: Vec<ProviderModelConfig>,
 }
 
@@ -70,20 +72,25 @@ impl Config {
         let mut models = Vec::new();
 
         for provider_cfg in &self.providers {
+            let base_url = provider_cfg.base_url.clone();
             let provider = match provider_cfg.name.as_str() {
                 "openai" => Provider::OpenAi {
                     api_key: self.openai_api_key.clone(),
+                    base_url,
                 },
                 "openai-responses" => Provider::OpenAiResponses {
                     auth: OpenAiResponsesAuth::ApiKey {
                         api_key: self.openai_api_key.clone(),
                     },
+                    base_url,
                 },
                 "openai-codex" => Provider::OpenAiResponses {
                     auth: OpenAiResponsesAuth::Subscription,
+                    base_url,
                 },
                 _ => Provider::Anthropic {
                     api_key: self.anthropic_api_key.clone(),
+                    base_url,
                 },
             };
 


### PR DESCRIPTION
## Summary

- Add optional `base_url` field to provider config, enabling use of alternative endpoints (OpenRouter, local Llama/vLLM, proxies) in place of the hardcoded OpenAI/Anthropic URLs
- Each client appends its standard API path (`/v1/messages`, `/v1/chat/completions`, `/v1/responses`) to the base URL
- API-key prefix validation (`sk-ant-`, `sk-`) is skipped when a custom URL is configured, since alternative providers use different credential formats

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (all new fields are `Option` with `#[serde(default)]`)
- [ ] Manual: add `base_url` to a provider in `drua.yml`, start server, verify logs show custom endpoint and no key-prefix warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)