### PR TITLE
refactor(auth): remove WorkspaceId from AuthSubject agent variants

### DIFF
--- a/core/src/agent/entity.rs
+++ b/core/src/agent/entity.rs
@@ -73,7 +73,14 @@ pub struct Agent {
 
 impl Agent {
     fn scopes_vec(&self) -> Vec<AuthScope> {
-        self.authz_scopes.iter().cloned().collect()
+        let mut scopes: Vec<AuthScope> = self.authz_scopes.iter().cloned().collect();
+        // Always inject WorkspaceMember so workspace_id() can derive
+        // the workspace from scopes alone.
+        let ws_member = AuthScope::WorkspaceMember(self.workspace_id);
+        if !scopes.contains(&ws_member) {
+            scopes.push(ws_member);
+        }
+        scopes
     }
 
     /// The id of the sandbox this agent is currently attached to, if any.
@@ -84,17 +91,18 @@ impl Agent {
         self.attached_sandbox.map(|(id, _)| id)
     }
 
-    /// The auth subject this agent acts as when invoking tools — its own
-    /// workspace + id, carrying the scopes persisted on the `Initialized`
-    /// event. Use when no originating user can be attributed.
+    /// The auth subject this agent acts as when invoking tools — carrying
+    /// the scopes persisted on the `Initialized` event plus an injected
+    /// [`AuthScope::WorkspaceMember`] for workspace identity.
+    /// Use when no originating user can be attributed.
     pub fn auth_subject(&self) -> AuthSubject {
-        AuthSubject::Agent(self.workspace_id, self.id, self.scopes_vec())
+        AuthSubject::Agent(self.id, self.scopes_vec())
     }
 
     /// Same as [`Self::auth_subject`] but tagged with the user that triggered
     /// the agent's work, so downstream actions can be attributed back to them.
     pub fn auth_subject_for_user(&self, user_id: UserId) -> AuthSubject {
-        AuthSubject::AgentOnBehalfOfUser(user_id, self.workspace_id, self.id, self.scopes_vec())
+        AuthSubject::AgentOnBehalfOfUser(user_id, self.id, self.scopes_vec())
     }
 
     /// Apply a batch of scope additions/removals as a single

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -571,8 +571,8 @@ impl Agents {
         // rejected.
         match &subject {
             AuthSubject::User(_) | AuthSubject::ExportedAgent(_, _, _) => {}
-            AuthSubject::Agent(ws, _, _) | AuthSubject::AgentOnBehalfOfUser(_, ws, _, _)
-                if *ws == agent.workspace_id => {}
+            AuthSubject::Agent(_, _) | AuthSubject::AgentOnBehalfOfUser(_, _, _)
+                if subject.workspace_id() == Some(agent.workspace_id) => {}
             _ => return Err(AgentError::Unauthorized),
         }
 

--- a/core/src/audit/mod.rs
+++ b/core/src/audit/mod.rs
@@ -40,13 +40,17 @@ impl Audit {
             AuthSubject::ExportedAgent(user_id, _, _) => {
                 ctx.acting_user_id = Some(*user_id);
             }
-            AuthSubject::Agent(workspace_id, agent_id, _) => {
-                Self::set_resource_id(ctx, "workspace_id", *workspace_id);
+            AuthSubject::Agent(agent_id, _) => {
+                if let Some(workspace_id) = auth.workspace_id() {
+                    Self::set_resource_id(ctx, "workspace_id", workspace_id);
+                }
                 ctx.acting_agent_id = Some(*agent_id);
             }
-            AuthSubject::AgentOnBehalfOfUser(user_id, workspace_id, agent_id, _) => {
+            AuthSubject::AgentOnBehalfOfUser(user_id, agent_id, _) => {
                 ctx.acting_agent_id = Some(*agent_id);
-                Self::set_resource_id(ctx, "workspace_id", *workspace_id);
+                if let Some(workspace_id) = auth.workspace_id() {
+                    Self::set_resource_id(ctx, "workspace_id", workspace_id);
+                }
                 ctx.on_behalf_of_user_id = Some(*user_id);
             }
             AuthSubject::Anonymous => {}

--- a/core/src/auth/scope.rs
+++ b/core/src/auth/scope.rs
@@ -29,6 +29,12 @@ pub enum AuthScope {
     /// Read-only access — the agent may invoke sandbox tools that
     /// don't modify state. Granted on a `Read` attach.
     SandboxRead(SandboxId),
+    /// Workspace membership — the subject belongs to this workspace.
+    /// Granted to every agent in the workspace; carries the workspace
+    /// identity so [`super::AuthSubject::workspace_id`] can derive it
+    /// from scopes alone. Grants `Read` on workspace-scoped resources
+    /// (agents, sandboxes, audit log, etc.) within its workspace.
+    WorkspaceMember(WorkspaceId),
     /// An externally-defined scope string. Grants access only to
     /// [`AuthResource::External`] resources whose name matches.
     External(String),
@@ -44,6 +50,12 @@ impl AuthScope {
             // WorkspaceAdmin grants any verb on any resource within its workspace.
             AuthScope::WorkspaceAdmin(ws) => {
                 resource.workspace_id().is_some_and(|res_ws| res_ws == *ws)
+            }
+
+            // WorkspaceMember grants Read on resources in its workspace.
+            AuthScope::WorkspaceMember(ws) => {
+                verb == AuthVerb::Read
+                    && resource.workspace_id().is_some_and(|res_ws| res_ws == *ws)
             }
 
             // SandboxUse grants Use and Read on the matching sandbox
@@ -82,6 +94,7 @@ impl fmt::Display for AuthScope {
         match self {
             AuthScope::Admin => f.write_str("admin"),
             AuthScope::WorkspaceAdmin(id) => write!(f, "ws:{id}:admin"),
+            AuthScope::WorkspaceMember(id) => write!(f, "ws:{id}:member"),
             AuthScope::SandboxUse(id) => write!(f, "sandbox:{id}:use"),
             AuthScope::SandboxRead(id) => write!(f, "sandbox:{id}:read"),
             AuthScope::External(s) => f.write_str(s),
@@ -97,11 +110,16 @@ impl FromStr for AuthScope {
             return Ok(AuthScope::Admin);
         }
 
-        // Parse "ws:{uuid}:admin"
+        // Parse "ws:{uuid}:admin" and "ws:{uuid}:member"
         if let Some(rest) = s.strip_prefix("ws:") {
             if let Some(uuid_str) = rest.strip_suffix(":admin") {
                 if let Ok(uuid) = uuid_str.parse::<uuid::Uuid>() {
                     return Ok(AuthScope::WorkspaceAdmin(WorkspaceId::from(uuid)));
+                }
+            }
+            if let Some(uuid_str) = rest.strip_suffix(":member") {
+                if let Ok(uuid) = uuid_str.parse::<uuid::Uuid>() {
+                    return Ok(AuthScope::WorkspaceMember(WorkspaceId::from(uuid)));
                 }
             }
         }
@@ -188,6 +206,7 @@ mod tests {
         let variants = vec![
             AuthScope::Admin,
             AuthScope::WorkspaceAdmin(ws_id),
+            AuthScope::WorkspaceMember(ws_id),
             AuthScope::SandboxUse(sb_id),
             AuthScope::SandboxRead(sb_id),
             AuthScope::External("custom:thing".to_owned()),
@@ -272,6 +291,24 @@ mod tests {
     }
 
     #[test]
+    fn from_str_workspace_member() {
+        let ws_id = test_workspace_id();
+        let member: AuthScope = "ws:a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8:member"
+            .parse()
+            .unwrap();
+        assert_eq!(member, AuthScope::WorkspaceMember(ws_id));
+    }
+
+    #[test]
+    fn display_workspace_member() {
+        let ws_id = test_workspace_id();
+        assert_eq!(
+            AuthScope::WorkspaceMember(ws_id).to_string(),
+            "ws:a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8:member"
+        );
+    }
+
+    #[test]
     fn from_str_unknown_falls_back_to_external() {
         let scope: AuthScope = "read".parse().unwrap();
         assert_eq!(scope, AuthScope::External("read".to_owned()));
@@ -310,6 +347,10 @@ mod tests {
             (
                 AuthScope::WorkspaceAdmin(ws_id),
                 r#""ws:a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8:admin""#,
+            ),
+            (
+                AuthScope::WorkspaceMember(ws_id),
+                r#""ws:a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8:member""#,
             ),
             (AuthScope::External("custom".to_owned()), r#""custom""#),
         ];

--- a/core/src/auth/subject.rs
+++ b/core/src/auth/subject.rs
@@ -2,6 +2,10 @@ use super::{error::AuthorizationError, AuthResource, AuthScope, AuthVerb};
 use crate::primitives::{AgentId, McpCredsId, SandboxId, UserId, UserMessageSource, WorkspaceId};
 
 /// Unified authentication subject resolved from session or bearer token.
+///
+/// Workspace identity for agent variants is carried inside the scopes
+/// vec as [`AuthScope::WorkspaceMember`] — use [`Self::workspace_id`]
+/// to extract it.
 #[derive(Debug, Clone)]
 pub enum AuthSubject {
     /// Authenticated via session cookie (human user in browser).
@@ -9,12 +13,16 @@ pub enum AuthSubject {
     /// Authenticated via bearer token issued to a user (exported agent credential).
     ExportedAgent(UserId, McpCredsId, Vec<AuthScope>),
     /// Agent acting within its workspace without user attribution.
-    Agent(WorkspaceId, AgentId, Vec<AuthScope>),
+    /// Workspace identity is encoded as a [`AuthScope::WorkspaceMember`]
+    /// scope in the scopes vec.
+    Agent(AgentId, Vec<AuthScope>),
     /// Agent acting within its workspace on behalf of a known user — used
     /// when the agent's tool calls are triggered by a request that itself
     /// originated from a `User` or `ExportedAgent`. Carries enough context
     /// to attribute downstream actions back to the originating user.
-    AgentOnBehalfOfUser(UserId, WorkspaceId, AgentId, Vec<AuthScope>),
+    /// Workspace identity is encoded as a [`AuthScope::WorkspaceMember`]
+    /// scope in the scopes vec.
+    AgentOnBehalfOfUser(UserId, AgentId, Vec<AuthScope>),
     /// No authentication provided.
     Anonymous,
 }
@@ -42,8 +50,8 @@ impl AuthSubject {
         match self {
             AuthSubject::User(user_id) => Ok(*user_id),
             AuthSubject::ExportedAgent(_, _, _) => Err("ExportedAgent auth not allowed here"),
-            AuthSubject::Agent(_, _, _) => Err("Agent auth not allowed here"),
-            AuthSubject::AgentOnBehalfOfUser(_, _, _, _) => Err("Agent auth not allowed here"),
+            AuthSubject::Agent(_, _) => Err("Agent auth not allowed here"),
+            AuthSubject::AgentOnBehalfOfUser(_, _, _) => Err("Agent auth not allowed here"),
             AuthSubject::Anonymous => Err("Authentication required"),
         }
     }
@@ -55,25 +63,27 @@ impl AuthSubject {
         match self {
             AuthSubject::User(user_id) => Some(*user_id),
             AuthSubject::ExportedAgent(user_id, _, _) => Some(*user_id),
-            AuthSubject::AgentOnBehalfOfUser(user_id, _, _, _) => Some(*user_id),
-            AuthSubject::Agent(_, _, _) | AuthSubject::Anonymous => None,
+            AuthSubject::AgentOnBehalfOfUser(user_id, _, _) => Some(*user_id),
+            AuthSubject::Agent(_, _) | AuthSubject::Anonymous => None,
         }
     }
 
     /// Return the workspace this subject is acting within, if any.
+    ///
+    /// Derives the workspace from the subject's scopes — specifically
+    /// [`AuthScope::WorkspaceMember`] or [`AuthScope::WorkspaceAdmin`].
     pub fn workspace_id(&self) -> Option<WorkspaceId> {
-        match self {
-            AuthSubject::Agent(workspace_id, _, _) => Some(*workspace_id),
-            AuthSubject::AgentOnBehalfOfUser(_, workspace_id, _, _) => Some(*workspace_id),
+        self.scopes().iter().find_map(|s| match s {
+            AuthScope::WorkspaceMember(ws) | AuthScope::WorkspaceAdmin(ws) => Some(*ws),
             _ => None,
-        }
+        })
     }
 
     /// Return the agent that is acting, if any.
     pub fn acting_agent_id(&self) -> Option<AgentId> {
         match self {
-            AuthSubject::Agent(_, agent_id, _) => Some(*agent_id),
-            AuthSubject::AgentOnBehalfOfUser(_, _, agent_id, _) => Some(*agent_id),
+            AuthSubject::Agent(agent_id, _) => Some(*agent_id),
+            AuthSubject::AgentOnBehalfOfUser(_, agent_id, _) => Some(*agent_id),
             _ => None,
         }
     }
@@ -82,8 +92,8 @@ impl AuthSubject {
     pub fn scopes(&self) -> &[AuthScope] {
         match self {
             AuthSubject::ExportedAgent(_, _, scopes)
-            | AuthSubject::Agent(_, _, scopes)
-            | AuthSubject::AgentOnBehalfOfUser(_, _, _, scopes) => scopes,
+            | AuthSubject::Agent(_, scopes)
+            | AuthSubject::AgentOnBehalfOfUser(_, _, scopes) => scopes,
             _ => &[],
         }
     }
@@ -116,8 +126,8 @@ impl AuthSubject {
         match self {
             AuthSubject::User(_) => true,
             AuthSubject::ExportedAgent(_, _, scopes)
-            | AuthSubject::Agent(_, _, scopes)
-            | AuthSubject::AgentOnBehalfOfUser(_, _, _, scopes) => scopes.contains(scope),
+            | AuthSubject::Agent(_, scopes)
+            | AuthSubject::AgentOnBehalfOfUser(_, _, scopes) => scopes.contains(scope),
             AuthSubject::Anonymous => false,
         }
     }
@@ -128,7 +138,7 @@ impl AuthSubject {
     pub fn is_agent(&self) -> bool {
         matches!(
             self,
-            AuthSubject::Agent(_, _, _) | AuthSubject::AgentOnBehalfOfUser(_, _, _, _)
+            AuthSubject::Agent(_, _) | AuthSubject::AgentOnBehalfOfUser(_, _, _)
         )
     }
 
@@ -162,10 +172,11 @@ impl AuthSubject {
                 user_id: *user_id,
                 creds_id: *creds_id,
             },
-            AuthSubject::Agent(_, agent_id, _)
-            | AuthSubject::AgentOnBehalfOfUser(_, _, agent_id, _) => UserMessageSource::Agent {
-                agent_id: *agent_id,
-            },
+            AuthSubject::Agent(agent_id, _) | AuthSubject::AgentOnBehalfOfUser(_, agent_id, _) => {
+                UserMessageSource::Agent {
+                    agent_id: *agent_id,
+                }
+            }
             AuthSubject::Anonymous => panic!("Anonymous subject has no message source"),
         }
     }

--- a/core/src/toolset/top_level/whoami.rs
+++ b/core/src/toolset/top_level/whoami.rs
@@ -76,9 +76,11 @@ impl TopLevelTool for WhoAmI {
                         .into(),
                 );
             }
-            AuthSubject::Agent(workspace_id, agent_id, scopes) => {
+            AuthSubject::Agent(agent_id, scopes) => {
                 info.insert("type".into(), "agent".into());
-                info.insert("workspace_id".into(), workspace_id.to_string().into());
+                if let Some(workspace_id) = subject.workspace_id() {
+                    info.insert("workspace_id".into(), workspace_id.to_string().into());
+                }
                 info.insert("agent_id".into(), agent_id.to_string().into());
                 info.insert(
                     "scopes".into(),
@@ -89,10 +91,12 @@ impl TopLevelTool for WhoAmI {
                         .into(),
                 );
             }
-            AuthSubject::AgentOnBehalfOfUser(user_id, workspace_id, agent_id, scopes) => {
+            AuthSubject::AgentOnBehalfOfUser(user_id, agent_id, scopes) => {
                 info.insert("type".into(), "agent_on_behalf_of_user".into());
                 info.insert("user_id".into(), user_id.to_string().into());
-                info.insert("workspace_id".into(), workspace_id.to_string().into());
+                if let Some(workspace_id) = subject.workspace_id() {
+                    info.insert("workspace_id".into(), workspace_id.to_string().into());
+                }
                 info.insert("agent_id".into(), agent_id.to_string().into());
                 info.insert(
                     "scopes".into(),

--- a/mcp-gateway/src/lib.rs
+++ b/mcp-gateway/src/lib.rs
@@ -61,7 +61,7 @@ impl McpGateway {
             .and_then(|parts| parts.extensions.get::<AuthSubject>());
         match auth {
             Some(auth @ AuthSubject::ExportedAgent(_, _, _))
-            | Some(auth @ AuthSubject::Agent(_, _, _)) => Ok(auth),
+            | Some(auth @ AuthSubject::Agent(_, _)) => Ok(auth),
             _ => Err(ErrorData::new(
                 ErrorCode::INVALID_REQUEST,
                 "Authentication required: provide a valid Bearer token",

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1770,8 +1770,8 @@ async fn api_agent_secrets(
     Path(id): Path<uuid::Uuid>,
 ) -> Response {
     // Only allow Agent auth (SA token from sandbox pods)
-    let (workspace_id, jwt_agent_id) = match &auth {
-        AuthSubject::Agent(workspace_id, agent_id, _) => (*workspace_id, *agent_id),
+    let (workspace_id, jwt_agent_id) = match (&auth, auth.workspace_id()) {
+        (AuthSubject::Agent(agent_id, _), Some(workspace_id)) => (workspace_id, *agent_id),
         _ => return axum::http::StatusCode::UNAUTHORIZED.into_response(),
     };
 


### PR DESCRIPTION
## Summary
- Adds `AuthScope::WorkspaceMember(WorkspaceId)` — a lightweight workspace-membership scope injected at `AuthSubject` construction time, granting `Read` on workspace-scoped resources
- Removes `WorkspaceId` from `Agent(WorkspaceId, AgentId, Vec<AuthScope>)` → `Agent(AgentId, Vec<AuthScope>)` and `AgentOnBehalfOfUser(UserId, WorkspaceId, AgentId, Vec<AuthScope>)` → `AgentOnBehalfOfUser(UserId, AgentId, Vec<AuthScope>)`
- `workspace_id()` now derives workspace identity from scopes (`WorkspaceMember` or `WorkspaceAdmin`) instead of reading a variant field

## Motivation
The top-level `WorkspaceId` in agent variants was redundant — workspace identity can be carried in the scopes vec and extracted via `workspace_id()`. This simplifies the enum, makes the scope system self-contained for workspace identification, and removes a source of potential inconsistency between the variant field and scope contents.

## Key design decisions
- `WorkspaceMember` is injected in `Agent::scopes_vec()` (the method that builds the scope vec for `AuthSubject` construction), so it's transient — no migration or event-store changes needed
- `WorkspaceMember` grants `Read` on workspace-scoped resources, matching baseline access for any workspace agent
- `WorkspaceAdmin` still takes priority in `workspace_id()` extraction (checked alongside `WorkspaceMember`)

## Test plan
- [x] All existing unit tests pass (`nix flake check`)
- [x] Clippy clean with `--deny warnings`
- [x] New scope variant has round-trip Display/FromStr/serde tests
- [ ] Integration tests (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)