### PR TITLE
refactor: complete galoy-agents → drua rename across infra and code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ reset-test-library:
 
 add-test-skill:
 	@test -d $(TEST_LIBRARY_DIR)/.git || (echo "Run 'make reset-test-library' first" && exit 1)
-	@printf '# CI Check\n\nInvestigate the latest CI status for a Concourse pipeline.\n\n---\n\nUsing the concourse tools, find the most recent build failure of the **galoy-agents-bin** pipeline.\n\n1. List recent builds and identify the last failed one\n2. Fetch the build logs and summarize the failure reason\n3. If all recent builds passed, report that the pipeline is green\n\nIf $$ARGUMENTS is provided, check that pipeline instead.\n' \
+	@printf '# CI Check\n\nInvestigate the latest CI status for a Concourse pipeline.\n\n---\n\nUsing the concourse tools, find the most recent build failure of the **drua-bin** pipeline.\n\n1. List recent builds and identify the last failed one\n2. Fetch the build logs and summarize the failure reason\n3. If all recent builds passed, report that the pipeline is green\n\nIf $$ARGUMENTS is provided, check that pipeline instead.\n' \
 		> $(TEST_LIBRARY_DIR)/runtime/skills/ci-check.md
 	cd $(TEST_LIBRARY_DIR) && git pull --rebase origin main && \
 		git add -A && \

--- a/charts/drua/Chart.yaml
+++ b/charts/drua/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-name: galoy-agents
+name: drua
 description: Helm chart for deploying GaloyMoney/drua
 type: application
 version: 0.1.0-dev

--- a/charts/drua/templates/_helpers.tpl
+++ b/charts/drua/templates/_helpers.tpl
@@ -3,7 +3,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contain chart name it will be used as a full name.
 */}}
-{{- define "galoyAgents.fullname" -}}
+{{- define "drua.fullname" -}}
 {{- if .Values.fullnameOverride }}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
@@ -19,26 +19,26 @@ If release name contain chart name it will be used as a full name.
 {{/*
 Postgres MCP fullname: <release>-postgres-mcp
 */}}
-{{- define "galoyAgents.postgresMcp.fullname" -}}
+{{- define "drua.postgresMcp.fullname" -}}
 {{- printf "%s-postgres-mcp" .Release.Name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
-Postgres MCP secret name: defaults to the main galoy-agents secret (which already
-holds `pg-con`). Allows override via .Values.galoyAgents.postgresMcp.databaseUrlSecret.name.
+Postgres MCP secret name: defaults to the main drua secret (which already
+holds `pg-con`). Allows override via .Values.drua.postgresMcp.databaseUrlSecret.name.
 */}}
-{{- define "galoyAgents.postgresMcp.secretName" -}}
-{{- if .Values.galoyAgents.postgresMcp.databaseUrlSecret.name -}}
-{{- .Values.galoyAgents.postgresMcp.databaseUrlSecret.name -}}
+{{- define "drua.postgresMcp.secretName" -}}
+{{- if .Values.drua.postgresMcp.databaseUrlSecret.name -}}
+{{- .Values.drua.postgresMcp.databaseUrlSecret.name -}}
 {{- else -}}
-{{- template "galoyAgents.fullname" . -}}
+{{- template "drua.fullname" . -}}
 {{- end -}}
 {{- end -}}
 
 {{/*
 Sandbox namespace: use .Values.sandbox.namespace if set, otherwise .Release.Namespace
 */}}
-{{- define "galoyAgents.sandboxNamespace" -}}
+{{- define "drua.sandboxNamespace" -}}
 {{- if .Values.sandbox.namespace -}}
 {{- .Values.sandbox.namespace -}}
 {{- else -}}
@@ -50,7 +50,7 @@ Sandbox namespace: use .Values.sandbox.namespace if set, otherwise .Release.Name
 Sandbox controller namespace: use .Values.sandbox.controllerNamespace if set,
 otherwise "agent-sandbox-system" (upstream default).
 */}}
-{{- define "galoyAgents.controllerNamespace" -}}
+{{- define "drua.controllerNamespace" -}}
 {{- if .Values.sandbox.controllerNamespace -}}
 {{- .Values.sandbox.controllerNamespace -}}
 {{- else -}}

--- a/charts/drua/templates/configmap.yaml
+++ b/charts/drua/templates/configmap.yaml
@@ -1,31 +1,31 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "galoyAgents.fullname" . }}-config
+  name: {{ template "drua.fullname" . }}-config
   namespace: {{ .Release.Namespace }}
 data:
   drua.yml: |-
     server:
-      port: {{ .Values.galoyAgents.server.service.port }}
-      host: {{ .Values.galoyAgents.config.server.host | quote }}
-      secure_cookies: {{ .Values.galoyAgents.config.server.secureCookies }}
-      mcp_endpoint: {{ .Values.galoyAgents.config.server.mcpEndpoint | quote }}
+      port: {{ .Values.drua.server.service.port }}
+      host: {{ .Values.drua.config.server.host | quote }}
+      secure_cookies: {{ .Values.drua.config.server.secureCookies }}
+      mcp_endpoint: {{ .Values.drua.config.server.mcpEndpoint | quote }}
       tunnel:
         deployments:
-        {{- range $deployment_id, $public_key := .Values.galoyAgents.config.server.tunnel.deployments }}
+        {{- range $deployment_id, $public_key := .Values.drua.config.server.tunnel.deployments }}
           {{ $deployment_id }}: |
             {{- $public_key | nindent 12 }}
         {{- end }}
     oauth:
-      github_client_id: {{ .Values.galoyAgents.config.oauth.githubClientId | quote }}
-      github_redirect_uri: {{ .Values.galoyAgents.config.oauth.githubRedirectUri | quote }}
-    {{- if .Values.galoyAgents.config.oauth.githubAllowedTeams }}
+      github_client_id: {{ .Values.drua.config.oauth.githubClientId | quote }}
+      github_redirect_uri: {{ .Values.drua.config.oauth.githubRedirectUri | quote }}
+    {{- if .Values.drua.config.oauth.githubAllowedTeams }}
       github_allowed_teams:
-      {{- range .Values.galoyAgents.config.oauth.githubAllowedTeams }}
+      {{- range .Values.drua.config.oauth.githubAllowedTeams }}
         - {{ . | quote }}
       {{- end }}
     {{- end }}
-    {{- with .Values.galoyAgents.config.providers }}
+    {{- with .Values.drua.config.providers }}
     providers:
     {{- range . }}
       - name: {{ .name | quote }}
@@ -40,8 +40,8 @@ data:
     agents:
       builtin_roles:
         workspace_lead:
-          model: {{ .Values.galoyAgents.config.agents.workspaceLead.model | quote }}
-          {{- with .Values.galoyAgents.config.agents.workspaceLead.compaction }}
+          model: {{ .Values.drua.config.agents.workspaceLead.model | quote }}
+          {{- with .Values.drua.config.agents.workspaceLead.compaction }}
           compaction:
             {{- with .resetTimeDeltaSeconds }}
             reset_time_delta_seconds: {{ . }}
@@ -50,8 +50,8 @@ data:
           system:
             - type: text
               text: |-
-                {{- .Values.galoyAgents.config.agents.workspaceLead.systemPrompt | nindent 16 }}
-        {{- with .Values.galoyAgents.config.agents.agent }}
+                {{- .Values.drua.config.agents.workspaceLead.systemPrompt | nindent 16 }}
+        {{- with .Values.drua.config.agents.agent }}
         agent:
           model: {{ .model | quote }}
           {{- with .compaction }}
@@ -67,17 +67,17 @@ data:
         {{- end }}
     toolsets:
       code_assistant:
-        db_path: {{ .Values.galoyAgents.config.codeAssistant.dbPath | quote }}
+        db_path: {{ .Values.drua.config.codeAssistant.dbPath | quote }}
       concourse:
-        enabled: {{ .Values.galoyAgents.config.concourse.enabled }}
-        url: {{ .Values.galoyAgents.config.concourse.url | quote }}
-        team: {{ .Values.galoyAgents.config.concourse.team | quote }}
-      {{- $hasUpstreams := .Values.galoyAgents.config.mcpUpstreams }}
+        enabled: {{ .Values.drua.config.concourse.enabled }}
+        url: {{ .Values.drua.config.concourse.url | quote }}
+        team: {{ .Values.drua.config.concourse.team | quote }}
+      {{- $hasUpstreams := .Values.drua.config.mcpUpstreams }}
       {{- $k8sMcp := index .Values "kubernetes-mcp-server" }}
-      {{- $pgMcp := .Values.galoyAgents.postgresMcp }}
+      {{- $pgMcp := .Values.drua.postgresMcp }}
       {{- if or $hasUpstreams (and $k8sMcp $k8sMcp.enabled) (and $pgMcp $pgMcp.enabled) }}
       mcp_upstreams:
-      {{- range .Values.galoyAgents.config.mcpUpstreams }}
+      {{- range .Values.drua.config.mcpUpstreams }}
         - name: {{ .name | quote }}
           url: {{ .url | quote }}
           {{- if .authHeaderName }}
@@ -132,7 +132,7 @@ data:
       {{- end }}
       {{- if and $pgMcp $pgMcp.enabled }}
         - name: "postgres"
-          url: "http://{{ template "galoyAgents.postgresMcp.fullname" . }}:{{ $pgMcp.service.port }}/mcp"
+          url: "http://{{ template "drua.postgresMcp.fullname" . }}:{{ $pgMcp.service.port }}/mcp"
           auth_required: false
           tool_prefix: "pg"
           category: "database"
@@ -141,7 +141,7 @@ data:
             - "admin"
       {{- end }}
       {{- end }}
-    {{- with .Values.galoyAgents.config.library }}
+    {{- with .Values.drua.config.library }}
     library:
       {{- with .dataDir }}
       data_dir: {{ . | quote }}
@@ -150,10 +150,10 @@ data:
       repo_url: {{ . | quote }}
       {{- end }}
     {{- end }}
-    {{- if .Values.galoyAgents.config.githubApp.enabled }}
+    {{- if .Values.drua.config.githubApp.enabled }}
     github_app:
-      client_id: {{ .Values.galoyAgents.config.githubApp.clientId | quote }}
-      installation_id: {{ .Values.galoyAgents.config.githubApp.installationId | quote }}
+      client_id: {{ .Values.drua.config.githubApp.clientId | quote }}
+      installation_id: {{ .Values.drua.config.githubApp.installationId | quote }}
     {{- end }}
     {{- if .Values.sandbox.namespace }}
     # Sandbox provisioning. Without this section the binary defaults to

--- a/charts/drua/templates/deployment.yaml
+++ b/charts/drua/templates/deployment.yaml
@@ -1,13 +1,13 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "galoyAgents.fullname" . }}
+  name: {{ template "drua.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
-    kube-monkey/identifier: {{ template "galoyAgents.fullname" . }}
+    kube-monkey/identifier: {{ template "drua.fullname" . }}
     kube-monkey/enabled: enabled
     kube-monkey/kill-mode: fixed
     kube-monkey/kill-value: "1"
@@ -15,31 +15,31 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ template "galoyAgents.fullname" . }}
+      app: {{ template "drua.fullname" . }}
       release: {{ .Release.Name }}
-  replicas: {{ .Values.galoyAgents.replicas }}
+  replicas: {{ .Values.drua.replicas }}
   template:
     metadata:
       labels:
-        app: {{ template "galoyAgents.fullname" . }}
+        app: {{ template "drua.fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
-        kube-monkey/identifier: {{ template "galoyAgents.fullname" . }}
+        kube-monkey/identifier: {{ template "drua.fullname" . }}
         kube-monkey/enabled: enabled
-      {{- with .Values.galoyAgents.labels }}
+      {{- with .Values.drua.labels }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
       annotations:
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
-        {{- if .Values.galoyAgents.secrets.create }}
+        {{- if .Values.drua.secrets.create }}
         checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
         {{- end }}
-        {{- if .Values.galoyAgents.secretChecksum }}
-        checksum/external-secret: {{ .Values.galoyAgents.secretChecksum | quote }}
+        {{- if .Values.drua.secretChecksum }}
+        checksum/external-secret: {{ .Values.drua.secretChecksum | quote }}
         {{- end }}
     spec:
       {{- if .Values.sandbox.enabled }}
-      serviceAccountName: {{ template "galoyAgents.fullname" . }}-sandbox
+      serviceAccountName: {{ template "drua.fullname" . }}-sandbox
       {{- end }}
       initContainers:
       - name: wait-for-postgresql
@@ -57,11 +57,11 @@ spec:
         - name: PG_CON
           valueFrom:
             secretKeyRef:
-              name: {{ template "galoyAgents.fullname" . }}
+              name: {{ template "drua.fullname" . }}
               key: "pg-con"
-      {{- if .Values.galoyAgents.codeAssistant.indexHash }}
+      {{- if .Values.drua.codeAssistant.indexHash }}
       - name: init-code-assistant
-        image: {{ .Values.galoyAgents.codeAssistant.initImage }}
+        image: {{ .Values.drua.codeAssistant.initImage }}
         command:
           - "sh"
           - "-c"
@@ -71,9 +71,9 @@ spec:
               printf '%s' "$GCS_CREDS" > /tmp/gcs-key.json
               gcloud auth activate-service-account --key-file=/tmp/gcs-key.json
             fi
-            echo "Downloading index {{ .Values.galoyAgents.codeAssistant.indexHash }}..."
+            echo "Downloading index {{ .Values.drua.codeAssistant.indexHash }}..."
             gsutil cp \
-              "gs://{{ .Values.galoyAgents.codeAssistant.gcsBucket }}/index/{{ .Values.galoyAgents.codeAssistant.indexHash }}.tar.gz" \
+              "gs://{{ .Values.drua.codeAssistant.gcsBucket }}/index/{{ .Values.drua.codeAssistant.indexHash }}.tar.gz" \
               /tmp/code-assistant-index.tar.gz
             mkdir -p /data
             tar -xzf /tmp/code-assistant-index.tar.gz -C /data
@@ -81,10 +81,10 @@ spec:
             if [ -f /data/style-agent.db ] && [ ! -f /data/code-assistant.db ]; then
               mv /data/style-agent.db /data/code-assistant.db
             fi
-            {{- if .Values.galoyAgents.codeAssistant.embedderHash }}
-            echo "Downloading embedder {{ .Values.galoyAgents.codeAssistant.embedderHash }}..."
+            {{- if .Values.drua.codeAssistant.embedderHash }}
+            echo "Downloading embedder {{ .Values.drua.codeAssistant.embedderHash }}..."
             gsutil cp \
-              "gs://{{ .Values.galoyAgents.codeAssistant.gcsBucket }}/embedder/{{ .Values.galoyAgents.codeAssistant.embedderHash }}.tar.gz" \
+              "gs://{{ .Values.drua.codeAssistant.gcsBucket }}/embedder/{{ .Values.drua.codeAssistant.embedderHash }}.tar.gz" \
               /tmp/embedder.tar.gz
             tar -xzf /tmp/embedder.tar.gz -C /data
             {{- end }}
@@ -93,7 +93,7 @@ spec:
         - name: GCS_CREDS
           valueFrom:
             secretKeyRef:
-              name: {{ template "galoyAgents.fullname" . }}
+              name: {{ template "drua.fullname" . }}
               key: "gcs-creds"
               optional: true
         volumeMounts:
@@ -102,27 +102,27 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Chart.Name }}
-        image: "{{ .Values.galoyAgents.image.repository }}{{- if .Values.galoyAgents.image.tag -}}:{{ .Values.galoyAgents.image.tag }}{{- else -}}@{{ .Values.galoyAgents.image.digest }}{{- end }}"
+        image: "{{ .Values.drua.image.repository }}{{- if .Values.drua.image.tag -}}:{{ .Values.drua.image.tag }}{{- else -}}@{{ .Values.drua.image.digest }}{{- end }}"
         ports:
         - name: server
-          containerPort: {{ .Values.galoyAgents.server.service.port }}
+          containerPort: {{ .Values.drua.server.service.port }}
           protocol: TCP
         volumeMounts:
         - name: config
           mountPath: "/config/drua.yml"
           subPath: "drua.yml"
           readOnly: true
-        {{- if .Values.galoyAgents.codeAssistant.indexHash }}
+        {{- if .Values.drua.codeAssistant.indexHash }}
         - name: code-assistant-data
           mountPath: /data/code-assistant
         {{- end }}
-        {{- with .Values.galoyAgents.config.library }}
+        {{- with .Values.drua.config.library }}
         {{- with .dataDir }}
         - name: library-data
           mountPath: {{ . }}
         {{- end }}
         {{- end }}
-        {{- if .Values.galoyAgents.config.githubApp.enabled }}
+        {{- if .Values.drua.config.githubApp.enabled }}
         - name: github-app-key
           mountPath: /secrets/github-app
           readOnly: true
@@ -131,44 +131,44 @@ spec:
         - name: DRUA_CONFIG
           value: "/config/drua.yml"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: {{ .Values.galoyAgents.tracing.otelExporterOtlpEndpoint | quote }}
+          value: {{ .Values.drua.tracing.otelExporterOtlpEndpoint | quote }}
         - name: PG_CON
           valueFrom:
             secretKeyRef:
-              name: {{ template "galoyAgents.fullname" . }}
+              name: {{ template "drua.fullname" . }}
               key: "pg-con"
         - name: GITHUB_CLIENT_SECRET
           valueFrom:
             secretKeyRef:
-              name: {{ template "galoyAgents.fullname" . }}
+              name: {{ template "drua.fullname" . }}
               key: "github-client-secret"
         - name: CONCOURSE_USERNAME
           valueFrom:
             secretKeyRef:
-              name: {{ template "galoyAgents.fullname" . }}
+              name: {{ template "drua.fullname" . }}
               key: "concourse-username"
               optional: true
         - name: CONCOURSE_PASSWORD
           valueFrom:
             secretKeyRef:
-              name: {{ template "galoyAgents.fullname" . }}
+              name: {{ template "drua.fullname" . }}
               key: "concourse-password"
               optional: true
-        {{- range .Values.galoyAgents.config.mcpUpstreams }}
+        {{- range .Values.drua.config.mcpUpstreams }}
         - name: {{ .name | upper }}_AUTH_HEADER
           valueFrom:
             secretKeyRef:
-              name: {{ template "galoyAgents.fullname" $ }}
+              name: {{ template "drua.fullname" $ }}
               key: {{ printf "%s-auth-header" .name | quote }}
               optional: true
         {{- end }}
         - name: ANTHROPIC_API_KEY
           valueFrom:
             secretKeyRef:
-              name: {{ template "galoyAgents.fullname" . }}
+              name: {{ template "drua.fullname" . }}
               key: "anthropic-api-key"
               optional: true
-        {{- if .Values.galoyAgents.config.githubApp.enabled }}
+        {{- if .Values.drua.config.githubApp.enabled }}
         - name: GITHUB_APP_PRIVATE_KEY_PATH
           value: "/secrets/github-app/private-key.pem"
         {{- end }}
@@ -177,31 +177,31 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: spec.nodeName
-        {{- if .Values.galoyAgents.codeAssistant.indexHash }}
+        {{- if .Values.drua.codeAssistant.indexHash }}
         - name: FASTEMBED_CACHE_DIR
           value: /data/code-assistant/.fastembed_cache
         {{- end }}
         resources:
-        {{- toYaml .Values.galoyAgents.resources | nindent 10 }}
+        {{- toYaml .Values.drua.resources | nindent 10 }}
       volumes:
       - name: config
         configMap:
-          name: {{ template "galoyAgents.fullname" . }}-config
-      {{- if .Values.galoyAgents.codeAssistant.indexHash }}
+          name: {{ template "drua.fullname" . }}-config
+      {{- if .Values.drua.codeAssistant.indexHash }}
       - name: code-assistant-data
         emptyDir: {}
       {{- end }}
-      {{- with .Values.galoyAgents.config.library }}
+      {{- with .Values.drua.config.library }}
       {{- with .dataDir }}
       - name: library-data
         persistentVolumeClaim:
-          claimName: {{ template "galoyAgents.fullname" $ }}-library
+          claimName: {{ template "drua.fullname" $ }}-library
       {{- end }}
       {{- end }}
-      {{- if .Values.galoyAgents.config.githubApp.enabled }}
+      {{- if .Values.drua.config.githubApp.enabled }}
       - name: github-app-key
         secret:
-          secretName: {{ template "galoyAgents.fullname" . }}
+          secretName: {{ template "drua.fullname" . }}
           items:
             - key: "github-app-private-key"
               path: "private-key.pem"

--- a/charts/drua/templates/ingress.yaml
+++ b/charts/drua/templates/ingress.yaml
@@ -1,34 +1,34 @@
-{{- if .Values.galoyAgents.ingress.enabled }}
+{{- if .Values.drua.ingress.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ template "galoyAgents.fullname" . }}
+  name: {{ template "drua.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
-  {{- with .Values.galoyAgents.ingress.annotations }}
+  {{- with .Values.drua.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if .Values.galoyAgents.ingress.ingressClassName }}
-  ingressClassName: {{ .Values.galoyAgents.ingress.ingressClassName }}
+  {{- if .Values.drua.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.drua.ingress.ingressClassName }}
   {{- end }}
-  {{- if .Values.galoyAgents.ingress.tls }}
+  {{- if .Values.drua.ingress.tls }}
   tls:
-    {{- toYaml .Values.galoyAgents.ingress.tls | nindent 4 }}
+    {{- toYaml .Values.drua.ingress.tls | nindent 4 }}
   {{- end }}
   rules:
-  - host: {{ .Values.galoyAgents.ingress.host }}
+  - host: {{ .Values.drua.ingress.host }}
     http:
       paths:
       - path: /
         pathType: Prefix
         backend:
           service:
-            name: {{ template "galoyAgents.fullname" . }}
+            name: {{ template "drua.fullname" . }}
             port:
-              number: {{ .Values.galoyAgents.server.service.port }}
+              number: {{ .Values.drua.server.service.port }}
 {{- end }}

--- a/charts/drua/templates/library-pvc.yaml
+++ b/charts/drua/templates/library-pvc.yaml
@@ -1,19 +1,19 @@
-{{- with .Values.galoyAgents.config.library }}
+{{- with .Values.drua.config.library }}
 {{- with .dataDir }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: {{ template "galoyAgents.fullname" $ }}-library
+  name: {{ template "drua.fullname" $ }}-library
   namespace: {{ $.Release.Namespace }}
   labels:
-    app: {{ template "galoyAgents.fullname" $ }}
+    app: {{ template "drua.fullname" $ }}
 spec:
   accessModes:
     - ReadWriteOnce
   resources:
     requests:
-      storage: {{ $.Values.galoyAgents.config.library.size | default "1Gi" }}
-  {{- with $.Values.galoyAgents.config.library.storageClassName }}
+      storage: {{ $.Values.drua.config.library.size | default "1Gi" }}
+  {{- with $.Values.drua.config.library.storageClassName }}
   storageClassName: {{ . }}
   {{- end }}
 {{- end }}

--- a/charts/drua/templates/postgres-mcp-deployment.yaml
+++ b/charts/drua/templates/postgres-mcp-deployment.yaml
@@ -1,26 +1,26 @@
-{{- if .Values.galoyAgents.postgresMcp.enabled -}}
+{{- if .Values.drua.postgresMcp.enabled -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "galoyAgents.postgresMcp.fullname" . }}
+  name: {{ template "drua.postgresMcp.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "galoyAgents.postgresMcp.fullname" . }}
+    app: {{ template "drua.postgresMcp.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
-  replicas: {{ .Values.galoyAgents.postgresMcp.replicas }}
+  replicas: {{ .Values.drua.postgresMcp.replicas }}
   selector:
     matchLabels:
-      app: {{ template "galoyAgents.postgresMcp.fullname" . }}
+      app: {{ template "drua.postgresMcp.fullname" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ template "galoyAgents.postgresMcp.fullname" . }}
+        app: {{ template "drua.postgresMcp.fullname" . }}
         chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
         release: "{{ .Release.Name }}"
-      {{- with .Values.galoyAgents.labels }}
+      {{- with .Values.drua.labels }}
         {{ toYaml . | nindent 8 }}
       {{- end }}
     spec:
@@ -32,23 +32,23 @@ spec:
           type: RuntimeDefault
       containers:
       - name: postgres-mcp
-        image: "{{ .Values.galoyAgents.postgresMcp.image.repository }}:{{ .Values.galoyAgents.postgresMcp.image.tag }}"
-        imagePullPolicy: {{ .Values.galoyAgents.postgresMcp.image.pullPolicy }}
+        image: "{{ .Values.drua.postgresMcp.image.repository }}:{{ .Values.drua.postgresMcp.image.tag }}"
+        imagePullPolicy: {{ .Values.drua.postgresMcp.image.pullPolicy }}
         args:
           - "--transport=http"
-          - "--port={{ .Values.galoyAgents.postgresMcp.service.port }}"
+          - "--port={{ .Values.drua.postgresMcp.service.port }}"
         env:
         - name: DSN
           valueFrom:
             secretKeyRef:
-              name: {{ template "galoyAgents.postgresMcp.secretName" . }}
-              key: {{ .Values.galoyAgents.postgresMcp.databaseUrlSecret.key }}
+              name: {{ template "drua.postgresMcp.secretName" . }}
+              key: {{ .Values.drua.postgresMcp.databaseUrlSecret.key }}
         ports:
         - name: http
-          containerPort: {{ .Values.galoyAgents.postgresMcp.service.port }}
+          containerPort: {{ .Values.drua.postgresMcp.service.port }}
           protocol: TCP
         resources:
-          {{- toYaml .Values.galoyAgents.postgresMcp.resources | nindent 10 }}
+          {{- toYaml .Values.drua.postgresMcp.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/charts/drua/templates/postgres-mcp-service.yaml
+++ b/charts/drua/templates/postgres-mcp-service.yaml
@@ -1,20 +1,20 @@
-{{- if .Values.galoyAgents.postgresMcp.enabled -}}
+{{- if .Values.drua.postgresMcp.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "galoyAgents.postgresMcp.fullname" . }}
+  name: {{ template "drua.postgresMcp.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "galoyAgents.postgresMcp.fullname" . }}
+    app: {{ template "drua.postgresMcp.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
-  type: {{ .Values.galoyAgents.postgresMcp.service.type }}
+  type: {{ .Values.drua.postgresMcp.service.type }}
   ports:
-  - port: {{ .Values.galoyAgents.postgresMcp.service.port }}
-    targetPort: {{ .Values.galoyAgents.postgresMcp.service.port }}
+  - port: {{ .Values.drua.postgresMcp.service.port }}
+    targetPort: {{ .Values.drua.postgresMcp.service.port }}
     protocol: TCP
     name: http
   selector:
-    app: {{ template "galoyAgents.postgresMcp.fullname" . }}
+    app: {{ template "drua.postgresMcp.fullname" . }}
 {{- end }}

--- a/charts/drua/templates/sandbox-controller.yaml
+++ b/charts/drua/templates/sandbox-controller.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.sandbox.enabled .Values.sandbox.installController }}
-{{ .Files.Get "vendor/agent-sandbox/manifest.yaml" | replace "agent-sandbox-system" (include "galoyAgents.controllerNamespace" .) }}
+{{ .Files.Get "vendor/agent-sandbox/manifest.yaml" | replace "agent-sandbox-system" (include "drua.controllerNamespace" .) }}
 ---
-{{ .Files.Get "vendor/agent-sandbox/extensions.yaml" | replace "agent-sandbox-system" (include "galoyAgents.controllerNamespace" .) }}
+{{ .Files.Get "vendor/agent-sandbox/extensions.yaml" | replace "agent-sandbox-system" (include "drua.controllerNamespace" .) }}
 {{- end }}

--- a/charts/drua/templates/sandbox-namespace.yaml
+++ b/charts/drua/templates/sandbox-namespace.yaml
@@ -5,7 +5,7 @@ kind: Namespace
 metadata:
   name: {{ .Values.sandbox.namespace }}
   labels:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 {{- end }}

--- a/charts/drua/templates/sandbox-network-policy.yaml
+++ b/charts/drua/templates/sandbox-network-policy.yaml
@@ -3,10 +3,10 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: {{ template "galoyAgents.fullname" . }}-sandbox-isolation
-  namespace: {{ include "galoyAgents.sandboxNamespace" . }}
+  name: {{ template "drua.fullname" . }}-sandbox-isolation
+  namespace: {{ include "drua.sandboxNamespace" . }}
   labels:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -24,7 +24,7 @@ spec:
           kubernetes.io/metadata.name: {{ .Release.Namespace }}
       podSelector:
         matchLabels:
-          app: {{ template "galoyAgents.fullname" . }}
+          app: {{ template "drua.fullname" . }}
           release: {{ .Release.Name }}
   egress:
   # 1. DNS — allow kube-dns for internal service resolution
@@ -43,14 +43,14 @@ spec:
   # 2. Dashboard callback — drua server ClusterIP
   - ports:
     - protocol: TCP
-      port: {{ .Values.galoyAgents.server.service.port }}
+      port: {{ .Values.drua.server.service.port }}
     to:
     - namespaceSelector:
         matchLabels:
           kubernetes.io/metadata.name: {{ .Release.Namespace }}
       podSelector:
         matchLabels:
-          app: {{ template "galoyAgents.fullname" . }}
+          app: {{ template "drua.fullname" . }}
           release: {{ .Release.Name }}
   # 3. OTel collector — allow trace export (OTLP HTTP/protobuf)
   {{- if .Values.sandbox.otelCollectorNamespace }}

--- a/charts/drua/templates/sandbox-rbac.yaml
+++ b/charts/drua/templates/sandbox-rbac.yaml
@@ -3,20 +3,20 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "galoyAgents.fullname" . }}-sandbox
+  name: {{ template "drua.fullname" . }}-sandbox
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ template "galoyAgents.fullname" . }}-sandbox-manager
-  namespace: {{ include "galoyAgents.sandboxNamespace" . }}
+  name: {{ template "drua.fullname" . }}-sandbox-manager
+  namespace: {{ include "drua.sandboxNamespace" . }}
   labels:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 rules:
@@ -45,28 +45,28 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ template "galoyAgents.fullname" . }}-sandbox-manager
-  namespace: {{ include "galoyAgents.sandboxNamespace" . }}
+  name: {{ template "drua.fullname" . }}-sandbox-manager
+  namespace: {{ include "drua.sandboxNamespace" . }}
   labels:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ template "galoyAgents.fullname" . }}-sandbox-manager
+  name: {{ template "drua.fullname" . }}-sandbox-manager
 subjects:
 - kind: ServiceAccount
-  name: {{ template "galoyAgents.fullname" . }}-sandbox
+  name: {{ template "drua.fullname" . }}-sandbox
   namespace: {{ .Release.Namespace }}
 ---
 # TokenReview — allows the server to validate SA tokens presented by sandbox agents
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ template "galoyAgents.fullname" . }}-token-reviewer
+  name: {{ template "drua.fullname" . }}-token-reviewer
   labels:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 rules:
@@ -77,17 +77,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ template "galoyAgents.fullname" . }}-token-reviewer
+  name: {{ template "drua.fullname" . }}-token-reviewer
   labels:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ template "galoyAgents.fullname" . }}-token-reviewer
+  name: {{ template "drua.fullname" . }}-token-reviewer
 subjects:
 - kind: ServiceAccount
-  name: {{ template "galoyAgents.fullname" . }}-sandbox
+  name: {{ template "drua.fullname" . }}-sandbox
   namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/drua/templates/sandbox-template.yaml
+++ b/charts/drua/templates/sandbox-template.yaml
@@ -3,9 +3,9 @@ apiVersion: extensions.agents.x-k8s.io/v1alpha1
 kind: SandboxTemplate
 metadata:
   name: {{ .Values.sandbox.templateName }}
-  namespace: {{ include "galoyAgents.sandboxNamespace" . }}
+  namespace: {{ include "drua.sandboxNamespace" . }}
   labels:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
 spec:
@@ -48,9 +48,9 @@ spec:
         - name: {{ .name }}
           value: {{ .value | quote }}
         {{- end }}
-        {{- if .Values.galoyAgents.tracing }}
+        {{- if .Values.drua.tracing }}
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
-          value: {{ .Values.galoyAgents.tracing.otelExporterOtlpEndpoint | replace ":4317" ":4318" | quote }}
+          value: {{ .Values.drua.tracing.otelExporterOtlpEndpoint | replace ":4317" ":4318" | quote }}
         {{- end }}
         {{- if .Values.sandbox.anthropicApiKeySecret }}
         - name: ANTHROPIC_API_KEY
@@ -65,7 +65,7 @@ spec:
         {{- end }}
         volumeMounts:
         - name: mcp-token
-          mountPath: /var/run/secrets/galoy-agents
+          mountPath: /var/run/secrets/drua
           readOnly: true
         - name: workspace-secrets
           mountPath: /run/secrets
@@ -77,7 +77,7 @@ spec:
         projected:
           sources:
           - serviceAccountToken:
-              audience: {{ .Values.sandbox.saTokenAudience | default "galoy-agents-mcp" }}
+              audience: {{ .Values.sandbox.saTokenAudience | default "drua-mcp" }}
               expirationSeconds: 3600
               path: token
       dnsConfig:

--- a/charts/drua/templates/secret.yaml
+++ b/charts/drua/templates/secret.yaml
@@ -1,34 +1,34 @@
-{{- if .Values.galoyAgents.secrets.create }}
+{{- if .Values.drua.secrets.create }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "galoyAgents.fullname" . }}
+  name: {{ template "drua.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
-  {{- if .Values.galoyAgents.secrets.annotations }}
+  {{- if .Values.drua.secrets.annotations }}
   annotations:
-{{ toYaml .Values.galoyAgents.secrets.annotations | indent 4 }}
+{{ toYaml .Values.drua.secrets.annotations | indent 4 }}
   {{- end }}
 type: Opaque
 data:
-  pg-con: {{ .Values.galoyAgents.secrets.pgCon | trim | b64enc | trim }}
-  {{- if .Values.galoyAgents.secrets.pgMcpUri }}
-  pg-mcp-uri: {{ .Values.galoyAgents.secrets.pgMcpUri | trim | b64enc | trim }}
+  pg-con: {{ .Values.drua.secrets.pgCon | trim | b64enc | trim }}
+  {{- if .Values.drua.secrets.pgMcpUri }}
+  pg-mcp-uri: {{ .Values.drua.secrets.pgMcpUri | trim | b64enc | trim }}
   {{- end }}
-  github-client-secret: {{ .Values.galoyAgents.secrets.githubClientSecret | trim | b64enc | trim }}
-  {{- if .Values.galoyAgents.secrets.concourseUsername }}
-  concourse-username: {{ .Values.galoyAgents.secrets.concourseUsername | trim | b64enc | trim }}
+  github-client-secret: {{ .Values.drua.secrets.githubClientSecret | trim | b64enc | trim }}
+  {{- if .Values.drua.secrets.concourseUsername }}
+  concourse-username: {{ .Values.drua.secrets.concourseUsername | trim | b64enc | trim }}
   {{- end }}
-  {{- if .Values.galoyAgents.secrets.concoursePassword }}
-  concourse-password: {{ .Values.galoyAgents.secrets.concoursePassword | trim | b64enc | trim }}
+  {{- if .Values.drua.secrets.concoursePassword }}
+  concourse-password: {{ .Values.drua.secrets.concoursePassword | trim | b64enc | trim }}
   {{- end }}
-  {{- if .Values.galoyAgents.codeAssistant.gcsCreds }}
-  gcs-creds: {{ .Values.galoyAgents.codeAssistant.gcsCreds | trim | b64enc | trim }}
+  {{- if .Values.drua.codeAssistant.gcsCreds }}
+  gcs-creds: {{ .Values.drua.codeAssistant.gcsCreds | trim | b64enc | trim }}
   {{- end }}
-  {{- if .Values.galoyAgents.secrets.anthropicApiKey }}
-  anthropic-api-key: {{ .Values.galoyAgents.secrets.anthropicApiKey | trim | b64enc | trim }}
+  {{- if .Values.drua.secrets.anthropicApiKey }}
+  anthropic-api-key: {{ .Values.drua.secrets.anthropicApiKey | trim | b64enc | trim }}
   {{- end }}
 {{- end }}

--- a/charts/drua/templates/service.yaml
+++ b/charts/drua/templates/service.yaml
@@ -1,23 +1,23 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "galoyAgents.fullname" . }}
+  name: {{ template "drua.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
-  {{- with .Values.galoyAgents.server.service.annotations }}
+  {{- with .Values.drua.server.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.galoyAgents.server.service.type }}
+  type: {{ .Values.drua.server.service.type }}
   ports:
-  - port: {{ .Values.galoyAgents.server.service.port }}
+  - port: {{ .Values.drua.server.service.port }}
     targetPort: server
     protocol: TCP
     name: http
   selector:
-    app: {{ template "galoyAgents.fullname" . }}
+    app: {{ template "drua.fullname" . }}
     release: {{ .Release.Name }}

--- a/charts/drua/values-minikube.yaml
+++ b/charts/drua/values-minikube.yaml
@@ -1,6 +1,6 @@
-galoyAgents:
+drua:
   image:
-    repository: us.gcr.io/galoyorg/galoy-agents
+    repository: us.gcr.io/galoyorg/drua
     tag: edge
     digest: ""
   config:
@@ -12,12 +12,12 @@ galoyAgents:
       githubRedirectUri: "http://localhost:5254/auth/callback"
   secrets:
     create: true
-    pgCon: "postgresql://galoy-agents:galoy-agents@galoy-agents-postgresql:5432/galoy-agents"
+    pgCon: "postgresql://drua:drua@drua-postgresql:5432/drua"
     githubClientSecret: "dummy-client-secret"
   codeAssistant:
     indexHash: "825ef7dd2d3b0ae5c61a97f4eb92d09e11c222d452e339d5614edc59c27bfd84"
     modelHash: "5049594d7ce4b8bd3c29c2aa9b7d64575b939e64db935f7922bacee466076696"
-    gcsBucket: galoy-agents-models
+    gcsBucket: drua-models
     initImage: google/cloud-sdk:slim
 postgresql:
   enabled: true
@@ -25,6 +25,6 @@ postgresql:
     tag: latest
   auth:
     enablePostgresUser: false
-    username: galoy-agents
-    password: galoy-agents
-    database: galoy-agents
+    username: drua
+    password: drua
+    database: drua

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -1,9 +1,9 @@
 fullnameOverride: ""
 nameOverride: ""
-galoyAgents:
+drua:
   resources: {}
   tracing:
-    serviceName: galoy-agents-dev
+    serviceName: drua-dev
     otelExporterOtlpEndpoint: "http://localhost:4317"
   server:
     service:
@@ -18,7 +18,7 @@ galoyAgents:
     tls: []
   labels: {}
   image:
-    repository: us.gcr.io/galoyorg/galoy-agents
+    repository: us.gcr.io/galoyorg/drua
     digest: "sha256:69a3157b6ad60c04e5514e1c6fcad69cf234fff2a644b42fc3e1f3df24525fcd"
     tag: edge
   replicas: 1
@@ -62,7 +62,7 @@ galoyAgents:
         compaction:
           resetTimeDeltaSeconds: 600
         systemPrompt: |
-          You are an agent operating inside a Galoy Agents workspace.
+          You are an agent operating inside a Drua workspace.
           You work on the tasks assigned to you and, when attached to
           a sandbox, you run commands and edit files inside it. Be
           concise and action-oriented.
@@ -121,7 +121,7 @@ galoyAgents:
       type: ClusterIP
       port: 8000
     ## Source of the postgres DSN (env var DSN). Defaults to the main
-    ## galoy-agents secret (key `pg-con`) populated by Terraform from the
+    ## drua secret (key `pg-con`) populated by Terraform from the
     ## GCP postgres module — no extra secret wiring required.
     databaseUrlSecret:
       name: ""
@@ -146,7 +146,7 @@ galoyAgents:
   codeAssistant:
     indexHash: "1b756a40fcceb95d482bfa5e93957d7830c9b407cc341483ab2a1aa6fe60b2c2"
     embedderHash: "569359897109da21014e728cd4d618843766f7f5a52f95c0c35e57250c117d06"
-    gcsBucket: galoy-agents-models
+    gcsBucket: drua-models
     gcsCreds: ""
     initImage: google/cloud-sdk:slim
 kubernetes-mcp-server:
@@ -236,7 +236,7 @@ sandbox:
   ## MCP gateway URL for sandbox pods (e.g. "http://drua.drua.svc.cluster.local:5254/mcp")
   mcpGatewayUrl: ""
   ## Audience claim for the projected SA token (must match gateway validation)
-  saTokenAudience: "galoy-agents-mcp"
+  saTokenAudience: "drua-mcp"
   image:
     repository: us.gcr.io/galoyorg/sandbox
     digest: ""
@@ -261,7 +261,7 @@ sandbox:
   ## Example: Override or supplement nix cache config at runtime
   # env:
   # - name: NIX_CONFIG
-  #   value: "extra-substituters = https://galoy-agents.cachix.org\nextra-trusted-public-keys = galoy-agents.cachix.org-1:wGb5wYMLJ3yPYoOvf2O5vt9gEZEJ7hHsqDCNPMELGPY="
+  #   value: "extra-substituters = https://drua.cachix.org\nextra-trusted-public-keys = drua.cachix.org-1:wGb5wYMLJ3yPYoOvf2O5vt9gEZEJ7hHsqDCNPMELGPY="
   persistence:
     mountPath: /workspace
     size: 10Gi
@@ -273,7 +273,7 @@ postgresql:
     tag: 14.5.0-debian-11-r35
   auth:
     enablePostgresUser: false
-    username: galoy-agents
-    password: galoy-agents
-    database: galoy-agents
+    username: drua
+    password: drua
+    database: drua
 resources: {}

--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -16,13 +16,13 @@ variable "anthropic_api_key" {
   default = ""
 }
 locals {
-  cluster_name         = "galoy-agents-cluster"
+  cluster_name         = "drua-cluster"
   cluster_location     = "us-east1-b"
-  gcp_project          = "galoy-agents"
-  namespace            = "galoy-agents"
-  sandbox_namespace    = "galoy-agents-sandboxes"
-  controller_namespace = "galoy-agents-sandbox-controller"
-  vpc_name             = "galoy-agents-vpc"
+  gcp_project          = "drua"
+  namespace            = "drua"
+  sandbox_namespace    = "drua-sandboxes"
+  controller_namespace = "drua-sandbox-controller"
+  vpc_name             = "drua-vpc"
   region               = "us-east1"
 
   github_app_private_key = fileexists("${path.module}/github-app-private-key.pem") ? file("${path.module}/github-app-private-key.pem") : ""
@@ -35,9 +35,9 @@ module "postgresql" {
 
   gcp_project      = local.gcp_project
   vpc_name         = local.vpc_name
-  instance_name    = "galoy-agents"
+  instance_name    = "drua"
   region           = local.region
-  databases        = ["galoy-agents"]
+  databases        = ["drua"]
   destroyable      = true
   highly_available = false
   tier             = "db-f1-micro"
@@ -45,7 +45,7 @@ module "postgresql" {
   readonly_users   = ["mcp"]
 }
 
-resource "kubernetes_namespace" "galoy_agents" {
+resource "kubernetes_namespace" "drua" {
   metadata {
     name = local.namespace
   }
@@ -63,18 +63,18 @@ resource "kubernetes_namespace" "sandbox_controller" {
   }
 }
 
-resource "kubernetes_secret" "galoy_agents" {
+resource "kubernetes_secret" "drua" {
   metadata {
-    name      = "galoy-agents"
+    name      = "drua"
     namespace = local.namespace
   }
 
   data = {
-    "pg-con"                 = module.postgresql.creds["galoy-agents"].conn
+    "pg-con"                 = module.postgresql.creds["drua"].conn
     # Read-only DSN for the postgres-mcp sidecar. `?sslmode=require` is
     # required — Cloud SQL's pg_hba.conf rejects unencrypted connections
     # and dbhub crash-loops without it.
-    "pg-mcp-uri"             = "postgres://${module.postgresql.creds["galoy-agents"].readonly_users["mcp"].user}:${module.postgresql.creds["galoy-agents"].readonly_users["mcp"].password}@${module.postgresql.creds["galoy-agents"].host}:5432/galoy-agents?sslmode=require"
+    "pg-mcp-uri"             = "postgres://${module.postgresql.creds["drua"].readonly_users["mcp"].user}:${module.postgresql.creds["drua"].readonly_users["mcp"].password}@${module.postgresql.creds["drua"].host}:5432/drua?sslmode=require"
     "github-client-secret"   = var.github_client_secret
     "gcs-creds"              = file("${path.module}/gcs-creds.json")
     "concourse-username"     = var.concourse_username
@@ -86,7 +86,7 @@ resource "kubernetes_secret" "galoy_agents" {
     "github-app-private-key" = local.github_app_private_key
   }
 
-  depends_on = [kubernetes_namespace.galoy_agents]
+  depends_on = [kubernetes_namespace.drua]
 }
 
 resource "kubernetes_secret" "sandbox_anthropic" {
@@ -184,15 +184,15 @@ resource "kubectl_manifest" "sandbox_extensions" {
 }
 
 resource "postgresql_extension" "vector" {
-  provider = postgresql.galoy_agents
+  provider = postgresql.drua
   name     = "vector"
-  database = "galoy-agents"
+  database = "drua"
 
   depends_on = [module.postgresql]
 }
 
-resource "helm_release" "galoy_agents" {
-  name      = "galoy-agents"
+resource "helm_release" "drua" {
+  name      = "drua"
   chart     = "${path.module}/chart"
   namespace = local.namespace
 
@@ -200,7 +200,7 @@ resource "helm_release" "galoy_agents" {
     templatefile("${path.module}/prod-values.yml.tmpl", {
       image_digest         = var.image_digest
       sandbox_image_digest = var.sandbox_image_digest
-      secret_checksum      = sha256(jsonencode(kubernetes_secret.galoy_agents.data))
+      secret_checksum      = sha256(jsonencode(kubernetes_secret.drua.data))
       tunnel_deployments   = local.tunnel_deployments
     })
   ]
@@ -209,7 +209,7 @@ resource "helm_release" "galoy_agents" {
   timeout           = 900 # 15 minutes
 
   depends_on = [
-    kubernetes_secret.galoy_agents,
+    kubernetes_secret.drua,
     kubernetes_namespace.sandbox,
     google_container_node_pool.gvisor,
     kubectl_manifest.sandbox_controller,
@@ -242,12 +242,12 @@ provider "kubectl" {
 }
 
 provider "postgresql" {
-  alias     = "galoy_agents"
-  host      = module.postgresql.creds["galoy-agents"].host
+  alias     = "drua"
+  host      = module.postgresql.creds["drua"].host
   port      = 5432
   username  = module.postgresql.admin-creds.user
   password  = module.postgresql.admin-creds.password
-  database  = "galoy-agents"
+  database  = "drua"
   superuser = false
 }
 

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -1,4 +1,4 @@
-galoyAgents:
+drua:
   image:
     digest: "${image_digest}"
     tag: ""
@@ -76,7 +76,7 @@ galoyAgents:
     tls:
       - hosts:
           - dashboard.agents.galoy.io
-        secretName: galoy-agents-tls
+        secretName: drua-tls
   secrets:
     create: false
   resources:
@@ -86,14 +86,14 @@ galoyAgents:
     limits:
       memory: 512Mi
   tracing:
-    serviceName: galoy-agents
-    otelExporterOtlpEndpoint: "http://opentelemetry-collector.galoy-agents-otel.svc.cluster.local:4317"
+    serviceName: drua
+    otelExporterOtlpEndpoint: "http://opentelemetry-collector.drua-otel.svc.cluster.local:4317"
 
 sandbox:
   enabled: true
   installController: false
-  namespace: galoy-agents-sandboxes
-  controllerNamespace: galoy-agents-sandbox-controller
+  namespace: drua-sandboxes
+  controllerNamespace: drua-sandbox-controller
   createNamespace: false
   templateName: agent-sandbox
   runtimeClassName: gvisor
@@ -106,8 +106,8 @@ sandbox:
     size: 10Gi
     storageClassName: standard-rwo
   anthropicApiKeySecret: anthropic-api-key
-  otelCollectorNamespace: galoy-agents-otel
-  mcpGatewayUrl: "http://galoy-agents.galoy-agents.svc.cluster.local:5254/mcp"
+  otelCollectorNamespace: drua-otel
+  mcpGatewayUrl: "http://drua.drua.svc.cluster.local:5254/mcp"
 
 kubernetes-mcp-server:
   enabled: true

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -4,7 +4,7 @@
 #@ )
 
 groups:
-- name: galoy-agents
+- name: drua
   jobs:
   - check-code
   - test-integration
@@ -187,8 +187,8 @@ jobs:
             printf '%s' "$TUNNEL_DEPLOYMENTS_PUBLIC_KEYS" > deployment/tf/tunnel-deployments-public-keys.json
             set -x
             echo "Deployment files prepared"
-  - put: tf-galoy-agents-prod
-    tags: [galoy-agents]
+  - put: tf-drua-prod
+    tags: [drua]
     params:
       env_name: prod
       vars_files: [deployment/tf/terraform.tfvars]
@@ -264,7 +264,7 @@ jobs:
             ln -s "$(pwd)/lana-repo" /tmp/repos/lana-bank
             ln -s "$(pwd)/job-repo" /tmp/repos/job
             ln -s "$(pwd)/obix-repo" /tmp/repos/obix
-            ln -s "$(pwd)/repo" /tmp/repos/galoy-agents
+            ln -s "$(pwd)/repo" /tmp/repos/drua
 
             cd repo
             nix run ./ci#build-code-assistant-index -- /tmp/repos "$(pwd)/../index" "$(pwd)/../embedder" "$(pwd)/../code-assistant-model"
@@ -299,11 +299,11 @@ jobs:
             cd repo-updated
             nix run ./ci#commit-hash -- "$(pwd)" \
               charts/drua/values.yaml \
-              "galoyAgents.codeAssistant.indexHash" \
+              "drua.codeAssistant.indexHash" \
               "$INDEX_HASH"
             nix run ./ci#commit-hash -- "$(pwd)" \
               charts/drua/values.yaml \
-              "galoyAgents.codeAssistant.embedderHash" \
+              "drua.codeAssistant.embedderHash" \
               "$EMBEDDER_HASH"
   - put: repo-chart-values
     params:
@@ -606,13 +606,13 @@ resources:
     password: #@ data.values.gar_registry_password
     repository: #@ data.values.gar_registry + "/tunnel-connector"
 
-- name: tf-galoy-agents-prod
+- name: tf-drua-prod
   type: terraform
   source:
     backend_type: gcs
     backend_config:
       bucket: #@ data.values.deploy_tf_state_bucket
-      prefix: galoy-agents/prod
+      prefix: drua/prod
       credentials: #@ data.values.deploy_gcp_creds_json
     env:
       GOOGLE_CREDENTIALS: #@ data.values.deploy_gcp_creds_json

--- a/ci/repipe
+++ b/ci/repipe
@@ -8,7 +8,7 @@ if [[ $(which ytt) == "" ]]; then
 fi
 
 target="${FLY_TARGET:-galoy}"
-team=galoy-agents
+team=drua
 
 TMPDIR=""
 TMPDIR=$(mktemp -d -t repipe.XXXXXX)
@@ -18,5 +18,5 @@ ytt -f ci > ${TMPDIR}/pipeline.yml
 
 echo "Updating pipeline @ ${target}"
 
-fly -t ${target} set-pipeline --team=${team} -p galoy-agents-bin -c ${TMPDIR}/pipeline.yml -n
-fly -t ${target} unpause-pipeline --team=${team} -p galoy-agents-bin
+fly -t ${target} set-pipeline --team=${team} -p drua-bin -c ${TMPDIR}/pipeline.yml -n
+fly -t ${target} unpause-pipeline --team=${team} -p drua-bin

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -10,24 +10,24 @@ gar_registry: us.gcr.io/galoyorg
 gar_registry_user: ((gar-creds.username))
 gar_registry_password: ((gar-creds.password))
 
-folder_registry_image: galoy-agents
+folder_registry_image: drua
 
 cala_git_uri: git@github.com:GaloyMoney/cala.git
 lana_git_uri: git@github.com:GaloyMoney/lana-bank.git
 job_git_uri: git@github.com:GaloyMoney/job.git
 obix_git_uri: git@github.com:GaloyMoney/obix.git
 
-gcs_creds_json: ((galoy-agents-gcp-creds.creds_json))
-code_assistant_gcs_bucket: galoy-agents-models
+gcs_creds_json: ((drua-gcp-creds.creds_json))
+code_assistant_gcs_bucket: drua-models
 
-deploy_gcp_creds_json: ((galoy-agents-gcp-creds.creds_json))
-deploy_tf_state_bucket: galoy-agents-tf-state
-deploy_github_client_secret: ((galoy-agents-prod-secrets.github_client_secret))
+deploy_gcp_creds_json: ((drua-gcp-creds.creds_json))
+deploy_tf_state_bucket: drua-tf-state
+deploy_github_client_secret: ((drua-prod-secrets.github_client_secret))
 deploy_concourse_username: ((galoybot-concourse-creds.username))
 deploy_concourse_password: ((galoybot-concourse-creds.password))
 honeycomb_api_key: ((mcp-upstream.honeycomb_api_key))
 github_pat: ((mcp-upstream.github_pat))
 lingo_api_key: ((mcp-upstream.lingo_dev_api_key))
 deploy_anthropic_api_key: ((anthropic-api-key.key))
-deploy_github_app_private_key: ((galoy-agents-prod-secrets.github_app_private_key))
+deploy_github_app_private_key: ((drua-prod-secrets.github_app_private_key))
 tunnel_deployments_public_keys: ((tunnel-deployments.public_keys))

--- a/core/src/agent/system_prompt.rs
+++ b/core/src/agent/system_prompt.rs
@@ -9,7 +9,7 @@ use super::session::message::SystemBlock;
 /// Identity line shared by every agent role. The workspace name is
 /// interpolated at construction time via [`build_base_block`].
 const BASE_PROMPT_PREFIX: &str = "You are an AI agent operating inside the \
-Galoy Agents platform, in workspace";
+Drua platform, in workspace";
 
 /// Behavioral guidelines shared by every agent role. These are
 /// high-ROI directives drawn from Anthropic's official prompting
@@ -169,7 +169,7 @@ mod tests {
         assert_eq!(blocks.len(), 4);
         match &blocks[0] {
             SystemBlock::Text { text } => {
-                assert!(text.contains("Galoy Agents platform"));
+                assert!(text.contains("Drua platform"));
                 assert!(text.contains("acme-corp"));
             }
         }

--- a/core/src/tunnel.rs
+++ b/core/src/tunnel.rs
@@ -1,7 +1,7 @@
 //! Tunnel transport for deployment-side MCP servers.
 //!
 //! Instead of exposing MCP servers on a public endpoint with JWT auth,
-//! a lightweight connector in the target cluster dials *out* to galoy-agents
+//! a lightweight connector in the target cluster dials *out* to drua
 //! over WebSocket. Tool calls are relayed through the already-authenticated
 //! tunnel — no ingress, Envoy, or JWT validation required in the target
 //! cluster.

--- a/images/tunnel-connector/src/main.rs
+++ b/images/tunnel-connector/src/main.rs
@@ -20,7 +20,7 @@ use serde::{Deserialize, Serialize};
 use tokio_tungstenite::tungstenite;
 
 // ---------------------------------------------------------------------------
-// Wire protocol (mirrored from galoy-agents-core::tunnel)
+// Wire protocol (mirrored from drua-core::tunnel)
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/infra/chart/drua-values.yml.tmpl
+++ b/infra/chart/drua-values.yml.tmpl
@@ -1,4 +1,4 @@
-galoyAgents:
+drua:
   image:
     tag: ${image_tag}
   secrets:
@@ -8,6 +8,6 @@ postgresql:
   image:
     tag: latest
   auth:
-    existingSecret: galoy-agents
+    existingSecret: drua
     secretKeys:
       userPasswordKey: "pg-user-pw"

--- a/infra/chart/main.tf
+++ b/infra/chart/main.tf
@@ -1,17 +1,17 @@
-variable "galoy_agents_namespace" {
-  description = "Namespace for the galoy-agents deployment"
+variable "drua_namespace" {
+  description = "Namespace for the drua deployment"
   type        = string
-  default     = "galoy-agents"
+  default     = "drua"
 }
 
-variable "galoy_agents_image_tag" {
-  description = "Image tag for galoy-agents"
+variable "drua_image_tag" {
+  description = "Image tag for drua"
   type        = string
   default     = "edge"
 }
 
-variable "galoy_agents_secrets" {
-  description = "JSON-encoded secrets for galoy-agents"
+variable "drua_secrets" {
+  description = "JSON-encoded secrets for drua"
   sensitive   = true
   type        = string
   default     = "{}"
@@ -47,26 +47,26 @@ provider "helm" {
 }
 
 locals {
-  secrets = length(var.galoy_agents_secrets) > 2 ? jsondecode(var.galoy_agents_secrets) : {}
+  secrets = length(var.drua_secrets) > 2 ? jsondecode(var.drua_secrets) : {}
 
-  pg_password = try(local.secrets.pg_password, "galoy-agents")
-  pg_con      = try(local.secrets.pg_con, "postgresql://galoy-agents:${local.pg_password}@galoy-agents-postgresql:5432/galoy-agents")
+  pg_password = try(local.secrets.pg_password, "drua")
+  pg_con      = try(local.secrets.pg_con, "postgresql://drua:${local.pg_password}@drua-postgresql:5432/drua")
 
   github_client_id     = try(local.secrets.github_client_id, "dummy-client-id")
   github_client_secret = try(local.secrets.github_client_secret, "dummy-client-secret")
   github_redirect_uri  = try(local.secrets.github_redirect_uri, "http://localhost:5254/auth/callback")
 }
 
-resource "kubernetes_namespace" "galoy_agents" {
+resource "kubernetes_namespace" "drua" {
   metadata {
-    name = var.galoy_agents_namespace
+    name = var.drua_namespace
   }
 }
 
-resource "kubernetes_secret" "galoy_agents" {
+resource "kubernetes_secret" "drua" {
   metadata {
-    name      = "galoy-agents"
-    namespace = kubernetes_namespace.galoy_agents.metadata[0].name
+    name      = "drua"
+    namespace = kubernetes_namespace.drua.metadata[0].name
   }
 
   data = {
@@ -78,18 +78,18 @@ resource "kubernetes_secret" "galoy_agents" {
   }
 }
 
-resource "helm_release" "galoy_agents" {
-  name      = "galoy-agents"
+resource "helm_release" "drua" {
+  name      = "drua"
   chart     = "${path.module}/../../charts/drua"
-  namespace = kubernetes_namespace.galoy_agents.metadata[0].name
+  namespace = kubernetes_namespace.drua.metadata[0].name
 
   values = [
     templatefile("${path.module}/drua-values.yml.tmpl", {
-      image_tag = var.galoy_agents_image_tag
+      image_tag = var.drua_image_tag
     })
   ]
 
-  depends_on = [kubernetes_secret.galoy_agents]
+  depends_on = [kubernetes_secret.drua]
 
   dependency_update = true
   timeout           = 900 # 15 minutes

--- a/server/templates/audit.html
+++ b/server/templates/audit.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Audit Log — Galoy Agents{% endblock %}
+{% block title %}Audit Log — Drua{% endblock %}
 
 {% block nav_audit %}class="active"{% endblock %}
 

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{% block title %}Galoy Agents{% endblock %}</title>
+  <title>{% block title %}Drua{% endblock %}</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
   <script src="https://unpkg.com/htmx.org@2.0.4"></script>
   <style>
@@ -203,7 +203,7 @@
 <body>
   <aside class="sidebar">
     {% block sidebar_content %}
-    <h4>Galoy Agents</h4>
+    <h4>Drua</h4>
 
     <div class="section-label">Workspaces</div>
     <div id="sidebar-ws-list"

--- a/server/templates/cli_login.html
+++ b/server/templates/cli_login.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>CLI Login — Galoy Agents</title>
+  <title>CLI Login — Drua</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
 </head>
 <body>
   <main class="container">
     <article style="margin-top: 4rem; max-width: 480px; margin-left: auto; margin-right: auto;">
       <header>
-        <h1>Galoy Agents CLI</h1>
+        <h1>Drua CLI</h1>
         <p>Sign in to generate a CLI token</p>
       </header>
       {% if dev_auth %}

--- a/server/templates/cli_token.html
+++ b/server/templates/cli_token.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>CLI Token — Galoy Agents</title>
+  <title>CLI Token — Drua</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
   <style>
     .token-box {

--- a/server/templates/code_assistant.html
+++ b/server/templates/code_assistant.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Code Assistant — Galoy Agents{% endblock %}
+{% block title %}Code Assistant — Drua{% endblock %}
 
 {% block nav_code_assistant %}class="active"{% endblock %}
 

--- a/server/templates/code_assistant_disabled.html
+++ b/server/templates/code_assistant_disabled.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Code Assistant — Galoy Agents{% endblock %}
+{% block title %}Code Assistant — Drua{% endblock %}
 
 {% block nav_code_assistant %}class="active"{% endblock %}
 

--- a/server/templates/dashboard.html
+++ b/server/templates/dashboard.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Dashboard — Galoy Agents{% endblock %}
+{% block title %}Dashboard — Drua{% endblock %}
 
 {% block nav_dashboard %}class="active"{% endblock %}
 

--- a/server/templates/login.html
+++ b/server/templates/login.html
@@ -3,14 +3,14 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Login — Galoy Agents</title>
+  <title>Login — Drua</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
 </head>
 <body>
   <main class="container">
     <article style="margin-top: 4rem; max-width: 480px; margin-left: auto; margin-right: auto;">
       <header>
-        <h1>Galoy Agents</h1>
+        <h1>Drua</h1>
         <p>Manage your MCP gateway agents</p>
       </header>
       {% if let Some(msg) = error %}

--- a/server/templates/workspace_agent_detail.html
+++ b/server/templates/workspace_agent_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ agent.name }} — {{ workspace.name }} — Galoy Agents{% endblock %}
+{% block title %}{{ agent.name }} — {{ workspace.name }} — Drua{% endblock %}
 
 {% block head %}
 <style>

--- a/server/templates/workspace_agent_new.html
+++ b/server/templates/workspace_agent_new.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}New Agent — {{ workspace.name }} — Galoy Agents{% endblock %}
+{% block title %}New Agent — {{ workspace.name }} — Drua{% endblock %}
 
 {% block head %}
 <style>

--- a/server/templates/workspace_chat.html
+++ b/server/templates/workspace_chat.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Chat — {{ workspace.name }} — Galoy Agents{% endblock %}
+{% block title %}Chat — {{ workspace.name }} — Drua{% endblock %}
 
 {% block nav_workspaces %}class="active"{% endblock %}
 

--- a/server/templates/workspace_detail.html
+++ b/server/templates/workspace_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ workspace.name }} — Settings — Galoy Agents{% endblock %}
+{% block title %}{{ workspace.name }} — Settings — Drua{% endblock %}
 
 {% block head %}
 <style>

--- a/server/templates/workspace_hub.html
+++ b/server/templates/workspace_hub.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Workspaces — Galoy Agents{% endblock %}
+{% block title %}Workspaces — Drua{% endblock %}
 
 {% block head %}
 <style>
@@ -175,7 +175,7 @@
 
 {% else %}
 {# ── Top-level mode: nav + workspace list ───────────────── #}
-<h4>Galoy Agents</h4>
+<h4>Drua</h4>
 
 <div class="section-label">Workspaces</div>
 {% for ws in workspaces %}

--- a/server/templates/workspace_new.html
+++ b/server/templates/workspace_new.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}New Workspace — Galoy Agents{% endblock %}
+{% block title %}New Workspace — Drua{% endblock %}
 
 {% block content %}
 <h2>New Workspace</h2>

--- a/server/templates/workspace_sandbox_detail.html
+++ b/server/templates/workspace_sandbox_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ sandbox.name }} — {{ workspace.name }} — Galoy Agents{% endblock %}
+{% block title %}{{ sandbox.name }} — {{ workspace.name }} — Drua{% endblock %}
 
 {% block head %}
 <style>

--- a/server/templates/workspace_sandbox_new.html
+++ b/server/templates/workspace_sandbox_new.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}New Sandbox — {{ workspace.name }} — Galoy Agents{% endblock %}
+{% block title %}New Sandbox — {{ workspace.name }} — Drua{% endblock %}
 
 {% block head %}
 <style>

--- a/server/templates/workspace_sandboxes.html
+++ b/server/templates/workspace_sandboxes.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Sandboxes — {{ workspace.name }} — Galoy Agents{% endblock %}
+{% block title %}Sandboxes — {{ workspace.name }} — Drua{% endblock %}
 
 {% block head %}
 <style>

--- a/server/templates/workspace_skill_detail.html
+++ b/server/templates/workspace_skill_detail.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}{{ skill.name }} — {{ workspace.name }} — Galoy Agents{% endblock %}
+{% block title %}{{ skill.name }} — {{ workspace.name }} — Drua{% endblock %}
 
 {% block head %}
 <style>

--- a/server/templates/workspace_skills.html
+++ b/server/templates/workspace_skills.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Skills — {{ workspace.name }} — Galoy Agents{% endblock %}
+{% block title %}Skills — {{ workspace.name }} — Drua{% endblock %}
 
 {% block head %}
 <style>

--- a/server/templates/workspaces.html
+++ b/server/templates/workspaces.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Workspaces — Galoy Agents{% endblock %}
+{% block title %}Workspaces — Drua{% endblock %}
 
 {% block nav_workspaces %}class="active"{% endblock %}
 


### PR DESCRIPTION
## Summary

Renames every remaining `galoy-agents`, `galoy_agents`, `galoyAgents`, and `Galoy Agents` reference to `drua`. Builds on PRs #150 and #163, which deferred infrastructure-coupled identifiers.

48 files changed, 290 / 290 line edits — all string-substitution, no logic changes.

## ⚠️  This PR changes live infrastructure identifiers

Do **not** merge without coordinating each cutover below. Several changes will trigger Terraform `destroy + create` plans on live resources unless `terraform state mv` is run first.

### Helm chart
- `Chart.yaml` `name: galoy-agents` → `drua`. `helm upgrade` on the existing release will fail; either rename the release or delete + recreate.
- All `.galoyAgents.*` value paths → `.drua.*`. Any out-of-tree values files mounted by the deploy pipeline must be updated in lockstep.
- Template helper names `galoyAgents.*` → `drua.*`.
- `serviceName: galoy-agents-dev` → `drua-dev` — changes the OpenTelemetry service identity in tracing backends.
- Postgres user/db/password `galoy-agents` → `drua` — recreates the database; existing data tied to old creds becomes unreachable until migrated.
- `gcsBucket: galoy-agents-models` → `drua-models` — bucket must exist under the new name.
- `saTokenAudience: galoy-agents-mcp` → `drua-mcp`.
- Image repo `us.gcr.io/galoyorg/galoy-agents` → `us.gcr.io/galoyorg/drua` — image must be pushed to new path. Org `galoyorg` left unchanged.

### Terraform (`infra/chart/main.tf`, `ci/deploy/drua/main.tf`)
- Resource addresses `kubernetes_namespace.galoy_agents`, `kubernetes_secret.galoy_agents`, `helm_release.galoy_agents`, `postgresql.galoy_agents` → `.drua`. **Run `terraform state mv` for each before `apply`** to preserve the live resource — otherwise the namespace and secret are destroyed and recreated, with downtime.
- Variables `galoy_agents_namespace`, `galoy_agents_image_tag`, `galoy_agents_secrets` → `drua_*`. Callers passing tfvars must be updated.
- String values `cluster_name`, `gcp_project`, `vpc_name`, `databases`, `namespace`, `sandbox_namespace`, `controller_namespace` all changed from `galoy-agents*` → `drua*`. **The GCP project, GKE cluster, VPC, and namespaces must already exist under the new names** or `apply` will try to create them.

### Concourse (`ci/pipeline.yml`, `ci/values.yml`, `ci/repipe`)
- Job and resource names: `galoy-agents`, `tf-galoy-agents-prod` → `drua`, `tf-drua-prod`.
- `team=galoy-agents` and pipeline `galoy-agents-bin` → `drua` and `drua-bin`. Concourse team must be renamed (or recreated) and the old pipeline destroyed — see paired PR in `galoy-org-infra`.
- Credhub bindings `((galoy-agents-prod-secrets.*))` and `((galoy-agents-gcp-creds.*))` → `((drua-prod-secrets.*))` / `((drua-gcp-creds.*))`. Secrets must be re-stored at new paths before pipeline runs.
- GCS buckets `galoy-agents-models`, `galoy-agents-tf-state` → `drua-models`, `drua-tf-state`.
- Image registry path `galoy-agents` → `drua`.

### Code & docs (cosmetic, no infra impact)
- `core/src/agent/system_prompt.rs` — base prompt text and matching test assertion.
- `core/src/tunnel.rs`, `images/tunnel-connector/src/main.rs` — doc comments referencing `galoy-agents-core`.
- `Makefile:67` — CI check skill prompt referencing `galoy-agents-bin`.
- `server/templates/*.html` — every `<title>Galoy Agents</title>` and brand string → `Drua`. **User-visible.**

## Companion PRs (must merge together)

- `galoy-deployments` — renames `gcp/galoy-agents/` directory, cepler state references, and the `enable_galoy_agents_mcp_access` module variable consumed by lana-bank.
- `galoy-org-infra` — renames the Concourse team TF resource and all Vault secret paths used by this pipeline.

## Recommended cutover order

1. Provision new GCP project / GCS buckets / Concourse team / Vault paths under the `drua` names (out of band).
2. Merge `galoy-org-infra` PR (Vault + Concourse team).
3. Merge `galoy-deployments` PR (cepler state + module var).
4. Merge this PR (chart + pipeline + code).
5. Run pipeline against staging first; verify; then prod.

## Test plan

- [ ] `helm template charts/drua` renders cleanly with renamed value paths
- [ ] `terraform plan` in `ci/deploy/drua/` shows no unexpected resource recreations after `terraform state mv`
- [ ] `terraform plan` in `infra/chart/` shows no unexpected resource recreations after `terraform state mv`
- [ ] `cargo test` passes (system_prompt assertion updated)
- [ ] Render workspace_hub.html locally, confirm "Drua" branding
- [ ] Staging deploy completes end-to-end before prod
- [ ] Old pipeline `galoy-agents-bin` paused/destroyed before new `drua-bin` set
- [ ] Old GCS buckets archived/deleted only after new buckets are populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)