### PR TITLE
feat(compose): describe_tool TS signature + split memory caps

### DIFF
--- a/charts/drua/templates/configmap.yaml
+++ b/charts/drua/templates/configmap.yaml
@@ -75,7 +75,8 @@ data:
       {{- with .Values.galoyAgents.config.compose }}
       compose:
         max_tool_calls: {{ printf "%d" (int .maxToolCalls) }}
-        max_result_bytes: {{ printf "%d" (int .maxResultBytes) }}
+        max_tool_result_bytes: {{ printf "%d" (int .maxToolResultBytes) }}
+        max_return_bytes: {{ printf "%d" (int .maxReturnBytes) }}
         memory_limit_bytes: {{ printf "%d" (int .memoryLimitBytes) }}
         stack_limit_bytes: {{ printf "%d" (int .stackLimitBytes) }}
         default_timeout_ms: {{ printf "%d" (int .defaultTimeoutMs) }}

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -74,14 +74,18 @@ galoyAgents:
       team: ""
     ## JS-engine sandbox limits for the `compose` top-level tool. Each
     ## key maps 1:1 to a JsEngine setter; missing keys fall back to the
-    ## drua-core defaults (50 calls / 100 KiB / 8 MiB / 512 KiB / 120 s
-    ## default / 300 s max). Byte-valued limits are quoted to keep YAML
-    ## from auto-promoting them to float64 — Helm's serializer otherwise
-    ## renders e.g. 16777216 as "1.6777216e+07", which Rust serde rejects
-    ## for usize fields.
+    ## drua-core defaults (50 calls / 4 MiB per inner tool result /
+    ## 100 KiB final return / 8 MiB / 512 KiB / 120 s default / 300 s max).
+    ## Byte-valued limits are quoted to keep YAML from auto-promoting them
+    ## to float64 — Helm's serializer otherwise renders e.g. 16777216 as
+    ## "1.6777216e+07", which Rust serde rejects for usize fields.
     compose:
       maxToolCalls: 50
-      maxResultBytes: "102400"
+      ## Per inner-tool-result cap. Scripts may pull large payloads
+      ## (logs, manifests) and filter them before returning.
+      maxToolResultBytes: "4194304"
+      ## Final-return cap. Bounded so the agent context stays clean.
+      maxReturnBytes: "102400"
       memoryLimitBytes: "8388608"
       stackLimitBytes: "524288"
       defaultTimeoutMs: 120000

--- a/core/src/agent/system_prompt.rs
+++ b/core/src/agent/system_prompt.rs
@@ -39,8 +39,10 @@ data off the conversation context. Reserve individual call_tool for \
 one-off lookups or when you need to inspect output before deciding \
 what to do next.
 
-Before writing the script, call `compose_types({tool_names: ['<prefix>_*']})` \
-to fetch typed signatures — never guess tool or parameter names.
+Before writing the script, fetch typed signatures via \
+`compose_types({tool_names: ['<prefix>_*']})` for batch lookups, or \
+`describe_tool({tool_name: '<name>'})` for a single-tool deep-dive — \
+never guess tool or parameter names.
 </use_compose_for_efficiency>
 
 <workspace_notes>
@@ -191,6 +193,7 @@ mod tests {
         assert!(blocks[2].text().contains("use_parallel_tool_calls"));
         assert!(blocks[2].text().contains("use_compose_for_efficiency"));
         assert!(blocks[2].text().contains("compose_types"));
+        assert!(blocks[2].text().contains("describe_tool"));
         assert!(matches!(&blocks[3], SystemBlock::Role { .. }));
         assert!(blocks[3].text().contains("workspace lead"));
     }
@@ -215,6 +218,7 @@ mod tests {
         assert!(blocks[2].text().contains("use_parallel_tool_calls"));
         assert!(blocks[2].text().contains("use_compose_for_efficiency"));
         assert!(blocks[2].text().contains("compose_types"));
+        assert!(blocks[2].text().contains("describe_tool"));
         assert!(matches!(&blocks[3], SystemBlock::Role { .. }));
         assert!(blocks[3].text().contains("task agent"));
         assert!(blocks[3].text().contains("default_to_action"));

--- a/core/src/toolset/config.rs
+++ b/core/src/toolset/config.rs
@@ -18,8 +18,14 @@ pub struct ToolSetsConfig {
 pub struct ComposeConfig {
     #[serde(default = "default_max_tool_calls")]
     pub max_tool_calls: usize,
-    #[serde(default = "default_max_result_bytes")]
-    pub max_result_bytes: usize,
+    /// Cap on a single inner-tool result, in bytes. Lets scripts pull
+    /// large payloads (logs, manifests) and filter them before returning.
+    #[serde(default = "default_max_tool_result_bytes")]
+    pub max_tool_result_bytes: usize,
+    /// Cap on the script's final return value, in bytes. Bounded so the
+    /// agent context stays clean.
+    #[serde(default = "default_max_return_bytes")]
+    pub max_return_bytes: usize,
     #[serde(default = "default_memory_limit_bytes")]
     pub memory_limit_bytes: usize,
     #[serde(default = "default_stack_limit_bytes")]
@@ -34,7 +40,8 @@ impl Default for ComposeConfig {
     fn default() -> Self {
         Self {
             max_tool_calls: default_max_tool_calls(),
-            max_result_bytes: default_max_result_bytes(),
+            max_tool_result_bytes: default_max_tool_result_bytes(),
+            max_return_bytes: default_max_return_bytes(),
             memory_limit_bytes: default_memory_limit_bytes(),
             stack_limit_bytes: default_stack_limit_bytes(),
             default_timeout_ms: default_default_timeout_ms(),
@@ -47,7 +54,11 @@ fn default_max_tool_calls() -> usize {
     50
 }
 
-fn default_max_result_bytes() -> usize {
+fn default_max_tool_result_bytes() -> usize {
+    4 * 1024 * 1024
+}
+
+fn default_max_return_bytes() -> usize {
     100 * 1024
 }
 

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -20,6 +20,7 @@ use crate::auth::AuthSubject;
 use super::super::error::ToolSetsError;
 use super::super::filter::OutputFilter;
 use super::super::traits::{SearchableToolSet, TopLevelTool};
+use super::compose::{output_schema_to_ts, schema_to_ts_params};
 use super::schema_for;
 
 // ---------------------------------------------------------------------------
@@ -295,14 +296,35 @@ impl DescribeCatalogTool {
             .and_then(|s| serde_json::to_string_pretty(s.as_ref()).ok())
             .map(|s| format!("\n\n### Output schema\n```json\n{s}\n```"))
             .unwrap_or_default();
+
+        // Embed a TypeScript signature so agents writing `compose` scripts
+        // can read the typed shape directly here, without a follow-up
+        // `compose_types` round trip. `compose_types` remains useful for
+        // batch / prefix-glob lookups.
+        let input_schema_value = serde_json::Value::Object(tool.input_schema.as_ref().clone());
+        let input_ts = schema_to_ts_params(&input_schema_value);
+        let output_ts = tool
+            .output_schema
+            .as_ref()
+            .map(|s| {
+                let v = serde_json::Value::Object(s.as_ref().clone());
+                output_schema_to_ts(&v)
+            })
+            .unwrap_or_else(|| "any".to_string());
+        let ts_signature = format!(
+            "\n\n### TypeScript signature (for use in `compose`)\n```ts\nfunction {tool}(args: {{ {input_ts} }}): Promise<{output_ts}>;\n```",
+            tool = entry.tool_name,
+        );
+
         format!(
-            "## {}\n\nUpstream: {}\nCategory: {}\n\n{}\n\n### Parameters\n```json\n{}\n```{}\n\n### Default output filter\n{}\n\nUse call_tool(\"{}\", {{...}}) to execute.",
+            "## {}\n\nUpstream: {}\nCategory: {}\n\n{}\n\n### Parameters\n```json\n{}\n```{}{}\n\n### Default output filter\n{}\n\nUse call_tool(\"{}\", {{...}}) to execute.",
             entry.prefixed_name,
             entry.upstream_name,
             entry.category,
             description,
             schema,
             output_section,
+            ts_signature,
             filter_desc,
             entry.prefixed_name,
         )
@@ -580,6 +602,36 @@ mod tests {
                     .collect(),
             }
         }
+
+        /// Build a stub with explicit input/output JSON Schemas, used to
+        /// exercise the TypeScript signature embed in `describe_tool`.
+        fn with_typed_tool(
+            name: &str,
+            description: &str,
+            input_schema: serde_json::Value,
+            output_schema: serde_json::Value,
+        ) -> Self {
+            let input: JsonObject = match input_schema {
+                serde_json::Value::Object(m) => m,
+                _ => Default::default(),
+            };
+            let out = match output_schema {
+                serde_json::Value::Object(m) => Some(Arc::new(m)),
+                _ => None,
+            };
+            let mut tool = Tool::default();
+            tool.name = name.to_string().into();
+            tool.description = Some(description.to_string().into());
+            tool.input_schema = Arc::new(input);
+            tool.output_schema = out;
+            Self {
+                entries: vec![ToolSetEntry {
+                    name: name.to_string(),
+                    description: tool,
+                    default_output_filter: None,
+                }],
+            }
+        }
     }
 
     #[async_trait::async_trait]
@@ -677,6 +729,68 @@ mod tests {
 
         let results = catalog.execute_search(&AuthSubject::Anonymous, Some("nonexistent"), None);
         assert!(results.is_empty());
+    }
+
+    #[test]
+    fn describe_tool_includes_ts_signature() {
+        // Tool with both an input and output schema; describe_tool's
+        // formatted output should embed the TypeScript signature so
+        // agents writing compose scripts get the typed shape inline.
+        let stub = StubToolSet::with_typed_tool(
+            "list_envs",
+            "List environments.",
+            json!({
+                "type": "object",
+                "properties": {
+                    "limit": { "type": "integer" },
+                    "name": { "type": "string" }
+                },
+                "required": ["name"]
+            }),
+            json!({
+                "type": "object",
+                "properties": {
+                    "id": { "type": "string" },
+                    "count": { "type": "integer" }
+                },
+                "required": ["id", "count"]
+            }),
+        );
+
+        let sets: Vec<Arc<dyn SearchableToolSet>> =
+            vec![Arc::new(stub) as Arc<dyn SearchableToolSet>];
+        let describe = DescribeCatalogTool::new(Arc::new(RwLock::new(sets)));
+        let entry = describe
+            .execute_describe(&AuthSubject::Anonymous, "stub_list_envs")
+            .expect("entry should be visible");
+        let formatted = DescribeCatalogTool::format_entry(&entry);
+
+        assert!(
+            formatted.contains("### TypeScript signature"),
+            "missing TS signature heading in:\n{formatted}"
+        );
+        assert!(
+            formatted.contains("function list_envs(args: {"),
+            "missing function declaration in:\n{formatted}"
+        );
+        // Required fields render without `?`, optional fields with `?`.
+        assert!(
+            formatted.contains("name: string"),
+            "missing required string param in:\n{formatted}"
+        );
+        assert!(
+            formatted.contains("limit?: number"),
+            "missing optional number param in:\n{formatted}"
+        );
+        // Output schema → inline object type with `Promise<...>` wrapper.
+        assert!(
+            formatted.contains("Promise<{"),
+            "missing Promise wrapper in:\n{formatted}"
+        );
+        assert!(
+            formatted.contains("id: string"),
+            "missing return field in:\n{formatted}"
+        );
     }
 
     #[test]

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -156,7 +156,8 @@ impl TopLevelTool for ComposeTool {
 
         let engine = js_engine::JsEngine::new()
             .with_max_tool_calls(self.config.max_tool_calls)
-            .with_max_result_bytes(self.config.max_result_bytes)
+            .with_max_tool_result_bytes(self.config.max_tool_result_bytes)
+            .with_max_return_bytes(self.config.max_return_bytes)
             .with_memory_limit(self.config.memory_limit_bytes)
             .with_stack_limit(self.config.stack_limit_bytes);
         let result = engine
@@ -358,7 +359,7 @@ fn extract_text(result: &CallToolResult) -> String {
 ///
 /// When a tool has an `output_schema`, the return type is derived from that
 /// schema instead of the default `any`.
-pub(super) fn generate_dts(
+pub(crate) fn generate_dts(
     subject: &AuthSubject,
     sets: &[Arc<dyn SearchableToolSet>],
     top_level: &HashMap<String, Arc<dyn TopLevelTool>>,
@@ -435,7 +436,7 @@ pub(super) fn generate_dts(
 /// object types. Arrays become `T[]`.
 ///
 /// Example output: `repo: string; state?: string; limit?: number`
-pub(super) fn schema_to_ts_params(schema: &serde_json::Value) -> String {
+pub(crate) fn schema_to_ts_params(schema: &serde_json::Value) -> String {
     let properties = match schema.get("properties").and_then(|p| p.as_object()) {
         Some(p) => p,
         None => return "...args: any".to_string(),
@@ -461,7 +462,7 @@ pub(super) fn schema_to_ts_params(schema: &serde_json::Value) -> String {
 }
 
 /// Convert a single JSON Schema type definition to a TypeScript type string.
-pub(super) fn json_schema_to_ts(schema: &serde_json::Value) -> &'static str {
+pub(crate) fn json_schema_to_ts(schema: &serde_json::Value) -> &'static str {
     match schema.get("type").and_then(|t| t.as_str()) {
         Some("string") => "string",
         Some("number" | "integer") => "number",
@@ -480,7 +481,7 @@ pub(super) fn json_schema_to_ts(schema: &serde_json::Value) -> &'static str {
 /// - `type: "array"` → `T[]` (recursing into `items` for object element types)
 ///
 /// Falls back to `any` for schemas that don't match either shape.
-pub(super) fn output_schema_to_ts(schema: &serde_json::Value) -> String {
+pub(crate) fn output_schema_to_ts(schema: &serde_json::Value) -> String {
     // Array: render items type with [] suffix.
     if schema.get("type").and_then(|t| t.as_str()) == Some("array") {
         if let Some(items) = schema.get("items") {
@@ -493,6 +494,7 @@ pub(super) fn output_schema_to_ts(schema: &serde_json::Value) -> String {
         }
         return "any[]".to_string();
     }
+
 
     let properties = match schema.get("properties").and_then(|p| p.as_object()) {
         Some(p) if !p.is_empty() => p,

--- a/dev/drua.default.yml
+++ b/dev/drua.default.yml
@@ -25,7 +25,8 @@ toolsets:
     db_path: ''
   compose:
     max_tool_calls: 50
-    max_result_bytes: 102400
+    max_tool_result_bytes: 4194304
+    max_return_bytes: 102400
     memory_limit_bytes: 8388608
     stack_limit_bytes: 524288
     default_timeout_ms: 120000

--- a/lib/js-engine/src/error.rs
+++ b/lib/js-engine/src/error.rs
@@ -14,6 +14,8 @@ pub enum JsEngineError {
     MemoryLimit,
     #[error("JsEngineError - ToolCallLimit: script exceeded {max} tool calls")]
     ToolCallLimit { max: usize },
-    #[error("JsEngineError - ResultTooLarge: {size} bytes (max {max})")]
-    ResultTooLarge { size: usize, max: usize },
+    #[error("JsEngineError - ToolResultTooLarge: {size} bytes (max {max}). The tool returned more data than compose can hold in a single result. Try a more specific query (e.g. limit/filter parameters) or fall back to call_tool with output_filter.")]
+    ToolResultTooLarge { size: usize, max: usize },
+    #[error("JsEngineError - ReturnTooLarge: {size} bytes (max {max}). Filter or summarize in the script before returning — compose's job is to shrink large tool results into a small agent-readable answer.")]
+    ReturnTooLarge { size: usize, max: usize },
 }

--- a/lib/js-engine/src/lib.rs
+++ b/lib/js-engine/src/lib.rs
@@ -44,7 +44,13 @@ pub struct JsEngine {
     memory_limit: usize,
     stack_limit: usize,
     max_tool_calls: usize,
-    max_result_bytes: usize,
+    /// Cap on a single inner-tool result, in bytes. Scripts can pull large
+    /// payloads (logs, manifests) and filter them before returning.
+    max_tool_result_bytes: usize,
+    /// Cap on the script's final return value, in bytes. Bounded so the
+    /// agent context stays clean; compose's job is to shrink large tool
+    /// results into small agent-readable answers.
+    max_return_bytes: usize,
 }
 
 impl Default for JsEngine {
@@ -59,7 +65,8 @@ impl JsEngine {
             memory_limit: 8 * 1024 * 1024, // 8 MB
             stack_limit: 512 * 1024,       // 512 KB
             max_tool_calls: 50,
-            max_result_bytes: 100 * 1024, // 100 KB
+            max_tool_result_bytes: 4 * 1024 * 1024, // 4 MB per inner tool result
+            max_return_bytes: 100 * 1024,           // 100 KB final return
         }
     }
 
@@ -68,8 +75,15 @@ impl JsEngine {
         self
     }
 
-    pub fn with_max_result_bytes(mut self, n: usize) -> Self {
-        self.max_result_bytes = n;
+    /// Set the cap on a single inner-tool result (in bytes).
+    pub fn with_max_tool_result_bytes(mut self, n: usize) -> Self {
+        self.max_tool_result_bytes = n;
+        self
+    }
+
+    /// Set the cap on the script's final return value (in bytes).
+    pub fn with_max_return_bytes(mut self, n: usize) -> Self {
+        self.max_return_bytes = n;
         self
     }
 
@@ -92,7 +106,8 @@ impl JsEngine {
     ) -> Result<ExecutionResult, JsEngineError> {
         let start = Instant::now();
         let max_tool_calls = self.max_tool_calls;
-        let max_result_bytes = self.max_result_bytes;
+        let max_tool_result_bytes = self.max_tool_result_bytes;
+        let max_return_bytes = self.max_return_bytes;
         let memory_limit = self.memory_limit;
         let stack_limit = self.stack_limit;
 
@@ -141,7 +156,7 @@ impl JsEngine {
                     Arc::clone(&dispatcher),
                     Arc::clone(&tool_call_count_inner),
                     max_tool_calls,
-                    max_result_bytes,
+                    max_tool_result_bytes,
                 )
                 .map_err(|e| JsEngineError::Runtime(format!("tool bridge registration: {e}")))?;
 
@@ -215,12 +230,14 @@ impl JsEngine {
         let value: serde_json::Value =
             serde_json::from_str(&value_json).unwrap_or(serde_json::Value::Null);
 
-        // Check result size
+        // Check final-return size against the small return cap. This is
+        // distinct from `max_tool_result_bytes` (per inner tool result):
+        // scripts can pull large payloads but must filter before returning.
         let result_size = value_json.len();
-        if result_size > max_result_bytes {
-            return Err(JsEngineError::ResultTooLarge {
+        if result_size > max_return_bytes {
+            return Err(JsEngineError::ReturnTooLarge {
                 size: result_size,
-                max: max_result_bytes,
+                max: max_return_bytes,
             });
         }
 
@@ -296,7 +313,7 @@ fn register_tool_bridge(
     dispatcher: Arc<dyn ToolDispatcher>,
     tool_call_count: Arc<AtomicUsize>,
     max_tool_calls: usize,
-    max_result_bytes: usize,
+    max_tool_result_bytes: usize,
 ) -> Result<(), rquickjs::Error> {
     ctx.globals().set(
         "__call_tool_raw",
@@ -323,9 +340,12 @@ fn register_tool_bridge(
                     Ok(result) => {
                         let result_json =
                             serde_json::to_string(&result).unwrap_or_else(|_| "null".into());
-                        if result_json.len() > max_result_bytes {
+                        if result_json.len() > max_tool_result_bytes {
                             return encode_error(&format!(
-                                "Tool result too large ({} bytes, max {max_result_bytes})",
+                                "Tool result too large ({} bytes, max {max_tool_result_bytes}). \
+                                 The tool returned more data than compose can hold in a single \
+                                 result. Try a more specific query (e.g. limit/filter parameters) \
+                                 or fall back to call_tool with output_filter.",
                                 result_json.len()
                             ));
                         }
@@ -671,6 +691,68 @@ mod tests {
             .unwrap();
         // Without an explicit return, the async IIFE returns undefined → null
         assert!(result.value.is_null());
+    }
+
+    /// Per-tool-result cap is independent of the final-return cap: a script
+    /// can pull a large inner result, summarize it, and return a small value.
+    #[tokio::test]
+    async fn separate_caps_let_script_filter_large_tool_results() {
+        // Dispatcher returns ~500 KB of data
+        struct LargeDispatcher;
+        #[async_trait::async_trait]
+        impl ToolDispatcher for LargeDispatcher {
+            async fn call_tool(
+                &self,
+                _name: &str,
+                _args: serde_json::Value,
+            ) -> Result<serde_json::Value, String> {
+                let big = "x".repeat(500 * 1024);
+                Ok(serde_json::json!({ "data": big }))
+            }
+        }
+
+        let engine = JsEngine::new()
+            .with_max_tool_result_bytes(1024 * 1024)
+            .with_max_return_bytes(1024);
+
+        let result = engine
+            .execute(
+                r#"
+                const r = await tools.big_tool({});
+                // Summarize the large payload to a tiny return value
+                return { len: r.data.length };
+                "#,
+                Arc::new(LargeDispatcher),
+                timeout(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(result.value, serde_json::json!({ "len": 500 * 1024 }));
+        assert_eq!(result.tool_calls_made, 1);
+    }
+
+    /// The return cap blocks oversized script output even when no tool
+    /// calls happen. Distinct error variant from the per-tool cap.
+    #[tokio::test]
+    async fn return_cap_blocks_oversized_script_output() {
+        let engine = JsEngine::new().with_max_return_bytes(1024);
+
+        let result = engine
+            .execute(
+                r#"return "x".repeat(5 * 1024);"#,
+                Arc::new(EchoDispatcher),
+                timeout(),
+            )
+            .await;
+
+        match result.unwrap_err() {
+            JsEngineError::ReturnTooLarge { size, max } => {
+                assert!(size > max);
+                assert_eq!(max, 1024);
+            }
+            other => panic!("expected ReturnTooLarge, got: {other}"),
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Motivation

Two compose UX issues surfaced from audit-log analysis of multiple
production runs in workspace `compose-test` (audit id 8183 fired on a
524 KB Concourse log payload):

1. The agent flow `search_tools → describe_tool → compose_types → write
   script` requires a third round trip just to translate the JSON Schema
   to TypeScript. For single-tool deep-dives this is pure waste.
2. The single `max_result_bytes` knob conflated two genuinely different
   limits — per-inner-tool-call payload vs. final script return. Raising
   it to fit the log would have let agents flood their context with
   hundreds of KB of raw data; lowering it would block legitimate
   "pull → filter → return" workflows.

## Item 1 — TypeScript signature in `describe_tool`

Embeds a TS function signature block after the existing JSON-Schema
section. Reuses the helpers already living in `compose.rs`
(`schema_to_ts_params`, `output_schema_to_ts`); their visibility was
nudged from `pub(super)` to `pub(crate)` so the catalog module can
consume them.

Softens the `<use_compose_for_efficiency>` system-prompt block so agents
can choose `compose_types` for batch / prefix-glob lookups or
`describe_tool` for single-tool deep-dives.

### Before / after

`describe_tool({tool_name: "honeycomb_list_environments"})` previously
returned `## name`, description, parameters JSON Schema, output JSON
Schema, default filter. Now it also includes:

```ts
function list_environments(args: { ... }): Promise<{ ... }>;
```

— ready to paste into a compose script without a third round trip.

## Item 2 — Split `max_result_bytes`

| Knob | Old | New | Default |
|---|---|---|---|
| Per inner tool result | `max_result_bytes` (shared) | `max_tool_result_bytes` | **4 MB** |
| Final script return | `max_result_bytes` (shared) | `max_return_bytes` | **100 KB** |

- `JsEngine` gains `with_max_tool_result_bytes` / `with_max_return_bytes`
  builders.
- `JsEngineError::ResultTooLarge` is split into `ToolResultTooLarge` and
  `ReturnTooLarge` with actionable hints embedded in the error message
  (e.g. "Filter or summarize in the script before returning…").
- `ComposeConfig` and the helm chart (`values.yaml` + `configmap.yaml`)
  expose the two new keys, using the same byte-coercion pattern from
  `dac28ab` (`printf "%d" (int .maxToolResultBytes)`).
- Generated default config (`dev/drua.default.yml`) regenerated.

### Configmap migration note

Rename `maxResultBytes` → `maxReturnBytes` and add `maxToolResultBytes`
(quoted strings to dodge YAML float coercion). Missing keys fall back to
the new defaults; operators carrying a custom override should update
both.

### Tests

Two new tokio tests in `lib/js-engine`:

- `separate_caps_let_script_filter_large_tool_results` — engine with
  1 MB tool cap and 1 KB return cap pulls a 500 KB payload and returns
  a 200-byte summary successfully.
- `return_cap_blocks_oversized_script_output` — small return cap blocks
  oversized script output with a `ReturnTooLarge` error.

Plus `describe_tool_includes_ts_signature` in the catalog tests
asserting the formatted output contains the function declaration with
the expected required/optional params and `Promise<{...}>` return type.

## Test plan

- [x] `nix flake check` (fmt + clippy + nextest + default-config + GraphQL schema)
- [x] `cargo nextest run -p js-engine` — 16/16 pass
- [x] `cargo nextest run -p drua-core --lib` — 175/175 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)