### PR TITLE
feat(library): sync workspace folder boilerplate on creation

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -194,7 +194,7 @@ impl App {
         ));
         toolsets.register_top_level(WorkspaceSandbox::new(Arc::clone(&sandboxes)));
 
-        let workspaces = Arc::new(Workspaces::new(pool, Arc::clone(&agents)));
+        let workspaces = Arc::new(Workspaces::new(pool, Arc::clone(&agents), library.clone()));
         toolsets.register_top_level(NotesTool::new(Arc::clone(&notes), Arc::clone(&workspaces)));
 
         // Admin tools live behind progressive disclosure (search_tools →

--- a/core/src/library/file.rs
+++ b/core/src/library/file.rs
@@ -66,6 +66,9 @@ pub enum RuntimeFile {
         slug: String,
         id_prefix: String,
     },
+    GitKeep {
+        workspace_name: String,
+    },
 }
 
 impl RuntimeFile {
@@ -95,13 +98,7 @@ impl RuntimeFile {
         }
     }
 
-    pub fn doc_type(&self) -> DocType {
-        match self {
-            RuntimeFile::Note { .. } => DocType::Note,
-        }
-    }
-
-    pub fn searchable_fields(&self) -> SearchableFields {
+    pub fn searchable_fields(&self) -> Option<SearchableFields> {
         match self {
             RuntimeFile::Note {
                 doc_id,
@@ -110,14 +107,15 @@ impl RuntimeFile {
                 body,
                 tags,
                 ..
-            } => SearchableFields {
+            } => Some(SearchableFields {
                 doc_id: uuid::Uuid::from(*doc_id),
                 doc_type: DocType::Note,
                 workspace_id: uuid::Uuid::from(*workspace_id),
                 title: title.clone(),
                 body: body.clone(),
                 tags: tags.clone(),
-            },
+            }),
+            RuntimeFile::GitKeep { .. } => None,
         }
     }
 
@@ -132,6 +130,9 @@ impl RuntimeFile {
                 "runtime/workspaces/{}/notes/{}-{}.md",
                 workspace_name, slug, id_prefix
             ),
+            RuntimeFile::GitKeep { workspace_name } => {
+                format!("runtime/workspaces/{}/notes/.gitkeep", workspace_name)
+            }
         }
     }
 
@@ -157,6 +158,7 @@ impl RuntimeFile {
                     doc_id, tags_str, created_at, updated_at, title, body
                 )
             }
+            RuntimeFile::GitKeep { .. } => String::new(),
         }
     }
 
@@ -165,6 +167,9 @@ impl RuntimeFile {
             RuntimeFile::Note {
                 slug, id_prefix, ..
             } => format!("note: {}-{}", slug, id_prefix),
+            RuntimeFile::GitKeep { workspace_name } => {
+                format!("workspace: scaffold {}", workspace_name)
+            }
         }
     }
 

--- a/core/src/library/inbox.rs
+++ b/core/src/library/inbox.rs
@@ -32,14 +32,15 @@ impl InboxHandler for LibraryWriteHandler {
     ) -> Result<InboxResult, Box<dyn std::error::Error + Send + Sync>> {
         let file: super::RuntimeFile = event.payload()?;
 
-        let fields = file.searchable_fields();
-        let embedding = self
-            .embedder
-            .embed_document(&fields.text_for_embedding())
-            .await?;
-        self.search
-            .set_embedding(fields.doc_id, fields.doc_type, embedding)
-            .await?;
+        if let Some(fields) = file.searchable_fields() {
+            let embedding = self
+                .embedder
+                .embed_document(&fields.text_for_embedding())
+                .await?;
+            self.search
+                .set_embedding(fields.doc_id, fields.doc_type, embedding)
+                .await?;
+        }
 
         let config = WriteToRuntimeConfig { file };
         self.write_spawner

--- a/core/src/library/mod.rs
+++ b/core/src/library/mod.rs
@@ -78,8 +78,9 @@ impl Library {
         op: &mut impl es_entity::AtomicOperation,
         file: &RuntimeFile,
     ) -> Result<(), LibraryError> {
-        let fields = file.searchable_fields();
-        self.search.upsert_in_op(op, &fields).await?;
+        if let Some(fields) = file.searchable_fields() {
+            self.search.upsert_in_op(op, &fields).await?;
+        }
 
         let idempotency_key = file.file_hash().to_string();
         let _ = self
@@ -87,6 +88,25 @@ impl Library {
             .persist_and_queue_job_in_op(op, idempotency_key, file)
             .await?;
 
+        Ok(())
+    }
+
+    /// Queue a `.gitkeep` file for a new workspace so the folder structure
+    /// is committed to the library repo.
+    #[tracing::instrument(name = "library.sync_workspace_folder_in_op", skip_all)]
+    pub async fn sync_workspace_folder_in_op(
+        &self,
+        op: &mut impl es_entity::AtomicOperation,
+        workspace_name: &str,
+    ) -> Result<(), LibraryError> {
+        let file = RuntimeFile::GitKeep {
+            workspace_name: workspace_name.to_string(),
+        };
+        let idempotency_key = file.file_hash().to_string();
+        let _ = self
+            .inbox
+            .persist_and_queue_job_in_op(op, idempotency_key, &file)
+            .await?;
         Ok(())
     }
 

--- a/core/src/workspace/error.rs
+++ b/core/src/workspace/error.rs
@@ -2,6 +2,7 @@ use thiserror::Error;
 
 use crate::agent::AgentError;
 use crate::auth::error::AuthorizationError;
+use crate::library::LibraryError;
 
 use super::repo::{
     WorkspaceCreateError, WorkspaceFindError, WorkspaceModifyError, WorkspaceQueryError,
@@ -23,4 +24,6 @@ pub enum WorkspaceError {
     Query(#[from] WorkspaceQueryError),
     #[error("WorkspaceError - Authorization: {0}")]
     Authorization(#[from] AuthorizationError),
+    #[error("WorkspaceError - Library: {0}")]
+    Library(#[from] LibraryError),
 }

--- a/core/src/workspace/mod.rs
+++ b/core/src/workspace/mod.rs
@@ -15,18 +15,24 @@ use repo::*;
 
 use crate::agent::Agents;
 use crate::audit::Audit;
+use crate::library::Library;
 use crate::primitives::*;
 
 #[derive(Clone)]
 pub struct Workspaces {
     repo: WorkspaceRepo,
     agents: Arc<Agents>,
+    library: Library,
 }
 
 impl Workspaces {
-    pub fn new(pool: &sqlx::PgPool, agents: Arc<Agents>) -> Self {
+    pub fn new(pool: &sqlx::PgPool, agents: Arc<Agents>, library: Library) -> Self {
         let repo = WorkspaceRepo::new(pool);
-        Self { repo, agents }
+        Self {
+            repo,
+            agents,
+            library,
+        }
     }
 
     #[instrument(name = "domain.workspace.create", skip(self))]
@@ -51,6 +57,10 @@ impl Workspaces {
 
         self.agents
             .create_workspace_lead_in_op(&mut op, lead_agent_id, workspace_id, "lead", &name)
+            .await?;
+
+        self.library
+            .sync_workspace_folder_in_op(&mut op, &name)
             .await?;
 
         op.commit().await?;


### PR DESCRIPTION
## Summary
- When a workspace is created, automatically queue a `.gitkeep` file at `runtime/workspaces/<name>/notes/.gitkeep` through the existing library inbox/job pipeline
- This ensures the workspace folder structure exists in the library git repo before any notes are created
- Integrates with the existing serialized job queue — no new mechanisms introduced

## Changes
- **`RuntimeFile::GitKeep`** — new variant for folder scaffolding files (empty content, no search indexing/embedding)
- **`searchable_fields()` → `Option<SearchableFields>`** — allows non-document files to skip search indexing and embedding computation
- **`Library::sync_workspace_folder_in_op()`** — convenience method that creates a `GitKeep` and queues it through the inbox
- **`Workspaces`** — now holds a `Library` reference and calls `sync_workspace_folder_in_op` within the atomic workspace creation operation

## Test plan
- [ ] Create a workspace and verify `.gitkeep` appears at `runtime/workspaces/<name>/notes/.gitkeep` in the library repo
- [ ] Create a note in the workspace and verify it still syncs correctly alongside the `.gitkeep`
- [ ] Verify idempotency — creating a workspace with the same name (after delete) doesn't fail on duplicate `.gitkeep`

🤖 Generated with [Claude Code](https://claude.com/claude-code)