### PR TITLE
refactor: normalize tunnel toolset name/prefix to underscores

### DIFF
--- a/core/src/tunnel.rs
+++ b/core/src/tunnel.rs
@@ -326,8 +326,8 @@ impl TunnelToolSet {
             })
             .collect();
 
-        let name = format!("{}-{}", deployment_id, registration.name);
-        let prefix = format!("{}_{}", deployment_id, registration.prefix);
+        let name = format!("{}_{}", deployment_id, registration.name).replace('-', "_");
+        let prefix = format!("{}_{}", deployment_id, registration.prefix).replace('-', "_");
 
         Ok(Self {
             name,


### PR DESCRIPTION
TL;DR `galoy-staging_kubenertes_xxx` -> `galoy_staging_kubernetes_xxx`.
Simple .replace change.
If we need to do it via serde_json cleanly, then many other places need to be updated.

## Summary
- Composed `TunnelToolSet.name` / `.prefix` now use `_` throughout, so tunnel-registered toolsets render as `galoy_staging_kubernetes` instead of `galoy-staging-kubernetes` in `search_tools` output and the MCP gateway catalog.
- Single-line change at the composition site in `core/src/tunnel.rs` — the `deployment_id` itself is left untouched, so handshake verification (`server/src/tunnel.rs:89,114`) and the `TunnelConfig.deployments` map lookup keep working unchanged.

## Background / research
The tunnel name is composed from two sources:
- `deployment_id` — from the verified handshake header (`server/src/tunnel.rs:89`), which must match a key in `TunnelConfig.deployments` (`server/src/config.rs:147-150`).
- `registration.name` / `registration.prefix` — from the connector's `Register` frame (`RegisteredToolSet` in `core/src/tunnel.rs:61-69`), currently hardcoded by the connector to the upstream name (`images/tunnel-connector/src/main.rs:187-193`).

The dashes in existing tunnel names come from `deployment_id` (e.g. `galoy-staging`), not from `registration.name` (just `kubernetes` / `postgres`). So the transformation has to cover the composed result, not just one input.

## Why not do this at serde level
Doing the `-` → `_` rewrite during deserialization was considered and rejected because it would force edits in several unrelated places to keep auth/lookup invariants consistent:

1. **`TunnelConfig.deployments` key deserialization** (server/src/config.rs:147-150) — custom deserializer to normalize map keys.
2. **Handshake header parsing** (server/src/tunnel.rs:89) — the `deployment_id` extracted from `Authorization: Tunnel <id>:<ts>:<sig>` would also need normalization; otherwise the lookup at server/src/tunnel.rs:114 misses (map has `galoy_staging`, header sent `galoy-staging` → handshake rejected).
3. **Helm / deployed config** (charts/drua/templates/configmap.yaml, drua.yml `server.tunnel.deployments`) — operators either rewrite the keys or accept that the on-disk id and runtime id diverge.
4. **`RegisteredToolSet` field deserializer** — only helpful for future multi-word upstream names; no-op for today's `kubernetes` / `postgres`.

Keeping it at the composition site means `deployment_id` stays byte-identical everywhere auth and config key lookup care about it, and the normalization is isolated to the presentational `name`/`prefix` fields consumed by catalog / search output.

## Test plan
- [ ] `cargo check -p drua-core` (passes locally)
- [ ] Reconnect a tunnel against a staging drua and confirm `search_tools` shows `galoy_staging_kubernetes` / `galoy_staging_postgres` in the category listing.
- [ ] Confirm handshake still succeeds (no change to `deployment_id` path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)