### PR TITLE
feat(workspace): robust cascade delete for all workspace entities

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -200,7 +200,15 @@ impl App {
         ));
         toolsets.register_top_level(WorkspaceSandbox::new(Arc::clone(&sandboxes)));
 
-        let workspaces = Arc::new(Workspaces::new(pool, Arc::clone(&agents), library.clone()));
+        let workspaces = Arc::new(Workspaces::new(
+            pool,
+            Arc::clone(&agents),
+            Arc::clone(&sandboxes),
+            Arc::clone(&skills),
+            Arc::clone(&notes),
+            workspace_secrets.clone(),
+            library.clone(),
+        ));
         toolsets.register_top_level(NotesTool::new(Arc::clone(&notes), Arc::clone(&workspaces)));
         toolsets.register_top_level(UseSkillTool::new(Arc::clone(&skills)));
 

--- a/core/src/library/file.rs
+++ b/core/src/library/file.rs
@@ -90,6 +90,10 @@ pub enum RuntimeFile {
         /// Subdirectory under the workspace folder (e.g. `"notes"`, `"skills"`).
         subdir: String,
     },
+    /// Queued when a workspace is deleted. The job runner removes the entire
+    /// `runtime/workspaces/{workspace_name}/` directory from the library
+    /// repo and pushes.
+    WorkspaceCleanup { workspace_name: String },
 }
 
 impl RuntimeFile {
@@ -206,7 +210,7 @@ impl RuntimeFile {
                 body: description.clone(),
                 tags: Vec::new(),
             }),
-            RuntimeFile::GitKeep { .. } => None,
+            RuntimeFile::GitKeep { .. } | RuntimeFile::WorkspaceCleanup { .. } => None,
         }
     }
 
@@ -235,6 +239,9 @@ impl RuntimeFile {
                 subdir,
             } => {
                 format!("runtime/workspaces/{workspace_name}/{subdir}/.gitkeep")
+            }
+            RuntimeFile::WorkspaceCleanup { workspace_name } => {
+                format!("runtime/workspaces/{workspace_name}")
             }
         }
     }
@@ -280,7 +287,7 @@ impl RuntimeFile {
                     body
                 )
             }
-            RuntimeFile::GitKeep { .. } => String::new(),
+            RuntimeFile::GitKeep { .. } | RuntimeFile::WorkspaceCleanup { .. } => String::new(),
         }
     }
 
@@ -297,6 +304,9 @@ impl RuntimeFile {
                 subdir,
             } => {
                 format!("workspace: scaffold {workspace_name}/{subdir}")
+            }
+            RuntimeFile::WorkspaceCleanup { workspace_name } => {
+                format!("workspace: delete {workspace_name}")
             }
         }
     }

--- a/core/src/library/job.rs
+++ b/core/src/library/job.rs
@@ -58,6 +58,31 @@ impl JobRunner for WriteToRuntimeRunner {
     ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
         self.upstream.pull().await?;
 
+        // Workspace cleanup: remove the entire workspace directory from
+        // the git repo. No hash comparison — always execute.
+        if let RuntimeFile::WorkspaceCleanup { workspace_name } = &self.file {
+            let dir_path = format!("runtime/workspaces/{workspace_name}");
+            let message = format!("workspace: delete {workspace_name}");
+
+            let err_msg = match self
+                .upstream
+                .remove_dir_and_commit(&dir_path, &message)
+                .await
+            {
+                Ok(()) => {
+                    self.upstream.push().await?;
+                    return Ok(JobCompletion::Complete);
+                }
+                Err(e) => e.to_string(),
+            };
+
+            tracing::warn!(error = %err_msg, "workspace cleanup failed, resetting working tree");
+            if let Err(reset_err) = self.upstream.reset_dirty_state().await {
+                tracing::error!(error = %reset_err, "reset after failed cleanup also failed");
+            }
+            return Err(err_msg.into());
+        }
+
         let new_hash = self.file.file_hash();
         if self
             .upstream

--- a/core/src/library/mod.rs
+++ b/core/src/library/mod.rs
@@ -160,6 +160,33 @@ impl Library {
         Ok(())
     }
 
+    /// Remove all search data for a workspace and queue a background job
+    /// to delete the `runtime/workspaces/<name>/` directory from the
+    /// library git repo. Call within the workspace delete transaction so
+    /// the search data is removed atomically.
+    #[tracing::instrument(name = "library.cleanup_workspace_in_op", skip_all)]
+    pub async fn cleanup_workspace_in_op(
+        &self,
+        op: &mut impl es_entity::AtomicOperation,
+        workspace_id: uuid::Uuid,
+        workspace_name: &str,
+    ) -> Result<(), LibraryError> {
+        self.search
+            .delete_for_workspace_in_op(op, workspace_id)
+            .await?;
+
+        let file = RuntimeFile::WorkspaceCleanup {
+            workspace_name: workspace_name.to_string(),
+        };
+        let idempotency_key = format!("workspace-cleanup:{workspace_name}");
+        let _ = self
+            .inbox
+            .persist_and_queue_job_in_op(op, idempotency_key, &file)
+            .await?;
+
+        Ok(())
+    }
+
     /// Pull the library repo and find skill files that changed since
     /// `last_sync_commit`. Returns parsed `RuntimeFile::Skill` variants.
     ///

--- a/core/src/library/search.rs
+++ b/core/src/library/search.rs
@@ -85,6 +85,21 @@ impl SearchStore {
         Ok(())
     }
 
+    /// Remove all search data rows belonging to a workspace within an
+    /// atomic operation. Called during workspace cascade deletion.
+    #[tracing::instrument(name = "library.search_store.delete_for_workspace_in_op", skip_all)]
+    pub async fn delete_for_workspace_in_op(
+        &self,
+        op: &mut impl es_entity::AtomicOperation,
+        workspace_id: uuid::Uuid,
+    ) -> Result<(), LibraryError> {
+        sqlx::query("DELETE FROM library_search_data WHERE workspace_id = $1")
+            .bind(workspace_id)
+            .execute(op.as_executor())
+            .await?;
+        Ok(())
+    }
+
     /// Hybrid search: FTS + vector similarity fused via Reciprocal Rank Fusion.
     #[tracing::instrument(name = "library.search_store.search", skip_all)]
     pub async fn search(

--- a/core/src/library/upstream.rs
+++ b/core/src/library/upstream.rs
@@ -398,6 +398,58 @@ impl Upstream {
         Ok(results)
     }
 
+    /// Remove an entire directory from the working tree, stage the
+    /// removal with `git rm -r`, and commit. No-op when the directory
+    /// doesn't exist.
+    pub async fn remove_dir_and_commit(
+        &self,
+        relative_dir: &str,
+        message: &str,
+    ) -> Result<(), LibraryError> {
+        self.require_git_repo()?;
+
+        let full_path = self.repo_path.join(relative_dir);
+        if !full_path.exists() {
+            return Ok(());
+        }
+
+        let rm = tokio::process::Command::new("git")
+            .args(["rm", "-r", "--", relative_dir])
+            .current_dir(&self.repo_path)
+            .output()
+            .await
+            .map_err(|e| LibraryError::Git(format!("git rm: {e}")))?;
+        if !rm.status.success() {
+            return Err(LibraryError::Git(format!(
+                "git rm -r failed: {}",
+                String::from_utf8_lossy(&rm.stderr)
+            )));
+        }
+
+        let commit = tokio::process::Command::new("git")
+            .args([
+                "-c",
+                "user.name=drua",
+                "-c",
+                "user.email=drua@galoy.io",
+                "commit",
+                "-m",
+                message,
+            ])
+            .current_dir(&self.repo_path)
+            .output()
+            .await
+            .map_err(|e| LibraryError::Git(format!("git commit: {e}")))?;
+        if !commit.status.success() {
+            let stderr = String::from_utf8_lossy(&commit.stderr);
+            if !stderr.contains("nothing to commit") {
+                return Err(LibraryError::Git(format!("git commit failed: {stderr}")));
+            }
+        }
+
+        Ok(())
+    }
+
     pub async fn push(&self) -> Result<(), LibraryError> {
         self.require_git_repo()?;
 

--- a/core/src/note/mod.rs
+++ b/core/src/note/mod.rs
@@ -291,6 +291,20 @@ impl Notes {
         Ok(result.entities)
     }
 
+    /// Bulk soft-delete all notes belonging to a workspace within a
+    /// transaction. Used during workspace cascade deletion.
+    #[instrument(name = "note.delete_for_workspace_in_op", skip_all)]
+    pub(crate) async fn delete_for_workspace_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        workspace_id: WorkspaceId,
+    ) -> Result<(), NoteError> {
+        self.repo
+            .cascade_delete_for_workspace_in_op(op, workspace_id)
+            .await?;
+        Ok(())
+    }
+
     /// Maximum total characters of pinned note content to inject into an
     /// agent's system prompt. Notes are included most-recently-updated-first;
     /// once this budget is exhausted, remaining pinned notes are omitted with

--- a/core/src/note/repo.rs
+++ b/core/src/note/repo.rs
@@ -31,6 +31,22 @@ impl NoteRepo {
         }
     }
 
+    /// Bulk soft-delete all notes belonging to a workspace. No event is
+    /// generated because the repo uses `soft_without_queries`, making a
+    /// column update equivalent to iterating each entity through
+    /// `delete_in_op`.
+    pub async fn cascade_delete_for_workspace_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        workspace_id: WorkspaceId,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE notes SET deleted = TRUE WHERE workspace_id = $1")
+            .bind(workspace_id)
+            .execute(op.as_executor())
+            .await?;
+        Ok(())
+    }
+
     /// Post-persist hook: sync note content to the git-backed library.
     /// Only fires on content changes (Initialized/Updated); skips pin/unpin.
     async fn sync_to_library<OP: es_entity::AtomicOperation>(

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -547,6 +547,40 @@ impl Sandboxes {
         Ok(sandbox)
     }
 
+    /// Suspend all sandboxes belonging to a workspace within an existing
+    /// transaction. Each sandbox's pod/process is torn down via the admin
+    /// client (best-effort) and the entity transitions to
+    /// [`SandboxState::Suspended`]. Failures on individual sandboxes are
+    /// logged and skipped so the overall workspace teardown can proceed.
+    #[instrument(name = "domain.sandbox.suspend_for_workspace_in_op", skip(self, op))]
+    pub async fn suspend_for_workspace_in_op(
+        &self,
+        op: &mut DbOp<'_>,
+        workspace_id: WorkspaceId,
+    ) -> Result<(), SandboxError> {
+        let query = PaginatedQueryArgs {
+            first: 100,
+            after: None,
+        };
+        let result = self
+            .repo
+            .list_for_workspace_id_by_created_at(workspace_id, query, ListDirection::Descending)
+            .await?;
+        for sandbox in result.entities {
+            if sandbox.state == SandboxState::Suspended {
+                continue;
+            }
+            if let Err(e) = self.suspend_in_op(op, sandbox.id).await {
+                tracing::warn!(
+                    sandbox_id = %sandbox.id,
+                    error = %e,
+                    "failed to suspend sandbox during workspace delete"
+                );
+            }
+        }
+        Ok(())
+    }
+
     #[instrument(name = "domain.sandbox.suspend", skip(self, sub))]
     pub async fn suspend(
         &self,

--- a/core/src/skill/mod.rs
+++ b/core/src/skill/mod.rs
@@ -393,6 +393,20 @@ impl Skills {
 }
 
 impl Skills {
+    /// Bulk soft-delete all workspace-scoped skills within a transaction.
+    /// Used during workspace cascade deletion.
+    #[instrument(name = "skill.delete_for_workspace_in_op", skip_all)]
+    pub(crate) async fn delete_for_workspace_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        workspace_id: WorkspaceId,
+    ) -> Result<(), SkillError> {
+        self.repo
+            .cascade_delete_for_workspace_in_op(op, workspace_id)
+            .await?;
+        Ok(())
+    }
+
     /// Constructor without library sync — for tests or contexts where
     /// git-backed persistence is not needed.
     pub fn new_without_library(pool: &sqlx::PgPool, sandboxes: Arc<Sandboxes>) -> Self {

--- a/core/src/skill/repo.rs
+++ b/core/src/skill/repo.rs
@@ -65,4 +65,19 @@ impl SkillRepo {
             library: None,
         }
     }
+
+    /// Bulk soft-delete all workspace-scoped skills. No event is generated
+    /// because the repo uses `soft_without_queries`, making a column update
+    /// equivalent to iterating each entity through `delete_in_op`.
+    pub async fn cascade_delete_for_workspace_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        workspace_id: WorkspaceId,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE skills SET deleted = TRUE WHERE workspace_id = $1")
+            .bind(workspace_id)
+            .execute(op.as_executor())
+            .await?;
+        Ok(())
+    }
 }

--- a/core/src/workspace/error.rs
+++ b/core/src/workspace/error.rs
@@ -3,6 +3,10 @@ use thiserror::Error;
 use crate::agent::AgentError;
 use crate::auth::error::AuthorizationError;
 use crate::library::LibraryError;
+use crate::note::NoteError;
+use crate::sandbox::SandboxError;
+use crate::skill::SkillError;
+use crate::workspace_secret::WorkspaceSecretError;
 
 use super::repo::{
     WorkspaceCreateError, WorkspaceFindError, WorkspaceModifyError, WorkspaceQueryError,
@@ -26,4 +30,12 @@ pub enum WorkspaceError {
     Authorization(#[from] AuthorizationError),
     #[error("WorkspaceError - Library: {0}")]
     Library(#[from] LibraryError),
+    #[error("WorkspaceError - Sandbox: {0}")]
+    Sandbox(#[from] SandboxError),
+    #[error("WorkspaceError - Skill: {0}")]
+    Skill(#[from] SkillError),
+    #[error("WorkspaceError - Note: {0}")]
+    Note(#[from] NoteError),
+    #[error("WorkspaceError - WorkspaceSecret: {0}")]
+    WorkspaceSecret(#[from] WorkspaceSecretError),
 }

--- a/core/src/workspace/mod.rs
+++ b/core/src/workspace/mod.rs
@@ -16,21 +16,41 @@ use repo::*;
 use crate::agent::Agents;
 use crate::audit::Audit;
 use crate::library::Library;
+use crate::note::Notes;
 use crate::primitives::*;
+use crate::sandbox::Sandboxes;
+use crate::skill::Skills;
+use crate::workspace_secret::WorkspaceSecrets;
 
 #[derive(Clone)]
 pub struct Workspaces {
     repo: WorkspaceRepo,
     agents: Arc<Agents>,
+    sandboxes: Arc<Sandboxes>,
+    skills: Arc<Skills>,
+    notes: Arc<Notes>,
+    secrets: WorkspaceSecrets,
     library: Library,
 }
 
 impl Workspaces {
-    pub fn new(pool: &sqlx::PgPool, agents: Arc<Agents>, library: Library) -> Self {
+    pub fn new(
+        pool: &sqlx::PgPool,
+        agents: Arc<Agents>,
+        sandboxes: Arc<Sandboxes>,
+        skills: Arc<Skills>,
+        notes: Arc<Notes>,
+        secrets: WorkspaceSecrets,
+        library: Library,
+    ) -> Self {
         let repo = WorkspaceRepo::new(pool);
         Self {
             repo,
             agents,
+            sandboxes,
+            skills,
+            notes,
+            secrets,
             library,
         }
     }
@@ -153,18 +173,50 @@ impl Workspaces {
             return Ok(workspace);
         }
 
-        // Cascade: soft-delete agents (which also destroys their sandboxes)
+        // ── 1. Suspend all workspace sandboxes ─────────────────────────
+        // Tear down pods/processes via the admin client before touching
+        // any DB state so in-flight sandbox work stops.
+        if let Err(e) = self.sandboxes.suspend_for_workspace_in_op(op, id).await {
+            tracing::warn!(error = %e, "failed to suspend sandboxes during workspace delete");
+        }
+
+        // ── 2. Cascade soft-delete agents (→ sessions → threads) ───────
         let agent_list = self.agents.list_for_workspace(_sub, id).await?;
         for agent in &agent_list {
             if let Err(e) = self.agents.delete_in_op(op, agent.id).await {
                 tracing::warn!(
                     agent_id = %agent.id,
                     error = %e,
-                    "Failed to delete agent during workspace delete"
+                    "failed to delete agent during workspace delete"
                 );
             }
         }
 
+        // ── 3. Cascade soft-delete workspace-scoped skills ─────────────
+        if let Err(e) = self.skills.delete_for_workspace_in_op(op, id).await {
+            tracing::warn!(error = %e, "failed to delete skills during workspace delete");
+        }
+
+        // ── 4. Cascade soft-delete workspace notes ─────────────────────
+        if let Err(e) = self.notes.delete_for_workspace_in_op(op, id).await {
+            tracing::warn!(error = %e, "failed to delete notes during workspace delete");
+        }
+
+        // ── 5. Cascade soft-delete workspace secrets ───────────────────
+        if let Err(e) = self.secrets.delete_for_workspace_in_op(op, id).await {
+            tracing::warn!(error = %e, "failed to delete secrets during workspace delete");
+        }
+
+        // ── 6. Clean up library search data + queue git dir removal ────
+        if let Err(e) = self
+            .library
+            .cleanup_workspace_in_op(op, uuid::Uuid::from(id), &workspace.name)
+            .await
+        {
+            tracing::warn!(error = %e, "failed to clean up library during workspace delete");
+        }
+
+        // ── 7. Archive + soft-delete the workspace entity itself ───────
         self.repo.update_in_op(op, &mut workspace).await?;
         self.repo
             .delete_in_op(op, self.repo.find_by_id(id).await?)

--- a/core/src/workspace/mod.rs
+++ b/core/src/workspace/mod.rs
@@ -223,9 +223,7 @@ impl Workspaces {
             .await?;
         Ok(workspace)
     }
-}
 
-impl Workspaces {
     /// Look up a workspace by name (internal, no auth check).
     /// Returns `Ok(None)` when no workspace matches.
     #[instrument(name = "domain.workspace.find_by_name", skip(self))]

--- a/core/src/workspace_secret/error.rs
+++ b/core/src/workspace_secret/error.rs
@@ -10,6 +10,8 @@ use super::repo::{
 
 #[derive(Error, Debug)]
 pub enum WorkspaceSecretError {
+    #[error("WorkspaceSecretError - Sqlx: {0}")]
+    Sqlx(#[from] sqlx::Error),
     #[error("WorkspaceSecretError - Create: {0}")]
     Create(#[from] WorkspaceSecretCreateError),
     #[error("WorkspaceSecretError - Modify: {0}")]

--- a/core/src/workspace_secret/mod.rs
+++ b/core/src/workspace_secret/mod.rs
@@ -148,6 +148,20 @@ impl WorkspaceSecrets {
         Ok(())
     }
 
+    /// Bulk soft-delete all secrets belonging to a workspace within a
+    /// transaction. Used during workspace cascade deletion.
+    #[instrument(name = "workspace_secret.delete_for_workspace_in_op", skip_all)]
+    pub(crate) async fn delete_for_workspace_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        workspace_id: WorkspaceId,
+    ) -> Result<(), WorkspaceSecretError> {
+        self.repo
+            .cascade_delete_for_workspace_in_op(op, workspace_id)
+            .await?;
+        Ok(())
+    }
+
     /// List secrets with decrypted values for a workspace (internal use — harness injection).
     #[instrument(name = "workspace_secret.list_decrypted", skip_all)]
     pub async fn list_decrypted(

--- a/core/src/workspace_secret/repo.rs
+++ b/core/src/workspace_secret/repo.rs
@@ -24,4 +24,20 @@ impl WorkspaceSecretRepo {
     pub fn new(pool: &PgPool) -> Self {
         Self { pool: pool.clone() }
     }
+
+    /// Bulk soft-delete all secrets belonging to a workspace. No event is
+    /// generated because the repo uses `soft_without_queries`, making a
+    /// column update equivalent to iterating each entity through
+    /// `delete_in_op`.
+    pub async fn cascade_delete_for_workspace_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        workspace_id: WorkspaceId,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE workspace_secrets SET deleted = TRUE WHERE workspace_id = $1")
+            .bind(workspace_id)
+            .execute(op.as_executor())
+            .await?;
+        Ok(())
+    }
 }


### PR DESCRIPTION
## Summary

- Workspace deletion now properly cascades to **all** workspace-scoped entities in the correct order: sandboxes (suspend via admin client), agents (→ sessions → threads), skills, notes, workspace secrets, and library data
- Previously only agents were cascaded, leaving orphaned sandbox pods, skills, notes, secrets, and stale library search data
- Adds `RuntimeFile::WorkspaceCleanup` variant to asynchronously remove the entire `runtime/workspaces/<name>/` directory from the library git repo via the existing job queue

## Changes

| File | What |
|------|------|
| `sandbox/mod.rs` | `suspend_for_workspace_in_op()` — bulk pod/process teardown |
| `skill/repo.rs` | `cascade_delete_for_workspace_in_op()` — bulk SQL soft-delete |
| `note/repo.rs` | `cascade_delete_for_workspace_in_op()` — bulk SQL soft-delete |
| `workspace_secret/repo.rs` | `cascade_delete_for_workspace_in_op()` — bulk SQL soft-delete |
| `library/mod.rs` | `cleanup_workspace_in_op()` — search data + git dir removal |
| `library/file.rs` | `RuntimeFile::WorkspaceCleanup` variant |
| `library/job.rs` | Handle cleanup variant in `WriteToRuntimeRunner` |
| `library/upstream.rs` | `remove_dir_and_commit()` via `git rm -r` |
| `library/search.rs` | `delete_for_workspace_in_op()` — clear search index |
| `workspace/mod.rs` | Expanded `delete_in_op()` with 7-step cascade |
| `workspace/error.rs` | Added `From` impls for new error types |
| `lib.rs` | Updated `Workspaces::new()` with new dependencies |

## Cascade order

1. **Suspend sandboxes** — admin client tears down pods/processes (best-effort)
2. **Delete agents** — cascades to sessions and threads via existing logic
3. **Delete skills** — bulk SQL `UPDATE skills SET deleted = TRUE`
4. **Delete notes** — bulk SQL `UPDATE notes SET deleted = TRUE`
5. **Delete secrets** — bulk SQL `UPDATE workspace_secrets SET deleted = TRUE`
6. **Library cleanup** — delete search data in-transaction, queue async git dir removal
7. **Archive + soft-delete workspace** — final entity cleanup

## Test plan

- [ ] Create a workspace with agents, sandboxes, skills, notes, and secrets
- [ ] Delete the workspace via API
- [ ] Verify all entities are soft-deleted (query DB directly)
- [ ] Verify sandboxes are suspended (check pod status)
- [ ] Verify library search data is cleared
- [ ] Verify git directory removal job executes
- [ ] Verify idempotent re-delete returns the archived workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)