### PR TITLE
feat(chart): expose drua's own postgres via MCP for admins

### DIFF
--- a/charts/drua/templates/_helpers.tpl
+++ b/charts/drua/templates/_helpers.tpl
@@ -17,6 +17,25 @@ If release name contain chart name it will be used as a full name.
 {{- end }}
 
 {{/*
+Postgres MCP fullname: <release>-postgres-mcp
+*/}}
+{{- define "galoyAgents.postgresMcp.fullname" -}}
+{{- printf "%s-postgres-mcp" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Postgres MCP secret name: defaults to the main galoy-agents secret (which already
+holds `pg-con`). Allows override via .Values.galoyAgents.postgresMcp.databaseUrlSecret.name.
+*/}}
+{{- define "galoyAgents.postgresMcp.secretName" -}}
+{{- if .Values.galoyAgents.postgresMcp.databaseUrlSecret.name -}}
+{{- .Values.galoyAgents.postgresMcp.databaseUrlSecret.name -}}
+{{- else -}}
+{{- template "galoyAgents.fullname" . -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Sandbox namespace: use .Values.sandbox.namespace if set, otherwise .Release.Namespace
 */}}
 {{- define "galoyAgents.sandboxNamespace" -}}

--- a/charts/drua/templates/configmap.yaml
+++ b/charts/drua/templates/configmap.yaml
@@ -74,7 +74,8 @@ data:
         team: {{ .Values.galoyAgents.config.concourse.team | quote }}
       {{- $hasUpstreams := .Values.galoyAgents.config.mcpUpstreams }}
       {{- $k8sMcp := index .Values "kubernetes-mcp-server" }}
-      {{- if or $hasUpstreams (and $k8sMcp $k8sMcp.enabled) }}
+      {{- $pgMcp := .Values.galoyAgents.postgresMcp }}
+      {{- if or $hasUpstreams (and $k8sMcp $k8sMcp.enabled) (and $pgMcp $pgMcp.enabled) }}
       mcp_upstreams:
       {{- range .Values.galoyAgents.config.mcpUpstreams }}
         - name: {{ .name | quote }}
@@ -128,6 +129,16 @@ data:
             - "pods_log"
             - "resources_list"
             - "resources_get"
+      {{- end }}
+      {{- if and $pgMcp $pgMcp.enabled }}
+        - name: "postgres"
+          url: "http://{{ template "galoyAgents.postgresMcp.fullname" . }}:{{ $pgMcp.service.port }}/mcp"
+          auth_required: false
+          tool_prefix: "pg"
+          category: "database"
+          category_description: "Drua's own PostgreSQL — schema inspection and read-only SQL"
+          required_scopes:
+            - "admin"
       {{- end }}
       {{- end }}
     {{- with .Values.galoyAgents.config.library }}

--- a/charts/drua/templates/postgres-mcp-deployment.yaml
+++ b/charts/drua/templates/postgres-mcp-deployment.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.galoyAgents.postgresMcp.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "galoyAgents.postgresMcp.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.postgresMcp.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+spec:
+  replicas: {{ .Values.galoyAgents.postgresMcp.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "galoyAgents.postgresMcp.fullname" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ template "galoyAgents.postgresMcp.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+      {{- with .Values.galoyAgents.labels }}
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      automountServiceAccountToken: false
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: postgres-mcp
+        image: "{{ .Values.galoyAgents.postgresMcp.image.repository }}:{{ .Values.galoyAgents.postgresMcp.image.tag }}"
+        imagePullPolicy: {{ .Values.galoyAgents.postgresMcp.image.pullPolicy }}
+        args:
+          - "--transport=http"
+          - "--port={{ .Values.galoyAgents.postgresMcp.service.port }}"
+        env:
+        - name: DSN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "galoyAgents.postgresMcp.secretName" . }}
+              key: {{ .Values.galoyAgents.postgresMcp.databaseUrlSecret.key }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.galoyAgents.postgresMcp.service.port }}
+          protocol: TCP
+        resources:
+          {{- toYaml .Values.galoyAgents.postgresMcp.resources | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop: ["ALL"]
+{{- end }}

--- a/charts/drua/templates/postgres-mcp-service.yaml
+++ b/charts/drua/templates/postgres-mcp-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.galoyAgents.postgresMcp.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "galoyAgents.postgresMcp.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.postgresMcp.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+spec:
+  type: {{ .Values.galoyAgents.postgresMcp.service.type }}
+  ports:
+  - port: {{ .Values.galoyAgents.postgresMcp.service.port }}
+    targetPort: {{ .Values.galoyAgents.postgresMcp.service.port }}
+    protocol: TCP
+    name: http
+  selector:
+    app: {{ template "galoyAgents.postgresMcp.fullname" . }}
+{{- end }}

--- a/charts/drua/templates/secret.yaml
+++ b/charts/drua/templates/secret.yaml
@@ -15,6 +15,9 @@ metadata:
 type: Opaque
 data:
   pg-con: {{ .Values.galoyAgents.secrets.pgCon | trim | b64enc | trim }}
+  {{- if .Values.galoyAgents.secrets.pgMcpUri }}
+  pg-mcp-uri: {{ .Values.galoyAgents.secrets.pgMcpUri | trim | b64enc | trim }}
+  {{- end }}
   github-client-secret: {{ .Values.galoyAgents.secrets.githubClientSecret | trim | b64enc | trim }}
   {{- if .Values.galoyAgents.secrets.concourseUsername }}
   concourse-username: {{ .Values.galoyAgents.secrets.concourseUsername | trim | b64enc | trim }}

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -107,9 +107,37 @@ galoyAgents:
       enabled: false
       clientId: ""
       installationId: ""
+  ## Optional postgres MCP sidecar exposing drua's own database to admins
+  ## via MCP Streamable-HTTP at /mcp. Uses bytebase/dbhub (the same image
+  ## lana-bank uses) — read-only posture should be enforced at the database
+  ## user layer (the DSN it reads must point to a read-only role).
+  postgresMcp:
+    enabled: false
+    image:
+      repository: bytebase/dbhub
+      tag: 0.21.1
+      pullPolicy: IfNotPresent
+    service:
+      type: ClusterIP
+      port: 8000
+    ## Source of the postgres DSN (env var DSN). Defaults to the main
+    ## galoy-agents secret (key `pg-con`) populated by Terraform from the
+    ## GCP postgres module — no extra secret wiring required.
+    databaseUrlSecret:
+      name: ""
+      key: pg-con
+    replicas: 1
+    resources:
+      requests:
+        cpu: 50m
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 256Mi
   secrets:
     create: true
     pgCon: ""
+    pgMcpUri: ""
     githubClientSecret: ""
     concourseUsername: ""
     concoursePassword: ""

--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -42,6 +42,7 @@ module "postgresql" {
   highly_available = false
   tier             = "db-f1-micro"
   replication      = false
+  readonly_users   = ["mcp"]
 }
 
 resource "kubernetes_namespace" "galoy_agents" {
@@ -70,6 +71,10 @@ resource "kubernetes_secret" "galoy_agents" {
 
   data = {
     "pg-con"                 = module.postgresql.creds["galoy-agents"].conn
+    # Read-only DSN for the postgres-mcp sidecar. `?sslmode=require` is
+    # required — Cloud SQL's pg_hba.conf rejects unencrypted connections
+    # and dbhub crash-loops without it.
+    "pg-mcp-uri"             = "postgres://${module.postgresql.creds["galoy-agents"].readonly_users["mcp"].user}:${module.postgresql.creds["galoy-agents"].readonly_users["mcp"].password}@${module.postgresql.creds["galoy-agents"].host}:5432/galoy-agents?sslmode=require"
     "github-client-secret"   = var.github_client_secret
     "gcs-creds"              = file("${path.module}/gcs-creds.json")
     "concourse-username"     = var.concourse_username

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -35,6 +35,10 @@ galoyAgents:
       enabled: true
       clientId: "Iv23liCAm3yHFqmGmayW"
       installationId: "123146136"
+  postgresMcp:
+    enabled: true
+    databaseUrlSecret:
+      key: pg-mcp-uri
     mcpUpstreams:
       - name: honeycomb
         url: https://mcp.honeycomb.io/mcp


### PR DESCRIPTION
## Summary
- Adds a `bytebase/dbhub` sidecar to the drua chart and registers it in the gateway as the `postgres` upstream (admin-scoped, tool prefix `pg`). Mirrors the existing `kubernetes-mcp` wiring — admins can now introspect drua's own database the same way they introspect its cluster.
- Provisions a dedicated read-only DB role via the galoy-infra postgres module's `readonly_users` construct (same pattern lana-bank uses through galoy-deployments) instead of reusing the admin `pg-con`. The resulting URI is threaded through the `galoy-agents` secret as `pg-mcp-uri` with `?sslmode=require` (Cloud SQL `pg_hba.conf` rejects unencrypted connections — verified live in lana-bank's deployment that dbhub crash-loops without it).
- Disabled by default in chart values; enabled via `ci/deploy/drua/prod-values.yml.tmpl`.

## Files
- `charts/drua/templates/postgres-mcp-{deployment,service}.yaml` — new dbhub deployment + ClusterIP service, hardened (read-only FS, non-root, no SA token, all caps dropped).
- `charts/drua/templates/_helpers.tpl` — `postgresMcp.fullname` and `postgresMcp.secretName` helpers.
- `charts/drua/templates/configmap.yaml` — registers `postgres` upstream in the gateway with `required_scopes: [admin]`.
- `charts/drua/templates/secret.yaml` + `values.yaml` — optional `pgMcpUri` secret key for dev parity.
- `ci/deploy/drua/main.tf` — `readonly_users = ["mcp"]` on the postgres module + `pg-mcp-uri` secret entry built from `module.postgresql.creds["galoy-agents"].readonly_users["mcp"]`.
- `ci/deploy/drua/prod-values.yml.tmpl` — enables `postgresMcp` and overrides `databaseUrlSecret.key` to `pg-mcp-uri`.

## Test plan
- [x] `helm template` with `postgresMcp.enabled=true` renders deployment, service, and the `postgres` MCP upstream block in the configmap.
- [x] `helm template` with default values produces no postgres-mcp resources (opt-in confirmed).
- [x] Prod values render: `DSN` env var resolves to `secretKeyRef{name=galoy-agents,key=pg-mcp-uri}`.
- [x] Dev secret renders `pg-mcp-uri` only when `secrets.pgMcpUri` is set (no broken empty key when omitted).
- [ ] After merge: `terraform apply` provisions the `galoy-agents-mcp` role and writes `pg-mcp-uri`; verify the dbhub pod reaches Ready and the `postgres` toolset shows up in the gateway under admin scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)