### PR TITLE
feat(graphql): migrate REST-only endpoints to GraphQL API

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -141,6 +141,7 @@
           export REPO_ROOT="$(pwd)"
           export PG_CON="postgres://user:password@localhost:5432/drua"
           export DATABASE_URL="$PG_CON"
+          export ORT_DYLIB_PATH="${pkgs.onnxruntime}/lib/libonnxruntime${pkgs.stdenv.hostPlatform.extensions.sharedLibrary}"
           export COMPOSE_CMD="''${COMPOSE_CMD:-podman-compose-runner}"
 
           cleanup() {

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -54,3 +54,11 @@ opentelemetry-otlp = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true }
 url = { workspace = true }
 uuid = { version = "1", features = ["v4"] }
+
+[dev-dependencies]
+async-graphql = { version = "8.0.0-rc.4", default-features = false }
+drua-core = { path = "../core", features = ["graphql"] }
+serde_json = "1.0"
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "uuid", "chrono", "json"] }
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+uuid = { version = "1", features = ["v4"] }

--- a/server/src/graphql/agent.rs
+++ b/server/src/graphql/agent.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use async_graphql::{ComplexObject, Context, Enum, SimpleObject};
+use async_graphql::{ComplexObject, Context, Enum, InputObject, SimpleObject};
 
 use super::primitives::*;
 
@@ -96,3 +96,41 @@ impl From<DomainAgentRole> for AgentRole {
         }
     }
 }
+
+impl From<SandboxAttachmentMode> for SandboxAgentMode {
+    fn from(mode: SandboxAttachmentMode) -> Self {
+        match mode {
+            SandboxAttachmentMode::Read => Self::Read,
+            SandboxAttachmentMode::Write => Self::Write,
+        }
+    }
+}
+
+// ── Mutation inputs & payloads ──────────────────────────────────────────
+
+#[derive(InputObject)]
+pub struct AgentCreateInput {
+    pub workspace_id: WorkspaceId,
+    pub name: String,
+    pub sandbox_id: Option<SandboxId>,
+    pub sandbox_mode: Option<SandboxAttachmentMode>,
+}
+
+mutation_payload! { AgentCreatePayload, agent: Agent }
+
+#[derive(InputObject)]
+pub struct AgentAttachSandboxInput {
+    pub agent_id: AgentId,
+    pub sandbox_id: SandboxId,
+    pub mode: SandboxAttachmentMode,
+}
+
+mutation_payload! { AgentAttachSandboxPayload, agent: Agent }
+
+#[derive(InputObject)]
+pub struct AgentDetachSandboxInput {
+    pub agent_id: AgentId,
+    pub sandbox_id: SandboxId,
+}
+
+mutation_payload! { AgentDetachSandboxPayload, agent: Agent }

--- a/server/src/graphql/audit.rs
+++ b/server/src/graphql/audit.rs
@@ -1,0 +1,51 @@
+use async_graphql::{InputObject, SimpleObject};
+
+use super::primitives::*;
+
+use drua_core::audit::primitives::AuditEntry as DomainAuditEntry;
+
+#[derive(SimpleObject, Clone)]
+pub struct AuditEntry {
+    acting_user_id: Option<UUID>,
+    acting_agent_id: Option<UUID>,
+    on_behalf_of_user_id: Option<UUID>,
+    entrypoint: Option<String>,
+    interaction_type: String,
+    action: String,
+    outcome: String,
+    error: Option<bool>,
+    duration_ms: Option<i32>,
+    tokens_returned: Option<i32>,
+    recorded_at: Timestamp,
+}
+
+impl From<DomainAuditEntry> for AuditEntry {
+    fn from(e: DomainAuditEntry) -> Self {
+        Self {
+            acting_user_id: e.acting_user_id.map(|id| UUID::from(uuid::Uuid::from(id))),
+            acting_agent_id: e.acting_agent_id.map(|id| UUID::from(uuid::Uuid::from(id))),
+            on_behalf_of_user_id: e
+                .on_behalf_of_user_id
+                .map(|id| UUID::from(uuid::Uuid::from(id))),
+            entrypoint: e.entrypoint,
+            interaction_type: e.interaction_type,
+            action: e.action,
+            outcome: e.outcome,
+            error: e.error,
+            duration_ms: e.duration_ms.map(|v| v as i32),
+            tokens_returned: e.tokens_returned.map(|v| v as i32),
+            recorded_at: Timestamp::from(e.recorded_at),
+        }
+    }
+}
+
+#[derive(InputObject)]
+pub struct AuditLogQueryInput {
+    pub workspace_id: Option<WorkspaceId>,
+    pub acting_agent_id: Option<AgentId>,
+    pub action: Option<String>,
+    pub outcome: Option<String>,
+    pub error: Option<bool>,
+    #[graphql(default = 20)]
+    pub limit: i32,
+}

--- a/server/src/graphql/mcp_creds.rs
+++ b/server/src/graphql/mcp_creds.rs
@@ -1,0 +1,48 @@
+use async_graphql::{InputObject, SimpleObject};
+
+use super::primitives::*;
+
+use drua_core::mcp_creds::McpCreds as DomainMcpCreds;
+
+#[derive(SimpleObject, Clone)]
+pub struct McpCreds {
+    id: McpCredsId,
+    name: String,
+    revoked: bool,
+    revoked_at: Option<Timestamp>,
+    created_at: Timestamp,
+}
+
+impl From<DomainMcpCreds> for McpCreds {
+    fn from(entity: DomainMcpCreds) -> Self {
+        Self {
+            id: entity.id,
+            name: entity.name.clone(),
+            revoked: entity.is_revoked(),
+            revoked_at: entity.revoked_at.map(Timestamp::from),
+            created_at: Timestamp::from(entity.created_at()),
+        }
+    }
+}
+
+#[derive(InputObject)]
+pub struct McpCredentialsCreateInput {
+    pub name: String,
+    /// The scopes to grant, as strings (e.g. "admin", "workspace_admin:<id>").
+    pub scopes: Vec<String>,
+}
+
+/// Returned on create — includes the plaintext token (shown only once).
+#[derive(SimpleObject)]
+pub struct McpCredentialsCreatePayload {
+    pub mcp_creds: McpCreds,
+    /// The plaintext token. Only returned once on creation.
+    pub token: String,
+}
+
+#[derive(InputObject)]
+pub struct McpCredentialsRevokeInput {
+    pub id: McpCredsId,
+}
+
+mutation_payload! { McpCredentialsRevokePayload, mcp_creds: McpCreds }

--- a/server/src/graphql/mod.rs
+++ b/server/src/graphql/mod.rs
@@ -1,13 +1,18 @@
 #[macro_use]
 pub(crate) mod macros;
 mod agent;
+mod audit;
+mod mcp_creds;
 mod mutation;
 pub(crate) mod primitives;
 mod query;
+mod sandbox;
 mod session;
+mod skill;
 mod subscription;
 mod types;
 mod workspace;
+mod workspace_secret;
 
 use std::convert::Infallible;
 

--- a/server/src/graphql/mutation.rs
+++ b/server/src/graphql/mutation.rs
@@ -1,6 +1,11 @@
 use async_graphql::{Context, Object};
 
+use super::agent::*;
+use super::mcp_creds::*;
+use super::sandbox::*;
+use super::skill::*;
 use super::workspace::*;
+use super::workspace_secret::*;
 
 pub struct Mutation;
 
@@ -9,6 +14,8 @@ impl Mutation {
     async fn ping(&self) -> &str {
         "pong"
     }
+
+    // ── Workspace ───────────────────────────────────────────────────────
 
     async fn workspace_create(
         &self,
@@ -44,5 +51,216 @@ impl Mutation {
         let (app, sub) = app_and_sub_from_ctx!(ctx);
         let ws = app.workspaces().delete(sub, input.id).await?;
         Ok(WorkspaceDeletePayload::from(Workspace::from(ws)))
+    }
+
+    // ── Agent ───────────────────────────────────────────────────────────
+
+    async fn agent_create(
+        &self,
+        ctx: &Context<'_>,
+        input: AgentCreateInput,
+    ) -> async_graphql::Result<AgentCreatePayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let attach = match (input.sandbox_id, input.sandbox_mode) {
+            (Some(sid), Some(mode)) => Some((sid, mode.into())),
+            _ => None,
+        };
+        let agent = app
+            .agents()
+            .create_agent(sub, input.workspace_id, input.name, attach)
+            .await?;
+        Ok(AgentCreatePayload::from(Agent::from(agent)))
+    }
+
+    async fn agent_attach_sandbox(
+        &self,
+        ctx: &Context<'_>,
+        input: AgentAttachSandboxInput,
+    ) -> async_graphql::Result<AgentAttachSandboxPayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let agent = app
+            .agents()
+            .attach_sandbox(sub, input.agent_id, input.sandbox_id, input.mode.into())
+            .await?;
+        Ok(AgentAttachSandboxPayload::from(Agent::from(agent)))
+    }
+
+    async fn agent_detach_sandbox(
+        &self,
+        ctx: &Context<'_>,
+        input: AgentDetachSandboxInput,
+    ) -> async_graphql::Result<AgentDetachSandboxPayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let agent = app
+            .agents()
+            .detach_sandbox(sub, input.agent_id, input.sandbox_id)
+            .await?;
+        Ok(AgentDetachSandboxPayload::from(Agent::from(agent)))
+    }
+
+    // ── Sandbox ─────────────────────────────────────────────────────────
+
+    async fn sandbox_create(
+        &self,
+        ctx: &Context<'_>,
+        input: SandboxCreateInput,
+    ) -> async_graphql::Result<SandboxCreatePayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let specs = drua_core::sandbox::SandboxSpecs {
+            cpu: input.cpu,
+            memory: input.memory,
+            disk_size: input.disk_size,
+        };
+        let mode = match input.mode {
+            SandboxCreateMode::Scratch => drua_core::sandbox::SandboxMode::Scratch,
+            SandboxCreateMode::Repo => drua_core::sandbox::SandboxMode::Repo {
+                repo_url: input.repo_url.unwrap_or_default(),
+                branch: input.branch,
+            },
+        };
+        let sb = app
+            .sandboxes()
+            .create(sub, input.workspace_id, input.name, specs, mode)
+            .await?;
+        Ok(SandboxCreatePayload::from(Sandbox::from(sb)))
+    }
+
+    async fn sandbox_suspend(
+        &self,
+        ctx: &Context<'_>,
+        input: SandboxSuspendInput,
+    ) -> async_graphql::Result<SandboxSuspendPayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let sb = app.sandboxes().suspend(sub, input.id).await?;
+        Ok(SandboxSuspendPayload::from(Sandbox::from(sb)))
+    }
+
+    async fn sandbox_restart(
+        &self,
+        ctx: &Context<'_>,
+        input: SandboxRestartInput,
+    ) -> async_graphql::Result<SandboxRestartPayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let sb = app.sandboxes().restart(sub, input.id).await?;
+        Ok(SandboxRestartPayload::from(Sandbox::from(sb)))
+    }
+
+    // ── Skill ───────────────────────────────────────────────────────────
+
+    async fn skill_create(
+        &self,
+        ctx: &Context<'_>,
+        input: SkillCreateInput,
+    ) -> async_graphql::Result<SkillCreatePayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let new = drua_core::skill::NewSkill::builder()
+            .workspace_id(input.workspace_id)
+            .name(input.name)
+            .description(input.description)
+            .body(input.body)
+            .build()
+            .map_err(|e| async_graphql::Error::new(e.to_string()))?;
+        let skill = app.skills().create(sub, new).await?;
+        Ok(SkillCreatePayload::from(Skill::from(skill)))
+    }
+
+    async fn skill_update(
+        &self,
+        ctx: &Context<'_>,
+        input: SkillUpdateInput,
+    ) -> async_graphql::Result<SkillUpdatePayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let mut skill = app.skills().find_by_id(sub, input.id).await?;
+        let _ = skill.update(input.name, input.description, input.body);
+        app.skills().update(sub, &mut skill).await?;
+        Ok(SkillUpdatePayload::from(Skill::from(skill)))
+    }
+
+    async fn skill_delete(
+        &self,
+        ctx: &Context<'_>,
+        input: SkillDeleteInput,
+    ) -> async_graphql::Result<SkillDeletePayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        app.skills().delete(sub, input.id).await?;
+        Ok(SkillDeletePayload {
+            deleted_id: input.id,
+        })
+    }
+
+    // ── Workspace Secret ────────────────────────────────────────────────
+
+    async fn workspace_secret_create(
+        &self,
+        ctx: &Context<'_>,
+        input: WorkspaceSecretCreateInput,
+    ) -> async_graphql::Result<WorkspaceSecretCreatePayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let secret = app
+            .workspace_secrets()
+            .create(
+                sub,
+                input.workspace_id,
+                &input.name,
+                input.secret_type.into(),
+                &input.value,
+            )
+            .await?;
+        Ok(WorkspaceSecretCreatePayload::from(WorkspaceSecret::from(
+            secret,
+        )))
+    }
+
+    async fn workspace_secret_delete(
+        &self,
+        ctx: &Context<'_>,
+        input: WorkspaceSecretDeleteInput,
+    ) -> async_graphql::Result<WorkspaceSecretDeletePayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        app.workspace_secrets().delete(sub, input.id).await?;
+        Ok(WorkspaceSecretDeletePayload {
+            deleted_id: input.id,
+        })
+    }
+
+    // ── MCP Credentials ─────────────────────────────────────────────────
+
+    async fn mcp_credentials_create(
+        &self,
+        ctx: &Context<'_>,
+        input: McpCredentialsCreateInput,
+    ) -> async_graphql::Result<McpCredentialsCreatePayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let user_id = sub
+            .originating_user_id()
+            .ok_or_else(|| async_graphql::Error::new("Authentication required"))?;
+
+        let scopes: Vec<drua_core::auth::AuthScope> =
+            input.scopes.iter().map(|s| s.as_str().into()).collect();
+
+        let (raw_token, token_hash) = drua_core::mcp_creds::token::generate_token();
+
+        let creds = app
+            .mcp_creds()
+            .create_for_user(sub, user_id, input.name, token_hash, scopes)
+            .await?;
+
+        Ok(McpCredentialsCreatePayload {
+            mcp_creds: McpCreds::from(creds),
+            token: raw_token,
+        })
+    }
+
+    async fn mcp_credentials_revoke(
+        &self,
+        ctx: &Context<'_>,
+        input: McpCredentialsRevokeInput,
+    ) -> async_graphql::Result<McpCredentialsRevokePayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let user_id = sub
+            .originating_user_id()
+            .ok_or_else(|| async_graphql::Error::new("Authentication required"))?;
+        let creds = app.mcp_creds().revoke(sub, user_id, input.id).await?;
+        Ok(McpCredentialsRevokePayload::from(McpCreds::from(creds)))
     }
 }

--- a/server/src/graphql/query.rs
+++ b/server/src/graphql/query.rs
@@ -4,7 +4,9 @@ use async_graphql::{
 };
 
 use super::agent::Agent;
+use super::audit::{AuditEntry, AuditLogQueryInput};
 use super::primitives::*;
+use super::sandbox::Sandbox;
 use super::workspace::Workspace;
 use super::AppConfigYaml;
 
@@ -102,5 +104,43 @@ impl Query {
         let (app, sub) = app_and_sub_from_ctx!(ctx);
         let jsonl = app.agents().export_thread(sub, agent_id, thread_id).await?;
         Ok(jsonl)
+    }
+
+    // ── Sandbox ─────────────────────────────────────────────────────────
+
+    /// Look up a single sandbox by ID.
+    async fn sandbox(
+        &self,
+        ctx: &Context<'_>,
+        id: SandboxId,
+    ) -> async_graphql::Result<Option<Sandbox>> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        match app.sandboxes().find_by_id(sub, id).await {
+            Ok(sb) => Ok(Some(Sandbox::from(sb))),
+            Err(drua_core::sandbox::SandboxError::Find(_)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    // ── Audit Log ───────────────────────────────────────────────────────
+
+    /// Query audit log entries.
+    async fn audit_log(
+        &self,
+        ctx: &Context<'_>,
+        input: AuditLogQueryInput,
+    ) -> async_graphql::Result<Vec<AuditEntry>> {
+        let (app, _sub) = app_and_sub_from_ctx!(ctx);
+        let query = drua_core::audit::AuditLogQuery {
+            workspace_id: input.workspace_id,
+            acting_agent_id: input.acting_agent_id,
+            action: input.action,
+            outcome: input.outcome,
+            error: input.error,
+            limit: input.limit.clamp(1, 100) as i64,
+            ..Default::default()
+        };
+        let entries = app.audit().find(&query).await?;
+        Ok(entries.into_iter().map(AuditEntry::from).collect())
     }
 }

--- a/server/src/graphql/sandbox.rs
+++ b/server/src/graphql/sandbox.rs
@@ -1,0 +1,132 @@
+use std::sync::Arc;
+
+use async_graphql::{ComplexObject, Enum, InputObject, SimpleObject};
+
+use super::agent::SandboxAttachmentMode;
+use super::primitives::*;
+
+use drua_core::sandbox::Sandbox as DomainSandbox;
+use drua_core::sandbox::SandboxState as DomainSandboxState;
+
+#[derive(SimpleObject, Clone)]
+#[graphql(complex)]
+pub struct Sandbox {
+    id: SandboxId,
+    workspace_id: WorkspaceId,
+    name: String,
+    state: SandboxStateEnum,
+    last_error: Option<String>,
+    mount_path: String,
+
+    #[graphql(skip)]
+    pub(super) entity: Arc<DomainSandbox>,
+}
+
+#[ComplexObject]
+impl Sandbox {
+    async fn created_at(&self) -> Timestamp {
+        self.entity.created_at().into()
+    }
+
+    async fn cpu(&self) -> &str {
+        &self.entity.specs.cpu
+    }
+
+    async fn memory(&self) -> &str {
+        &self.entity.specs.memory
+    }
+
+    async fn disk_size(&self) -> &str {
+        &self.entity.specs.disk_size
+    }
+
+    /// Agents currently attached to this sandbox.
+    async fn attached_agents(&self) -> Vec<SandboxAgentAttachment> {
+        self.entity
+            .attached_agents
+            .iter()
+            .map(|(agent_id, mode)| SandboxAgentAttachment {
+                agent_id: *agent_id,
+                mode: SandboxAttachmentMode::from(*mode),
+            })
+            .collect()
+    }
+}
+
+impl From<DomainSandbox> for Sandbox {
+    fn from(entity: DomainSandbox) -> Self {
+        Self {
+            id: entity.id,
+            workspace_id: entity.workspace_id,
+            name: entity.name.clone(),
+            state: SandboxStateEnum::from(entity.state),
+            last_error: entity.last_error.clone(),
+            mount_path: entity.mount_path.clone(),
+            entity: Arc::new(entity),
+        }
+    }
+}
+
+#[derive(SimpleObject, Clone)]
+pub struct SandboxAgentAttachment {
+    agent_id: AgentId,
+    mode: SandboxAttachmentMode,
+}
+
+#[derive(Enum, Clone, Copy, PartialEq, Eq)]
+pub enum SandboxStateEnum {
+    Provisioning,
+    Initializing,
+    Ready,
+    Suspended,
+    Errored,
+}
+
+impl From<DomainSandboxState> for SandboxStateEnum {
+    fn from(state: DomainSandboxState) -> Self {
+        match state {
+            DomainSandboxState::Provisioning => Self::Provisioning,
+            DomainSandboxState::Initializing => Self::Initializing,
+            DomainSandboxState::Ready => Self::Ready,
+            DomainSandboxState::Suspended => Self::Suspended,
+            DomainSandboxState::Errored => Self::Errored,
+        }
+    }
+}
+
+#[derive(Enum, Clone, Copy, PartialEq, Eq)]
+pub enum SandboxCreateMode {
+    Scratch,
+    Repo,
+}
+
+#[derive(InputObject)]
+pub struct SandboxCreateInput {
+    pub workspace_id: WorkspaceId,
+    pub name: String,
+    pub mode: SandboxCreateMode,
+    pub repo_url: Option<String>,
+    pub branch: Option<String>,
+    #[graphql(default_with = "\"500m\".to_string()")]
+    pub cpu: String,
+    #[graphql(default_with = "\"512Mi\".to_string()")]
+    pub memory: String,
+    #[graphql(default_with = "\"10Gi\".to_string()")]
+    pub disk_size: String,
+}
+
+mutation_payload! { SandboxCreatePayload, sandbox: Sandbox }
+
+#[derive(InputObject)]
+pub struct SandboxSuspendInput {
+    pub id: SandboxId,
+}
+
+mutation_payload! { SandboxSuspendPayload, sandbox: Sandbox }
+
+#[derive(InputObject)]
+pub struct SandboxRestartInput {
+    pub id: SandboxId,
+}
+
+mutation_payload! { SandboxRestartPayload, sandbox: Sandbox }

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -13,6 +13,36 @@ type Agent {
 	workspaceId: WorkspaceId!
 }
 
+input AgentAttachSandboxInput {
+	agentId: AgentId!
+	mode: SandboxAttachmentMode!
+	sandboxId: SandboxId!
+}
+
+type AgentAttachSandboxPayload {
+	agent: Agent!
+}
+
+input AgentCreateInput {
+	name: String!
+	sandboxId: SandboxId
+	sandboxMode: SandboxAttachmentMode
+	workspaceId: WorkspaceId!
+}
+
+type AgentCreatePayload {
+	agent: Agent!
+}
+
+input AgentDetachSandboxInput {
+	agentId: AgentId!
+	sandboxId: SandboxId!
+}
+
+type AgentDetachSandboxPayload {
+	agent: Agent!
+}
+
 scalar AgentId
 
 enum AgentRole {
@@ -48,6 +78,29 @@ type AssistantTextEvent {
 	text: String!
 }
 
+type AuditEntry {
+	actingAgentId: UUID
+	actingUserId: UUID
+	action: String!
+	durationMs: Int
+	entrypoint: String
+	error: Boolean
+	interactionType: String!
+	onBehalfOfUserId: UUID
+	outcome: String!
+	recordedAt: Timestamp!
+	tokensReturned: Int
+}
+
+input AuditLogQueryInput {
+	actingAgentId: AgentId
+	action: String
+	error: Boolean
+	limit: Int! = 20
+	outcome: String
+	workspaceId: WorkspaceId
+}
+
 union ChatContentBlock = TextContent | ToolUseContent | ThinkingContent | ToolResultContent | SandboxNotificationContent
 
 type ChatMessage {
@@ -70,6 +123,43 @@ type ErrorEvent {
 	message: String!
 }
 
+input McpCredentialsCreateInput {
+	name: String!
+	"""
+	The scopes to grant, as strings (e.g. "admin", "workspace_admin:<id>").
+	"""
+	scopes: [String!]!
+}
+
+"""
+Returned on create — includes the plaintext token (shown only once).
+"""
+type McpCredentialsCreatePayload {
+	mcpCreds: McpCreds!
+	"""
+	The plaintext token. Only returned once on creation.
+	"""
+	token: String!
+}
+
+input McpCredentialsRevokeInput {
+	id: McpCredsId!
+}
+
+type McpCredentialsRevokePayload {
+	mcpCreds: McpCreds!
+}
+
+type McpCreds {
+	createdAt: Timestamp!
+	id: McpCredsId!
+	name: String!
+	revoked: Boolean!
+	revokedAt: Timestamp
+}
+
+scalar McpCredsId
+
 type Me {
 	email: String
 	githubUsername: String
@@ -78,9 +168,22 @@ type Me {
 }
 
 type Mutation {
+	agentAttachSandbox(input: AgentAttachSandboxInput!): AgentAttachSandboxPayload!
+	agentCreate(input: AgentCreateInput!): AgentCreatePayload!
+	agentDetachSandbox(input: AgentDetachSandboxInput!): AgentDetachSandboxPayload!
+	mcpCredentialsCreate(input: McpCredentialsCreateInput!): McpCredentialsCreatePayload!
+	mcpCredentialsRevoke(input: McpCredentialsRevokeInput!): McpCredentialsRevokePayload!
 	ping: String!
+	sandboxCreate(input: SandboxCreateInput!): SandboxCreatePayload!
+	sandboxRestart(input: SandboxRestartInput!): SandboxRestartPayload!
+	sandboxSuspend(input: SandboxSuspendInput!): SandboxSuspendPayload!
+	skillCreate(input: SkillCreateInput!): SkillCreatePayload!
+	skillDelete(input: SkillDeleteInput!): SkillDeletePayload!
+	skillUpdate(input: SkillUpdateInput!): SkillUpdatePayload!
 	workspaceCreate(input: WorkspaceCreateInput!): WorkspaceCreatePayload!
 	workspaceDelete(input: WorkspaceDeleteInput!): WorkspaceDeletePayload!
+	workspaceSecretCreate(input: WorkspaceSecretCreateInput!): WorkspaceSecretCreatePayload!
+	workspaceSecretDelete(input: WorkspaceSecretDeleteInput!): WorkspaceSecretDeletePayload!
 	workspaceUpdate(input: WorkspaceUpdateInput!): WorkspaceUpdatePayload!
 }
 
@@ -113,6 +216,10 @@ type Query {
 	agent(id: AgentId!): Agent
 	appConfig: Yaml!
 	"""
+	Query audit log entries.
+	"""
+	auditLog(input: AuditLogQueryInput!): [AuditEntry!]!
+	"""
 	Export a thread as Pi-compatible JSONL (v3 format).
 	
 	When `thread_id` is omitted the current main thread is exported.
@@ -123,8 +230,34 @@ type Query {
 	"""
 	me: Me
 	ping: String!
+	"""
+	Look up a single sandbox by ID.
+	"""
+	sandbox(id: SandboxId!): Sandbox
 	workspace(id: WorkspaceId!): Workspace
 	workspaces(after: String, first: Int!): WorkspaceConnection!
+}
+
+type Sandbox {
+	"""
+	Agents currently attached to this sandbox.
+	"""
+	attachedAgents: [SandboxAgentAttachment!]!
+	cpu: String!
+	createdAt: Timestamp!
+	diskSize: String!
+	id: SandboxId!
+	lastError: String
+	memory: String!
+	mountPath: String!
+	name: String!
+	state: SandboxStateEnum!
+	workspaceId: WorkspaceId!
+}
+
+type SandboxAgentAttachment {
+	agentId: AgentId!
+	mode: SandboxAttachmentMode!
 }
 
 type SandboxAttachment {
@@ -136,6 +269,26 @@ type SandboxAttachment {
 enum SandboxAttachmentMode {
 	READ
 	WRITE
+}
+
+input SandboxCreateInput {
+	branch: String
+	cpu: String! = "500m"
+	diskSize: String! = "10Gi"
+	memory: String! = "512Mi"
+	mode: SandboxCreateMode!
+	name: String!
+	repoUrl: String
+	workspaceId: WorkspaceId!
+}
+
+enum SandboxCreateMode {
+	REPO
+	SCRATCH
+}
+
+type SandboxCreatePayload {
+	sandbox: Sandbox!
 }
 
 scalar SandboxId
@@ -153,6 +306,35 @@ type SandboxNotificationContent {
 enum SandboxNotificationOperation {
 	ATTACH
 	DETACH
+}
+
+input SandboxRestartInput {
+	id: SandboxId!
+}
+
+type SandboxRestartPayload {
+	sandbox: Sandbox!
+}
+
+enum SandboxStateEnum {
+	ERRORED
+	INITIALIZING
+	PROVISIONING
+	READY
+	SUSPENDED
+}
+
+input SandboxSuspendInput {
+	id: SandboxId!
+}
+
+type SandboxSuspendPayload {
+	sandbox: Sandbox!
+}
+
+enum SecretTypeEnum {
+	ENV_VAR
+	FILE
 }
 
 type ServiceEvent {
@@ -181,6 +363,47 @@ type SessionThread {
 }
 
 scalar SessionThreadId
+
+type Skill {
+	body: String!
+	createdAt: Timestamp!
+	description: String!
+	id: SkillId!
+	name: String!
+	workspaceId: WorkspaceId!
+}
+
+input SkillCreateInput {
+	body: String!
+	description: String!
+	name: String!
+	workspaceId: WorkspaceId!
+}
+
+type SkillCreatePayload {
+	skill: Skill!
+}
+
+input SkillDeleteInput {
+	id: SkillId!
+}
+
+type SkillDeletePayload {
+	deletedId: SkillId!
+}
+
+scalar SkillId
+
+input SkillUpdateInput {
+	body: String
+	description: String
+	id: SkillId!
+	name: String
+}
+
+type SkillUpdatePayload {
+	skill: Skill!
+}
 
 type Subscription {
 	"""
@@ -297,7 +520,23 @@ type Workspace {
 	The workspace lead agent.
 	"""
 	lead: Agent!
+	"""
+	MCP credentials owned by the current user.
+	"""
+	mcpCredentials: [McpCreds!]!
 	name: String!
+	"""
+	All sandboxes in this workspace.
+	"""
+	sandboxes: [Sandbox!]!
+	"""
+	All secrets in this workspace (metadata only — values are never exposed via GraphQL).
+	"""
+	secrets: [WorkspaceSecret!]!
+	"""
+	All skills in this workspace.
+	"""
+	skills: [Skill!]!
 }
 
 type WorkspaceConnection {
@@ -347,6 +586,35 @@ type WorkspaceEdge {
 }
 
 scalar WorkspaceId
+
+type WorkspaceSecret {
+	createdAt: Timestamp!
+	id: WorkspaceSecretId!
+	name: String!
+	secretType: SecretTypeEnum!
+	workspaceId: WorkspaceId!
+}
+
+input WorkspaceSecretCreateInput {
+	name: String!
+	secretType: SecretTypeEnum!
+	value: String!
+	workspaceId: WorkspaceId!
+}
+
+type WorkspaceSecretCreatePayload {
+	workspaceSecret: WorkspaceSecret!
+}
+
+input WorkspaceSecretDeleteInput {
+	id: WorkspaceSecretId!
+}
+
+type WorkspaceSecretDeletePayload {
+	deletedId: WorkspaceSecretId!
+}
+
+scalar WorkspaceSecretId
 
 input WorkspaceUpdateInput {
 	description: String

--- a/server/src/graphql/skill.rs
+++ b/server/src/graphql/skill.rs
@@ -1,0 +1,70 @@
+use std::sync::Arc;
+
+use async_graphql::{ComplexObject, InputObject, SimpleObject};
+
+use super::primitives::*;
+
+use drua_core::skill::Skill as DomainSkill;
+
+#[derive(SimpleObject, Clone)]
+#[graphql(complex)]
+pub struct Skill {
+    id: SkillId,
+    workspace_id: WorkspaceId,
+    name: String,
+    description: String,
+    body: String,
+
+    #[graphql(skip)]
+    entity: Arc<DomainSkill>,
+}
+
+#[ComplexObject]
+impl Skill {
+    async fn created_at(&self) -> Timestamp {
+        self.entity.created_at().into()
+    }
+}
+
+impl From<DomainSkill> for Skill {
+    fn from(entity: DomainSkill) -> Self {
+        Self {
+            id: entity.id,
+            workspace_id: entity.workspace_id,
+            name: entity.name.clone(),
+            description: entity.description.clone(),
+            body: entity.body.clone(),
+            entity: Arc::new(entity),
+        }
+    }
+}
+
+#[derive(InputObject)]
+pub struct SkillCreateInput {
+    pub workspace_id: WorkspaceId,
+    pub name: String,
+    pub description: String,
+    pub body: String,
+}
+
+mutation_payload! { SkillCreatePayload, skill: Skill }
+
+#[derive(InputObject)]
+pub struct SkillUpdateInput {
+    pub id: SkillId,
+    pub name: Option<String>,
+    pub description: Option<String>,
+    pub body: Option<String>,
+}
+
+mutation_payload! { SkillUpdatePayload, skill: Skill }
+
+#[derive(InputObject)]
+pub struct SkillDeleteInput {
+    pub id: SkillId,
+}
+
+#[derive(async_graphql::SimpleObject)]
+pub struct SkillDeletePayload {
+    pub deleted_id: SkillId,
+}

--- a/server/src/graphql/workspace.rs
+++ b/server/src/graphql/workspace.rs
@@ -3,7 +3,11 @@ use std::sync::Arc;
 use async_graphql::{ComplexObject, Context, InputObject, SimpleObject};
 
 use super::agent::Agent;
+use super::mcp_creds::McpCreds;
 use super::primitives::*;
+use super::sandbox::Sandbox;
+use super::skill::Skill;
+use super::workspace_secret::WorkspaceSecret;
 
 use drua_core::workspace::Workspace as DomainWorkspace;
 
@@ -41,6 +45,46 @@ impl Workspace {
         let lead_id = self.entity.lead_agent_id;
         agents.sort_by_key(|a| if a.id == lead_id { 0 } else { 1 });
         Ok(agents.into_iter().map(Agent::from).collect())
+    }
+
+    /// All sandboxes in this workspace.
+    async fn sandboxes(&self, ctx: &Context<'_>) -> async_graphql::Result<Vec<Sandbox>> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let sandboxes = app
+            .sandboxes()
+            .list_for_workspace(sub, self.entity.id)
+            .await?;
+        Ok(sandboxes.into_iter().map(Sandbox::from).collect())
+    }
+
+    /// All skills in this workspace.
+    async fn skills(&self, ctx: &Context<'_>) -> async_graphql::Result<Vec<Skill>> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let skills = app
+            .skills()
+            .list_by_workspace_id(sub, self.entity.id)
+            .await?;
+        Ok(skills.into_iter().map(Skill::from).collect())
+    }
+
+    /// All secrets in this workspace (metadata only — values are never exposed via GraphQL).
+    async fn secrets(&self, ctx: &Context<'_>) -> async_graphql::Result<Vec<WorkspaceSecret>> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let secrets = app
+            .workspace_secrets()
+            .list_by_workspace(sub, self.entity.id)
+            .await?;
+        Ok(secrets.into_iter().map(WorkspaceSecret::from).collect())
+    }
+
+    /// MCP credentials owned by the current user.
+    async fn mcp_credentials(&self, ctx: &Context<'_>) -> async_graphql::Result<Vec<McpCreds>> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let user_id = sub
+            .originating_user_id()
+            .ok_or_else(|| async_graphql::Error::new("Authentication required"))?;
+        let creds = app.mcp_creds().list_all_for_user(sub, user_id).await?;
+        Ok(creds.into_iter().map(McpCreds::from).collect())
     }
 }
 

--- a/server/src/graphql/workspace_secret.rs
+++ b/server/src/graphql/workspace_secret.rs
@@ -1,0 +1,83 @@
+use std::sync::Arc;
+
+use async_graphql::{ComplexObject, Enum, InputObject, SimpleObject};
+
+use super::primitives::*;
+
+use drua_core::workspace_secret::primitives::SecretType as DomainSecretType;
+use drua_core::workspace_secret::WorkspaceSecret as DomainWorkspaceSecret;
+
+#[derive(SimpleObject, Clone)]
+#[graphql(complex)]
+pub struct WorkspaceSecret {
+    id: WorkspaceSecretId,
+    workspace_id: WorkspaceId,
+    name: String,
+    secret_type: SecretTypeEnum,
+
+    #[graphql(skip)]
+    entity: Arc<DomainWorkspaceSecret>,
+}
+
+#[ComplexObject]
+impl WorkspaceSecret {
+    async fn created_at(&self) -> Timestamp {
+        self.entity.created_at().into()
+    }
+}
+
+impl From<DomainWorkspaceSecret> for WorkspaceSecret {
+    fn from(entity: DomainWorkspaceSecret) -> Self {
+        Self {
+            id: entity.id,
+            workspace_id: entity.workspace_id,
+            name: entity.name.clone(),
+            secret_type: SecretTypeEnum::from(entity.secret_type),
+            entity: Arc::new(entity),
+        }
+    }
+}
+
+#[derive(Enum, Clone, Copy, PartialEq, Eq)]
+pub enum SecretTypeEnum {
+    EnvVar,
+    File,
+}
+
+impl From<DomainSecretType> for SecretTypeEnum {
+    fn from(t: DomainSecretType) -> Self {
+        match t {
+            DomainSecretType::EnvVar => Self::EnvVar,
+            DomainSecretType::File => Self::File,
+        }
+    }
+}
+
+impl From<SecretTypeEnum> for DomainSecretType {
+    fn from(t: SecretTypeEnum) -> Self {
+        match t {
+            SecretTypeEnum::EnvVar => Self::EnvVar,
+            SecretTypeEnum::File => Self::File,
+        }
+    }
+}
+
+#[derive(InputObject)]
+pub struct WorkspaceSecretCreateInput {
+    pub workspace_id: WorkspaceId,
+    pub name: String,
+    pub secret_type: SecretTypeEnum,
+    pub value: String,
+}
+
+mutation_payload! { WorkspaceSecretCreatePayload, workspace_secret: WorkspaceSecret }
+
+#[derive(InputObject)]
+pub struct WorkspaceSecretDeleteInput {
+    pub id: WorkspaceSecretId,
+}
+
+#[derive(async_graphql::SimpleObject)]
+pub struct WorkspaceSecretDeletePayload {
+    pub deleted_id: WorkspaceSecretId,
+}

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1,8 +1,8 @@
 use axum::{
     extract::{Path, Query, State},
     response::{IntoResponse, Redirect, Response},
-    routing::{get, post},
-    Extension, Form, Json, Router,
+    routing::get,
+    Extension, Json, Router,
 };
 use serde::Deserialize;
 use tower_sessions::Session;
@@ -41,10 +41,7 @@ pub fn router() -> Router<AppState> {
         .route("/workspaces", get(workspaces_page))
         .route("/workspaces/new", get(workspace_new))
         .route("/workspaces/sidebar", get(workspace_sidebar_list))
-        .route("/workspaces", post(workspace_create))
         .route("/workspaces/{id}", get(workspace_detail))
-        .route("/workspaces/{id}", post(workspace_update))
-        .route("/workspaces/{id}/delete", post(workspace_delete))
         .route("/workspaces/{id}/secrets/list", get(workspace_secrets_list))
         .route("/workspaces/{id}/skills", get(workspace_skills_page))
         .route("/workspaces/{id}/skills/new", get(workspace_skill_new))
@@ -462,44 +459,6 @@ async fn workspace_new(session: Session) -> Response {
     WorkspaceNewTemplate {}.into_response()
 }
 
-#[derive(serde::Deserialize)]
-pub struct WorkspaceCreateForm {
-    name: String,
-    description: Option<String>,
-}
-
-#[derive(serde::Deserialize)]
-pub struct WorkspaceUpdateForm {
-    description: Option<String>,
-}
-
-#[instrument(name = "web.workspace_create", skip_all)]
-async fn workspace_create(
-    State(state): State<AppState>,
-    session: Session,
-    Form(form): Form<WorkspaceCreateForm>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-
-    let sub = AuthSubject::User(user_id);
-    let description = form.description.filter(|d| !d.is_empty());
-    match state
-        .app
-        .workspaces()
-        .create(&sub, &form.name, description)
-        .await
-    {
-        Ok(ws) => Redirect::to(&format!("/workspaces/{}/chat", ws.id)).into_response(),
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to create workspace");
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
-        }
-    }
-}
-
 #[instrument(name = "web.workspace_detail", skip_all)]
 async fn workspace_detail(
     State(state): State<AppState>,
@@ -526,71 +485,6 @@ async fn workspace_detail(
         agents: agent_views,
     }
     .into_response()
-}
-
-#[instrument(name = "web.workspace_update", skip_all)]
-async fn workspace_update(
-    State(state): State<AppState>,
-    session: Session,
-    Path(id): Path<uuid::Uuid>,
-    Form(form): Form<WorkspaceUpdateForm>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-
-    let sub = AuthSubject::User(user_id);
-    let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let description = form.description.filter(|d| !d.is_empty());
-    match state
-        .app
-        .workspaces()
-        .update(&sub, workspace_id, description)
-        .await
-    {
-        Ok(_) => Redirect::to(&format!("/workspaces/{id}")).into_response(),
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to update workspace");
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
-        }
-    }
-}
-
-#[instrument(name = "web.workspace_delete", skip_all)]
-async fn workspace_delete(
-    State(state): State<AppState>,
-    session: Session,
-    Path(id): Path<uuid::Uuid>,
-    headers: axum::http::HeaderMap,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-
-    let sub = AuthSubject::User(user_id);
-    let workspace_id = domain::primitives::WorkspaceId::from(id);
-    match state.app.workspaces().delete(&sub, workspace_id).await {
-        Ok(_) => {
-            // If called via HTMX, redirect client-side using HX-Redirect
-            if headers.contains_key("hx-request") {
-                return (
-                    [(
-                        axum::http::header::HeaderName::from_static("hx-redirect"),
-                        "/workspaces".parse::<axum::http::HeaderValue>().unwrap(),
-                    )],
-                    "",
-                )
-                    .into_response();
-            }
-            Redirect::to("/workspaces").into_response()
-        }
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to delete workspace");
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
-        }
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -11,10 +11,9 @@ use tracing::instrument;
 use drua_core as domain;
 
 use domain::auth::AuthSubject;
-use domain::mcp_creds::token::generate_token;
 use domain::mcp_creds::McpCreds;
-use domain::primitives::{AgentId, McpCredsId, SandboxId, SkillId, UserId, WorkspaceSecretId};
-use domain::sandbox::{SandboxAgentMode, SandboxMode, SandboxSpecs};
+use domain::primitives::{AgentId, SandboxId, SkillId, UserId};
+use domain::sandbox::{SandboxAgentMode, SandboxMode};
 
 use crate::templates::*;
 use crate::AppState;
@@ -29,8 +28,6 @@ pub fn router() -> Router<AppState> {
         .route("/", get(index))
         .route("/dashboard", get(dashboard))
         .route("/dashboard/mcp-creds", get(mcp_creds_list))
-        .route("/mcp-creds/create", post(create_mcp_creds))
-        .route("/mcp-creds/{id}/revoke", post(revoke_mcp_creds))
         .route("/audit", get(audit_page))
         .route("/audit/entries", get(audit_entries))
         .route("/code-assistant", get(code_assistant_dashboard))
@@ -48,55 +45,23 @@ pub fn router() -> Router<AppState> {
         .route("/workspaces/{id}", get(workspace_detail))
         .route("/workspaces/{id}", post(workspace_update))
         .route("/workspaces/{id}/delete", post(workspace_delete))
-        .route("/workspaces/{id}/secrets", post(workspace_secret_create))
         .route("/workspaces/{id}/secrets/list", get(workspace_secrets_list))
-        .route(
-            "/workspaces/{id}/secrets/{secret_id}/delete",
-            post(workspace_secret_delete),
-        )
         .route("/workspaces/{id}/skills", get(workspace_skills_page))
         .route("/workspaces/{id}/skills/new", get(workspace_skill_new))
-        .route("/workspaces/{id}/skills", post(workspace_skill_create))
         .route(
             "/workspaces/{id}/skills/{skill_id}",
             get(workspace_skill_edit),
         )
-        .route(
-            "/workspaces/{id}/skills/{skill_id}",
-            post(workspace_skill_update),
-        )
-        .route(
-            "/workspaces/{id}/skills/{skill_id}/delete",
-            post(workspace_skill_delete),
-        )
         .route("/workspaces/{id}/sandboxes", get(workspace_sandboxes_page))
         .route("/workspaces/{id}/sandboxes/new", get(workspace_sandbox_new))
-        .route("/workspaces/{id}/sandboxes", post(workspace_sandbox_create))
         .route(
             "/workspaces/{id}/sandboxes/{sandbox_id}",
             get(workspace_sandbox_detail),
         )
-        .route(
-            "/workspaces/{id}/sandboxes/{sandbox_id}/suspend",
-            post(workspace_sandbox_suspend),
-        )
-        .route(
-            "/workspaces/{id}/sandboxes/{sandbox_id}/restart",
-            post(workspace_sandbox_restart),
-        )
         .route("/workspaces/{id}/agents/new", get(workspace_agent_new))
-        .route("/workspaces/{id}/agents", post(workspace_agent_create))
         .route(
             "/workspaces/{id}/agents/{agent_id}",
             get(workspace_agent_detail),
-        )
-        .route(
-            "/workspaces/{id}/agents/{agent_id}/attach_sandbox",
-            post(workspace_agent_attach_sandbox),
-        )
-        .route(
-            "/workspaces/{id}/agents/{agent_id}/detach_sandbox",
-            post(workspace_agent_detach_sandbox),
         )
 }
 
@@ -156,90 +121,6 @@ async fn dashboard(State(state): State<AppState>, session: Session) -> Response 
         mcp_creds: mcp_creds.iter().map(mcp_creds_to_view).collect(),
     }
     .into_response()
-}
-
-#[derive(serde::Deserialize)]
-pub struct CreateMcpCredsForm {
-    name: String,
-    #[serde(default)]
-    admin: Option<String>,
-}
-
-fn build_mcp_config(mcp_endpoint: &str, token: &str) -> (String, String) {
-    let server_config = serde_json::json!({
-        "type": "http",
-        "url": mcp_endpoint,
-        "headers": {
-            "Authorization": format!("Bearer {token}")
-        }
-    });
-    let mcp_json = serde_json::json!({
-        "drua": &server_config
-    })
-    .to_string();
-    let cli_command = format!("claude mcp add-json --scope user drua '{}'", server_config);
-    (mcp_json, cli_command)
-}
-
-#[instrument(name = "web.create_mcp_creds", skip_all)]
-async fn create_mcp_creds(
-    State(state): State<AppState>,
-    session: Session,
-    Form(form): Form<CreateMcpCredsForm>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-
-    let (raw_token, token_hash) = generate_token();
-
-    let sub = AuthSubject::User(user_id);
-    let scopes: Vec<domain::primitives::AuthScope> = if form.admin.as_deref() == Some("true") {
-        vec![domain::primitives::AuthScope::Admin]
-    } else {
-        vec![]
-    };
-
-    match state
-        .app
-        .mcp_creds()
-        .create_for_user(&sub, user_id, &form.name, token_hash, scopes)
-        .await
-    {
-        Ok(_) => {
-            let (mcp_json, cli_command) = build_mcp_config(&state.mcp_endpoint, &raw_token);
-            McpCredsCreatedTemplate {
-                creds_name: form.name,
-                mcp_json,
-                cli_command,
-            }
-            .into_response()
-        }
-        Err(_) => axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-    }
-}
-
-#[instrument(name = "web.revoke_mcp_creds", skip_all)]
-async fn revoke_mcp_creds(
-    State(state): State<AppState>,
-    session: Session,
-    Path(id): Path<uuid::Uuid>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-
-    let sub = AuthSubject::User(user_id);
-    let creds_id = McpCredsId::from(id);
-    match state.app.mcp_creds().revoke(&sub, user_id, creds_id).await {
-        Ok(creds) => McpCredsRowTemplate {
-            creds: mcp_creds_to_view(&creds),
-        }
-        .into_response(),
-        Err(_) => axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-    }
 }
 
 #[instrument(name = "web.mcp_creds_list", skip_all)]
@@ -756,92 +637,6 @@ async fn workspace_secrets_list(
     }
 }
 
-#[derive(Deserialize)]
-struct CreateSecretForm {
-    name: String,
-    secret_type: String,
-    value: String,
-}
-
-#[instrument(name = "web.workspace_secret_create", skip_all)]
-async fn workspace_secret_create(
-    State(state): State<AppState>,
-    session: Session,
-    Path(id): Path<uuid::Uuid>,
-    Form(form): Form<CreateSecretForm>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
-    };
-    let sub = AuthSubject::User(user_id);
-
-    let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let secret_type: domain::workspace_secret::SecretType = match form.secret_type.parse() {
-        Ok(t) => t,
-        Err(_) => return axum::http::StatusCode::BAD_REQUEST.into_response(),
-    };
-
-    if let Err(e) = state
-        .app
-        .workspace_secrets()
-        .create(&sub, workspace_id, &form.name, secret_type, &form.value)
-        .await
-    {
-        tracing::error!(error = %e, "Failed to create workspace secret");
-        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
-    }
-
-    // Return updated list
-    match state
-        .app
-        .workspace_secrets()
-        .list_by_workspace(&sub, workspace_id)
-        .await
-    {
-        Ok(secrets) => WorkspaceSecretsListTemplate {
-            secrets: secrets.iter().map(secret_to_view).collect(),
-        }
-        .into_response(),
-        Err(_) => axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-    }
-}
-
-#[instrument(name = "web.workspace_secret_delete", skip_all)]
-async fn workspace_secret_delete(
-    State(state): State<AppState>,
-    session: Session,
-    Path((id, secret_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
-    };
-    let sub = AuthSubject::User(user_id);
-
-    let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let secret_id = WorkspaceSecretId::from(secret_id);
-
-    if let Err(e) = state.app.workspace_secrets().delete(&sub, secret_id).await {
-        tracing::error!(error = %e, "Failed to delete workspace secret");
-        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
-    }
-
-    // Return updated list
-    match state
-        .app
-        .workspace_secrets()
-        .list_by_workspace(&sub, workspace_id)
-        .await
-    {
-        Ok(secrets) => WorkspaceSecretsListTemplate {
-            secrets: secrets.iter().map(secret_to_view).collect(),
-        }
-        .into_response(),
-        Err(_) => axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response(),
-    }
-}
-
 // ---------------------------------------------------------------------------
 // Workspace Skills
 // ---------------------------------------------------------------------------
@@ -921,43 +716,6 @@ async fn workspace_skill_new(
     .into_response()
 }
 
-#[derive(Deserialize)]
-struct CreateSkillForm {
-    name: String,
-    description: String,
-    body: String,
-}
-
-#[instrument(name = "web.workspace_skill_create", skip_all)]
-async fn workspace_skill_create(
-    State(state): State<AppState>,
-    session: Session,
-    Path(id): Path<uuid::Uuid>,
-    Form(form): Form<CreateSkillForm>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-    let sub = AuthSubject::User(user_id);
-
-    let workspace_id = domain::primitives::WorkspaceId::from(id);
-    let new_skill = domain::skill::NewSkill::builder()
-        .workspace_id(workspace_id)
-        .name(form.name)
-        .description(form.description)
-        .body(form.body)
-        .build()
-        .expect("Could not build new skill");
-
-    if let Err(e) = state.app.skills().create(&sub, new_skill).await {
-        tracing::error!(error = %e, "Failed to create skill");
-        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
-    }
-
-    Redirect::to(&format!("/workspaces/{id}/skills")).into_response()
-}
-
 #[instrument(name = "web.workspace_skill_edit", skip_all)]
 async fn workspace_skill_edit(
     State(state): State<AppState>,
@@ -991,67 +749,6 @@ async fn workspace_skill_edit(
         skill: skill_to_view(&skill),
     }
     .into_response()
-}
-
-#[derive(Deserialize)]
-struct UpdateSkillForm {
-    name: String,
-    description: String,
-    body: String,
-}
-
-#[instrument(name = "web.workspace_skill_update", skip_all)]
-async fn workspace_skill_update(
-    State(state): State<AppState>,
-    session: Session,
-    Path((id, skill_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-    Form(form): Form<UpdateSkillForm>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-    let sub = AuthSubject::User(user_id);
-
-    let skill_id = SkillId::from(skill_id);
-    let mut skill = match state.app.skills().find_by_id(&sub, skill_id).await {
-        Ok(s) => s,
-        Err(_) => return Redirect::to(&format!("/workspaces/{id}/skills")).into_response(),
-    };
-
-    if skill
-        .update(Some(form.name), Some(form.description), Some(form.body))
-        .did_execute()
-    {
-        if let Err(e) = state.app.skills().update(&sub, &mut skill).await {
-            tracing::error!(error = %e, "Failed to update skill");
-            return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
-        }
-    }
-
-    Redirect::to(&format!("/workspaces/{id}/skills")).into_response()
-}
-
-#[instrument(name = "web.workspace_skill_delete", skip_all)]
-async fn workspace_skill_delete(
-    State(state): State<AppState>,
-    session: Session,
-    Path((id, skill_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-    let sub = AuthSubject::User(user_id);
-
-    let skill_id = SkillId::from(skill_id);
-
-    if let Err(e) = state.app.skills().delete(&sub, skill_id).await {
-        tracing::error!(error = %e, "Failed to delete skill");
-        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
-    }
-
-    Redirect::to(&format!("/workspaces/{id}/skills")).into_response()
 }
 
 // ---------------------------------------------------------------------------
@@ -1203,85 +900,6 @@ async fn workspace_sandbox_new(
     .into_response()
 }
 
-#[derive(Deserialize)]
-struct CreateSandboxForm {
-    name: String,
-    mode: String,
-    #[serde(default)]
-    repo_url: Option<String>,
-    #[serde(default)]
-    branch: Option<String>,
-    cpu: String,
-    memory: String,
-    disk_size: String,
-}
-
-#[instrument(name = "web.workspace_sandbox_create", skip_all)]
-async fn workspace_sandbox_create(
-    State(state): State<AppState>,
-    session: Session,
-    Path(id): Path<uuid::Uuid>,
-    Form(form): Form<CreateSandboxForm>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-    let sub = AuthSubject::User(user_id);
-
-    let workspace_id = domain::primitives::WorkspaceId::from(id);
-
-    let mode = match form.mode.as_str() {
-        "scratch" => SandboxMode::Scratch,
-        "repo" => {
-            let repo_url = form
-                .repo_url
-                .as_deref()
-                .map(str::trim)
-                .filter(|s| !s.is_empty())
-                .map(str::to_string);
-            match repo_url {
-                Some(repo_url) => {
-                    let branch = form
-                        .branch
-                        .as_deref()
-                        .map(str::trim)
-                        .filter(|s| !s.is_empty())
-                        .map(str::to_string);
-                    SandboxMode::Repo { repo_url, branch }
-                }
-                None => {
-                    tracing::warn!("repo mode requires a non-empty repo_url");
-                    return Redirect::to(&format!("/workspaces/{id}/sandboxes/new"))
-                        .into_response();
-                }
-            }
-        }
-        other => {
-            tracing::warn!(mode = %other, "unknown sandbox mode");
-            return Redirect::to(&format!("/workspaces/{id}/sandboxes/new")).into_response();
-        }
-    };
-
-    let specs = SandboxSpecs {
-        cpu: form.cpu,
-        memory: form.memory,
-        disk_size: form.disk_size,
-    };
-
-    if let Err(e) = state
-        .app
-        .sandboxes()
-        .create(&sub, workspace_id, form.name, specs, mode)
-        .await
-    {
-        tracing::error!(error = %e, "Failed to create sandbox");
-        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
-    }
-
-    Redirect::to(&format!("/workspaces/{id}/sandboxes")).into_response()
-}
-
 #[instrument(name = "web.workspace_sandbox_detail", skip_all)]
 async fn workspace_sandbox_detail(
     State(state): State<AppState>,
@@ -1317,50 +935,8 @@ async fn workspace_sandbox_detail(
     .into_response()
 }
 
-#[instrument(name = "web.workspace_sandbox_suspend", skip_all)]
-async fn workspace_sandbox_suspend(
-    State(state): State<AppState>,
-    session: Session,
-    Path((id, sandbox_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-    let sub = AuthSubject::User(user_id);
-
-    let sandbox_id = SandboxId::from(sandbox_id);
-    if let Err(e) = state.app.sandboxes().suspend(&sub, sandbox_id).await {
-        tracing::error!(error = %e, "Failed to suspend sandbox");
-        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
-    }
-
-    Redirect::to(&format!("/workspaces/{id}/sandboxes/{sandbox_id}")).into_response()
-}
-
-#[instrument(name = "web.workspace_sandbox_restart", skip_all)]
-async fn workspace_sandbox_restart(
-    State(state): State<AppState>,
-    session: Session,
-    Path((id, sandbox_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-    let sub = AuthSubject::User(user_id);
-
-    let sandbox_id = SandboxId::from(sandbox_id);
-    if let Err(e) = state.app.sandboxes().restart(&sub, sandbox_id).await {
-        tracing::error!(error = %e, "Failed to restart sandbox");
-        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
-    }
-
-    Redirect::to(&format!("/workspaces/{id}/sandboxes/{sandbox_id}")).into_response()
-}
-
 // ---------------------------------------------------------------------------
-// Workspace Agents (create form)
+// Workspace Agents
 // ---------------------------------------------------------------------------
 
 #[instrument(name = "web.workspace_agent_new", skip_all)]
@@ -1404,64 +980,6 @@ async fn workspace_agent_new(
         sandbox_options,
     }
     .into_response()
-}
-
-#[derive(Deserialize)]
-struct CreateAgentForm {
-    name: String,
-    /// Empty string when no sandbox selected; parsed as UUID otherwise.
-    #[serde(default)]
-    sandbox_id: Option<String>,
-    #[serde(default)]
-    attach_mode: Option<String>,
-}
-
-#[instrument(name = "web.workspace_agent_create", skip_all)]
-async fn workspace_agent_create(
-    State(state): State<AppState>,
-    session: Session,
-    Path(id): Path<uuid::Uuid>,
-    Form(form): Form<CreateAgentForm>,
-) -> Response {
-    let user_id = match extract_user_id(&session).await {
-        Some(id) => id,
-        None => return Redirect::to("/").into_response(),
-    };
-    let sub = AuthSubject::User(user_id);
-
-    let workspace_id = domain::primitives::WorkspaceId::from(id);
-
-    // Pair sandbox_id + attach_mode into Some((id, mode)) only when both are
-    // present and valid; otherwise treat as "no attachment".
-    let attach = form
-        .sandbox_id
-        .as_deref()
-        .map(str::trim)
-        .filter(|s| !s.is_empty())
-        .and_then(|sb| sb.parse::<uuid::Uuid>().ok())
-        .map(SandboxId::from)
-        .map(|sb| {
-            let mode = match form.attach_mode.as_deref().unwrap_or("read") {
-                "write" => SandboxAgentMode::Write,
-                _ => SandboxAgentMode::Read,
-            };
-            (sb, mode)
-        });
-
-    match state
-        .app
-        .agents()
-        .create_agent(&sub, workspace_id, form.name, attach)
-        .await
-    {
-        Ok(agent) => {
-            Redirect::to(&format!("/workspaces/{id}/chat?agent={}", agent.id)).into_response()
-        }
-        Err(e) => {
-            tracing::error!(error = %e, "Failed to create agent");
-            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
-        }
-    }
 }
 
 fn role_label(role: domain::agent::AgentRole) -> &'static str {
@@ -1559,100 +1077,6 @@ async fn workspace_agent_detail(
         error: query.error,
     }
     .into_response()
-}
-
-/// Build `/workspaces/{id}/agents/{agent_id}?error=<encoded>` so the
-/// detail page can render a flash banner explaining why the last
-/// attach/detach failed.
-fn agent_detail_redirect_with_error(
-    workspace_id: uuid::Uuid,
-    agent_id: AgentId,
-    msg: &str,
-) -> Response {
-    let query: String = url::form_urlencoded::Serializer::new(String::new())
-        .append_pair("error", msg)
-        .finish();
-    Redirect::to(&format!(
-        "/workspaces/{workspace_id}/agents/{agent_id}?{query}"
-    ))
-    .into_response()
-}
-
-#[derive(Deserialize)]
-struct AttachSandboxForm {
-    sandbox_id: String,
-    mode: String,
-}
-
-#[instrument(name = "web.workspace_agent_attach_sandbox", skip_all)]
-async fn workspace_agent_attach_sandbox(
-    State(state): State<AppState>,
-    session: Session,
-    Path((id, agent_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-    Form(form): Form<AttachSandboxForm>,
-) -> Response {
-    let Some(user_id) = extract_user_id(&session).await else {
-        return Redirect::to("/").into_response();
-    };
-    let subject = AuthSubject::User(user_id);
-
-    let agent_id = AgentId::from(agent_id);
-    let Ok(sandbox_uuid) = form.sandbox_id.parse::<uuid::Uuid>() else {
-        tracing::warn!(raw = %form.sandbox_id, "invalid sandbox_id in attach form");
-        return Redirect::to(&format!("/workspaces/{id}/agents/{agent_id}")).into_response();
-    };
-    let sandbox_id = SandboxId::from(sandbox_uuid);
-    let mode = match form.mode.as_str() {
-        "write" => SandboxAgentMode::Write,
-        _ => SandboxAgentMode::Read,
-    };
-
-    if let Err(e) = state
-        .app
-        .agents()
-        .attach_sandbox(&subject, agent_id, sandbox_id, mode)
-        .await
-    {
-        tracing::warn!(error = %e, "attach_sandbox failed");
-        return agent_detail_redirect_with_error(id, agent_id, &e.to_string());
-    }
-
-    Redirect::to(&format!("/workspaces/{id}/agents/{agent_id}")).into_response()
-}
-
-#[instrument(name = "web.workspace_agent_detach_sandbox", skip_all)]
-async fn workspace_agent_detach_sandbox(
-    State(state): State<AppState>,
-    session: Session,
-    Path((id, agent_id)): Path<(uuid::Uuid, uuid::Uuid)>,
-) -> Response {
-    let Some(user_id) = extract_user_id(&session).await else {
-        return Redirect::to("/").into_response();
-    };
-    let subject = AuthSubject::User(user_id);
-
-    let agent_id = AgentId::from(agent_id);
-    // The handler needs the sandbox_id; fetch the agent to look it up.
-    let sandbox_id = match state.app.agents().find_by_id(&subject, agent_id).await {
-        Ok(a) => a.attached_sandbox.map(|(sbx, _)| sbx),
-        Err(_) => return Redirect::to(&format!("/workspaces/{id}")).into_response(),
-    };
-    let Some(sandbox_id) = sandbox_id else {
-        // Already detached; nothing to do.
-        return Redirect::to(&format!("/workspaces/{id}/agents/{agent_id}")).into_response();
-    };
-
-    if let Err(e) = state
-        .app
-        .agents()
-        .detach_sandbox(&subject, agent_id, sandbox_id)
-        .await
-    {
-        tracing::warn!(error = %e, "detach_sandbox failed");
-        return agent_detail_redirect_with_error(id, agent_id, &e.to_string());
-    }
-
-    Redirect::to(&format!("/workspaces/{id}/agents/{agent_id}")).into_response()
 }
 
 // ---------------------------------------------------------------------------

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -82,6 +82,122 @@
       color: var(--pico-del-color);
     }
   </style>
+  <script>
+    // Shared GraphQL mutation helper used by all forms.
+    // Returns the parsed JSON response (with data/errors).
+    async function gqlMutate(query, variables) {
+      const res = await fetch('/graphql', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ query, variables }),
+      });
+      return res.json();
+    }
+
+    // Wire a <form data-gql-mutation="..."> to submit via GraphQL.
+    //
+    //   data-gql-mutation   — the GraphQL mutation string (with $input variable)
+    //   data-gql-build      — name of a global JS function that builds the
+    //                          mutation input object from the FormData
+    //   data-gql-redirect   — URL to redirect to on success (template vars
+    //                          like {id} are replaced from the response)
+    //   data-gql-reload     — if "true", reload the current page on success
+    //   data-gql-target     — CSS selector; on success, replace innerHTML with
+    //                          a GET to data-gql-refresh-url
+    //   data-gql-refresh-url — URL to GET for refreshing the target element
+    //   data-gql-confirm    — confirmation message (skips if user cancels)
+    //
+    document.addEventListener('submit', async function(e) {
+      const form = e.target;
+      if (!form.dataset.gqlMutation) return;
+      e.preventDefault();
+
+      if (form.dataset.gqlConfirm && !confirm(form.dataset.gqlConfirm)) return;
+
+      const fd = new FormData(form);
+      const buildFn = window[form.dataset.gqlBuild];
+      const input = buildFn ? buildFn(fd) : Object.fromEntries(fd);
+
+      const result = await gqlMutate(form.dataset.gqlMutation, { input });
+
+      if (result.errors) {
+        alert(result.errors.map(e => e.message).join('\n'));
+        return;
+      }
+
+      if (form.dataset.gqlRedirect) {
+        let url = form.dataset.gqlRedirect;
+        // Replace {fieldName} placeholders from the response data
+        const data = result.data;
+        if (data) {
+          const payload = Object.values(data)[0];
+          if (payload) {
+            const entity = Object.values(payload)[0];
+            if (entity && typeof entity === 'object') {
+              url = url.replace(/\{(\w+)\}/g, (_, k) => entity[k] || '');
+            }
+          }
+        }
+        window.location.href = url;
+        return;
+      }
+
+      if (form.dataset.gqlReload === 'true') {
+        window.location.reload();
+        return;
+      }
+
+      if (form.dataset.gqlTarget && form.dataset.gqlRefreshUrl) {
+        const target = document.querySelector(form.dataset.gqlTarget);
+        if (target) {
+          const html = await fetch(form.dataset.gqlRefreshUrl).then(r => r.text());
+          target.innerHTML = html;
+          form.reset();
+        }
+        return;
+      }
+    });
+
+    // Wire <button data-gql-mutation="..."> (non-form buttons like delete/revoke).
+    document.addEventListener('click', async function(e) {
+      const btn = e.target.closest('[data-gql-mutation]');
+      if (!btn || btn.tagName === 'FORM') return;
+      if (btn.closest('form[data-gql-mutation]')) return; // handled by form submit
+
+      if (btn.dataset.gqlConfirm && !confirm(btn.dataset.gqlConfirm)) return;
+
+      const input = JSON.parse(btn.dataset.gqlInput || '{}');
+      const result = await gqlMutate(btn.dataset.gqlMutation, { input });
+
+      if (result.errors) {
+        alert(result.errors.map(e => e.message).join('\n'));
+        return;
+      }
+
+      if (btn.dataset.gqlRedirect) {
+        window.location.href = btn.dataset.gqlRedirect;
+        return;
+      }
+      if (btn.dataset.gqlReload === 'true') {
+        window.location.reload();
+        return;
+      }
+      if (btn.dataset.gqlTarget && btn.dataset.gqlRefreshUrl) {
+        const target = document.querySelector(btn.dataset.gqlTarget);
+        if (target) {
+          const html = await fetch(btn.dataset.gqlRefreshUrl).then(r => r.text());
+          target.innerHTML = html;
+        }
+        return;
+      }
+      // For HTMX-style row replacement
+      if (btn.dataset.gqlRemove) {
+        const el = document.querySelector(btn.dataset.gqlRemove);
+        if (el) el.remove();
+        return;
+      }
+    });
+  </script>
   {% block head %}{% endblock %}
 </head>
 <body>

--- a/server/templates/dashboard.html
+++ b/server/templates/dashboard.html
@@ -9,7 +9,7 @@
 
 <section>
   <h2>Create MCP Credentials</h2>
-  <form hx-post="/mcp-creds/create" hx-target="#creds-result" hx-swap="innerHTML">
+  <form id="create-creds-form">
     <label>
       Name
       <input type="text" name="name" required placeholder="my-creds">
@@ -21,6 +21,33 @@
     <button type="submit">Create Credentials</button>
   </form>
   <div id="creds-result"></div>
+  <script>
+    document.getElementById('create-creds-form').addEventListener('submit', async (e) => {
+      e.preventDefault();
+      const fd = new FormData(e.target);
+      const scopes = fd.get('admin') === 'true' ? ['admin'] : [];
+      const result = await gqlMutate(
+        `mutation($input: McpCredentialsCreateInput!) { mcpCredentialsCreate(input: $input) { mcpCreds { id name } token } }`,
+        { input: { name: fd.get('name'), scopes } }
+      );
+      if (result.errors) { alert(result.errors.map(e => e.message).join('\n')); return; }
+      const { token, mcpCreds } = result.data.mcpCredentialsCreate;
+      const mcp_endpoint = window.location.origin + '/mcp';
+      const serverConfig = JSON.stringify({type:"http",url:mcp_endpoint,headers:{Authorization:"Bearer "+token}});
+      const cliCmd = `claude mcp add-json --scope user drua '${serverConfig}'`;
+      document.getElementById('creds-result').innerHTML = `
+        <h3>MCP Credentials Created: ${mcpCreds.name}</h3>
+        <p class="token-warning">This configuration will not be shown again. Copy it now.</p>
+        <p><strong>Claude Code CLI:</strong></p>
+        <div class="token-box"><code>${cliCmd}</code><button onclick="navigator.clipboard.writeText(this.previousElementSibling.textContent)">Copy</button></div>
+        <p><strong>MCP JSON:</strong></p>
+        <div class="token-box"><code>${JSON.stringify({drua:JSON.parse(serverConfig)})}</code><button onclick="navigator.clipboard.writeText(this.previousElementSibling.textContent)">Copy</button></div>
+      `;
+      // Refresh the credentials list
+      const listHtml = await fetch('/dashboard/mcp-creds').then(r => r.text());
+      document.getElementById('creds-list').innerHTML = new DOMParser().parseFromString(listHtml, 'text/html').querySelector('tbody')?.innerHTML || '';
+    });
+  </script>
 </section>
 
 <section>

--- a/server/templates/mcp_creds_row.html
+++ b/server/templates/mcp_creds_row.html
@@ -11,10 +11,10 @@
   <td>
     {% if !creds.is_revoked %}
     <button
-      hx-post="/mcp-creds/{{ creds.id }}/revoke"
-      hx-target="#creds-{{ creds.id }}"
-      hx-swap="outerHTML"
-      hx-confirm="Are you sure you want to revoke these credentials?"
+      data-gql-mutation="mutation($input: McpCredentialsRevokeInput!) { mcpCredentialsRevoke(input: $input) { mcpCreds { id } } }"
+      data-gql-input='{"id":"{{ creds.id }}"}'
+      data-gql-confirm="Are you sure you want to revoke these credentials?"
+      data-gql-reload="true"
       class="secondary outline"
       style="padding: 0.25rem 0.5rem; margin: 0;"
     >

--- a/server/templates/workspace_agent_detail.html
+++ b/server/templates/workspace_agent_detail.html
@@ -145,22 +145,33 @@
   <a href="/workspaces/{{ workspace.id }}/sandboxes/{{ sb.id }}"><strong>{{ sb.name }}</strong></a>
   in <code>{{ sb.mode }}</code> mode <small>(sandbox state: <code>{{ sb.state }}</code>)</small>.
 </p>
-<form method="post" action="/workspaces/{{ workspace.id }}/agents/{{ agent.id }}/detach_sandbox">
-  <button
-    type="submit"
-    onclick="return confirm('Detach this sandbox from the agent? The sandbox itself is not deleted.')"
-    class="secondary outline"
-  >
-    Detach Sandbox
-  </button>
-</form>
+<button
+  id="detach-btn"
+  data-gql-confirm="Detach this sandbox from the agent? The sandbox itself is not deleted."
+  class="secondary outline"
+>
+  Detach Sandbox
+</button>
+<script>
+  document.getElementById('detach-btn').addEventListener('click', async () => {
+    if (!confirm('Detach this sandbox from the agent? The sandbox itself is not deleted.')) return;
+    const result = await gqlMutate(
+      `mutation($input: AgentDetachSandboxInput!) { agentDetachSandbox(input: $input) { agent { id } } }`,
+      { input: { agentId: "{{ agent.id }}", sandboxId: "{{ sb.id }}" } }
+    );
+    if (result.errors) { alert(result.errors.map(e => e.message).join('\n')); return; }
+    window.location.reload();
+  });
+</script>
 
 {% when None %}
 {% if sandbox_options.is_empty() %}
 <p><em>No sandboxes in this workspace yet — <a href="/workspaces/{{ workspace.id }}/sandboxes/new">create one</a> first.</em></p>
 {% else %}
 <p><small>The agent can hold at most one sandbox at a time. Write mode is exclusive; Read mode is shared.</small></p>
-<form method="post" action="/workspaces/{{ workspace.id }}/agents/{{ agent.id }}/attach_sandbox">
+<form data-gql-mutation="mutation($input: AgentAttachSandboxInput!) { agentAttachSandbox(input: $input) { agent { id } } }"
+      data-gql-build="buildAttachSandbox"
+      data-gql-reload="true">
   <label>
     Sandbox
     <select name="sandbox_id" required>
@@ -172,12 +183,17 @@
   <label>
     Mode
     <select name="mode" required>
-      <option value="read">Read — shared, multiple agents allowed</option>
-      <option value="write">Write — exclusive, one agent at a time</option>
+      <option value="READ">Read — shared, multiple agents allowed</option>
+      <option value="WRITE">Write — exclusive, one agent at a time</option>
     </select>
   </label>
   <button type="submit">Attach Sandbox</button>
 </form>
+<script>
+  function buildAttachSandbox(fd) {
+    return { agentId: "{{ agent.id }}", sandboxId: fd.get('sandbox_id'), mode: fd.get('mode') };
+  }
+</script>
 {% endif %}
 {% endmatch %}
 {% endif %}

--- a/server/templates/workspace_agent_new.html
+++ b/server/templates/workspace_agent_new.html
@@ -106,7 +106,9 @@
 <a href="/workspaces/{{ workspace.id }}" style="font-size: 0.85rem; text-decoration: none; color: var(--pico-muted-color);">&larr; Back to {{ workspace.name }}</a>
 <h2>New Agent</h2>
 
-<form method="post" action="/workspaces/{{ workspace.id }}/agents">
+<form data-gql-mutation="mutation($input: AgentCreateInput!) { agentCreate(input: $input) { agent { id } } }"
+      data-gql-build="buildAgentCreate"
+      data-gql-redirect="/workspaces/{{ workspace.id }}/chat?agent={id}">
   <label>
     Name
     <input type="text" name="name" required placeholder="research">
@@ -126,8 +128,8 @@
     <label>
       Mode <small>(only used when a sandbox is selected)</small>
       <select name="attach_mode">
-        <option value="read">Read — shared, multiple agents allowed</option>
-        <option value="write">Write — exclusive, one agent at a time</option>
+        <option value="READ">Read — shared, multiple agents allowed</option>
+        <option value="WRITE">Write — exclusive, one agent at a time</option>
       </select>
     </label>
   </fieldset>
@@ -137,4 +139,15 @@
     <a href="/workspaces/{{ workspace.id }}" role="button" class="outline">Cancel</a>
   </div>
 </form>
+<script>
+  function buildAgentCreate(fd) {
+    const input = { workspaceId: "{{ workspace.id }}", name: fd.get('name') };
+    const sbId = (fd.get('sandbox_id') || '').trim();
+    if (sbId) {
+      input.sandboxId = sbId;
+      input.sandboxMode = fd.get('attach_mode') || 'READ';
+    }
+    return input;
+  }
+</script>
 {% endblock %}

--- a/server/templates/workspace_detail.html
+++ b/server/templates/workspace_detail.html
@@ -100,7 +100,9 @@
 {% block content %}
 <h2>Workspace Settings</h2>
 
-<form method="post" action="/workspaces/{{ workspace.id }}">
+<form data-gql-mutation="mutation($input: WorkspaceUpdateInput!) { workspaceUpdate(input: $input) { workspace { id } } }"
+      data-gql-build="buildWorkspaceUpdate"
+      data-gql-reload="true">
   <label>
     Name
     <input type="text" value="{{ workspace.name }}" disabled>
@@ -114,6 +116,12 @@
     <a href="/workspaces/{{ workspace.id }}/chat" role="button" class="outline">Back to Chat</a>
   </div>
 </form>
+<script>
+  function buildWorkspaceUpdate(fd) {
+    const desc = fd.get('description');
+    return { id: "{{ workspace.id }}", name: "{{ workspace.name }}", description: desc || null };
+  }
+</script>
 
 <hr>
 
@@ -129,10 +137,10 @@
 
 <details>
   <summary>Add Secret</summary>
-  <form hx-post="/workspaces/{{ workspace.id }}/secrets"
-        hx-target="#secrets-list"
-        hx-swap="innerHTML"
-        hx-on::after-request="if(event.detail.successful) this.reset()">
+  <form data-gql-mutation="mutation($input: WorkspaceSecretCreateInput!) { workspaceSecretCreate(input: $input) { workspaceSecret { id } } }"
+        data-gql-build="buildSecretCreate"
+        data-gql-target="#secrets-list"
+        data-gql-refresh-url="/workspaces/{{ workspace.id }}/secrets/list">
     <label>
       Name
       <input type="text" name="name" required placeholder="e.g. GITHUB_TOKEN" pattern="[A-Za-z_][A-Za-z0-9_]*">
@@ -140,8 +148,8 @@
     <label>
       Type
       <select name="secret_type" required>
-        <option value="env_var">Environment Variable</option>
-        <option value="file">File (/run/secrets/&lt;name&gt;)</option>
+        <option value="ENV_VAR">Environment Variable</option>
+        <option value="FILE">File (/run/secrets/&lt;name&gt;)</option>
       </select>
     </label>
     <label>
@@ -150,6 +158,11 @@
     </label>
     <button type="submit">Add Secret</button>
   </form>
+  <script>
+    function buildSecretCreate(fd) {
+      return { workspaceId: "{{ workspace.id }}", name: fd.get('name'), secretType: fd.get('secret_type'), value: fd.get('value') };
+    }
+  </script>
 </details>
 
 <hr>
@@ -157,8 +170,10 @@
   <summary>Danger Zone</summary>
   <p>Deleting a workspace will archive it and revoke MCP credentials for all its agents.</p>
   <button
-    hx-post="/workspaces/{{ workspace.id }}/delete"
-    hx-confirm="Are you sure you want to delete this workspace? This will revoke all agent credentials."
+    data-gql-mutation="mutation($input: WorkspaceDeleteInput!) { workspaceDelete(input: $input) { workspace { id } } }"
+    data-gql-input='{"id":"{{ workspace.id }}"}'
+    data-gql-confirm="Are you sure you want to delete this workspace? This will revoke all agent credentials."
+    data-gql-redirect="/workspaces"
     class="secondary outline"
     style="color: var(--pico-color-red-500, #c62828);"
   >

--- a/server/templates/workspace_list.html
+++ b/server/templates/workspace_list.html
@@ -21,8 +21,10 @@
           <a href="/workspaces/{{ ws.id }}/chat">Chat</a>
           <a href="/workspaces/{{ ws.id }}">Edit</a>
           <button
-            hx-post="/workspaces/{{ ws.id }}/delete"
-            hx-confirm="Are you sure you want to delete this workspace?"
+            data-gql-mutation="mutation($input: WorkspaceDeleteInput!) { workspaceDelete(input: $input) { workspace { id } } }"
+            data-gql-input='{"id":"{{ ws.id }}"}'
+            data-gql-confirm="Are you sure you want to delete this workspace?"
+            data-gql-reload="true"
             class="secondary outline"
             style="padding: 0.25rem 0.5rem; margin: 0; font-size: 0.85em;"
           >

--- a/server/templates/workspace_new.html
+++ b/server/templates/workspace_new.html
@@ -5,7 +5,9 @@
 {% block content %}
 <h2>New Workspace</h2>
 
-<form method="post" action="/workspaces">
+<form data-gql-mutation="mutation($input: WorkspaceCreateInput!) { workspaceCreate(input: $input) { workspace { id } } }"
+      data-gql-build="buildWorkspaceCreate"
+      data-gql-redirect="/workspaces/{id}/chat">
   <label>
     Name
     <input type="text" name="name" required placeholder="e.g. platform-team">
@@ -20,4 +22,10 @@
     <a href="/workspaces" role="button" class="outline">Cancel</a>
   </div>
 </form>
+<script>
+  function buildWorkspaceCreate(fd) {
+    const desc = fd.get('description');
+    return { name: fd.get('name'), description: desc || null };
+  }
+</script>
 {% endblock %}

--- a/server/templates/workspace_sandbox_detail.html
+++ b/server/templates/workspace_sandbox_detail.html
@@ -132,20 +132,21 @@
      is suspended or errored; Suspend is offered when it's ready.
      Mid-flight states (provisioning / initializing) get no button. #}
   {% if sandbox.state == "suspended" || sandbox.state == "errored" %}
-  <form method="post" action="/workspaces/{{ workspace.id }}/sandboxes/{{ sandbox.id }}/restart" style="margin: 0;">
-    <button type="submit" style="margin: 0;">Restart Sandbox</button>
-  </form>
+  <button
+    data-gql-mutation="mutation($input: SandboxRestartInput!) { sandboxRestart(input: $input) { sandbox { id } } }"
+    data-gql-input='{"id":"{{ sandbox.id }}"}'
+    data-gql-reload="true"
+    style="margin: 0;"
+  >Restart Sandbox</button>
   {% else if sandbox.state == "ready" %}
-  <form method="post" action="/workspaces/{{ workspace.id }}/sandboxes/{{ sandbox.id }}/suspend" style="margin: 0;">
-    <button
-      type="submit"
-      onclick="return confirm('Suspend this sandbox? The underlying pod/process will be deleted; workspace state is retained.')"
-      class="secondary outline"
-      style="margin: 0;"
-    >
-      Suspend Sandbox
-    </button>
-  </form>
+  <button
+    data-gql-mutation="mutation($input: SandboxSuspendInput!) { sandboxSuspend(input: $input) { sandbox { id } } }"
+    data-gql-input='{"id":"{{ sandbox.id }}"}'
+    data-gql-confirm="Suspend this sandbox? The underlying pod/process will be deleted; workspace state is retained."
+    data-gql-reload="true"
+    class="secondary outline"
+    style="margin: 0;"
+  >Suspend Sandbox</button>
   {% endif %}
 </div>
 

--- a/server/templates/workspace_sandbox_new.html
+++ b/server/templates/workspace_sandbox_new.html
@@ -102,7 +102,9 @@
 <a href="/workspaces/{{ workspace.id }}/sandboxes" style="font-size: 0.85rem; text-decoration: none; color: var(--pico-muted-color);">&larr; Back to Sandboxes</a>
 <h2>New Sandbox</h2>
 
-<form method="post" action="/workspaces/{{ workspace.id }}/sandboxes">
+<form data-gql-mutation="mutation($input: SandboxCreateInput!) { sandboxCreate(input: $input) { sandbox { id } } }"
+      data-gql-build="buildSandboxCreate"
+      data-gql-redirect="/workspaces/{{ workspace.id }}/sandboxes">
   <label>
     Name
     <input type="text" name="name" required placeholder="my-sandbox">
@@ -111,8 +113,8 @@
   <label>
     Mode
     <select name="mode" required>
-      <option value="scratch">Scratch — empty workspace</option>
-      <option value="repo">Repo — clone a git repository</option>
+      <option value="SCRATCH">Scratch — empty workspace</option>
+      <option value="REPO">Repo — clone a git repository</option>
     </select>
   </label>
 
@@ -146,4 +148,21 @@
     <a href="/workspaces/{{ workspace.id }}/sandboxes" role="button" class="outline">Cancel</a>
   </div>
 </form>
+<script>
+  function buildSandboxCreate(fd) {
+    const input = {
+      workspaceId: "{{ workspace.id }}",
+      name: fd.get('name'),
+      mode: fd.get('mode'),
+      cpu: fd.get('cpu'),
+      memory: fd.get('memory'),
+      diskSize: fd.get('disk_size'),
+    };
+    const repoUrl = (fd.get('repo_url') || '').trim();
+    if (repoUrl) input.repoUrl = repoUrl;
+    const branch = (fd.get('branch') || '').trim();
+    if (branch) input.branch = branch;
+    return input;
+  }
+</script>
 {% endblock %}

--- a/server/templates/workspace_secrets_list.html
+++ b/server/templates/workspace_secrets_list.html
@@ -18,10 +18,11 @@
       <td><small>{{ secret.updated_at }}</small></td>
       <td>
         <button
-          hx-post="/workspaces/{{ secret.workspace_id }}/secrets/{{ secret.id }}/delete"
-          hx-target="#secrets-list"
-          hx-swap="innerHTML"
-          hx-confirm="Delete secret '{{ secret.name }}'?"
+          data-gql-mutation="mutation($input: WorkspaceSecretDeleteInput!) { workspaceSecretDelete(input: $input) { deletedId } }"
+          data-gql-input='{"id":"{{ secret.id }}"}'
+          data-gql-confirm="Delete secret '{{ secret.name }}'?"
+          data-gql-target="#secrets-list"
+          data-gql-refresh-url="/workspaces/{{ secret.workspace_id }}/secrets/list"
           class="outline secondary"
           style="padding: 0.25rem 0.5rem; margin: 0;"
         >Delete</button>

--- a/server/templates/workspace_skill_edit.html
+++ b/server/templates/workspace_skill_edit.html
@@ -103,7 +103,9 @@
 <a href="/workspaces/{{ workspace.id }}/skills" style="font-size: 0.85rem; text-decoration: none; color: var(--pico-muted-color);">&larr; Back to Skills</a>
 <h2>Edit Skill</h2>
 
-<form method="post" action="/workspaces/{{ workspace.id }}/skills/{{ skill.id }}">
+<form data-gql-mutation="mutation($input: SkillUpdateInput!) { skillUpdate(input: $input) { skill { id } } }"
+      data-gql-build="buildSkillUpdate"
+      data-gql-redirect="/workspaces/{{ workspace.id }}/skills">
   <label>
     Name
     <input type="text" name="name" required value="{{ skill.name }}">
@@ -121,20 +123,25 @@
     <a href="/workspaces/{{ workspace.id }}/skills" role="button" class="outline">Cancel</a>
   </div>
 </form>
+<script>
+  function buildSkillUpdate(fd) {
+    return { id: "{{ skill.id }}", name: fd.get('name'), description: fd.get('description'), body: fd.get('body') };
+  }
+</script>
 
 <hr>
 <details>
   <summary>Danger Zone</summary>
-  <form method="post" action="/workspaces/{{ workspace.id }}/skills/{{ skill.id }}/delete" style="display: inline;">
-    <button
-      type="submit"
-      onclick="return confirm('Are you sure you want to delete this skill?')"
-      class="secondary outline"
-      style="color: var(--pico-color-red-500, #c62828);"
-    >
-      Delete Skill
-    </button>
-  </form>
+  <button
+    data-gql-mutation="mutation($input: SkillDeleteInput!) { skillDelete(input: $input) { deletedId } }"
+    data-gql-input='{"id":"{{ skill.id }}"}'
+    data-gql-confirm="Are you sure you want to delete this skill?"
+    data-gql-redirect="/workspaces/{{ workspace.id }}/skills"
+    class="secondary outline"
+    style="color: var(--pico-color-red-500, #c62828);"
+  >
+    Delete Skill
+  </button>
 </details>
 
 <footer>

--- a/server/templates/workspace_skill_new.html
+++ b/server/templates/workspace_skill_new.html
@@ -103,7 +103,9 @@
 <a href="/workspaces/{{ workspace.id }}/skills" style="font-size: 0.85rem; text-decoration: none; color: var(--pico-muted-color);">&larr; Back to Skills</a>
 <h2>New Skill</h2>
 
-<form method="post" action="/workspaces/{{ workspace.id }}/skills">
+<form data-gql-mutation="mutation($input: SkillCreateInput!) { skillCreate(input: $input) { skill { id } } }"
+      data-gql-build="buildSkillCreate"
+      data-gql-redirect="/workspaces/{{ workspace.id }}/skills">
   <label>
     Name
     <input type="text" name="name" required placeholder="e.g. code-review">
@@ -121,4 +123,9 @@
     <a href="/workspaces/{{ workspace.id }}/skills" role="button" class="outline">Cancel</a>
   </div>
 </form>
+<script>
+  function buildSkillCreate(fd) {
+    return { workspaceId: "{{ workspace.id }}", name: fd.get('name'), description: fd.get('description') || '', body: fd.get('body') };
+  }
+</script>
 {% endblock %}

--- a/server/tests/graphql.rs
+++ b/server/tests/graphql.rs
@@ -5,6 +5,8 @@
 /// expected shapes. They hit a real Postgres database — run via:
 ///
 ///   DATABASE_URL=postgres://user:password@localhost:5432/drua cargo nextest run -p drua-server
+use std::collections::HashMap;
+
 const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
 
 async fn pool() -> sqlx::PgPool {
@@ -16,19 +18,52 @@ fn test_sub() -> drua_core::auth::AuthSubject {
     drua_core::auth::AuthSubject::User(drua_core::primitives::UserId::new())
 }
 
-/// Build a minimal GraphQL schema with a live App injected.
+/// Build a minimal App suitable for GraphQL integration tests.
 ///
-/// Because `App::init` requires external services (prompt executor, etc.),
-/// we skip it and wire the domain services we need manually. For the
-/// integration test we use the `schema(None)` path and inject services
-/// into the request data directly — the resolvers pull `App` from context
-/// via `data_unchecked`, so we just need a real `App` handle.
-///
-/// Since App::init is complex (needs LLM keys, etc.), we instead test by
-/// inserting directly into the DB and querying through the GraphQL layer.
-/// For mutation tests that don't need the full App, we use domain services
-/// directly and verify via queries.
-#[allow(dead_code)]
+/// Uses default configs with the minimum required agent role setup.
+/// No real LLM keys needed — prompt executor boots with empty models.
+async fn test_app(pool: &sqlx::PgPool) -> drua_core::App {
+    use drua_core::agent::{AgentsConfig, ModelDefaults, RoleConfig};
+
+    let model_name = "test-model".to_string();
+    let mut builtin_roles = HashMap::new();
+    for role in [
+        drua_core::agent::AgentRole::WorkspaceLead,
+        drua_core::agent::AgentRole::Agent,
+    ] {
+        builtin_roles.insert(
+            role,
+            RoleConfig {
+                model: model_name.clone(),
+                compaction: Default::default(),
+            },
+        );
+    }
+    let mut models = HashMap::new();
+    models.insert(
+        model_name.clone(),
+        ModelDefaults {
+            model: model_name,
+            max_tokens_per_response: 1024,
+            context_window_tokens: 200_000,
+            ..Default::default()
+        },
+    );
+
+    let config = drua_core::AppConfig {
+        agents: AgentsConfig {
+            builtin_roles,
+            models,
+        },
+        ..Default::default()
+    };
+
+    drua_core::App::init(pool, config)
+        .await
+        .expect("init test app")
+}
+
+/// Execute a GraphQL query/mutation against a schema with App + AuthSubject injected.
 async fn execute_graphql(
     schema: &drua_server::graphql::AgentsSchema,
     app: &drua_core::App,
@@ -55,21 +90,19 @@ async fn execute_graphql(
     serde_json::to_value(&response).unwrap()
 }
 
-/// Helper: create a workspace through the domain layer and return its id.
-async fn create_workspace(pool: &sqlx::PgPool) -> drua_core::primitives::WorkspaceId {
-    let id = drua_core::primitives::WorkspaceId::new();
-    sqlx::query("INSERT INTO workspaces (id, name, created_at) VALUES ($1, $2, NOW())")
-        .bind(id)
-        .bind(format!("test-ws-{}", uuid::Uuid::from(id)))
-        .execute(pool)
-        .await
-        .expect("insert workspace");
-    id
+/// Helper: assert no GraphQL errors in the response and return the data object.
+fn assert_no_errors(result: &serde_json::Value) -> &serde_json::Value {
+    if let Some(errors) = result.get("errors") {
+        panic!(
+            "GraphQL errors: {}",
+            serde_json::to_string_pretty(errors).unwrap()
+        );
+    }
+    result.get("data").expect("response should have 'data'")
 }
 
-// ─── Workspace CRUD tests ───────────────────────────────────────────────────
+// ─── Baseline tests ─────────────────────────────────────────────────────────
 
-/// Verify that the schema builds and the ping query works (baseline sanity check).
 #[tokio::test]
 async fn ping_query_works() {
     let schema = drua_server::graphql::schema(None);
@@ -80,7 +113,6 @@ async fn ping_query_works() {
     assert_eq!(json["data"]["ping"], "pong");
 }
 
-/// Verify that the ping mutation works.
 #[tokio::test]
 async fn ping_mutation_works() {
     let schema = drua_server::graphql::schema(None);
@@ -91,103 +123,424 @@ async fn ping_mutation_works() {
     assert_eq!(json["data"]["ping"], "pong");
 }
 
-// ─── Skill CRUD tests (domain-level, verifying GraphQL types compile) ───────
+// ─── Workspace mutation tests ───────────────────────────────────────────────
 
-/// Verify the skill GraphQL types work by creating through domain and reading back.
 #[tokio::test]
-async fn skill_create_domain_roundtrip() {
+async fn workspace_create_update_delete_via_graphql() {
     let pool = pool().await;
-    let ws_id = create_workspace(&pool).await;
+    let app = test_app(&pool).await;
+    let schema = drua_server::graphql::schema(Some(app.clone()));
     let sub = test_sub();
 
-    let sandboxes = std::sync::Arc::new(
-        drua_core::sandbox::Sandboxes::init(
-            &pool,
-            drua_core::sandbox::SandboxConfig::default(),
-            None,
-        )
-        .await
-        .expect("init sandboxes"),
+    // Create
+    let ws_name = format!("gql-ws-test-{}", uuid::Uuid::new_v4());
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: WorkspaceCreateInput!) {
+            workspaceCreate(input: $input) { workspace { id name description } }
+        }"#,
+        serde_json::json!({ "input": { "name": ws_name, "description": "test workspace" } }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    let ws = &data["workspaceCreate"]["workspace"];
+    assert_eq!(ws["name"], ws_name);
+    assert_eq!(ws["description"], "test workspace");
+    let ws_id = ws["id"].as_str().unwrap().to_string();
+
+    // Update
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: WorkspaceUpdateInput!) {
+            workspaceUpdate(input: $input) { workspace { id name description } }
+        }"#,
+        serde_json::json!({ "input": { "id": ws_id, "description": "updated" } }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    assert_eq!(
+        data["workspaceUpdate"]["workspace"]["description"],
+        "updated"
     );
-    let skills = drua_core::skill::Skills::new(&pool, sandboxes);
-
-    let new = drua_core::skill::NewSkill::builder()
-        .workspace_id(ws_id)
-        .name("test-skill")
-        .description("A test skill")
-        .body("Do the thing")
-        .build()
-        .unwrap();
-
-    let skill = skills.create(&sub, new).await.expect("create skill");
-    assert_eq!(skill.name, "test-skill");
-    assert_eq!(skill.description, "A test skill");
-    assert_eq!(skill.body, "Do the thing");
-    assert_eq!(skill.workspace_id, ws_id);
-
-    // Verify list
-    let listed = skills
-        .list_by_workspace_id(&sub, ws_id)
-        .await
-        .expect("list skills");
-    assert!(listed.iter().any(|s| s.id == skill.id));
-
-    // Verify update
-    let mut skill = skills.find_by_id(&sub, skill.id).await.expect("find skill");
-    let _ = skill.update(Some("updated-name".into()), None, None);
-    skills.update(&sub, &mut skill).await.expect("update skill");
-    assert_eq!(skill.name, "updated-name");
-
-    // Verify delete
-    skills.delete(&sub, skill.id).await.expect("delete skill");
-    let listed = skills
-        .list_by_workspace_id(&sub, ws_id)
-        .await
-        .expect("list after delete");
-    assert!(!listed.iter().any(|s| s.id == skill.id));
-}
-
-// ─── Workspace Secret tests ────────────────────────────────────────────────
-
-#[tokio::test]
-async fn workspace_secret_create_and_list_domain_roundtrip() {
-    let pool = pool().await;
-    let ws_id = create_workspace(&pool).await;
-    let sub = test_sub();
-
-    let key = drua_core::encryption::EncryptionKey::new([42u8; 32]);
-    let secrets = drua_core::workspace_secret::WorkspaceSecrets::new(&pool, key);
-
-    let secret = secrets
-        .create(
-            &sub,
-            ws_id,
-            "GQL_TEST_KEY",
-            drua_core::workspace_secret::SecretType::EnvVar,
-            "secret-value",
-        )
-        .await
-        .expect("create secret");
-    assert_eq!(secret.name, "GQL_TEST_KEY");
-
-    let listed = secrets
-        .list_by_workspace(&sub, ws_id)
-        .await
-        .expect("list secrets");
-    assert!(listed.iter().any(|s| s.id == secret.id));
 
     // Delete
-    secrets.delete(&sub, secret.id).await.expect("delete");
-    let listed = secrets
-        .list_by_workspace(&sub, ws_id)
-        .await
-        .expect("list after delete");
-    assert!(!listed.iter().any(|s| s.id == secret.id));
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: WorkspaceDeleteInput!) {
+            workspaceDelete(input: $input) { workspace { id } }
+        }"#,
+        serde_json::json!({ "input": { "id": ws_id } }),
+    )
+    .await;
+    assert_no_errors(&result);
+
+    // Verify workspace is gone
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"query($id: WorkspaceId!) { workspace(id: $id) { id } }"#,
+        serde_json::json!({ "id": ws_id }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    assert!(
+        data["workspace"].is_null(),
+        "deleted workspace should return null"
+    );
 }
 
-// ─── Schema introspection tests ──────────────────────────────────────────
+// ─── Skill mutation tests ───────────────────────────────────────────────────
 
-/// Verify the schema exposes all new mutation fields.
+#[tokio::test]
+async fn skill_create_update_delete_via_graphql() {
+    let pool = pool().await;
+    let app = test_app(&pool).await;
+    let schema = drua_server::graphql::schema(Some(app.clone()));
+    let sub = test_sub();
+
+    // Create workspace first
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: WorkspaceCreateInput!) {
+            workspaceCreate(input: $input) { workspace { id } }
+        }"#,
+        serde_json::json!({ "input": { "name": format!("skill-test-ws-{}", uuid::Uuid::new_v4()) } }),
+    )
+    .await;
+    let ws_id = assert_no_errors(&result)["workspaceCreate"]["workspace"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create skill
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: SkillCreateInput!) {
+            skillCreate(input: $input) { skill { id name description body workspaceId } }
+        }"#,
+        serde_json::json!({ "input": {
+            "workspaceId": ws_id,
+            "name": "test-skill",
+            "description": "A skill for testing",
+            "body": "Do the thing"
+        }}),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    let skill = &data["skillCreate"]["skill"];
+    assert_eq!(skill["name"], "test-skill");
+    assert_eq!(skill["description"], "A skill for testing");
+    assert_eq!(skill["body"], "Do the thing");
+    let skill_id = skill["id"].as_str().unwrap().to_string();
+
+    // Update skill
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: SkillUpdateInput!) {
+            skillUpdate(input: $input) { skill { id name description body } }
+        }"#,
+        serde_json::json!({ "input": {
+            "id": skill_id,
+            "name": "updated-skill",
+            "body": "Updated body"
+        }}),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    assert_eq!(data["skillUpdate"]["skill"]["name"], "updated-skill");
+    assert_eq!(data["skillUpdate"]["skill"]["body"], "Updated body");
+
+    // Verify skill appears in workspace skills list
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"query($id: WorkspaceId!) { workspace(id: $id) { skills { id name } } }"#,
+        serde_json::json!({ "id": ws_id }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    let skills = data["workspace"]["skills"].as_array().unwrap();
+    assert!(skills.iter().any(|s| s["id"].as_str() == Some(&skill_id)));
+
+    // Delete skill
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: SkillDeleteInput!) {
+            skillDelete(input: $input) { deletedId }
+        }"#,
+        serde_json::json!({ "input": { "id": skill_id } }),
+    )
+    .await;
+    assert_no_errors(&result);
+
+    // Verify skill is gone from workspace
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"query($id: WorkspaceId!) { workspace(id: $id) { skills { id } } }"#,
+        serde_json::json!({ "id": ws_id }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    let skills = data["workspace"]["skills"].as_array().unwrap();
+    assert!(!skills.iter().any(|s| s["id"].as_str() == Some(&skill_id)));
+
+    // Cleanup
+    let _ = execute_graphql(
+        &schema, &app, &sub,
+        r#"mutation($input: WorkspaceDeleteInput!) { workspaceDelete(input: $input) { workspace { id } } }"#,
+        serde_json::json!({ "input": { "id": ws_id } }),
+    ).await;
+}
+
+// ─── Workspace Secret mutation tests ────────────────────────────────────────
+
+#[tokio::test]
+async fn workspace_secret_create_delete_via_graphql() {
+    let pool = pool().await;
+    let app = test_app(&pool).await;
+    let schema = drua_server::graphql::schema(Some(app.clone()));
+    let sub = test_sub();
+
+    // Create workspace
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: WorkspaceCreateInput!) {
+            workspaceCreate(input: $input) { workspace { id } }
+        }"#,
+        serde_json::json!({ "input": { "name": format!("secret-test-ws-{}", uuid::Uuid::new_v4()) } }),
+    )
+    .await;
+    let ws_id = assert_no_errors(&result)["workspaceCreate"]["workspace"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create secret
+    let result = execute_graphql(
+        &schema, &app, &sub,
+        r#"mutation($input: WorkspaceSecretCreateInput!) {
+            workspaceSecretCreate(input: $input) { workspaceSecret { id name secretType workspaceId } }
+        }"#,
+        serde_json::json!({ "input": {
+            "workspaceId": ws_id,
+            "name": "TEST_API_KEY",
+            "secretType": "ENV_VAR",
+            "value": "sk-secret-123"
+        }}),
+    ).await;
+    let data = assert_no_errors(&result);
+    let secret = &data["workspaceSecretCreate"]["workspaceSecret"];
+    assert_eq!(secret["name"], "TEST_API_KEY");
+    assert_eq!(secret["secretType"], "ENV_VAR");
+    let secret_id = secret["id"].as_str().unwrap().to_string();
+
+    // Verify secret appears in workspace secrets list
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"query($id: WorkspaceId!) { workspace(id: $id) { secrets { id name secretType } } }"#,
+        serde_json::json!({ "id": ws_id }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    let secrets = data["workspace"]["secrets"].as_array().unwrap();
+    assert!(secrets.iter().any(|s| s["name"] == "TEST_API_KEY"));
+    // Ensure no 'value' field is exposed
+    assert!(secrets.iter().all(|s| s.get("value").is_none()));
+
+    // Delete secret
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: WorkspaceSecretDeleteInput!) {
+            workspaceSecretDelete(input: $input) { deletedId }
+        }"#,
+        serde_json::json!({ "input": { "id": secret_id } }),
+    )
+    .await;
+    assert_no_errors(&result);
+
+    // Verify secret is gone
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"query($id: WorkspaceId!) { workspace(id: $id) { secrets { id } } }"#,
+        serde_json::json!({ "id": ws_id }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    let secrets = data["workspace"]["secrets"].as_array().unwrap();
+    assert!(!secrets.iter().any(|s| s["id"].as_str() == Some(&secret_id)));
+
+    // Cleanup
+    let _ = execute_graphql(
+        &schema, &app, &sub,
+        r#"mutation($input: WorkspaceDeleteInput!) { workspaceDelete(input: $input) { workspace { id } } }"#,
+        serde_json::json!({ "input": { "id": ws_id } }),
+    ).await;
+}
+
+// ─── MCP Credentials mutation tests ─────────────────────────────────────────
+
+#[tokio::test]
+async fn mcp_credentials_create_revoke_via_graphql() {
+    let pool = pool().await;
+    let app = test_app(&pool).await;
+    let schema = drua_server::graphql::schema(Some(app.clone()));
+    let sub = test_sub();
+
+    // Create credentials
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: McpCredentialsCreateInput!) {
+            mcpCredentialsCreate(input: $input) { mcpCreds { id name revoked } token }
+        }"#,
+        serde_json::json!({ "input": { "name": "test-creds", "scopes": [] } }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    let payload = &data["mcpCredentialsCreate"];
+    assert_eq!(payload["mcpCreds"]["name"], "test-creds");
+    assert_eq!(payload["mcpCreds"]["revoked"], false);
+    assert!(
+        payload["token"].as_str().unwrap().len() > 10,
+        "token should be non-trivial"
+    );
+    let creds_id = payload["mcpCreds"]["id"].as_str().unwrap().to_string();
+
+    // Revoke credentials
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: McpCredentialsRevokeInput!) {
+            mcpCredentialsRevoke(input: $input) { mcpCreds { id revoked revokedAt } }
+        }"#,
+        serde_json::json!({ "input": { "id": creds_id } }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    let creds = &data["mcpCredentialsRevoke"]["mcpCreds"];
+    assert_eq!(creds["revoked"], true);
+    assert!(
+        creds["revokedAt"].as_str().is_some(),
+        "revokedAt should be set"
+    );
+}
+
+// ─── Agent mutation tests ───────────────────────────────────────────────────
+
+#[tokio::test]
+async fn agent_create_via_graphql() {
+    let pool = pool().await;
+    let app = test_app(&pool).await;
+    let schema = drua_server::graphql::schema(Some(app.clone()));
+    let sub = test_sub();
+
+    // Create workspace
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: WorkspaceCreateInput!) {
+            workspaceCreate(input: $input) { workspace { id } }
+        }"#,
+        serde_json::json!({ "input": { "name": format!("agent-test-ws-{}", uuid::Uuid::new_v4()) } }),
+    )
+    .await;
+    let ws_id = assert_no_errors(&result)["workspaceCreate"]["workspace"]["id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    // Create agent
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: AgentCreateInput!) {
+            agentCreate(input: $input) { agent { id name role workspaceId } }
+        }"#,
+        serde_json::json!({ "input": { "workspaceId": ws_id, "name": "research" } }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    let agent = &data["agentCreate"]["agent"];
+    assert_eq!(agent["name"], "research");
+    assert_eq!(agent["role"], "AGENT");
+    assert_eq!(agent["workspaceId"], ws_id);
+
+    // Verify agent appears in workspace agents list
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"query($id: WorkspaceId!) { workspace(id: $id) { agents { id name role } } }"#,
+        serde_json::json!({ "id": ws_id }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    let agents = data["workspace"]["agents"].as_array().unwrap();
+    assert!(agents.iter().any(|a| a["name"] == "research"));
+    // Lead should be first
+    assert_eq!(agents[0]["role"], "WORKSPACE_LEAD");
+
+    // Cleanup
+    let _ = execute_graphql(
+        &schema, &app, &sub,
+        r#"mutation($input: WorkspaceDeleteInput!) { workspaceDelete(input: $input) { workspace { id } } }"#,
+        serde_json::json!({ "input": { "id": ws_id } }),
+    ).await;
+}
+
+// ─── Sandbox query test ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn sandbox_query_returns_null_for_missing() {
+    let pool = pool().await;
+    let app = test_app(&pool).await;
+    let schema = drua_server::graphql::schema(Some(app.clone()));
+    let sub = test_sub();
+
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"query($id: SandboxId!) { sandbox(id: $id) { id } }"#,
+        serde_json::json!({ "id": "00000000-0000-0000-0000-000000000000" }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    assert!(data["sandbox"].is_null());
+}
+
+// ─── Schema introspection tests ─────────────────────────────────────────────
+
 #[tokio::test]
 async fn schema_has_expected_mutations() {
     let schema = drua_server::graphql::schema(None);
@@ -231,7 +584,6 @@ async fn schema_has_expected_mutations() {
     }
 }
 
-/// Verify the schema exposes all new query fields.
 #[tokio::test]
 async fn schema_has_expected_queries() {
     let schema = drua_server::graphql::schema(None);
@@ -257,7 +609,6 @@ async fn schema_has_expected_queries() {
     }
 }
 
-/// Verify the Workspace type exposes sandboxes, skills, secrets, and mcpCredentials.
 #[tokio::test]
 async fn schema_workspace_has_new_fields() {
     let schema = drua_server::graphql::schema(None);
@@ -283,7 +634,6 @@ async fn schema_workspace_has_new_fields() {
     }
 }
 
-/// Verify the Sandbox type has expected fields.
 #[tokio::test]
 async fn schema_sandbox_type_has_expected_fields() {
     let schema = drua_server::graphql::schema(None);
@@ -321,7 +671,6 @@ async fn schema_sandbox_type_has_expected_fields() {
     }
 }
 
-/// Verify the Skill type has expected fields.
 #[tokio::test]
 async fn schema_skill_type_has_expected_fields() {
     let schema = drua_server::graphql::schema(None);
@@ -354,7 +703,6 @@ async fn schema_skill_type_has_expected_fields() {
     }
 }
 
-/// Verify the WorkspaceSecret type has expected fields (no value exposed!).
 #[tokio::test]
 async fn schema_workspace_secret_type_has_expected_fields() {
     let schema = drua_server::graphql::schema(None);
@@ -378,19 +726,16 @@ async fn schema_workspace_secret_type_has_expected_fields() {
             "Missing workspace secret field: {name}. Available: {fields:?}"
         );
     }
-
-    // Ensure the plaintext value is NOT exposed
     assert!(
         !fields.contains(&"value".to_string()),
-        "WorkspaceSecret should NOT expose 'value' field"
+        "should NOT expose 'value'"
     );
     assert!(
         !fields.contains(&"encryptedValue".to_string()),
-        "WorkspaceSecret should NOT expose 'encryptedValue' field"
+        "should NOT expose 'encryptedValue'"
     );
 }
 
-/// Verify the AuditEntry type has expected fields.
 #[tokio::test]
 async fn schema_audit_entry_type_has_expected_fields() {
     let schema = drua_server::graphql::schema(None);
@@ -425,7 +770,6 @@ async fn schema_audit_entry_type_has_expected_fields() {
     }
 }
 
-/// Verify the McpCreds type has expected fields.
 #[tokio::test]
 async fn schema_mcp_creds_type_has_expected_fields() {
     let schema = drua_server::graphql::schema(None);

--- a/server/tests/graphql.rs
+++ b/server/tests/graphql.rs
@@ -60,10 +60,7 @@ async fn create_workspace(pool: &sqlx::PgPool) -> drua_core::primitives::Workspa
     let id = drua_core::primitives::WorkspaceId::new();
     sqlx::query("INSERT INTO workspaces (id, name, created_at) VALUES ($1, $2, NOW())")
         .bind(id)
-        .bind(format!(
-            "test-ws-{}",
-            uuid::Uuid::from(id).to_string().split('-').next().unwrap()
-        ))
+        .bind(format!("test-ws-{}", uuid::Uuid::from(id)))
         .execute(pool)
         .await
         .expect("insert workspace");

--- a/server/tests/graphql.rs
+++ b/server/tests/graphql.rs
@@ -1,0 +1,455 @@
+/// Integration tests for the GraphQL API layer.
+///
+/// These tests exercise the async-graphql schema directly (no HTTP server) to
+/// verify that resolvers correctly wire up to domain services and return the
+/// expected shapes. They hit a real Postgres database — run via:
+///
+///   DATABASE_URL=postgres://user:password@localhost:5432/drua cargo nextest run -p drua-server
+const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
+
+async fn pool() -> sqlx::PgPool {
+    let url = std::env::var("DATABASE_URL").unwrap_or_else(|_| PG_CON.to_string());
+    sqlx::PgPool::connect(&url).await.expect("connect to pg")
+}
+
+fn test_sub() -> drua_core::auth::AuthSubject {
+    drua_core::auth::AuthSubject::User(drua_core::primitives::UserId::new())
+}
+
+/// Build a minimal GraphQL schema with a live App injected.
+///
+/// Because `App::init` requires external services (prompt executor, etc.),
+/// we skip it and wire the domain services we need manually. For the
+/// integration test we use the `schema(None)` path and inject services
+/// into the request data directly — the resolvers pull `App` from context
+/// via `data_unchecked`, so we just need a real `App` handle.
+///
+/// Since App::init is complex (needs LLM keys, etc.), we instead test by
+/// inserting directly into the DB and querying through the GraphQL layer.
+/// For mutation tests that don't need the full App, we use domain services
+/// directly and verify via queries.
+#[allow(dead_code)]
+async fn execute_graphql(
+    schema: &drua_server::graphql::AgentsSchema,
+    app: &drua_core::App,
+    sub: &drua_core::auth::AuthSubject,
+    query: &str,
+    variables: serde_json::Value,
+) -> serde_json::Value {
+    let mut request = async_graphql::Request::new(query);
+
+    if let serde_json::Value::Object(vars) = variables {
+        let mut gql_vars = async_graphql::Variables::default();
+        for (k, v) in vars {
+            gql_vars.insert(
+                async_graphql::Name::new(k),
+                async_graphql::Value::from_json(v).unwrap(),
+            );
+        }
+        request = request.variables(gql_vars);
+    }
+
+    request = request.data(app.clone()).data(sub.clone());
+
+    let response = schema.execute(request).await;
+    serde_json::to_value(&response).unwrap()
+}
+
+/// Helper: create a workspace through the domain layer and return its id.
+async fn create_workspace(pool: &sqlx::PgPool) -> drua_core::primitives::WorkspaceId {
+    let id = drua_core::primitives::WorkspaceId::new();
+    sqlx::query("INSERT INTO workspaces (id, name, created_at) VALUES ($1, $2, NOW())")
+        .bind(id)
+        .bind(format!(
+            "test-ws-{}",
+            uuid::Uuid::from(id).to_string().split('-').next().unwrap()
+        ))
+        .execute(pool)
+        .await
+        .expect("insert workspace");
+    id
+}
+
+// ─── Workspace CRUD tests ───────────────────────────────────────────────────
+
+/// Verify that the schema builds and the ping query works (baseline sanity check).
+#[tokio::test]
+async fn ping_query_works() {
+    let schema = drua_server::graphql::schema(None);
+    let response = schema
+        .execute(async_graphql::Request::new("{ ping }"))
+        .await;
+    let json = serde_json::to_value(&response).unwrap();
+    assert_eq!(json["data"]["ping"], "pong");
+}
+
+/// Verify that the ping mutation works.
+#[tokio::test]
+async fn ping_mutation_works() {
+    let schema = drua_server::graphql::schema(None);
+    let response = schema
+        .execute(async_graphql::Request::new("mutation { ping }"))
+        .await;
+    let json = serde_json::to_value(&response).unwrap();
+    assert_eq!(json["data"]["ping"], "pong");
+}
+
+// ─── Skill CRUD tests (domain-level, verifying GraphQL types compile) ───────
+
+/// Verify the skill GraphQL types work by creating through domain and reading back.
+#[tokio::test]
+async fn skill_create_domain_roundtrip() {
+    let pool = pool().await;
+    let ws_id = create_workspace(&pool).await;
+    let sub = test_sub();
+
+    let sandboxes = std::sync::Arc::new(
+        drua_core::sandbox::Sandboxes::init(
+            &pool,
+            drua_core::sandbox::SandboxConfig::default(),
+            None,
+        )
+        .await
+        .expect("init sandboxes"),
+    );
+    let skills = drua_core::skill::Skills::new(&pool, sandboxes);
+
+    let new = drua_core::skill::NewSkill::builder()
+        .workspace_id(ws_id)
+        .name("test-skill")
+        .description("A test skill")
+        .body("Do the thing")
+        .build()
+        .unwrap();
+
+    let skill = skills.create(&sub, new).await.expect("create skill");
+    assert_eq!(skill.name, "test-skill");
+    assert_eq!(skill.description, "A test skill");
+    assert_eq!(skill.body, "Do the thing");
+    assert_eq!(skill.workspace_id, ws_id);
+
+    // Verify list
+    let listed = skills
+        .list_by_workspace_id(&sub, ws_id)
+        .await
+        .expect("list skills");
+    assert!(listed.iter().any(|s| s.id == skill.id));
+
+    // Verify update
+    let mut skill = skills.find_by_id(&sub, skill.id).await.expect("find skill");
+    let _ = skill.update(Some("updated-name".into()), None, None);
+    skills.update(&sub, &mut skill).await.expect("update skill");
+    assert_eq!(skill.name, "updated-name");
+
+    // Verify delete
+    skills.delete(&sub, skill.id).await.expect("delete skill");
+    let listed = skills
+        .list_by_workspace_id(&sub, ws_id)
+        .await
+        .expect("list after delete");
+    assert!(!listed.iter().any(|s| s.id == skill.id));
+}
+
+// ─── Workspace Secret tests ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn workspace_secret_create_and_list_domain_roundtrip() {
+    let pool = pool().await;
+    let ws_id = create_workspace(&pool).await;
+    let sub = test_sub();
+
+    let key = drua_core::encryption::EncryptionKey::new([42u8; 32]);
+    let secrets = drua_core::workspace_secret::WorkspaceSecrets::new(&pool, key);
+
+    let secret = secrets
+        .create(
+            &sub,
+            ws_id,
+            "GQL_TEST_KEY",
+            drua_core::workspace_secret::SecretType::EnvVar,
+            "secret-value",
+        )
+        .await
+        .expect("create secret");
+    assert_eq!(secret.name, "GQL_TEST_KEY");
+
+    let listed = secrets
+        .list_by_workspace(&sub, ws_id)
+        .await
+        .expect("list secrets");
+    assert!(listed.iter().any(|s| s.id == secret.id));
+
+    // Delete
+    secrets.delete(&sub, secret.id).await.expect("delete");
+    let listed = secrets
+        .list_by_workspace(&sub, ws_id)
+        .await
+        .expect("list after delete");
+    assert!(!listed.iter().any(|s| s.id == secret.id));
+}
+
+// ─── Schema introspection tests ──────────────────────────────────────────
+
+/// Verify the schema exposes all new mutation fields.
+#[tokio::test]
+async fn schema_has_expected_mutations() {
+    let schema = drua_server::graphql::schema(None);
+    let response = schema
+        .execute(async_graphql::Request::new(
+            r#"{ __type(name: "Mutation") { fields { name } } }"#,
+        ))
+        .await;
+    let json = serde_json::to_value(&response).unwrap();
+    let fields: Vec<String> = json["data"]["__type"]["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["name"].as_str().unwrap().to_string())
+        .collect();
+
+    let expected = [
+        "agentCreate",
+        "agentAttachSandbox",
+        "agentDetachSandbox",
+        "sandboxCreate",
+        "sandboxSuspend",
+        "sandboxRestart",
+        "skillCreate",
+        "skillUpdate",
+        "skillDelete",
+        "workspaceSecretCreate",
+        "workspaceSecretDelete",
+        "mcpCredentialsCreate",
+        "mcpCredentialsRevoke",
+        "workspaceCreate",
+        "workspaceUpdate",
+        "workspaceDelete",
+    ];
+
+    for name in expected {
+        assert!(
+            fields.contains(&name.to_string()),
+            "Missing mutation: {name}. Available: {fields:?}"
+        );
+    }
+}
+
+/// Verify the schema exposes all new query fields.
+#[tokio::test]
+async fn schema_has_expected_queries() {
+    let schema = drua_server::graphql::schema(None);
+    let response = schema
+        .execute(async_graphql::Request::new(
+            r#"{ __type(name: "Query") { fields { name } } }"#,
+        ))
+        .await;
+    let json = serde_json::to_value(&response).unwrap();
+    let fields: Vec<String> = json["data"]["__type"]["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["name"].as_str().unwrap().to_string())
+        .collect();
+
+    let expected = ["sandbox", "auditLog", "agent", "workspace", "workspaces"];
+    for name in expected {
+        assert!(
+            fields.contains(&name.to_string()),
+            "Missing query: {name}. Available: {fields:?}"
+        );
+    }
+}
+
+/// Verify the Workspace type exposes sandboxes, skills, secrets, and mcpCredentials.
+#[tokio::test]
+async fn schema_workspace_has_new_fields() {
+    let schema = drua_server::graphql::schema(None);
+    let response = schema
+        .execute(async_graphql::Request::new(
+            r#"{ __type(name: "Workspace") { fields { name } } }"#,
+        ))
+        .await;
+    let json = serde_json::to_value(&response).unwrap();
+    let fields: Vec<String> = json["data"]["__type"]["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["name"].as_str().unwrap().to_string())
+        .collect();
+
+    let expected = ["sandboxes", "skills", "secrets", "mcpCredentials"];
+    for name in expected {
+        assert!(
+            fields.contains(&name.to_string()),
+            "Missing workspace field: {name}. Available: {fields:?}"
+        );
+    }
+}
+
+/// Verify the Sandbox type has expected fields.
+#[tokio::test]
+async fn schema_sandbox_type_has_expected_fields() {
+    let schema = drua_server::graphql::schema(None);
+    let response = schema
+        .execute(async_graphql::Request::new(
+            r#"{ __type(name: "Sandbox") { fields { name } } }"#,
+        ))
+        .await;
+    let json = serde_json::to_value(&response).unwrap();
+    let fields: Vec<String> = json["data"]["__type"]["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["name"].as_str().unwrap().to_string())
+        .collect();
+
+    let expected = [
+        "id",
+        "workspaceId",
+        "name",
+        "state",
+        "lastError",
+        "mountPath",
+        "createdAt",
+        "cpu",
+        "memory",
+        "diskSize",
+        "attachedAgents",
+    ];
+    for name in expected {
+        assert!(
+            fields.contains(&name.to_string()),
+            "Missing sandbox field: {name}. Available: {fields:?}"
+        );
+    }
+}
+
+/// Verify the Skill type has expected fields.
+#[tokio::test]
+async fn schema_skill_type_has_expected_fields() {
+    let schema = drua_server::graphql::schema(None);
+    let response = schema
+        .execute(async_graphql::Request::new(
+            r#"{ __type(name: "Skill") { fields { name } } }"#,
+        ))
+        .await;
+    let json = serde_json::to_value(&response).unwrap();
+    let fields: Vec<String> = json["data"]["__type"]["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["name"].as_str().unwrap().to_string())
+        .collect();
+
+    let expected = [
+        "id",
+        "workspaceId",
+        "name",
+        "description",
+        "body",
+        "createdAt",
+    ];
+    for name in expected {
+        assert!(
+            fields.contains(&name.to_string()),
+            "Missing skill field: {name}. Available: {fields:?}"
+        );
+    }
+}
+
+/// Verify the WorkspaceSecret type has expected fields (no value exposed!).
+#[tokio::test]
+async fn schema_workspace_secret_type_has_expected_fields() {
+    let schema = drua_server::graphql::schema(None);
+    let response = schema
+        .execute(async_graphql::Request::new(
+            r#"{ __type(name: "WorkspaceSecret") { fields { name } } }"#,
+        ))
+        .await;
+    let json = serde_json::to_value(&response).unwrap();
+    let fields: Vec<String> = json["data"]["__type"]["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["name"].as_str().unwrap().to_string())
+        .collect();
+
+    let expected = ["id", "workspaceId", "name", "secretType", "createdAt"];
+    for name in expected {
+        assert!(
+            fields.contains(&name.to_string()),
+            "Missing workspace secret field: {name}. Available: {fields:?}"
+        );
+    }
+
+    // Ensure the plaintext value is NOT exposed
+    assert!(
+        !fields.contains(&"value".to_string()),
+        "WorkspaceSecret should NOT expose 'value' field"
+    );
+    assert!(
+        !fields.contains(&"encryptedValue".to_string()),
+        "WorkspaceSecret should NOT expose 'encryptedValue' field"
+    );
+}
+
+/// Verify the AuditEntry type has expected fields.
+#[tokio::test]
+async fn schema_audit_entry_type_has_expected_fields() {
+    let schema = drua_server::graphql::schema(None);
+    let response = schema
+        .execute(async_graphql::Request::new(
+            r#"{ __type(name: "AuditEntry") { fields { name } } }"#,
+        ))
+        .await;
+    let json = serde_json::to_value(&response).unwrap();
+    let fields: Vec<String> = json["data"]["__type"]["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["name"].as_str().unwrap().to_string())
+        .collect();
+
+    let expected = [
+        "actingUserId",
+        "actingAgentId",
+        "entrypoint",
+        "interactionType",
+        "action",
+        "outcome",
+        "error",
+        "recordedAt",
+    ];
+    for name in expected {
+        assert!(
+            fields.contains(&name.to_string()),
+            "Missing audit entry field: {name}. Available: {fields:?}"
+        );
+    }
+}
+
+/// Verify the McpCreds type has expected fields.
+#[tokio::test]
+async fn schema_mcp_creds_type_has_expected_fields() {
+    let schema = drua_server::graphql::schema(None);
+    let response = schema
+        .execute(async_graphql::Request::new(
+            r#"{ __type(name: "McpCreds") { fields { name } } }"#,
+        ))
+        .await;
+    let json = serde_json::to_value(&response).unwrap();
+    let fields: Vec<String> = json["data"]["__type"]["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["name"].as_str().unwrap().to_string())
+        .collect();
+
+    let expected = ["id", "name", "revoked", "revokedAt", "createdAt"];
+    for name in expected {
+        assert!(
+            fields.contains(&name.to_string()),
+            "Missing mcp creds field: {name}. Available: {fields:?}"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- Adds GraphQL mutations for agents (create, attach/detach sandbox), sandboxes (create, suspend, restart), skills (CRUD), workspace secrets (create, delete), and MCP credentials (create, revoke)
- Adds GraphQL queries for sandbox lookup and audit log with filtering
- Adds list fields on Workspace type: sandboxes, skills, secrets, mcpCredentials
- Includes 12 integration tests (schema introspection + domain roundtrips)

## New mutations (13 total, was 3)
`agentCreate`, `agentAttachSandbox`, `agentDetachSandbox`, `sandboxCreate`, `sandboxSuspend`, `sandboxRestart`, `skillCreate`, `skillUpdate`, `skillDelete`, `workspaceSecretCreate`, `workspaceSecretDelete`, `mcpCredentialsCreate`, `mcpCredentialsRevoke`

## New queries
- `sandbox(id)` — single sandbox lookup
- `auditLog(input)` — filtered audit entries

## New Workspace fields
- `sandboxes`, `skills`, `secrets`, `mcpCredentials`

## Test plan
- [x] Schema introspection tests verify all new types, fields, queries, and mutations exist
- [x] Domain roundtrip tests for skills and workspace secrets
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean
- [ ] Full CI integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)