### PR TITLE
fix(compose): steer agents toward compose_types before guessing

### DIFF
--- a/core/src/agent/system_prompt.rs
+++ b/core/src/agent/system_prompt.rs
@@ -38,6 +38,9 @@ and use Promise.all() — reducing latency and keeping large intermediate \
 data off the conversation context. Reserve individual call_tool for \
 one-off lookups or when you need to inspect output before deciding \
 what to do next.
+
+Before writing the script, call `compose_types({tool_names: ['<prefix>_*']})` \
+to fetch typed signatures — never guess tool or parameter names.
 </use_compose_for_efficiency>
 
 <workspace_notes>
@@ -187,6 +190,7 @@ mod tests {
         assert!(blocks[2].text().contains("investigate_before_answering"));
         assert!(blocks[2].text().contains("use_parallel_tool_calls"));
         assert!(blocks[2].text().contains("use_compose_for_efficiency"));
+        assert!(blocks[2].text().contains("compose_types"));
         assert!(matches!(&blocks[3], SystemBlock::Role { .. }));
         assert!(blocks[3].text().contains("workspace lead"));
     }
@@ -210,6 +214,7 @@ mod tests {
         assert!(blocks[2].text().contains("investigate_before_answering"));
         assert!(blocks[2].text().contains("use_parallel_tool_calls"));
         assert!(blocks[2].text().contains("use_compose_for_efficiency"));
+        assert!(blocks[2].text().contains("compose_types"));
         assert!(matches!(&blocks[3], SystemBlock::Role { .. }));
         assert!(blocks[3].text().contains("task agent"));
         assert!(blocks[3].text().contains("default_to_action"));

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -96,7 +96,8 @@ impl TopLevelTool for ComposeTool {
          (e.g. `tools.honeycomb.list_environments({...})`). Flat prefixed names also work \
          (e.g. `tools.honeycomb_list_environments({...})`). \
          Use `return` for the final value. Top-level `await` and `Promise.all()` are supported. \
-         TypeScript declarations for available tools are included in the execution context.\n\n\
+         **Call `compose_types` first** to fetch exact tool signatures and parameter names \
+         — guessing leads to runtime errors that waste a round trip.\n\n\
          Example:\n```js\nconst envs = await tools.honeycomb.list_environments({});\n\
          const issues = await tools.github.list_issues({ repo: 'org/repo', state: 'open' });\n\
          const stale = issues.filter(i => Date.now() - Date.parse(i.updated_at) > 7*86400*1000);\n\
@@ -235,10 +236,12 @@ impl js_engine::ToolDispatcher for CatalogDispatcher {
             let result = set
                 .call(&self.subject, &tool_name, inner_args)
                 .await
-                .map_err(|e| e.to_string())?;
+                .map_err(|e| with_hint(name, e.to_string()))?;
 
             let filter = default_filter.unwrap_or_else(OutputFilter::global_default);
-            let filtered = filter.apply(result).map_err(|e| e.to_string())?;
+            let filtered = filter
+                .apply(result)
+                .map_err(|e| with_hint(name, e.to_string()))?;
 
             if let Some(structured) = &filtered.structured_content {
                 return Ok(structured.clone());
@@ -296,7 +299,7 @@ impl CatalogDispatcher {
             map.get(name)
                 .filter(|t| t.composable() && t.is_visible(&self.subject))
                 .cloned()
-                .ok_or_else(|| format!("Tool not found: {name}"))?
+                .ok_or_else(|| with_hint(name, format!("Tool not found: {name}")))?
         };
 
         Audit::record_action(format!("compose > top_level: {name}"));
@@ -310,7 +313,7 @@ impl CatalogDispatcher {
         let result = tool
             .call(&self.subject, inner_args)
             .await
-            .map_err(|e| e.to_string())?;
+            .map_err(|e| with_hint(name, e.to_string()))?;
 
         // Prefer structured_content (typed JSON) over text parsing
         if let Some(structured) = &result.structured_content {
@@ -496,4 +499,28 @@ pub(super) fn output_schema_to_ts(schema: &serde_json::Value) -> String {
         parts.push(format!("{name}{optional}: {ts_type}"));
     }
     format!("{{ {} }}", parts.join("; "))
+}
+
+/// Append a "call `compose_types` first" suggestion to a dispatcher error so
+/// the agent learns to fetch real signatures instead of re-guessing. The
+/// prefix is derived from the requested tool name (everything before the
+/// first underscore) so the hint scopes to the relevant namespace.
+fn with_hint(tool_name: &str, raw: String) -> String {
+    let prefix = tool_name.split('_').next().unwrap_or("*");
+    format!(
+        "{raw}\nHint: call compose_types({{tool_names:[\"{prefix}_*\"]}}) \
+         to see available signatures."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn with_hint_appends_compose_types_suggestion() {
+        let out = with_hint("concourse_list_builds", "Tool not found".to_string());
+        assert!(out.contains("compose_types"));
+        assert!(out.contains("concourse_*"));
+    }
 }


### PR DESCRIPTION
## Summary

Three small reliability fixes for the `compose` tool, motivated by a production test in workspace `compose-test` that burned **235k tokens across 12 turns** (audit entries `8135-8144`) before the agent stopped hallucinating tool/parameter names and called `compose_types` to discover real signatures.

### Fix 1 — `ComposeTool::description`
Replace the misleading line claiming "TypeScript declarations for available tools are included in the execution context" (true at script *runtime*, but invisible to the agent *authoring* the script) with an explicit directive: **call `compose_types` first** to fetch exact tool signatures and parameter names.

### Fix 2 — `<use_compose_for_efficiency>` system-prompt block
Append a one-line instruction to call `compose_types({tool_names: ['<prefix>_*']})` before writing the script — never guess tool or parameter names. Both `system_prompt` tests now assert the block contains `compose_types`.

### Fix 3 — `CatalogDispatcher` error paths
Add a `with_hint(tool_name, raw)` helper that appends a scoped suggestion (`call compose_types({tool_names:["<prefix>_*"]})`) to every dispatcher error. Wired into all four `Err` sites in `CatalogDispatcher::call_tool` and `call_top_level` (`set.call`, `filter.apply`, `Tool not found`, `tool.call`). Includes a unit test.

Fix 4 (auto-include compose_types output in error responses) deliberately deferred — try the cheap fixes first.

## Test plan

- [x] `nix flake check` passes (fmt, clippy, nextest, graphql, default-config)
- [x] `with_hint_appends_compose_types_suggestion` unit test covers prefix derivation
- [x] `system_prompt` tests assert the new `compose_types` directive in both `WorkspaceLead` and `Agent` roles

🤖 Generated with [Claude Code](https://claude.com/claude-code)