### PR TITLE
fix(compose): handle array output schemas in TS declaration generator

### DIFF
--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -473,10 +473,27 @@ pub(super) fn json_schema_to_ts(schema: &serde_json::Value) -> &'static str {
     }
 }
 
-/// Convert an output JSON Schema (root type "object") into a TypeScript
-/// inline object type, e.g. `{ temperature: number; humidity: number }`.
-/// Falls back to `any` for schemas that aren't simple object types.
+/// Convert an output JSON Schema into a TypeScript inline type.
+///
+/// Handles the two common shapes catalog tools produce:
+/// - `type: "object"` → `{ key: T; ... }`
+/// - `type: "array"` → `T[]` (recursing into `items` for object element types)
+///
+/// Falls back to `any` for schemas that don't match either shape.
 pub(super) fn output_schema_to_ts(schema: &serde_json::Value) -> String {
+    // Array: render items type with [] suffix.
+    if schema.get("type").and_then(|t| t.as_str()) == Some("array") {
+        if let Some(items) = schema.get("items") {
+            // Object items → recurse for typed properties.
+            if items.get("properties").is_some() {
+                return format!("{}[]", output_schema_to_ts(items));
+            }
+            // Primitive items (string[], number[], etc.).
+            return format!("{}[]", json_schema_to_ts(items));
+        }
+        return "any[]".to_string();
+    }
+
     let properties = match schema.get("properties").and_then(|p| p.as_object()) {
         Some(p) if !p.is_empty() => p,
         _ => return "any".to_string(),
@@ -522,5 +539,44 @@ mod tests {
         let out = with_hint("concourse_list_builds", "Tool not found".to_string());
         assert!(out.contains("compose_types"));
         assert!(out.contains("concourse_*"));
+    }
+
+    #[test]
+    fn output_schema_array_of_objects() {
+        let schema = serde_json::json!({
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "build_id": { "type": "integer" },
+                    "name": { "type": "string" }
+                },
+                "required": ["build_id", "name"]
+            }
+        });
+        let ts = output_schema_to_ts(&schema);
+        assert!(ts.contains("build_id: number"));
+        assert!(ts.contains("name: string"));
+        assert!(ts.ends_with("[]"));
+    }
+
+    #[test]
+    fn output_schema_array_of_primitives() {
+        let schema = serde_json::json!({
+            "type": "array",
+            "items": { "type": "string" }
+        });
+        assert_eq!(output_schema_to_ts(&schema), "string[]");
+    }
+
+    #[test]
+    fn output_schema_flat_object_still_works() {
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": { "logs": { "type": "string" } },
+            "required": ["logs"]
+        });
+        let ts = output_schema_to_ts(&schema);
+        assert!(ts.contains("logs: string"));
     }
 }


### PR DESCRIPTION
## Summary

`output_schema_to_ts` in `core/src/toolset/top_level/compose.rs` only matched `type: \"object\"` schemas, so any catalog tool returning `Vec<T>` rendered as `Promise<any>` in `compose_types` — even when the upstream schema was fully declared.

Concretely, `concourse_list_builds_for_job` (declared via `LazyLock::new(schema_for::<Vec<BuildSummaryOutput>>)` in #208) was emitting:

\`\`\`ts
function list_builds_for_job(args: {...}): Promise<any>;
\`\`\`

instead of:

\`\`\`ts
function list_builds_for_job(args: {...}): Promise<{ build_id: number; name: string; status: string; start_time?: number; end_time?: number }[]>;
\`\`\`

Production audit log (workspace `compose-test`, agent id `019dcf14-fd93-7c00-bd72-734b300f2773`) shows the agent making **5 probe calls** to `list_builds_for_job` to learn that `build_id` (numeric API id) and `name` (display string like \"748\") are different fields. With the typed signature, the distinction is obvious and the probes go away.

## What changed

Add an array branch at the top of `output_schema_to_ts`:
- Object items → recurse for typed `{ key: T; ... }[]`.
- Primitive items → `string[]` / `number[]` / etc. via the existing `json_schema_to_ts` mapper.
- No items → `any[]`.

Object handling below is unchanged.

## Known related gaps (not fixed here)

The generator still doesn't handle `oneOf`, `enum`, `$ref`, or nullable unions like `[\"integer\", \"null\"]`. Discussed with PM — this PR keeps scope small; broader generator work is a separate design conversation (no obvious off-the-shelf Rust runtime crate for JSON Schema → TS).

## Test plan

- [x] `nix flake check` (fmt + clippy + nextest + graphql + default-config) green
- [x] `output_schema_array_of_objects` — `[{ build_id: number; name: string }]`
- [x] `output_schema_array_of_primitives` — `string[]`
- [x] `output_schema_flat_object_still_works` — regression guard for the existing object path

🤖 Generated with [Claude Code](https://claude.com/claude-code)