### PR TITLE
feat: add optional content field to ToolResultEvent

### DIFF
--- a/client/src/graphql.rs
+++ b/client/src/graphql.rs
@@ -88,7 +88,7 @@ subscription AgentMessage($agentId: AgentId!, $prompt: String!) {
     ... on ThinkingEvent { text }
     ... on UserMessageEvent { text }
     ... on ToolCallEvent { name arguments }
-    ... on ToolResultEvent { name isError }
+    ... on ToolResultEvent { name isError content }
     ... on AssistantDoneEvent { turns inputTokens outputTokens durationMs costUsd }
     ... on ErrorEvent { message }
     ... on ServiceEvent { message }

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -879,10 +879,21 @@ async fn fan_out_tool_calls(
     let outcomes = futures::future::join_all(dispatches).await;
     let mut results = Vec::with_capacity(outcomes.len());
     for (name, result) in outcomes {
+        // Truncate content to keep the stream lightweight.
+        const MAX_CONTENT_LEN: usize = 4096;
+        let content = if result.content.is_empty() {
+            None
+        } else if result.content.len() <= MAX_CONTENT_LEN {
+            Some(result.content.clone())
+        } else {
+            let truncated: String = result.content.chars().take(MAX_CONTENT_LEN).collect();
+            Some(truncated + "…")
+        };
         let _ = tx
             .send(ChatOutputEvent::ToolResult {
                 name,
                 is_error: result.is_error,
+                content,
             })
             .await;
         results.push(result);

--- a/core/src/primitives/chat_output_event.rs
+++ b/core/src/primitives/chat_output_event.rs
@@ -39,6 +39,8 @@ pub enum ChatOutputEvent {
     ToolResult {
         name: String,
         is_error: bool,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        content: Option<String>,
     },
     AssistantDone {
         turns: u32,

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -313,9 +313,14 @@ async fn send_message_dispatches_registered_tool_call() {
         events[1]
     );
     match &events[2] {
-        ChatOutputEvent::ToolResult { name, is_error } => {
+        ChatOutputEvent::ToolResult {
+            name,
+            is_error,
+            content,
+        } => {
             assert_eq!(name, "ping");
             assert!(!is_error, "ping tool should succeed");
+            assert!(content.is_some(), "content should be populated");
         }
         other => panic!("event[2] should be ToolResult, got {other:?}"),
     }

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -277,6 +277,7 @@ type ToolResultContent {
 }
 
 type ToolResultEvent {
+	content: String
 	isError: Boolean!
 	name: String!
 }

--- a/server/src/graphql/subscription.rs
+++ b/server/src/graphql/subscription.rs
@@ -53,6 +53,7 @@ pub struct ToolCallInputDeltaEvent {
 pub struct ToolResultEvent {
     pub name: String,
     pub is_error: bool,
+    pub content: Option<String>,
 }
 
 #[derive(SimpleObject)]
@@ -119,9 +120,15 @@ impl From<drua_core::primitives::ChatOutputEvent> for ChatStreamEvent {
             ChatOutputEvent::ToolCallInputDelta { partial_json } => {
                 Self::ToolCallInputDelta(ToolCallInputDeltaEvent { partial_json })
             }
-            ChatOutputEvent::ToolResult { name, is_error } => {
-                Self::ToolResult(ToolResultEvent { name, is_error })
-            }
+            ChatOutputEvent::ToolResult {
+                name,
+                is_error,
+                content,
+            } => Self::ToolResult(ToolResultEvent {
+                name,
+                is_error,
+                content,
+            }),
             ChatOutputEvent::AssistantDone {
                 turns,
                 input_tokens,

--- a/server/templates/workspace_chat.html
+++ b/server/templates/workspace_chat.html
@@ -119,7 +119,7 @@ const AGENT_MESSAGE_SUBSCRIPTION = `subscription ($agentId: AgentId!, $prompt: S
     ... on ThinkingEvent { text }
     ... on UserMessageEvent { text }
     ... on ToolCallEvent { name arguments }
-    ... on ToolResultEvent { name isError }
+    ... on ToolResultEvent { name isError content }
     ... on AssistantDoneEvent { turns inputTokens outputTokens durationMs costUsd }
     ... on ErrorEvent { message }
     ... on ServiceEvent { message }

--- a/server/templates/workspace_hub.html
+++ b/server/templates/workspace_hub.html
@@ -261,7 +261,7 @@
           ... on ThinkingEvent { text }
           ... on UserMessageEvent { text }
           ... on ToolCallEvent { name arguments }
-          ... on ToolResultEvent { name isError }
+          ... on ToolResultEvent { name isError content }
           ... on AssistantDoneEvent { turns inputTokens outputTokens durationMs costUsd }
           ... on ErrorEvent { message }
           ... on ServiceEvent { message }


### PR DESCRIPTION
## Summary
- Adds an optional `content: Option<String>` field to `ToolResultEvent` so clients can see what a tool actually returned, making it symmetric with `ToolCallEvent` (which carries full arguments)
- Populates the field from tool execution results in `fan_out_tool_calls`, truncating to 4096 chars to keep the stream lightweight
- Updates the GraphQL schema, subscription resolver, and all client-side queries (TUI, HTML templates) to include the new field

## Test plan
- [ ] Verify `cargo check` passes (confirmed locally)
- [ ] Run existing `send_message_dispatches_registered_tool_call` test to confirm the new `content` field is populated
- [ ] Send a message to an agent via the GraphQL subscription and confirm `ToolResultEvent` now includes `content`
- [ ] Verify HTML dashboard and TUI client continue to work (queries updated but rendering unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)