### PR TITLE
feat(audit): capture error message on failed tool calls

### DIFF
--- a/.sqlx/query-184d05ec72d3cdb7c6164309e7a52f4e063b4fdee6106e85f753f6d7cc71b89a.json
+++ b/.sqlx/query-184d05ec72d3cdb7c6164309e7a52f4e063b4fdee6106e85f753f6d7cc71b89a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n                id AS \"id: AuditEntryId\",\n                acting_user_id AS \"acting_user_id: UserId\",\n                acting_agent_id AS \"acting_agent_id: AgentId\",\n                on_behalf_of_user_id AS \"on_behalf_of_user_id: UserId\",\n                resource_ids AS \"resource_ids: serde_json::Value\",\n                entrypoint,\n                interaction_type,\n                action,\n                metadata AS \"metadata: serde_json::Value\",\n                outcome,\n                error,\n                duration_ms,\n                tokens_returned,\n                recorded_at\n            FROM audit_entries\n            WHERE ($1::text IS NULL OR resource_ids->>'workspace_id' = $1)\n              AND ($2::uuid IS NULL OR acting_user_id = $2)\n              AND ($3::uuid IS NULL OR acting_agent_id = $3)\n              AND ($4::uuid IS NULL OR acting_agent_id IS NULL OR acting_agent_id != $4)\n              AND ($5::text IS NULL OR resource_ids->>'sandbox_id' = $5)\n              AND ($6::text IS NULL OR entrypoint ILIKE $6)\n              AND ($7::text IS NULL OR action ILIKE $7)\n              AND ($8::text IS NULL OR outcome ILIKE $8)\n              AND ($9::bool IS NULL OR error = $9)\n            ORDER BY id DESC\n            LIMIT $10",
+  "query": "INSERT INTO audit_entries\n                (acting_user_id, acting_agent_id, on_behalf_of_user_id,\n                 resource_ids, entrypoint, interaction_type, action, metadata,\n                 outcome, error, error_message, duration_ms, tokens_returned)\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)\n            RETURNING\n                id AS \"id: AuditEntryId\",\n                acting_user_id AS \"acting_user_id: UserId\",\n                acting_agent_id AS \"acting_agent_id: AgentId\",\n                on_behalf_of_user_id AS \"on_behalf_of_user_id: UserId\",\n                resource_ids AS \"resource_ids: serde_json::Value\",\n                entrypoint,\n                interaction_type,\n                action,\n                metadata AS \"metadata: serde_json::Value\",\n                outcome,\n                error,\n                error_message,\n                duration_ms,\n                tokens_returned,\n                recorded_at",
   "describe": {
     "columns": [
       {
@@ -60,31 +60,39 @@
       },
       {
         "ordinal": 11,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
         "name": "duration_ms",
         "type_info": "Int8"
       },
       {
-        "ordinal": 12,
+        "ordinal": 13,
         "name": "tokens_returned",
         "type_info": "Int8"
       },
       {
-        "ordinal": 13,
+        "ordinal": 14,
         "name": "recorded_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Text",
         "Uuid",
         "Uuid",
         "Uuid",
+        "Jsonb",
         "Text",
-        "Text",
-        "Text",
-        "Text",
+        "Varchar",
+        "Varchar",
+        "Jsonb",
+        "Varchar",
         "Bool",
+        "Text",
+        "Int8",
         "Int8"
       ]
     },
@@ -102,8 +110,9 @@
       true,
       true,
       true,
+      true,
       false
     ]
   },
-  "hash": "7468585e8c6e93d243c6cbbb214827efc87bf5d38ba8e0ec2c1e80ba2ccdfd2b"
+  "hash": "184d05ec72d3cdb7c6164309e7a52f4e063b4fdee6106e85f753f6d7cc71b89a"
 }

--- a/.sqlx/query-7e9c3c51f029e48ae3da054309da841d0838710c2151597ecb10550674c89d25.json
+++ b/.sqlx/query-7e9c3c51f029e48ae3da054309da841d0838710c2151597ecb10550674c89d25.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "SELECT\n                id AS \"id: AuditEntryId\",\n                acting_user_id AS \"acting_user_id: UserId\",\n                acting_agent_id AS \"acting_agent_id: AgentId\",\n                on_behalf_of_user_id AS \"on_behalf_of_user_id: UserId\",\n                resource_ids AS \"resource_ids: serde_json::Value\",\n                entrypoint,\n                interaction_type,\n                action,\n                metadata AS \"metadata: serde_json::Value\",\n                outcome,\n                error,\n                duration_ms,\n                tokens_returned,\n                recorded_at\n            FROM audit_entries\n            ORDER BY id DESC\n            LIMIT $1",
+  "query": "SELECT\n                id AS \"id: AuditEntryId\",\n                acting_user_id AS \"acting_user_id: UserId\",\n                acting_agent_id AS \"acting_agent_id: AgentId\",\n                on_behalf_of_user_id AS \"on_behalf_of_user_id: UserId\",\n                resource_ids AS \"resource_ids: serde_json::Value\",\n                entrypoint,\n                interaction_type,\n                action,\n                metadata AS \"metadata: serde_json::Value\",\n                outcome,\n                error,\n                error_message,\n                duration_ms,\n                tokens_returned,\n                recorded_at\n            FROM audit_entries\n            ORDER BY id DESC\n            LIMIT $1",
   "describe": {
     "columns": [
       {
@@ -60,16 +60,21 @@
       },
       {
         "ordinal": 11,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
         "name": "duration_ms",
         "type_info": "Int8"
       },
       {
-        "ordinal": 12,
+        "ordinal": 13,
         "name": "tokens_returned",
         "type_info": "Int8"
       },
       {
-        "ordinal": 13,
+        "ordinal": 14,
         "name": "recorded_at",
         "type_info": "Timestamptz"
       }
@@ -93,8 +98,9 @@
       true,
       true,
       true,
+      true,
       false
     ]
   },
-  "hash": "4ba2321e2aeee9b6ce689c6dad78fc72b453261b6649dc2b2b1a86ca146d4577"
+  "hash": "7e9c3c51f029e48ae3da054309da841d0838710c2151597ecb10550674c89d25"
 }

--- a/.sqlx/query-dc4391a03bc96f1ac7c50a88c1c0878cf3c566054178227d758a0370b53c1727.json
+++ b/.sqlx/query-dc4391a03bc96f1ac7c50a88c1c0878cf3c566054178227d758a0370b53c1727.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "INSERT INTO audit_entries\n                (acting_user_id, acting_agent_id, on_behalf_of_user_id,\n                 resource_ids, entrypoint, interaction_type, action, metadata,\n                 outcome, error, duration_ms, tokens_returned)\n            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)\n            RETURNING\n                id AS \"id: AuditEntryId\",\n                acting_user_id AS \"acting_user_id: UserId\",\n                acting_agent_id AS \"acting_agent_id: AgentId\",\n                on_behalf_of_user_id AS \"on_behalf_of_user_id: UserId\",\n                resource_ids AS \"resource_ids: serde_json::Value\",\n                entrypoint,\n                interaction_type,\n                action,\n                metadata AS \"metadata: serde_json::Value\",\n                outcome,\n                error,\n                duration_ms,\n                tokens_returned,\n                recorded_at",
+  "query": "SELECT\n                id AS \"id: AuditEntryId\",\n                acting_user_id AS \"acting_user_id: UserId\",\n                acting_agent_id AS \"acting_agent_id: AgentId\",\n                on_behalf_of_user_id AS \"on_behalf_of_user_id: UserId\",\n                resource_ids AS \"resource_ids: serde_json::Value\",\n                entrypoint,\n                interaction_type,\n                action,\n                metadata AS \"metadata: serde_json::Value\",\n                outcome,\n                error,\n                error_message,\n                duration_ms,\n                tokens_returned,\n                recorded_at\n            FROM audit_entries\n            WHERE ($1::text IS NULL OR resource_ids->>'workspace_id' = $1)\n              AND ($2::uuid IS NULL OR acting_user_id = $2)\n              AND ($3::uuid IS NULL OR acting_agent_id = $3)\n              AND ($4::uuid IS NULL OR acting_agent_id IS NULL OR acting_agent_id != $4)\n              AND ($5::text IS NULL OR resource_ids->>'sandbox_id' = $5)\n              AND ($6::text IS NULL OR entrypoint ILIKE $6)\n              AND ($7::text IS NULL OR action ILIKE $7)\n              AND ($8::text IS NULL OR outcome ILIKE $8)\n              AND ($9::bool IS NULL OR error = $9)\n            ORDER BY id DESC\n            LIMIT $10",
   "describe": {
     "columns": [
       {
@@ -60,33 +60,36 @@
       },
       {
         "ordinal": 11,
+        "name": "error_message",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
         "name": "duration_ms",
         "type_info": "Int8"
       },
       {
-        "ordinal": 12,
+        "ordinal": 13,
         "name": "tokens_returned",
         "type_info": "Int8"
       },
       {
-        "ordinal": 13,
+        "ordinal": 14,
         "name": "recorded_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Uuid",
-        "Uuid",
-        "Jsonb",
         "Text",
-        "Varchar",
-        "Varchar",
-        "Jsonb",
-        "Varchar",
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
         "Bool",
-        "Int8",
         "Int8"
       ]
     },
@@ -104,8 +107,9 @@
       true,
       true,
       true,
+      true,
       false
     ]
   },
-  "hash": "076532d0bf4db2e95e2a31501a2edfe76ee5d7d04625f4f25afa5f2f4ec4a03a"
+  "hash": "dc4391a03bc96f1ac7c50a88c1c0878cf3c566054178227d758a0370b53c1727"
 }

--- a/core/migrations/20260427000001_audit_entries_error_message.sql
+++ b/core/migrations/20260427000001_audit_entries_error_message.sql
@@ -1,0 +1,9 @@
+-- Add `error_message` column to capture the failure reason text.
+--
+-- The boolean `error` flag already records whether the interaction failed
+-- but the actual error string was discarded at the persistence boundary.
+-- Storing the message text makes failed tool calls debuggable directly
+-- from the audit log.
+--
+-- Capped at 4 KiB by the application layer before insertion.
+ALTER TABLE audit_entries ADD COLUMN error_message TEXT;

--- a/core/src/audit/mod.rs
+++ b/core/src/audit/mod.rs
@@ -12,6 +12,24 @@ pub use primitives::*;
 /// [`EventContext`].
 const AUDIT_CONTEXT_KEY: &str = "audit";
 
+/// Maximum number of bytes persisted for an error message. Anything beyond
+/// this is dropped — the goal is debuggability, not storing entire stack
+/// traces. Set generously at 4 KiB so typical messages fit without truncation.
+pub const MAX_ERROR_MESSAGE_BYTES: usize = 4096;
+
+/// Truncate `s` to at most [`MAX_ERROR_MESSAGE_BYTES`] bytes without
+/// splitting a UTF-8 code point.
+fn truncate_error_message(s: &str) -> String {
+    if s.len() <= MAX_ERROR_MESSAGE_BYTES {
+        return s.to_owned();
+    }
+    let mut end = MAX_ERROR_MESSAGE_BYTES;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_owned()
+}
+
 #[derive(Clone)]
 pub struct Audit {
     pool: sqlx::PgPool,
@@ -185,7 +203,7 @@ impl Audit {
         }
         let audit = self.clone();
         tokio::spawn(async move {
-            if let Err(e) = audit.insert(&ctx_data).await {
+            if let Err(e) = audit.record(&ctx_data).await {
                 tracing::warn!(error = %e, "Failed to record audit entry");
             }
         });
@@ -208,6 +226,7 @@ impl Audit {
                 metadata AS "metadata: serde_json::Value",
                 outcome,
                 error,
+                error_message,
                 duration_ms,
                 tokens_returned,
                 recorded_at
@@ -256,6 +275,7 @@ impl Audit {
                 metadata AS "metadata: serde_json::Value",
                 outcome,
                 error,
+                error_message,
                 duration_ms,
                 tokens_returned,
                 recorded_at
@@ -287,7 +307,12 @@ impl Audit {
         Ok(rows)
     }
 
-    async fn insert(&self, ctx: &AuditContextData) -> Result<AuditEntry, AuditError> {
+    /// Persist an audit entry from the given context data.
+    ///
+    /// Synchronous variant of [`Self::record_from_context`] — callers (and
+    /// tests) that need the inserted row should use this directly rather
+    /// than the fire-and-forget context helper.
+    pub async fn record(&self, ctx: &AuditContextData) -> Result<AuditEntry, AuditError> {
         let acting_user_id = ctx.acting_user_id.map(uuid::Uuid::from);
         let acting_agent_id = ctx.acting_agent_id.map(uuid::Uuid::from);
         let on_behalf_of = ctx.on_behalf_of_user_id.map(uuid::Uuid::from);
@@ -303,6 +328,10 @@ impl Audit {
         let outcome = ctx.outcome.as_ref().unwrap_or(&InteractionOutcome::Success);
         let out = outcome.to_string();
         let error = matches!(outcome, InteractionOutcome::Error { .. });
+        let error_message = match outcome {
+            InteractionOutcome::Error { message } => Some(truncate_error_message(message)),
+            InteractionOutcome::Success => None,
+        };
         let dur = ctx.duration_ms.map(|ms| ms as i64);
         let tokens = ctx.tokens_returned.map(|t| t as i64);
 
@@ -311,8 +340,8 @@ impl Audit {
             r#"INSERT INTO audit_entries
                 (acting_user_id, acting_agent_id, on_behalf_of_user_id,
                  resource_ids, entrypoint, interaction_type, action, metadata,
-                 outcome, error, duration_ms, tokens_returned)
-            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+                 outcome, error, error_message, duration_ms, tokens_returned)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
             RETURNING
                 id AS "id: AuditEntryId",
                 acting_user_id AS "acting_user_id: UserId",
@@ -325,6 +354,7 @@ impl Audit {
                 metadata AS "metadata: serde_json::Value",
                 outcome,
                 error,
+                error_message,
                 duration_ms,
                 tokens_returned,
                 recorded_at"#,
@@ -338,11 +368,43 @@ impl Audit {
             metadata,
             out,
             error,
+            error_message,
             dur,
             tokens,
         )
         .fetch_one(&self.pool)
         .await?;
         Ok(row)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn truncate_error_message_short_passthrough() {
+        let s = "boom";
+        assert_eq!(truncate_error_message(s), "boom");
+    }
+
+    #[test]
+    fn truncate_error_message_caps_at_limit() {
+        let s = "x".repeat(MAX_ERROR_MESSAGE_BYTES + 100);
+        let out = truncate_error_message(&s);
+        assert_eq!(out.len(), MAX_ERROR_MESSAGE_BYTES);
+    }
+
+    #[test]
+    fn truncate_error_message_respects_utf8_boundaries() {
+        // 4-byte char (😀 = 0xF0 0x9F 0x98 0x80) straddling the cap.
+        let prefix_len = MAX_ERROR_MESSAGE_BYTES - 2;
+        let mut s = "a".repeat(prefix_len);
+        s.push('😀');
+        s.push_str("tail");
+        let out = truncate_error_message(&s);
+        // Cut should land on the char boundary before the emoji.
+        assert_eq!(out.len(), prefix_len);
+        assert!(out.is_char_boundary(out.len()));
     }
 }

--- a/core/src/audit/primitives.rs
+++ b/core/src/audit/primitives.rs
@@ -131,6 +131,11 @@ pub struct AuditEntry {
     pub metadata: serde_json::Value,
     pub outcome: String,
     pub error: Option<bool>,
+    /// Error message text recorded for failed interactions. Truncated to
+    /// [`MAX_ERROR_MESSAGE_BYTES`](super::MAX_ERROR_MESSAGE_BYTES) at
+    /// insertion time. `None` for successful interactions or rows
+    /// recorded before this column was introduced.
+    pub error_message: Option<String>,
     pub duration_ms: Option<i64>,
     pub tokens_returned: Option<i64>,
     pub recorded_at: chrono::DateTime<chrono::Utc>,

--- a/core/src/toolset/top_level/log.rs
+++ b/core/src/toolset/top_level/log.rs
@@ -124,6 +124,9 @@ struct AuditEntryOutput {
     /// Whether this entry was an error.
     #[serde(skip_serializing_if = "Option::is_none")]
     error: Option<bool>,
+    /// Error message text for failed interactions (truncated to 4 KiB).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error_message: Option<String>,
     duration_ms: Option<i64>,
     /// Acting user UUID.
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -155,6 +158,7 @@ impl From<&AuditEntry> for AuditEntryOutput {
             action: e.action.clone(),
             outcome: e.outcome.clone(),
             error: e.error,
+            error_message: e.error_message.clone(),
             duration_ms: e.duration_ms,
             acting_user_id: e.acting_user_id.map(|id| id.to_string()),
             acting_agent_id: e.acting_agent_id.map(|id| id.to_string()),

--- a/core/tests/audit.rs
+++ b/core/tests/audit.rs
@@ -1,0 +1,96 @@
+use drua_core::audit::{
+    Audit, AuditContextData, AuditLogQuery, InteractionOutcome, InteractionType,
+    MAX_ERROR_MESSAGE_BYTES,
+};
+use drua_core::primitives::UserId;
+
+const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
+
+async fn pool() -> sqlx::PgPool {
+    let url = std::env::var("DATABASE_URL").unwrap_or_else(|_| PG_CON.to_string());
+    sqlx::PgPool::connect(&url).await.expect("connect to pg")
+}
+
+fn ctx_with_outcome(action: &str, outcome: InteractionOutcome) -> AuditContextData {
+    AuditContextData {
+        acting_user_id: Some(UserId::new()),
+        interaction_type: Some(InteractionType::McpCall),
+        action: Some(action.to_string()),
+        entrypoint: Some(format!("mcp: {action}")),
+        outcome: Some(outcome),
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn record_failed_call_persists_error_message() {
+    let pool = pool().await;
+    let audit = Audit::new(&pool);
+
+    let user_id = UserId::new();
+    let mut ctx = ctx_with_outcome(
+        "test.failing_tool",
+        InteractionOutcome::Error {
+            message: "upstream MCP timeout after 30s".to_string(),
+        },
+    );
+    ctx.acting_user_id = Some(user_id);
+
+    let entry = audit.record(&ctx).await.expect("record entry");
+    assert_eq!(entry.error, Some(true));
+    assert_eq!(
+        entry.error_message.as_deref(),
+        Some("upstream MCP timeout after 30s"),
+    );
+
+    // Round-trip via the read path so we cover both insert RETURNING and
+    // SELECT projections.
+    let rows = audit
+        .find(&AuditLogQuery {
+            acting_user_id: Some(user_id),
+            limit: 10,
+            ..Default::default()
+        })
+        .await
+        .expect("find entries");
+    let found = rows.iter().find(|e| e.id == entry.id).expect("entry found");
+    assert_eq!(
+        found.error_message.as_deref(),
+        Some("upstream MCP timeout after 30s"),
+    );
+}
+
+#[tokio::test]
+async fn record_successful_call_leaves_error_message_null() {
+    let pool = pool().await;
+    let audit = Audit::new(&pool);
+
+    let user_id = UserId::new();
+    let mut ctx = ctx_with_outcome("test.ok_tool", InteractionOutcome::Success);
+    ctx.acting_user_id = Some(user_id);
+
+    let entry = audit.record(&ctx).await.expect("record entry");
+    assert_eq!(entry.error, Some(false));
+    assert!(entry.error_message.is_none());
+}
+
+#[tokio::test]
+async fn record_truncates_oversized_error_message() {
+    let pool = pool().await;
+    let audit = Audit::new(&pool);
+
+    let user_id = UserId::new();
+    let huge = "x".repeat(MAX_ERROR_MESSAGE_BYTES + 1024);
+    let mut ctx = ctx_with_outcome(
+        "test.huge_error",
+        InteractionOutcome::Error {
+            message: huge.clone(),
+        },
+    );
+    ctx.acting_user_id = Some(user_id);
+
+    let entry = audit.record(&ctx).await.expect("record entry");
+    let stored = entry.error_message.expect("error message");
+    assert_eq!(stored.len(), MAX_ERROR_MESSAGE_BYTES);
+    assert!(stored.chars().all(|c| c == 'x'));
+}


### PR DESCRIPTION
## Motivation

The audit log already recorded a boolean `error` flag for failed
interactions, and the in-memory `InteractionOutcome::Error { message }`
carries the failure reason from every emit site (MCP tool dispatch in
`core/src/toolset/mod.rs`, the HTTP middleware in `server/src/server.rs`).

But that `message` was being **dropped** at the persistence boundary — the
`Audit::insert` method only wrote the boolean flag to the DB. PR #208 added
an `AuditEntryOutput` struct on the read side, yet `error_message` was
unreachable since nothing ever wrote it. Failed tool calls were
undebuggable from the audit log alone.

## Where the error was being dropped

In `core/src/audit/mod.rs::insert`, the `outcome.message` from
`InteractionOutcome::Error { message }` was matched only for the
`error: bool` flag — the string itself was never bound to a SQL parameter.

## Schema changes

- New migration `20260427000001_audit_entries_error_message.sql`:
  ``ALTER TABLE audit_entries ADD COLUMN error_message TEXT``.
- `AuditEntry` gains `error_message: Option<String>`.
- `AuditEntryOutput` (read-side, used by the `log` MCP tool) gains a
  matching `error_message` field.

## Implementation notes

- New `MAX_ERROR_MESSAGE_BYTES = 4096` constant + `truncate_error_message`
  helper that respects UTF-8 code-point boundaries.
- `Audit::insert` is renamed to `Audit::record` and made `pub` so tests
  (and any future synchronous caller) can persist a context without going
  through the fire-and-forget `record_from_context` path.
- All emit sites already passed the message via
  `Audit::record_error(e.to_string())`; **no call-site updates were
  required** — the only fix was at the storage layer.

## Tests

- `core/tests/audit.rs`: 3 integration tests covering
  - failed call persists & round-trips the error message
  - successful call leaves `error_message` NULL
  - oversized messages are truncated to the 4 KiB cap
- `core/src/audit/mod.rs::tests`: 3 unit tests for the truncation
  helper (passthrough, exact cap, UTF-8 boundary safety).

## Test plan

- [x] `nix develop -c cargo fmt`
- [x] `nix develop -c cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run --package drua-core --test audit` — 3/3 passing
- [x] `cargo nextest run --package drua-core --lib audit::` — 3/3 passing
- [x] `nix flake check` (fmt + clippy + nextest + graphql-schema + default-config)