### PR TITLE
ci: auto-bump galoy-charts tunnel-connector image digest

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,6 +13,7 @@ groups:
   - build-edge-image
   - build-sandbox-image
   - build-tunnel-connector-image
+  - bump-galoy-charts-tunnel-connector-image
   - deploy-to-prod
   - train-classifier
   - build-code-assistant-index
@@ -393,6 +394,63 @@ jobs:
     get_params:
       skip_download: true
 
+#! After `build-tunnel-connector-image` publishes a fresh digest, open
+#! (or force-update) a PR on GaloyMoney/galoy-charts that pins
+#! `tunnelConnector.image.digest` in `charts/galoy-deps/values.yaml`.
+#! Using a digest instead of the mutable `:edge` tag means a drua CI push
+#! does not silently roll any running connector — the bump becomes an
+#! auditable PR humans merge when convenient.
+- name: bump-galoy-charts-tunnel-connector-image
+  serial: true
+  plan:
+  - in_parallel:
+    - get: tunnel-connector-edge-image
+      trigger: true
+      passed: [build-tunnel-connector-image]
+      params:
+        skip_download: true
+    - get: repo
+    - get: galoy-charts-repo
+  - task: update-digest
+    config:
+      platform: linux
+      image_resource: #@ nix_flake_image_config()
+      inputs:
+      - name: repo
+      - name: tunnel-connector-edge-image
+      - name: galoy-charts-repo
+      outputs:
+      - name: galoy-charts-repo
+      caches:
+      - path: /nix-cache
+      run:
+        path: repo/ci/tasks/with-nix-cache.sh
+        args:
+          - repo/ci/tasks/bump-galoy-charts-tunnel-connector.sh
+  - put: galoy-charts-bump-branch
+    params:
+      repository: galoy-charts-repo
+      branch: bump-tunnel-connector-image-bot-branch
+      force: true
+  - task: open-pr
+    config:
+      platform: linux
+      image_resource: #@ nix_flake_image_config()
+      inputs:
+      - name: repo
+      - name: galoy-charts-repo
+      caches:
+      - path: /nix-cache
+      params:
+        GITHUB_PAT: #@ data.values.github_pat
+        BOT_BRANCH: bump-tunnel-connector-image-bot-branch
+        BASE_BRANCH: main
+        TARGET_REPO: GaloyMoney/galoy-charts
+      run:
+        path: repo/ci/tasks/with-nix-cache.sh
+        args:
+          - repo/ci/tasks/open-galoy-charts-tunnel-connector-pr.sh
+
 resource_types:
 - name: terraform
   type: registry-image
@@ -446,6 +504,26 @@ resources:
     - flake.nix
     - Cargo.toml
     - Cargo.lock
+
+#! Read-only clone of galoy-charts main. The `bump-galoy-charts-
+#! tunnel-connector-image` job uses this to build the commit that gets
+#! force-pushed to the bot branch below.
+- name: galoy-charts-repo
+  type: git
+  source:
+    uri: git@github.com:GaloyMoney/galoy-charts.git
+    branch: main
+    private_key: #@ data.values.github_private_key
+
+#! Write target for the bump commit. The job force-pushes here every
+#! time drua publishes a new image, and the open-pr task then opens (or
+#! re-opens) the bot PR for this branch on galoy-charts.
+- name: galoy-charts-bump-branch
+  type: git
+  source:
+    uri: git@github.com:GaloyMoney/galoy-charts.git
+    branch: bump-tunnel-connector-image-bot-branch
+    private_key: #@ data.values.github_private_key
 
 - name: repo-labels
   type: git

--- a/ci/tasks/bump-galoy-charts-tunnel-connector.sh
+++ b/ci/tasks/bump-galoy-charts-tunnel-connector.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Writes the current `tunnel-connector:edge` digest into
+# `charts/galoy-deps/values.yaml` in the galoy-charts clone and commits.
+# Paired with `open-galoy-charts-tunnel-connector-pr.sh`, which opens/updates
+# the PR on galoy-charts after this task's commit is force-pushed to the
+# bot branch.
+#
+# Runs inside the nix-flakes Concourse image — `nix shell` pulls in
+# `yq-go` and `git` from nixpkgs because the base image has neither.
+#
+# No-op (no commit) when the digest in values.yaml already matches —
+# otherwise the bot branch would churn an identical commit every time
+# the registry-image resource polls.
+
+set -euo pipefail
+
+exec nix shell nixpkgs#yq-go nixpkgs#git nixpkgs#coreutils --command bash <<'SCRIPT'
+set -euo pipefail
+
+DIGEST=$(cat tunnel-connector-edge-image/digest)
+VALUES="galoy-charts-repo/charts/galoy-deps/values.yaml"
+
+CURRENT=$(yq '.tunnelConnector.image.digest' "$VALUES")
+if [[ "$CURRENT" == "$DIGEST" ]]; then
+  echo "galoy-charts tunnelConnector.image.digest already at $DIGEST — nothing to do"
+  exit 0
+fi
+
+yq -i ".tunnelConnector.image.digest = \"${DIGEST}\"" "$VALUES"
+
+if [[ -z $(git config --global user.email || true) ]]; then
+  git config --global user.email "bot@galoy.io"
+  git config --global user.name "Galoy CI Bot"
+fi
+
+cd galoy-charts-repo
+git add -A
+git status
+
+if ! git diff --cached --exit-code; then
+  git commit -m "chore(deps): bump tunnel-connector image digest to ${DIGEST}"
+fi
+SCRIPT

--- a/ci/tasks/open-galoy-charts-tunnel-connector-pr.sh
+++ b/ci/tasks/open-galoy-charts-tunnel-connector-pr.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Opens (or re-opens) a PR against GaloyMoney/galoy-charts for the bot
+# branch that `bump-galoy-charts-tunnel-connector.sh` force-pushes to.
+# Closes any existing PR on the branch first — the bot branch is
+# continuously force-pushed, and the goal is one always-current open PR
+# rather than a list of stale superseded ones.
+#
+# Uses `GITHUB_PAT` (wired from the pipeline) as the `gh` auth token.
+# `nix shell` pulls `gh` and `yq-go` since the base image has neither.
+
+set -euo pipefail
+
+: "${GITHUB_PAT:?GITHUB_PAT must be set}"
+: "${BOT_BRANCH:?BOT_BRANCH must be set}"
+: "${BASE_BRANCH:?BASE_BRANCH must be set}"
+: "${TARGET_REPO:?TARGET_REPO must be set (owner/repo)}"
+
+exec nix shell nixpkgs#gh nixpkgs#yq-go nixpkgs#coreutils --command bash <<SCRIPT
+set -euo pipefail
+
+DIGEST=\$(yq '.tunnelConnector.image.digest' galoy-charts-repo/charts/galoy-deps/values.yaml)
+
+cat > /tmp/pr-body.md <<BODY
+Auto-bump of \\\`tunnelConnector.image.digest\\\` in \\\`charts/galoy-deps/values.yaml\\\` to the latest \\\`tunnel-connector:edge\\\` digest published by drua CI:
+
+\\\`\\\`\\\`
+\${DIGEST}
+\\\`\\\`\\\`
+
+The drua CI bot force-pushes this branch on every new image, so this PR is always current — merge when convenient. Pinning the digest (instead of tracking the mutable \\\`:edge\\\` tag) means a drua CI push does not silently roll a running connector.
+
+Opened by GaloyMoney/drua CI via \\\`ci/tasks/open-galoy-charts-tunnel-connector-pr.sh\\\`.
+BODY
+
+export GH_TOKEN="\${GITHUB_PAT}"
+
+gh pr close "\${BOT_BRANCH}" --repo "\${TARGET_REPO}" || true
+gh pr create \\
+  --repo "\${TARGET_REPO}" \\
+  --title "chore(deps): bump tunnel-connector image digest" \\
+  --body-file /tmp/pr-body.md \\
+  --base "\${BASE_BRANCH}" \\
+  --head "\${BOT_BRANCH}" \\
+  --label galoybot \\
+  --label tunnel-connector
+SCRIPT


### PR DESCRIPTION
## Summary

Adds a Concourse job that chains off `build-tunnel-connector-image`. On every new image push, the job opens (or force-updates) a PR on [GaloyMoney/galoy-charts](https://github.com/GaloyMoney/galoy-charts) that pins `tunnelConnector.image.digest` in `charts/galoy-deps/values.yaml` to the latest published digest.

## Why drua-side rather than galoy-charts-side

The publisher (drua) is the source of truth for what has been published. Having drua drive the bump keeps galoy-charts CI passive — it only reacts to merges, not to external poll loops. It also means the bump fires at the exact moment a new image is available, not after the next poll interval.

## Why digest rather than `:edge`

`:edge` is mutable. Without digest pinning, every drua CI push would silently roll every running connector on the next kubelet restart or pod reschedule. Pinning to the digest makes each bump an auditable PR; humans decide when it actually rolls.

## Mechanism

1. Two new git resources — `galoy-charts-repo` (read, `main`) and `galoy-charts-bump-branch` (write, bot branch). Both use the existing `github_private_key` over SSH.
2. `ci/tasks/bump-galoy-charts-tunnel-connector.sh` — runs `yq` + `git` inside a `nix shell` (the base image has neither), writes the digest, commits only if it actually changed.
3. Put to `galoy-charts-bump-branch` with `force: true`.
4. `ci/tasks/open-galoy-charts-tunnel-connector-pr.sh` — runs `gh` inside a `nix shell`, closes any existing bot PR on that branch and re-creates it. Auth uses `GITHUB_PAT` (already plumbed through `ci/values.yml`). No new credentials needed.

## Dependencies

- **GaloyMoney/galoy-charts#259** must land first. That PR adds the `tunnelConnector.image.digest` field this job writes into, plus the Deployment template logic that prefers digest over tag. Without it, `yq -i '.tunnelConnector.image.digest = ...'` either fails (no struct) or writes a dangling key the template ignores.

## Verified

- `ytt -f ci/pipeline.yml -f ci/fragments.lib.yml -f ci/values.yml` renders cleanly.
- Generated job, tasks, and two new resources look correct.
- Script logic is a straight port of galoy-charts' existing `update-helm-dep.sh` + `open-update-helm-deps-pr.sh` pattern.

## Test plan

- [x] ytt renders cleanly
- [ ] Merge GaloyMoney/galoy-charts#259 first
- [ ] Repipe galoy-agents, confirm `bump-galoy-charts-tunnel-connector-image` appears in the galoy-agents group downstream of `build-tunnel-connector-image`
- [ ] Trigger a drua main push and confirm the bot opens a PR on galoy-charts with the current digest
- [ ] Merge the bot PR, confirm the rollout actually happens in staging (connector pod restarts with new digest)

## Related

- Companion: GaloyMoney/galoy-charts#259 (defines the `digest` field this job writes to)
- Parent: GaloyMoney/volcano-wip#729

🤖 Generated with [Claude Code](https://claude.com/claude-code)