### PR TITLE
feat(agent): add compose efficiency guideline to system prompt

### DIFF
--- a/core/src/agent/system_prompt.rs
+++ b/core/src/agent/system_prompt.rs
@@ -29,6 +29,17 @@ parallel. For example, when reading several files, read them all at \
 once rather than one at a time.
 </use_parallel_tool_calls>
 
+<use_compose_for_efficiency>
+When a task involves multiple dependent tool calls, data filtering, or \
+fan-out patterns (e.g. checking N items in parallel), prefer the \
+`compose` tool over sequential `call_tool` round trips. A single \
+compose call executes JavaScript that can chain tools, filter results, \
+and use Promise.all() — reducing latency and keeping large intermediate \
+data off the conversation context. Reserve individual call_tool for \
+one-off lookups or when you need to inspect output before deciding \
+what to do next.
+</use_compose_for_efficiency>
+
 <workspace_notes>
 The workspace has a shared notes system (the `notes` tool). Notes are \
 concise knowledge snippets that persist across agent sessions. They are \
@@ -180,6 +191,7 @@ mod tests {
             SystemBlock::Text { text } => {
                 assert!(text.contains("investigate_before_answering"));
                 assert!(text.contains("use_parallel_tool_calls"));
+                assert!(text.contains("use_compose_for_efficiency"));
             }
         }
         match &blocks[3] {
@@ -209,6 +221,7 @@ mod tests {
             SystemBlock::Text { text } => {
                 assert!(text.contains("investigate_before_answering"));
                 assert!(text.contains("use_parallel_tool_calls"));
+                assert!(text.contains("use_compose_for_efficiency"));
             }
         }
         match &blocks[3] {


### PR DESCRIPTION
## Summary

- Adds `<use_compose_for_efficiency>` behavioral directive to the shared agent system prompt
- Sits alongside the existing `<use_parallel_tool_calls>` guideline — same category of efficiency pattern
- Nudges agents to prefer `compose` for dependent multi-step tool chains, data filtering, and fan-out patterns (`Promise.all()`)
- Visible to both workspace leads and task agents

Informed by Anthropic's [Code Execution with MCP](https://www.anthropic.com/engineering/code-execution-with-mcp) and [Writing Tools for Agents](https://www.anthropic.com/engineering/writing-tools-for-agents) guidance on reducing round trips and keeping intermediate data off the conversation context.

## Test plan

- [x] Both `system_prompt` tests updated and passing
- [x] `nix flake check` (fmt, clippy, nextest) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)