### PR TITLE
fix(config): regenerate default-config with tunnel.deployments

### DIFF
--- a/dev/drua.default.yml
+++ b/dev/drua.default.yml
@@ -3,6 +3,8 @@ server:
   host: 0.0.0.0
   secure_cookies: true
   mcp_endpoint: http://localhost:4200/mcp
+  tunnel:
+    deployments: {}
 oauth:
   login: github
   github_redirect_uri: ''


### PR DESCRIPTION
## Summary
- Adds the missing `server.tunnel.deployments: {}` block to `dev/drua.default.yml` so the `default-config-check` flake derivation passes.
- #186 introduced the `tunnel.deployments` field on `Config` but did not regenerate the committed default-config snapshot, so every post-merge `check-code` build on `main` has been failing since then.

## Test plan
- [ ] Concourse `check-code` goes green
- [ ] `make generate-default-config` locally produces no diff against this file

🤖 Generated with [Claude Code](https://claude.com/claude-code)