### PR TITLE
fix(compose): bump per-tool cap for real payloads + doc Concourse time units

### DIFF
--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -74,22 +74,25 @@ galoyAgents:
       team: ""
     ## JS-engine sandbox limits for the `compose` top-level tool. Each
     ## key maps 1:1 to a JsEngine setter; missing keys fall back to the
-    ## drua-core defaults (50 calls / 4 MiB per inner tool result /
-    ## 100 KiB final return / 8 MiB / 512 KiB / 120 s default / 300 s max).
+    ## drua-core defaults (50 calls / 32 MiB per inner tool result /
+    ## 100 KiB final return / 64 MiB / 512 KiB / 120 s default / 300 s max).
     ## Byte-valued limits are quoted to keep YAML from auto-promoting them
     ## to float64 — Helm's serializer otherwise renders e.g. 16777216 as
     ## "1.6777216e+07", which Rust serde rejects for usize fields.
     compose:
       maxToolCalls: 50
       ## Per inner-tool-result cap. Scripts may pull large payloads
-      ## (logs, manifests) and filter them before returning.
-      maxToolResultBytes: "4194304"
+      ## (logs, manifests) and filter them before returning. Sized to
+      ## hold realistic Concourse build logs (95–99th percentile).
+      maxToolResultBytes: "33554432"
       ## Final-return cap. Bounded so the agent context stays clean.
       maxReturnBytes: "102400"
       ## Console buffer cap. Tail-truncated when exceeded — newest lines
       ## kept, oldest dropped. ~1% of agent context at 8 KiB.
       maxConsoleBytes: "8192"
-      memoryLimitBytes: "8388608"
+      ## JS heap. Must be ≥ 2× maxToolResultBytes so scripts have working
+      ## headroom for split / filter / sort over the parsed payload.
+      memoryLimitBytes: "67108864"
       stackLimitBytes: "524288"
       defaultTimeoutMs: 120000
       maxTimeoutMs: 300000

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -31,9 +31,13 @@ galoyAgents:
       team: "dev"
     compose:
       maxToolCalls: 1000
-      maxToolResultBytes: "8388608"
+      ## 32 MiB per inner-tool result — sized for realistic Concourse
+      ## build logs (35–60 min builds typically 10–30 MiB).
+      maxToolResultBytes: "33554432"
       maxReturnBytes: "262144"
-      memoryLimitBytes: "16777216"
+      ## JS heap kept at ≥ 2× the per-tool cap so scripts have working
+      ## room for split / filter / sort over the parsed payload.
+      memoryLimitBytes: "67108864"
       stackLimitBytes: "1048576"
       defaultTimeoutMs: 120000
       maxTimeoutMs: 300000

--- a/core/src/toolset/config.rs
+++ b/core/src/toolset/config.rs
@@ -61,7 +61,12 @@ fn default_max_tool_calls() -> usize {
 }
 
 fn default_max_tool_result_bytes() -> usize {
-    4 * 1024 * 1024
+    // 32 MiB. Sized to comfortably hold realistic Concourse build logs
+    // and similar large payloads. Compose's value proposition is reaching
+    // *uncapped* data so scripts can filter / cross-reference in JS — the
+    // cap exists for safety against pathological cases, not as a normal
+    // throttle.
+    32 * 1024 * 1024
 }
 
 fn default_max_return_bytes() -> usize {
@@ -73,7 +78,10 @@ fn default_max_console_bytes() -> usize {
 }
 
 fn default_memory_limit_bytes() -> usize {
-    8 * 1024 * 1024
+    // 64 MiB. Must remain a comfortable multiple of
+    // `max_tool_result_bytes` (≥ 2×) so scripts have working room for
+    // `.split()` / `.filter()` / sorting on top of the parsed payload.
+    64 * 1024 * 1024
 }
 
 fn default_stack_limit_bytes() -> usize {

--- a/core/src/toolset/searchable/concourse.rs
+++ b/core/src/toolset/searchable/concourse.rs
@@ -163,7 +163,11 @@ struct BuildStatusOutput {
     status: String,
     pipeline: Option<String>,
     job: Option<String>,
+    /// Build start time as Unix epoch **seconds** (multiply by 1000 for
+    /// `new Date(start_time * 1000)` in JavaScript).
     start_time: Option<i64>,
+    /// Build end time as Unix epoch **seconds** (multiply by 1000 for
+    /// `new Date(end_time * 1000)` in JavaScript).
     end_time: Option<i64>,
 }
 
@@ -193,8 +197,52 @@ struct BuildSummaryOutput {
     build_id: u64,
     name: String,
     status: String,
+    /// Build start time as Unix epoch **seconds** (multiply by 1000 for
+    /// `new Date(start_time * 1000)` in JavaScript).
     start_time: Option<i64>,
+    /// Build end time as Unix epoch **seconds** (multiply by 1000 for
+    /// `new Date(end_time * 1000)` in JavaScript).
     end_time: Option<i64>,
+}
+
+#[cfg(test)]
+mod schema_tests {
+    use super::*;
+
+    /// Doc comments on schemars-derived structs land in the rendered
+    /// JSON Schema's `description` field for that property. They flow
+    /// through to `compose_types` (TS signature for compose scripts) and
+    /// `describe_tool` (raw JSON Schema), so agents see the time-unit
+    /// guidance before writing scripts that touch these fields.
+    fn description_for(schema: &serde_json::Value, field: &str) -> String {
+        schema
+            .get("properties")
+            .and_then(|p| p.get(field))
+            .and_then(|f| f.get("description"))
+            .and_then(|d| d.as_str())
+            .unwrap_or("")
+            .to_string()
+    }
+
+    #[test]
+    fn build_summary_time_fields_carry_unit_descriptions() {
+        let schema = schema_for::<BuildSummaryOutput>();
+        assert!(
+            description_for(&schema, "start_time").contains("seconds"),
+            "start_time description missing 'seconds' guidance: {schema:#}"
+        );
+        assert!(
+            description_for(&schema, "end_time").contains("seconds"),
+            "end_time description missing 'seconds' guidance: {schema:#}"
+        );
+    }
+
+    #[test]
+    fn build_status_time_fields_carry_unit_descriptions() {
+        let schema = schema_for::<BuildStatusOutput>();
+        assert!(description_for(&schema, "start_time").contains("seconds"));
+        assert!(description_for(&schema, "end_time").contains("seconds"));
+    }
 }
 
 #[derive(serde::Serialize, schemars::JsonSchema)]

--- a/dev/drua.default.yml
+++ b/dev/drua.default.yml
@@ -25,10 +25,10 @@ toolsets:
     db_path: ''
   compose:
     max_tool_calls: 50
-    max_tool_result_bytes: 4194304
+    max_tool_result_bytes: 33554432
     max_return_bytes: 102400
     max_console_bytes: 8192
-    memory_limit_bytes: 8388608
+    memory_limit_bytes: 67108864
     stack_limit_bytes: 524288
     default_timeout_ms: 120000
     max_timeout_ms: 300000


### PR DESCRIPTION
Two independent fixes per memo `019dd0bb`, addressing the most common
compose reliability failures observed in production audit logs.

## 1. Cap bumps for real-world payloads

Compose's value proposition is **reaching uncapped data** so scripts can
filter / cross-reference in JS — the per-tool cap exists only as a
safety net against pathological cases. The previous defaults fired well
before realistic Concourse build logs finished streaming, aborting
scripts before their own tail-filter could run (e.g. audit id 8229, a
35-min build that ran past 4 MiB).

| Setting | Old | New | Rationale |
|---|---|---|---|
| `max_tool_result_bytes` | 4 MiB | **32 MiB** | Covers 95–99th percentile build logs |
| `memory_limit_bytes`    | 8 MiB | **64 MiB** | Kept at ≥ 2× the per-tool cap for working room |
| everything else         | — | unchanged | |

Cost is pay-as-you-go: the cap check is O(1) and QuickJS heap grows
lazily, so scripts that don't fetch large payloads pay nothing.

Updates flow through:
- `ComposeConfig::default` in `core/src/toolset/config.rs`
- chart defaults in `charts/drua/values.yaml`
- prod overrides in `ci/deploy/drua/prod-values.yml.tmpl` (was 8 MiB / 16 MiB)
- regenerated `dev/drua.default.yml` snapshot

## 2. Concourse time-unit docs

`BuildSummaryOutput` and `BuildStatusOutput` declared `start_time` /
`end_time` as bare `Option<i64>`. The Concourse API returns Unix epoch
**seconds**, but JavaScript's `new Date(n)` treats `n` as milliseconds —
yielding 1970 timestamps that sent agents on verification detours
(e.g. audit id 8225 → 8226).

Doc comments on schemars-derived structs surface in the rendered JSON
Schema's `description` field for that property. That flows through both
`compose_types` (TS signature compose scripts see) and `describe_tool`
(raw schema), so agents see the guidance **before** writing any script
that touches these fields.

A new `schema_tests` module asserts the descriptions actually land at
`properties.<field>.description` in the rendered schema.

## Combined impact

Both fixes are tiny, low-risk, and orthogonal — but the memo recommended
shipping them together because they fix the same observed failure trace
end-to-end. After both, comparable runs land in ~8–9 turns rather than 13.

## Test plan

- [x] `cargo fmt`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo nextest run` — full suite via `nix flake check`
- [x] new `schema_tests::build_summary_time_fields_carry_unit_descriptions` + `build_status_time_fields_carry_unit_descriptions` — pass
- [x] `nix flake check` (fmt + clippy + nextest + graphql-schema + default-config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)