### PR TITLE
feat(toolset): add GitHub Actions read-only MCP upstream

### DIFF
--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -95,6 +95,21 @@ galoyAgents:
     #     - issue_read
     #     - list_issues
     #     - search_issues
+    # - name: github_actions
+    #   url: https://api.githubcopilot.com/x/actions/readonly
+    #   toolPrefix: github_actions
+    #   category: ci
+    #   categoryDescription: "GitHub Actions workflows, runs, jobs, and logs"
+    #   allowedTools:
+    #     - list_workflows
+    #     - list_workflow_runs
+    #     - get_workflow_run
+    #     - get_workflow_run_logs
+    #     - get_workflow_run_usage
+    #     - list_workflow_jobs
+    #     - get_job_logs
+    #     - list_workflow_run_artifacts
+    #     - download_workflow_run_artifact
     # - name: lingo
     #   url: https://mcp.lingo.dev/account
     #   authHeaderName: x-api-key

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -60,6 +60,21 @@ galoyAgents:
           - issue_read
           - list_issues
           - search_issues
+      - name: github_actions
+        url: https://api.githubcopilot.com/x/actions/readonly
+        toolPrefix: github_actions
+        category: ci
+        categoryDescription: "GitHub Actions workflows, runs, jobs, and logs"
+        allowedTools:
+          - list_workflows
+          - list_workflow_runs
+          - get_workflow_run
+          - get_workflow_run_logs
+          - get_workflow_run_usage
+          - list_workflow_jobs
+          - get_job_logs
+          - list_workflow_run_artifacts
+          - download_workflow_run_artifact
       - name: lingo
         url: https://mcp.lingo.dev/account
         authHeaderName: x-api-key

--- a/drua.yml
+++ b/drua.yml
@@ -75,6 +75,21 @@ toolsets:
         - issue_read
         - list_issues
         - search_issues
+    - name: github_actions
+      url: https://api.githubcopilot.com/x/actions/readonly
+      tool_prefix: github_actions
+      category: ci
+      category_description: "GitHub Actions workflows, runs, jobs, and logs"
+      allowed_tools:
+        - list_workflows
+        - list_workflow_runs
+        - get_workflow_run
+        - get_workflow_run_logs
+        - get_workflow_run_usage
+        - list_workflow_jobs
+        - get_job_logs
+        - list_workflow_run_artifacts
+        - download_workflow_run_artifact
     - name: lingo
       url: https://mcp.lingo.dev/account
       auth_header_name: x-api-key


### PR DESCRIPTION
## Summary
- Adds a second GitHub MCP upstream pointing to `api.githubcopilot.com/x/actions/readonly` — the Actions-specific endpoint that exposes workflow/run/job tools not available on the default `/mcp/readonly` endpoint
- Whitelists 9 read-only tools: `list_workflows`, `list_workflow_runs`, `get_workflow_run`, `get_workflow_run_logs`, `get_workflow_run_usage`, `list_workflow_jobs`, `get_job_logs`, `list_workflow_run_artifacts`, `download_workflow_run_artifact`
- Uses `tool_prefix: github_actions` and `category: ci` to namespace alongside the existing `github` source-control tools
- Auth uses the same mechanism as all upstreams: `GITHUB_ACTIONS_AUTH_HEADER` env var (auto-wired from K8s secret key `github_actions-auth-header` by the Helm deployment template)

## Files changed
- `drua.yml` — local dev config
- `ci/deploy/drua/prod-values.yml.tmpl` — production Helm values
- `charts/drua/values.yaml` — Helm chart default values (commented-out example)

## Test plan
- [x] `nix flake check` passes (fmt, clippy, nextest, config validation, graphql schema)
- [ ] Verify in staging that `search_tools(query="actions")` discovers the new tools
- [ ] Verify `call_tool("github_actions_list_workflow_runs", {...})` returns data
- [ ] Confirm existing `github_*` source-control tools still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)