### PR TITLE
fix(session): strip orphaned tool_use blocks on non-ToolUse stop

### DIFF
--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -411,6 +411,19 @@ impl AgentSession {
             .collect();
         let is_tool_use = matches!(stop_reason, StopReason::ToolUse) && !tool_uses.is_empty();
 
+        // Strip orphaned tool_use blocks when we won't execute them (e.g.
+        // stop_reason is EndTurn/MaxTokens/None). Persisting tool_use blocks
+        // without matching tool_result blocks causes the next prompt to be
+        // rejected by the API.
+        let content = if !is_tool_use && !tool_uses.is_empty() {
+            content
+                .into_iter()
+                .filter(|b| !matches!(b, AssistantBlock::ToolUse { .. }))
+                .collect()
+        } else {
+            content
+        };
+
         self.events
             .push(AgentSessionEvent::AssistantResponseReceived {
                 thread_id,


### PR DESCRIPTION
## Summary
- When the LLM returns tool_use blocks but with a non-ToolUse stop reason (end_turn, max_tokens, or missing), the tool calls are never executed and no tool_result blocks are collected
- Persisting these orphaned tool_use blocks causes the next prompt to be rejected by the Anthropic API: `"tool_use ids were found without tool_result blocks immediately after"`
- Strip tool_use blocks from the assistant response content when we won't be executing them

## Root cause
In `assistant_response_received`, the condition `is_tool_use = matches!(stop_reason, StopReason::ToolUse) && !tool_uses.is_empty()` gates tool execution. When false but tool_use blocks exist in the content (e.g. streaming connection drop, max_tokens truncation), those blocks are persisted as a regular assistant message without matching tool_results.

## Test plan
- [ ] All 34 existing session tests pass
- [ ] Reproduce: send a message that triggers tool calls, interrupt mid-stream, then send another message — should no longer error
- [ ] Normal tool call flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)