### PR TITLE
fix(js-engine): bounded ring-buffer for console output

### DIFF
--- a/charts/drua/templates/configmap.yaml
+++ b/charts/drua/templates/configmap.yaml
@@ -77,6 +77,7 @@ data:
         max_tool_calls: {{ printf "%d" (int .maxToolCalls) }}
         max_tool_result_bytes: {{ printf "%d" (int .maxToolResultBytes) }}
         max_return_bytes: {{ printf "%d" (int .maxReturnBytes) }}
+        max_console_bytes: {{ printf "%d" (int .maxConsoleBytes) }}
         memory_limit_bytes: {{ printf "%d" (int .memoryLimitBytes) }}
         stack_limit_bytes: {{ printf "%d" (int .stackLimitBytes) }}
         default_timeout_ms: {{ printf "%d" (int .defaultTimeoutMs) }}

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -86,6 +86,9 @@ galoyAgents:
       maxToolResultBytes: "4194304"
       ## Final-return cap. Bounded so the agent context stays clean.
       maxReturnBytes: "102400"
+      ## Console buffer cap. Tail-truncated when exceeded — newest lines
+      ## kept, oldest dropped. ~1% of agent context at 8 KiB.
+      maxConsoleBytes: "8192"
       memoryLimitBytes: "8388608"
       stackLimitBytes: "524288"
       defaultTimeoutMs: 120000

--- a/core/src/toolset/config.rs
+++ b/core/src/toolset/config.rs
@@ -26,6 +26,11 @@ pub struct ComposeConfig {
     /// agent context stays clean.
     #[serde(default = "default_max_return_bytes")]
     pub max_return_bytes: usize,
+    /// Cap on the console buffer in bytes. Tail-truncated when exceeded
+    /// (oldest lines dropped first) so a runaway log loop never floods
+    /// the agent context. ~1% of context at 8 KB.
+    #[serde(default = "default_max_console_bytes")]
+    pub max_console_bytes: usize,
     #[serde(default = "default_memory_limit_bytes")]
     pub memory_limit_bytes: usize,
     #[serde(default = "default_stack_limit_bytes")]
@@ -42,6 +47,7 @@ impl Default for ComposeConfig {
             max_tool_calls: default_max_tool_calls(),
             max_tool_result_bytes: default_max_tool_result_bytes(),
             max_return_bytes: default_max_return_bytes(),
+            max_console_bytes: default_max_console_bytes(),
             memory_limit_bytes: default_memory_limit_bytes(),
             stack_limit_bytes: default_stack_limit_bytes(),
             default_timeout_ms: default_default_timeout_ms(),
@@ -60,6 +66,10 @@ fn default_max_tool_result_bytes() -> usize {
 
 fn default_max_return_bytes() -> usize {
     100 * 1024
+}
+
+fn default_max_console_bytes() -> usize {
+    8 * 1024
 }
 
 fn default_memory_limit_bytes() -> usize {

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -158,6 +158,7 @@ impl TopLevelTool for ComposeTool {
             .with_max_tool_calls(self.config.max_tool_calls)
             .with_max_tool_result_bytes(self.config.max_tool_result_bytes)
             .with_max_return_bytes(self.config.max_return_bytes)
+            .with_max_console_bytes(self.config.max_console_bytes)
             .with_memory_limit(self.config.memory_limit_bytes)
             .with_stack_limit(self.config.stack_limit_bytes);
         let result = engine

--- a/dev/drua.default.yml
+++ b/dev/drua.default.yml
@@ -27,6 +27,7 @@ toolsets:
     max_tool_calls: 50
     max_tool_result_bytes: 4194304
     max_return_bytes: 102400
+    max_console_bytes: 8192
     memory_limit_bytes: 8388608
     stack_limit_bytes: 524288
     default_timeout_ms: 120000

--- a/lib/js-engine/src/lib.rs
+++ b/lib/js-engine/src/lib.rs
@@ -8,6 +8,7 @@ mod error;
 
 pub use error::JsEngineError;
 
+use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
@@ -51,6 +52,11 @@ pub struct JsEngine {
     /// agent context stays clean; compose's job is to shrink large tool
     /// results into small agent-readable answers.
     max_return_bytes: usize,
+    /// Cap on the console buffer in bytes. Drops oldest entries (tail
+    /// truncation) when exceeded. Console is a debug sidecar, not primary
+    /// output — kept small so a runaway log loop can never flood the agent
+    /// context. Memory is bounded *during* execution, not just at the end.
+    max_console_bytes: usize,
 }
 
 impl Default for JsEngine {
@@ -67,6 +73,7 @@ impl JsEngine {
             max_tool_calls: 50,
             max_tool_result_bytes: 4 * 1024 * 1024, // 4 MB per inner tool result
             max_return_bytes: 100 * 1024,           // 100 KB final return
+            max_console_bytes: 8 * 1024,            // 8 KB console tail (~2k tokens)
         }
     }
 
@@ -84,6 +91,13 @@ impl JsEngine {
     /// Set the cap on the script's final return value (in bytes).
     pub fn with_max_return_bytes(mut self, n: usize) -> Self {
         self.max_return_bytes = n;
+        self
+    }
+
+    /// Set the cap on the console buffer (in bytes). When exceeded, oldest
+    /// entries are dropped (tail truncation) and a marker line is prepended.
+    pub fn with_max_console_bytes(mut self, n: usize) -> Self {
+        self.max_console_bytes = n;
         self
     }
 
@@ -110,10 +124,11 @@ impl JsEngine {
         let max_return_bytes = self.max_return_bytes;
         let memory_limit = self.memory_limit;
         let stack_limit = self.stack_limit;
+        let max_console_bytes = self.max_console_bytes;
 
         // Shared state between Rust host and JS guest
-        let console_buf: Arc<std::sync::Mutex<Vec<String>>> =
-            Arc::new(std::sync::Mutex::new(Vec::new()));
+        let console_buf: Arc<std::sync::Mutex<ConsoleBuf>> =
+            Arc::new(std::sync::Mutex::new(ConsoleBuf::new(max_console_bytes)));
         let tool_call_count = Arc::new(AtomicUsize::new(0));
         let timed_out = Arc::new(AtomicBool::new(false));
 
@@ -241,7 +256,9 @@ impl JsEngine {
             });
         }
 
-        let console_output = console_buf.lock().unwrap().clone();
+        // Drain the ring buffer into a Vec, prepending the dropped-line
+        // marker if any entries were truncated.
+        let console_output = console_buf.lock().unwrap().snapshot();
         let tool_calls_made = tool_call_count.load(Ordering::Relaxed);
 
         Ok(ExecutionResult {
@@ -255,11 +272,62 @@ impl JsEngine {
 
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
+/// Bounded ring buffer for console output. Drops the oldest entries (tail
+/// truncation) when total bytes exceed `max_bytes`. Tracks how many were
+/// dropped so a marker line can be emitted when the buffer is read.
+///
+/// Tail truncation (not head): the last log lines carry the most signal
+/// — final state on success, the operation just before a crash on failure.
+/// Mirrors the convention of every other log handler in the codebase.
+struct ConsoleBuf {
+    lines: VecDeque<String>,
+    bytes: usize,
+    dropped: usize,
+    max_bytes: usize,
+}
+
+impl ConsoleBuf {
+    fn new(max_bytes: usize) -> Self {
+        Self {
+            lines: VecDeque::new(),
+            bytes: 0,
+            dropped: 0,
+            max_bytes,
+        }
+    }
+
+    fn push(&mut self, msg: String) {
+        let added = msg.len() + 1; // +1 for the implicit newline between lines
+        self.bytes += added;
+        self.lines.push_back(msg);
+
+        // Drop oldest until we fit. Always keep at least one line so the
+        // most recent push is never the one we drop (a single oversized
+        // line is preferable to silently dropping it).
+        while self.bytes > self.max_bytes && self.lines.len() > 1 {
+            if let Some(oldest) = self.lines.pop_front() {
+                self.bytes -= oldest.len() + 1;
+                self.dropped += 1;
+            }
+        }
+    }
+
+    /// Snapshot the buffer into a Vec (without consuming). Prepends a
+    /// `[... N earlier lines dropped]` marker if any entries were dropped.
+    fn snapshot(&self) -> Vec<String> {
+        let mut out: Vec<String> = self.lines.iter().cloned().collect();
+        if self.dropped > 0 {
+            out.insert(0, format!("[... {} earlier lines dropped]", self.dropped));
+        }
+        out
+    }
+}
+
 /// Register `console.log`, `console.warn`, `console.error`, `console.info`
-/// as native functions that capture output to a shared buffer.
+/// as native functions that capture output to a shared bounded ring buffer.
 fn register_console(
     ctx: &rquickjs::Ctx<'_>,
-    buf: Arc<std::sync::Mutex<Vec<String>>>,
+    buf: Arc<std::sync::Mutex<ConsoleBuf>>,
 ) -> Result<(), rquickjs::Error> {
     let console = Object::new(ctx.clone())?;
 
@@ -522,6 +590,100 @@ mod tests {
             result.console_output,
             vec!["hello", "[WARN] careful", "[ERROR] oops"]
         );
+    }
+
+    #[tokio::test]
+    async fn console_buffer_truncates_to_tail() {
+        let engine = JsEngine::new().with_max_console_bytes(200);
+        let result = engine
+            .execute(
+                r#"
+                for (let i = 0; i < 100; i++) {
+                    console.log("line " + i);
+                }
+                return "done";
+                "#,
+                Arc::new(EchoDispatcher),
+                timeout(),
+            )
+            .await
+            .unwrap();
+
+        // First entry is the dropped-count marker
+        assert!(result.console_output[0].starts_with("[..."));
+        assert!(result.console_output[0].contains("dropped"));
+
+        // Last entry should be near the end of the loop, not the start —
+        // tail truncation keeps the most recent lines.
+        let last = result.console_output.last().unwrap();
+        assert!(last.starts_with("line 9"), "tail not preserved: {last}");
+    }
+
+    #[tokio::test]
+    async fn console_buffer_under_cap_no_marker() {
+        let result = engine()
+            .execute(
+                r#"
+                console.log("a");
+                console.log("b");
+                console.log("c");
+                return "done";
+                "#,
+                Arc::new(EchoDispatcher),
+                timeout(),
+            )
+            .await
+            .unwrap();
+
+        // No marker — all three short lines fit well under the 8 KB default.
+        assert_eq!(result.console_output, vec!["a", "b", "c"]);
+    }
+
+    #[tokio::test]
+    async fn console_buffer_marker_reflects_drop_count() {
+        let engine = JsEngine::new().with_max_console_bytes(50);
+        let result = engine
+            .execute(
+                r#"
+                for (let i = 0; i < 20; i++) console.log("xxxxxxxxxx");
+                return "done";
+                "#,
+                Arc::new(EchoDispatcher),
+                timeout(),
+            )
+            .await
+            .unwrap();
+
+        // The first entry is the marker; the dropped count parsed out of it
+        // should reflect that most of the 20 lines were truncated.
+        let marker = &result.console_output[0];
+        assert!(marker.contains("dropped"), "no marker: {marker}");
+        let parsed: Option<usize> = marker.split_whitespace().find_map(|w| w.parse().ok());
+        assert!(
+            parsed.unwrap_or(0) > 10,
+            "expected >10 drops, got: {marker}"
+        );
+    }
+
+    #[tokio::test]
+    async fn console_buffer_keeps_at_least_one_line() {
+        // A single very large line should still appear. The ring buffer
+        // never drops to empty — preserving a single oversized line is
+        // strictly better than silently swallowing it.
+        let engine = JsEngine::new().with_max_console_bytes(10);
+        let result = engine
+            .execute(
+                r#"console.log("this is much longer than 10 bytes"); return "done";"#,
+                Arc::new(EchoDispatcher),
+                timeout(),
+            )
+            .await
+            .unwrap();
+
+        assert!(result
+            .console_output
+            .iter()
+            .any(|s| s.contains("longer than")));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

The compose JS engine's `console` buffer was unbounded — not subject to the per-tool-result cap or the script-return cap. A pathological log loop (`for (let i=0; i<100000; i++) console.log("hi"); return "done";`) could attach a 200 KB+ console array to a 5-byte return value, flooding the agent context.

Latent footgun (not yet observed in production), cheap to fix preemptively.

## What changed

- **`lib/js-engine/src/lib.rs`** — Introduced `ConsoleBuf`, a `VecDeque`-backed ring buffer. `push()` drops the oldest entries when total bytes exceed `max_bytes`; `snapshot()` returns a `Vec<String>` with a `[... N earlier lines dropped]` marker prepended when truncation occurred. Preserves at least one line so a single oversized log call still appears.
- **`JsEngine`** — New `max_console_bytes` field (default 8 KiB) + `with_max_console_bytes()` builder method.
- **`ComposeConfig`** — New `max_console_bytes` (default 8192).
- **`charts/drua/values.yaml` + `templates/configmap.yaml`** — New `maxConsoleBytes` (default 8192), quoted to avoid YAML float64 promotion (same convention as the other byte-sized values).
- **`dev/drua.default.yml`** — `max_console_bytes: 8192`.

## Why tail truncation, why 8 KiB

- **Tail (not head)**: the most recent lines carry the signal — final state on success, the operation just before a crash on failure. Matches `OutputFilter::Tail`, `concourse_get_build_logs` defaults, and Unix `tail`.
- **8 KiB ≈ ~2 000 tokens, ~1 % of a 200k context.** Console is a debug sidecar, not primary output — visibly smaller than the 100 KiB return cap so agents don't mistake it for the answer. Comfortably fits typical debug patterns (5–10 `console.log` calls, a handful of build objects, verbose progress through ~100 iterations).
- **Memory bounded *during* execution**, not just at the end — the JS heap limit (8 MB) doesn't apply to the Rust-side buffer, so a runaway log loop is now safely capped.

## Tests

Four new unit tests in `lib/js-engine/src/lib.rs`:
- `console_buffer_truncates_to_tail` — 100-iteration log loop with a tiny cap; first entry is the dropped marker, last entry is from the end of the loop.
- `console_buffer_under_cap_no_marker` — three short lines fit; no marker emitted.
- `console_buffer_marker_reflects_drop_count` — parse the integer out of the marker; assert it's >10 of 20 dropped lines.
- `console_buffer_keeps_at_least_one_line` — a single line longer than the cap is preserved (never drop to empty).

Existing `console_capture` continues to pass — three short strings well under 8 KiB.

## Test plan

- [x] `cargo nextest run -p js-engine` (20 passed, including 4 new)
- [x] `nix flake check` (fmt, clippy, nextest, default-config, graphql-schema)
- [ ] Confirm `maxConsoleBytes` flows from helm values → configmap → drua-core → JsEngine in a deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)