### PR TITLE
ci: open galoy-charts PR for tunnel-connector bump instead of pushing to main

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -396,13 +396,12 @@ jobs:
     get_params:
       skip_download: true
 
-#! After `build-tunnel-connector-image` publishes a fresh digest, push
-#! a commit to GaloyMoney/galoy-charts:main that pins
+#! After `build-tunnel-connector-image` publishes a fresh digest, open
+#! (or force-update) a PR on GaloyMoney/galoy-charts that pins
 #! `tunnelConnector.image.digest` in `charts/galoy-deps/values.yaml`.
-#! Pinning a digest (instead of tracking the mutable `:edge` tag) means a
-#! drua CI push doesn't silently roll a running connector on the next
-#! kubelet restart. `rebase: true` on the put handles the race where main
-#! moves between get and push.
+#! Using a digest instead of the mutable `:edge` tag means a drua CI push
+#! does not silently roll any running connector — the bump becomes an
+#! auditable PR humans merge when convenient.
 - name: bump-galoy-charts-tunnel-connector-image
   serial: true
   plan:
@@ -430,10 +429,30 @@ jobs:
         path: repo/ci/tasks/with-nix-cache.sh
         args:
           - repo/ci/tasks/bump-galoy-charts-tunnel-connector.sh
-  - put: galoy-charts-repo
+  - put: galoy-charts-bump-branch
     params:
       repository: galoy-charts-repo
-      rebase: true
+      branch: bump-tunnel-connector-image-bot-branch
+      force: true
+  - task: open-pr
+    config:
+      platform: linux
+      image_resource: #@ nix_flake_image_config()
+      inputs:
+      - name: repo
+      - name: galoy-charts-repo
+      caches:
+      - path: /nix-cache
+      params:
+        GH_APP_ID: #@ data.values.github_app_id
+        GH_APP_PRIVATE_KEY: #@ data.values.github_app_private_key
+        BOT_BRANCH: bump-tunnel-connector-image-bot-branch
+        BASE_BRANCH: main
+        TARGET_REPO: GaloyMoney/galoy-charts
+      run:
+        path: repo/ci/tasks/with-nix-cache.sh
+        args:
+          - repo/ci/tasks/open-galoy-charts-tunnel-connector-pr.sh
 
 resource_types:
 - name: terraform
@@ -489,13 +508,24 @@ resources:
     - Cargo.toml
     - Cargo.lock
 
-#! galoy-charts main — clone for `bump-galoy-charts-tunnel-connector-image`
-#! to read current digest from, and push the bumped commit back to.
+#! Read-only clone of galoy-charts main. The `bump-galoy-charts-
+#! tunnel-connector-image` job uses this to build the commit that gets
+#! force-pushed to the bot branch below.
 - name: galoy-charts-repo
   type: git
   source:
     uri: git@github.com:GaloyMoney/galoy-charts.git
     branch: main
+    private_key: #@ data.values.github_private_key
+
+#! Write target for the bump commit. The job force-pushes here every
+#! time drua publishes a new image, and the open-pr task then opens (or
+#! re-opens) the bot PR for this branch on galoy-charts.
+- name: galoy-charts-bump-branch
+  type: git
+  source:
+    uri: git@github.com:GaloyMoney/galoy-charts.git
+    branch: bump-tunnel-connector-image-bot-branch
     private_key: #@ data.values.github_private_key
 
 - name: repo-labels

--- a/ci/tasks/bump-galoy-charts-tunnel-connector.sh
+++ b/ci/tasks/bump-galoy-charts-tunnel-connector.sh
@@ -2,8 +2,8 @@
 
 # Writes the current `tunnel-connector:edge` digest into
 # `charts/galoy-deps/values.yaml` in the galoy-charts clone and commits.
-# The pipeline's `put: galoy-charts-repo` (with `rebase: true`) pushes
-# the commit straight to galoy-charts main.
+# The pipeline then force-pushes the resulting commit to a bot branch
+# and the `open-pr` task opens/refreshes a PR against main.
 #
 # Runs inside the nix-flakes Concourse image — `nix shell` pulls in
 # `yq-go` and `git` from nixpkgs because the base image has neither.

--- a/ci/tasks/open-galoy-charts-tunnel-connector-pr.sh
+++ b/ci/tasks/open-galoy-charts-tunnel-connector-pr.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+
+# Opens (or re-opens) a PR against GaloyMoney/galoy-charts for the bot
+# branch that `bump-galoy-charts-tunnel-connector.sh` force-pushes to.
+# Closes any existing PR on the branch first — the bot branch is
+# continuously force-pushed, and the goal is one always-current open PR
+# rather than a list of stale superseded ones.
+#
+# Auth: mints a short-lived installation token from the shared galoybot
+# GitHub App (App 359499 — same App that opens galoy-deployments and
+# galoy-charts bump PRs). `GH_APP_PRIVATE_KEY` is the base64-encoded
+# PEM stored in Vault and is passed straight through to `gh-token -b`.
+#
+# `nix shell` pulls `gh-token`, `gh`, `jq`, `yq-go` and `coreutils`
+# since the base nix-flakes image has none of them.
+
+set -euo pipefail
+
+: "${GH_APP_ID:?GH_APP_ID must be set}"
+: "${GH_APP_PRIVATE_KEY:?GH_APP_PRIVATE_KEY must be set (base64-encoded PEM)}"
+: "${BOT_BRANCH:?BOT_BRANCH must be set}"
+: "${BASE_BRANCH:?BASE_BRANCH must be set}"
+: "${TARGET_REPO:?TARGET_REPO must be set (owner/repo)}"
+
+exec nix shell \
+  nixpkgs#gh-token \
+  nixpkgs#gh \
+  nixpkgs#jq \
+  nixpkgs#yq-go \
+  nixpkgs#coreutils \
+  --command bash <<SCRIPT
+set -euo pipefail
+
+DIGEST=\$(yq '.tunnelConnector.image.digest' galoy-charts-repo/charts/galoy-deps/values.yaml)
+
+cat > /tmp/pr-body.md <<BODY
+Auto-bump of \\\`tunnelConnector.image.digest\\\` in \\\`charts/galoy-deps/values.yaml\\\` to the latest \\\`tunnel-connector:edge\\\` digest published by drua CI:
+
+\\\`\\\`\\\`
+\${DIGEST}
+\\\`\\\`\\\`
+
+The drua CI bot force-pushes this branch on every new image, so this PR is always current — merge when convenient. Pinning the digest (instead of tracking the mutable \\\`:edge\\\` tag) means a drua CI push does not silently roll a running connector.
+
+Opened by GaloyMoney/drua CI via \\\`ci/tasks/open-galoy-charts-tunnel-connector-pr.sh\\\`.
+BODY
+
+export GH_TOKEN="\$(gh-token generate -b "\${GH_APP_PRIVATE_KEY}" -i "\${GH_APP_ID}" | jq -r '.token')"
+
+gh pr close "\${BOT_BRANCH}" --repo "\${TARGET_REPO}" || true
+gh pr create \\
+  --repo "\${TARGET_REPO}" \\
+  --title "chore(deps): bump tunnel-connector image digest" \\
+  --body-file /tmp/pr-body.md \\
+  --base "\${BASE_BRANCH}" \\
+  --head "\${BOT_BRANCH}" \\
+  --label galoybot \\
+  --label tunnel-connector
+SCRIPT

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -3,6 +3,8 @@
 git_uri: git@github.com:GaloyMoney/drua.git
 git_branch: main
 github_private_key: ((github.private_key))
+github_app_id: ((github.github_app_id))
+github_app_private_key: ((github.github_app_private_key))
 
 gar_registry: us.gcr.io/galoyorg
 gar_registry_user: ((gar-creds.username))


### PR DESCRIPTION
Needs repipe after merge.

## Summary

- Replace the straight-to-main push (`put: galoy-charts-repo` with `rebase: true`) in `bump-galoy-charts-tunnel-connector-image` with a force-push to a bot branch + an `open-pr` task that opens/refreshes a PR against `GaloyMoney/galoy-charts`.
- Auth is via the shared **galoybot GitHub App (359499)** — same App that opens galoy-deployments and galoy-charts bump PRs. Org-infra already provisions `github_app_id` / `github_app_private_key` to the `galoy-agents` Concourse team via `vault_generic_secret.galoy_github_ssh` (`for_each = toset(local.team_names)`), so this only needs `ci/values.yml` to expose them.
- `gh-token` is in nixpkgs at 2.0.10, so the open-pr task pulls it via `nix shell` alongside `gh`/`jq`/`yq-go` — **no pipeline-image rebuild required**.

### Why not `((mcp-upstream.github_pat))`?

The original PR #184 used that PAT and build #2 failed for that reason — it's scoped for the upstream MCP tools and lacks `repo` write on `GaloyMoney/galoy-charts`. PR #189 was the workaround that switched to a direct push; this change reverts that direction with the right credential.

### Why not `((galoy-agents-prod-secrets.github_app_private_key))`?

That's a different GitHub App entirely (the OAuth app for the drua product itself), not the galoybot CI app. Wrong installation, wrong permissions.

## Test plan

- [ ] `ytt -f ci/pipeline.yml -f ci/fragments.lib.yml -f ci/values.yml` renders cleanly *(verified locally)*
- [ ] `bash -n` on both task scripts *(verified locally)*
- [ ] After merge: run `ci/repipe` so Concourse re-resolves the new `((github.github_app_id))` / `((github.github_app_private_key))` Vault refs
- [ ] Trigger `bump-galoy-charts-tunnel-connector-image` (or wait for the next `tunnel-connector:edge` push) and confirm a PR opens on GaloyMoney/galoy-charts targeting `bump-tunnel-connector-image-bot-branch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)