### PR TITLE
refactor: enforce transactional consistency in services with multiple repo calls

### DIFF
--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -433,6 +433,34 @@ impl Agents {
         Ok(result.entities)
     }
 
+    /// Composable variant of [`Self::list_for_workspace`] — used by the
+    /// workspace cascade-delete so the listing reads against the same op
+    /// in which agents are subsequently soft-deleted. No auth check; this
+    /// is `pub(crate)` and called from contexts that have already
+    /// authorized the workspace-level delete.
+    #[instrument(name = "domain.agent.list_for_workspace_in_op", skip(self, op))]
+    pub(crate) async fn list_for_workspace_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        workspace_id: WorkspaceId,
+    ) -> Result<Vec<Agent>, AgentError> {
+        Audit::record_workspace_id(workspace_id);
+        let query = es_entity::PaginatedQueryArgs {
+            first: 100,
+            after: None,
+        };
+        let result = self
+            .repo
+            .list_for_workspace_id_by_created_at_in_op(
+                &mut *op,
+                workspace_id,
+                query,
+                es_entity::ListDirection::Descending,
+            )
+            .await?;
+        Ok(result.entities)
+    }
+
     #[instrument(name = "domain.agent.delete_in_op", skip(self, op))]
     pub async fn delete_in_op(
         &self,
@@ -440,7 +468,12 @@ impl Agents {
         id: impl Into<AgentId> + std::fmt::Debug,
     ) -> Result<(), AgentError> {
         let id = id.into();
-        let agent = self.repo.find_by_id(id).await?;
+        // Load through the same op so the read-then-delete sequence is
+        // serialized with concurrent writers — without this, another
+        // session could mutate the agent (e.g. attach a sandbox) between
+        // the load and the soft-delete, and that mutation would silently
+        // be lost.
+        let agent = self.repo.find_by_id_in_op(&mut *op, id).await?;
         Audit::record_workspace_id(agent.workspace_id);
         Audit::record_agent_id(id);
         // Cascade soft-delete to the agent's session and all its threads
@@ -481,7 +514,10 @@ impl Agents {
         // Agent side first: `sandbox_attached` enforces the entity-level
         // invariants (lead can't attach; at most one sandbox per agent).
         // Failing here short-circuits before the sandbox-side round-trip.
-        let mut agent = self.repo.find_by_id(agent_id).await?;
+        // Load inside the op so the load + update + cross-service mutations
+        // form one serializable transaction (otherwise a concurrent
+        // attach/detach could win the race against this update).
+        let mut agent = self.repo.find_by_id_in_op(&mut op, agent_id).await?;
         if agent.sandbox_attached(sandbox_id, mode)?.did_execute() {
             self.repo.update_in_op(&mut op, &mut agent).await?;
         }
@@ -531,7 +567,9 @@ impl Agents {
         let mut op = self.repo.begin_op().await?;
 
         // Symmetric with attach: agent side first, then sandbox side.
-        let mut agent = self.repo.find_by_id(agent_id).await?;
+        // Load inside the op so the read + write are atomic (see comment
+        // in `attach_sandbox`).
+        let mut agent = self.repo.find_by_id_in_op(&mut op, agent_id).await?;
         if agent.sandbox_detached(sandbox_id).did_execute() {
             self.repo.update_in_op(&mut op, &mut agent).await?;
         }

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -433,11 +433,6 @@ impl Agents {
         Ok(result.entities)
     }
 
-    /// Composable variant of [`Self::list_for_workspace`] — used by the
-    /// workspace cascade-delete so the listing reads against the same op
-    /// in which agents are subsequently soft-deleted. No auth check; this
-    /// is `pub(crate)` and called from contexts that have already
-    /// authorized the workspace-level delete.
     #[instrument(name = "domain.agent.list_for_workspace_in_op", skip(self, op))]
     pub(crate) async fn list_for_workspace_in_op(
         &self,
@@ -468,11 +463,6 @@ impl Agents {
         id: impl Into<AgentId> + std::fmt::Debug,
     ) -> Result<(), AgentError> {
         let id = id.into();
-        // Load through the same op so the read-then-delete sequence is
-        // serialized with concurrent writers — without this, another
-        // session could mutate the agent (e.g. attach a sandbox) between
-        // the load and the soft-delete, and that mutation would silently
-        // be lost.
         let agent = self.repo.find_by_id_in_op(&mut *op, id).await?;
         Audit::record_workspace_id(agent.workspace_id);
         Audit::record_agent_id(id);
@@ -514,9 +504,6 @@ impl Agents {
         // Agent side first: `sandbox_attached` enforces the entity-level
         // invariants (lead can't attach; at most one sandbox per agent).
         // Failing here short-circuits before the sandbox-side round-trip.
-        // Load inside the op so the load + update + cross-service mutations
-        // form one serializable transaction (otherwise a concurrent
-        // attach/detach could win the race against this update).
         let mut agent = self.repo.find_by_id_in_op(&mut op, agent_id).await?;
         if agent.sandbox_attached(sandbox_id, mode)?.did_execute() {
             self.repo.update_in_op(&mut op, &mut agent).await?;
@@ -567,8 +554,6 @@ impl Agents {
         let mut op = self.repo.begin_op().await?;
 
         // Symmetric with attach: agent side first, then sandbox side.
-        // Load inside the op so the read + write are atomic (see comment
-        // in `attach_sandbox`).
         let mut agent = self.repo.find_by_id_in_op(&mut op, agent_id).await?;
         if agent.sandbox_detached(sandbox_id).did_execute() {
             self.repo.update_in_op(&mut op, &mut agent).await?;

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -81,11 +81,6 @@ impl Sessions {
         prompt: String,
         proposed_system_blocks: Vec<SystemBlock>,
     ) -> Result<AgentSessionResponse, AgentSessionError> {
-        // Load + update in a single op so concurrent turns on the same
-        // session (e.g. parallel `send_message` calls) can't lose each
-        // other's events. Without the shared op, two concurrent loaders
-        // would both see the pre-state and the second update overwrites
-        // the first.
         let mut op = self.repo.begin_op().await?;
         let mut session = self.repo.find_by_agent_id_in_op(&mut op, agent_id).await?;
         let _ = session.apply_proposed_system_blocks(proposed_system_blocks);

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -81,10 +81,17 @@ impl Sessions {
         prompt: String,
         proposed_system_blocks: Vec<SystemBlock>,
     ) -> Result<AgentSessionResponse, AgentSessionError> {
-        let mut session = self.repo.find_by_agent_id(agent_id).await?;
+        // Load + update in a single op so concurrent turns on the same
+        // session (e.g. parallel `send_message` calls) can't lose each
+        // other's events. Without the shared op, two concurrent loaders
+        // would both see the pre-state and the second update overwrites
+        // the first.
+        let mut op = self.repo.begin_op().await?;
+        let mut session = self.repo.find_by_agent_id_in_op(&mut op, agent_id).await?;
         let _ = session.apply_proposed_system_blocks(proposed_system_blocks);
         let response = session.add_user_input(target, source, prompt)?;
-        self.repo.update(&mut session).await?;
+        self.repo.update_in_op(&mut op, &mut session).await?;
+        op.commit().await?;
         Ok(response)
     }
 
@@ -94,9 +101,11 @@ impl Sessions {
         agent_id: AgentId,
         target: TargetThread,
     ) -> Result<llm::Prompt, AgentSessionError> {
-        let mut session = self.repo.find_by_agent_id(agent_id).await?;
+        let mut op = self.repo.begin_op().await?;
+        let mut session = self.repo.find_by_agent_id_in_op(&mut op, agent_id).await?;
         let prompt = session.next_prompt(target)?;
-        self.repo.update(&mut session).await?;
+        self.repo.update_in_op(&mut op, &mut session).await?;
+        op.commit().await?;
         Ok(prompt.into())
     }
 
@@ -110,7 +119,8 @@ impl Sessions {
         response: llm::PromptResponse,
         model: String,
     ) -> Result<AgentSessionResponse, AgentSessionError> {
-        let mut session = self.repo.find_by_agent_id(agent_id).await?;
+        let mut op = self.repo.begin_op().await?;
+        let mut session = self.repo.find_by_agent_id_in_op(&mut op, agent_id).await?;
         let thread_id = session
             .current_main_thread_id()
             .ok_or(AgentSessionError::ThreadNotFound)?;
@@ -129,7 +139,8 @@ impl Sessions {
 
         let result =
             session.assistant_response_received(thread_id, content, stop_reason, None, metadata)?;
-        self.repo.update(&mut session).await?;
+        self.repo.update_in_op(&mut op, &mut session).await?;
+        op.commit().await?;
         Ok(result)
     }
 
@@ -139,7 +150,8 @@ impl Sessions {
         agent_id: AgentId,
         results: Vec<llm::ToolUseResult>,
     ) -> Result<AgentSessionResponse, AgentSessionError> {
-        let mut session = self.repo.find_by_agent_id(agent_id).await?;
+        let mut op = self.repo.begin_op().await?;
+        let mut session = self.repo.find_by_agent_id_in_op(&mut op, agent_id).await?;
         let thread_id = session
             .current_main_thread_id()
             .ok_or(AgentSessionError::ThreadNotFound)?;
@@ -147,7 +159,8 @@ impl Sessions {
         let tool_results: Vec<ToolResultInput> =
             results.into_iter().map(ToolResultInput::from).collect();
         let result = session.add_tool_results(thread_id, tool_results)?;
-        self.repo.update(&mut session).await?;
+        self.repo.update_in_op(&mut op, &mut session).await?;
+        op.commit().await?;
         Ok(result)
     }
 

--- a/core/src/mcp_creds/mod.rs
+++ b/core/src/mcp_creds/mod.rs
@@ -76,7 +76,11 @@ impl McpCredentials {
         id: impl Into<McpCredsId> + std::fmt::Debug,
     ) -> Result<McpCreds, McpCredsError> {
         let id = id.into();
-        let mut creds = self.repo.find_by_id(id).await?;
+        // Load + update inside one op: otherwise a concurrent revoke
+        // could observe the same pre-state and the second update would
+        // overwrite the first's event.
+        let mut op = self.repo.begin_op().await?;
+        let mut creds = self.repo.find_by_id_in_op(&mut op, id).await?;
         sub.can(AuthVerb::Delete, AuthResource::McpCreds(Some(creds.id)))?;
 
         let is_owner =
@@ -91,8 +95,9 @@ impl McpCredentials {
         }
 
         if creds.revoke().did_execute() {
-            self.repo.update(&mut creds).await?;
+            self.repo.update_in_op(&mut op, &mut creds).await?;
         }
+        op.commit().await?;
 
         Ok(creds)
     }
@@ -104,7 +109,7 @@ impl McpCredentials {
         id: impl Into<McpCredsId> + std::fmt::Debug,
     ) -> Result<McpCreds, McpCredsError> {
         let id = id.into();
-        let mut creds = self.repo.find_by_id(id).await?;
+        let mut creds = self.repo.find_by_id_in_op(&mut *op, id).await?;
 
         if creds.revoke().did_execute() {
             self.repo.update_in_op(op, &mut creds).await?;

--- a/core/src/mcp_creds/mod.rs
+++ b/core/src/mcp_creds/mod.rs
@@ -76,9 +76,6 @@ impl McpCredentials {
         id: impl Into<McpCredsId> + std::fmt::Debug,
     ) -> Result<McpCreds, McpCredsError> {
         let id = id.into();
-        // Load + update inside one op: otherwise a concurrent revoke
-        // could observe the same pre-state and the second update would
-        // overwrite the first's event.
         let mut op = self.repo.begin_op().await?;
         let mut creds = self.repo.find_by_id_in_op(&mut op, id).await?;
         sub.can(AuthVerb::Delete, AuthResource::McpCreds(Some(creds.id)))?;

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -274,10 +274,6 @@ impl Sandboxes {
         response: &InitializeResponse,
     ) -> Result<(), SandboxError> {
         let mut op = self.repo.begin_op().await?;
-        // Load inside the op so the load+update form one serializable
-        // transaction; otherwise a concurrent suspend/restart could race
-        // and have its event silently overwritten by the stale entity
-        // loaded here.
         let mut sandbox = self.repo.find_by_id_in_op(&mut op, id).await?;
         if sandbox.initialized(response).did_execute() {
             self.repo.update_in_op(&mut op, &mut sandbox).await?;
@@ -480,9 +476,6 @@ impl Sandboxes {
         id: impl Into<SandboxId> + std::fmt::Debug,
     ) -> Result<Sandbox, SandboxError> {
         let id = id.into();
-        // Pre-op load purely for authorization; the authoritative load
-        // for the mutation happens inside the op below so the entity we
-        // mutate reflects the row state at transaction start.
         let pre = self.repo.find_by_id(id).await?;
         sub.can(
             AuthVerb::Update,
@@ -523,9 +516,6 @@ impl Sandboxes {
         Audit::record_sandbox_id(sandbox_id);
         Audit::record_workspace_id(workspace_id);
         Audit::record_agent_id(agent_id);
-        // Load through the caller's op so the single-writer invariant
-        // checked by `attach_agent` (and the resulting update) are
-        // serialized with concurrent attaches/detaches.
         let mut sandbox = self.repo.find_by_id_in_op(&mut *op, sandbox_id).await?;
         if sandbox
             .attach_agent(agent_id, workspace_id, mode)?
@@ -573,10 +563,6 @@ impl Sandboxes {
             first: 100,
             after: None,
         };
-        // List + suspend through the same op so the cascade is
-        // serialized with any concurrent sandbox creation in the
-        // workspace (would otherwise leave a freshly-created sandbox
-        // un-suspended through the workspace deletion).
         let result = self
             .repo
             .list_for_workspace_id_by_created_at_in_op(

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -274,7 +274,11 @@ impl Sandboxes {
         response: &InitializeResponse,
     ) -> Result<(), SandboxError> {
         let mut op = self.repo.begin_op().await?;
-        let mut sandbox = self.repo.find_by_id(id).await?;
+        // Load inside the op so the load+update form one serializable
+        // transaction; otherwise a concurrent suspend/restart could race
+        // and have its event silently overwritten by the stale entity
+        // loaded here.
+        let mut sandbox = self.repo.find_by_id_in_op(&mut op, id).await?;
         if sandbox.initialized(response).did_execute() {
             self.repo.update_in_op(&mut op, &mut sandbox).await?;
         }
@@ -285,7 +289,7 @@ impl Sandboxes {
     /// Idempotent transition into [`SandboxState::Initializing`].
     async fn run_initializing(&self, id: SandboxId) -> Result<(), SandboxError> {
         let mut op = self.repo.begin_op().await?;
-        let mut sandbox = self.repo.find_by_id(id).await?;
+        let mut sandbox = self.repo.find_by_id_in_op(&mut op, id).await?;
         if sandbox.initializing().did_execute() {
             self.repo.update_in_op(&mut op, &mut sandbox).await?;
         }
@@ -313,7 +317,7 @@ impl Sandboxes {
         reason: &str,
     ) -> Result<(), SandboxError> {
         let mut op = self.repo.begin_op().await?;
-        let mut sandbox = self.repo.find_by_id(id).await?;
+        let mut sandbox = self.repo.find_by_id_in_op(&mut op, id).await?;
         if sandbox.errored(step, reason).did_execute() {
             self.repo.update_in_op(&mut op, &mut sandbox).await?;
         }
@@ -476,15 +480,19 @@ impl Sandboxes {
         id: impl Into<SandboxId> + std::fmt::Debug,
     ) -> Result<Sandbox, SandboxError> {
         let id = id.into();
-        let mut sandbox = self.repo.find_by_id(id).await?;
+        // Pre-op load purely for authorization; the authoritative load
+        // for the mutation happens inside the op below so the entity we
+        // mutate reflects the row state at transaction start.
+        let pre = self.repo.find_by_id(id).await?;
         sub.can(
             AuthVerb::Update,
-            AuthResource::Sandbox(sandbox.workspace_id, Some(sandbox.id)),
+            AuthResource::Sandbox(pre.workspace_id, Some(pre.id)),
         )?;
         Audit::record_action_if_unset("sandbox.restart");
-        Audit::record_workspace_id(sandbox.workspace_id);
+        Audit::record_workspace_id(pre.workspace_id);
         Audit::record_sandbox_id(id);
         let mut op = self.repo.begin_op().await?;
+        let mut sandbox = self.repo.find_by_id_in_op(&mut op, id).await?;
         if sandbox.provisioning().did_execute() {
             self.repo.update_in_op(&mut op, &mut sandbox).await?;
         }
@@ -515,7 +523,10 @@ impl Sandboxes {
         Audit::record_sandbox_id(sandbox_id);
         Audit::record_workspace_id(workspace_id);
         Audit::record_agent_id(agent_id);
-        let mut sandbox = self.repo.find_by_id(sandbox_id).await?;
+        // Load through the caller's op so the single-writer invariant
+        // checked by `attach_agent` (and the resulting update) are
+        // serialized with concurrent attaches/detaches.
+        let mut sandbox = self.repo.find_by_id_in_op(&mut *op, sandbox_id).await?;
         if sandbox
             .attach_agent(agent_id, workspace_id, mode)?
             .did_execute()
@@ -540,7 +551,7 @@ impl Sandboxes {
     ) -> Result<Sandbox, SandboxError> {
         Audit::record_sandbox_id(sandbox_id);
         Audit::record_agent_id(agent_id);
-        let mut sandbox = self.repo.find_by_id(sandbox_id).await?;
+        let mut sandbox = self.repo.find_by_id_in_op(&mut *op, sandbox_id).await?;
         if sandbox.detach_agent(agent_id).did_execute() {
             self.repo.update_in_op(op, &mut sandbox).await?;
         }
@@ -562,9 +573,18 @@ impl Sandboxes {
             first: 100,
             after: None,
         };
+        // List + suspend through the same op so the cascade is
+        // serialized with any concurrent sandbox creation in the
+        // workspace (would otherwise leave a freshly-created sandbox
+        // un-suspended through the workspace deletion).
         let result = self
             .repo
-            .list_for_workspace_id_by_created_at(workspace_id, query, ListDirection::Descending)
+            .list_for_workspace_id_by_created_at_in_op(
+                &mut *op,
+                workspace_id,
+                query,
+                ListDirection::Descending,
+            )
             .await?;
         for sandbox in result.entities {
             if sandbox.state == SandboxState::Suspended {
@@ -615,7 +635,7 @@ impl Sandboxes {
     ) -> Result<Sandbox, SandboxError> {
         let id = id.into();
         Audit::record_sandbox_id(id);
-        let mut sandbox = self.repo.find_by_id(id).await?;
+        let mut sandbox = self.repo.find_by_id_in_op(&mut *op, id).await?;
 
         let resource_name = sandbox.resource_name();
         if let Err(e) = self.admin.delete_sandbox(&resource_name).await {

--- a/core/src/workspace/mod.rs
+++ b/core/src/workspace/mod.rs
@@ -137,9 +137,13 @@ impl Workspaces {
         sub.can(AuthVerb::Update, AuthResource::Workspace(Some(id)))?;
         Audit::record_action_if_unset("workspace.update");
         Audit::record_workspace_id(id);
-        let mut workspace = self.repo.find_by_id(id).await?;
+        // Load + update in the same op so a concurrent update or delete
+        // can't slip in between and produce a lost write.
+        let mut op = self.repo.begin_op().await?;
+        let mut workspace = self.repo.find_by_id_in_op(&mut op, id).await?;
         workspace.update(description);
-        self.repo.update(&mut workspace).await?;
+        self.repo.update_in_op(&mut op, &mut workspace).await?;
+        op.commit().await?;
         Ok(workspace)
     }
 
@@ -167,7 +171,9 @@ impl Workspaces {
         id: impl Into<WorkspaceId> + std::fmt::Debug,
     ) -> Result<Workspace, WorkspaceError> {
         let id = id.into();
-        let mut workspace = self.repo.find_by_id(id).await?;
+        // Load through the cascade op so the workspace state we observe
+        // here matches what the rest of this transaction operates on.
+        let mut workspace = self.repo.find_by_id_in_op(&mut *op, id).await?;
 
         if !workspace.archive().did_execute() {
             return Ok(workspace);
@@ -181,7 +187,10 @@ impl Workspaces {
         }
 
         // ── 2. Cascade soft-delete agents (→ sessions → threads) ───────
-        let agent_list = self.agents.list_for_workspace(_sub, id).await?;
+        // Use the op-aware listing so agents created concurrently with
+        // this transaction don't escape the cascade (the listing snapshot
+        // matches the rest of the cascade's view).
+        let agent_list = self.agents.list_for_workspace_in_op(op, id).await?;
         for agent in &agent_list {
             if let Err(e) = self.agents.delete_in_op(op, agent.id).await {
                 tracing::warn!(
@@ -217,10 +226,13 @@ impl Workspaces {
         }
 
         // ── 7. Archive + soft-delete the workspace entity itself ───────
-        self.repo.update_in_op(op, &mut workspace).await?;
-        self.repo
-            .delete_in_op(op, self.repo.find_by_id(id).await?)
-            .await?;
+        // Persist the archive event first; the second load is reused
+        // because `delete_in_op` moves the entity. Both operations go
+        // through `op` so the read-write sequence is serialized with any
+        // concurrent workspace updates.
+        self.repo.update_in_op(&mut *op, &mut workspace).await?;
+        let to_delete = self.repo.find_by_id_in_op(&mut *op, id).await?;
+        self.repo.delete_in_op(op, to_delete).await?;
         Ok(workspace)
     }
 

--- a/core/src/workspace/mod.rs
+++ b/core/src/workspace/mod.rs
@@ -137,8 +137,6 @@ impl Workspaces {
         sub.can(AuthVerb::Update, AuthResource::Workspace(Some(id)))?;
         Audit::record_action_if_unset("workspace.update");
         Audit::record_workspace_id(id);
-        // Load + update in the same op so a concurrent update or delete
-        // can't slip in between and produce a lost write.
         let mut op = self.repo.begin_op().await?;
         let mut workspace = self.repo.find_by_id_in_op(&mut op, id).await?;
         workspace.update(description);
@@ -171,8 +169,6 @@ impl Workspaces {
         id: impl Into<WorkspaceId> + std::fmt::Debug,
     ) -> Result<Workspace, WorkspaceError> {
         let id = id.into();
-        // Load through the cascade op so the workspace state we observe
-        // here matches what the rest of this transaction operates on.
         let mut workspace = self.repo.find_by_id_in_op(&mut *op, id).await?;
 
         if !workspace.archive().did_execute() {
@@ -187,9 +183,6 @@ impl Workspaces {
         }
 
         // ── 2. Cascade soft-delete agents (→ sessions → threads) ───────
-        // Use the op-aware listing so agents created concurrently with
-        // this transaction don't escape the cascade (the listing snapshot
-        // matches the rest of the cascade's view).
         let agent_list = self.agents.list_for_workspace_in_op(op, id).await?;
         for agent in &agent_list {
             if let Err(e) = self.agents.delete_in_op(op, agent.id).await {
@@ -226,10 +219,6 @@ impl Workspaces {
         }
 
         // ── 7. Archive + soft-delete the workspace entity itself ───────
-        // Persist the archive event first; the second load is reused
-        // because `delete_in_op` moves the entity. Both operations go
-        // through `op` so the read-write sequence is serialized with any
-        // concurrent workspace updates.
         self.repo.update_in_op(&mut *op, &mut workspace).await?;
         let to_delete = self.repo.find_by_id_in_op(&mut *op, id).await?;
         self.repo.delete_in_op(op, to_delete).await?;

--- a/core/src/workspace_secret/mod.rs
+++ b/core/src/workspace_secret/mod.rs
@@ -120,15 +120,19 @@ impl WorkspaceSecrets {
         id: WorkspaceSecretId,
         value: &str,
     ) -> Result<WorkspaceSecret, WorkspaceSecretError> {
-        let mut secret = self.repo.find_by_id(id).await?;
+        // Load + update through the same op so a concurrent rotate /
+        // delete can't slip in between and produce a lost update.
+        let mut op = self.repo.begin_op().await?;
+        let mut secret = self.repo.find_by_id_in_op(&mut op, id).await?;
         sub.can(
             AuthVerb::Update,
             AuthResource::WorkspaceSecret(secret.workspace_id, Some(secret.id)),
         )?;
         let encrypted_value = self.encryption_key.encrypt_string(value);
         if secret.update_value(encrypted_value).did_execute() {
-            self.repo.update(&mut secret).await?;
+            self.repo.update_in_op(&mut op, &mut secret).await?;
         }
+        op.commit().await?;
         Ok(secret)
     }
 
@@ -139,12 +143,14 @@ impl WorkspaceSecrets {
         sub: &AuthSubject,
         id: WorkspaceSecretId,
     ) -> Result<(), WorkspaceSecretError> {
-        let secret = self.repo.find_by_id(id).await?;
+        let mut op = self.repo.begin_op().await?;
+        let secret = self.repo.find_by_id_in_op(&mut op, id).await?;
         sub.can(
             AuthVerb::Delete,
             AuthResource::WorkspaceSecret(secret.workspace_id, Some(secret.id)),
         )?;
-        self.repo.delete(secret).await?;
+        self.repo.delete_in_op(&mut op, secret).await?;
+        op.commit().await?;
         Ok(())
     }
 

--- a/core/src/workspace_secret/mod.rs
+++ b/core/src/workspace_secret/mod.rs
@@ -120,8 +120,6 @@ impl WorkspaceSecrets {
         id: WorkspaceSecretId,
         value: &str,
     ) -> Result<WorkspaceSecret, WorkspaceSecretError> {
-        // Load + update through the same op so a concurrent rotate /
-        // delete can't slip in between and produce a lost update.
         let mut op = self.repo.begin_op().await?;
         let mut secret = self.repo.find_by_id_in_op(&mut op, id).await?;
         sub.can(


### PR DESCRIPTION
## Summary

Audited every service method in `core/src/**` for multi-round-trip
repo sequences that didn't share an atomic operation. The classic
shape

```rust
let mut entity = self.repo.find_by_id(id).await?;
entity.do_thing()?;
self.repo.update(&mut entity).await?;
```

opens a **lost-update window**: a concurrent writer can mutate the
entity between the load and the update, and that mutation is silently
overwritten when the second update commits. The same hazard applies
when an outer `op` is already in scope but a load is issued through
the standalone (non-`_in_op`) variant — the load reads outside the
serializable transaction the rest of the method runs in.

## Audit scope

Every service method across `core/src/{agent, agent/session, note,
skill, sandbox, workspace, workspace_secret, mcp_creds, user,
library, library/job}`. Approximately 80 service methods reviewed.

## Methods fixed

### `agent::Agents`
- `attach_sandbox`, `detach_sandbox`: load through `find_by_id_in_op`
  inside the new op (was loading outside, then issuing op-aware
  updates against potentially stale state)
- `delete_in_op`: load through `find_by_id_in_op` (was loading outside
  the cascade op)
- New `list_for_workspace_in_op` (pub(crate)) so the workspace
  cascade-delete snapshots agents through the same op it deletes them
  in — agents created concurrently with the cascade can no longer
  escape soft-deletion

### `agent::session::Sessions`
- `add_user_input`, `next_prompt`, `assistant_response_received`,
  `add_tool_results`: every one was a `find_by_agent_id` + `update`
  pair with no shared transaction. Concurrent turns on the same
  session (parallel `send_message` calls, or a tool-result write
  racing a user-input write) could each load the same pre-state and
  the second update overwrites the first's events. All four are now
  wrapped in `begin_op` / `find_by_agent_id_in_op` / `update_in_op` /
  `commit`

### `sandbox::Sandboxes`
- `apply_initialized`, `run_initializing`, `persist_errored`: lifecycle
  state-transition methods that began an op, then loaded outside it,
  then updated inside it
- `restart`: pre-op load was used both for authz **and** as the entity
  passed to `update_in_op`; split so the authz load is read-only and
  the mutation load goes through the op
- `suspend_in_op`, `attach_to_agent_in_op`, `detach_from_agent_in_op`:
  `_in_op` methods that received a caller op but issued the load via
  the non-op variant
- `suspend_for_workspace_in_op`: `list_for_workspace_id_by_created_at`
  was outside the cascade op — sandboxes created concurrently with
  the workspace deletion could escape suspension. Now uses the
  generated `_in_op` listing variant

### `workspace::Workspaces`
- `update`: wrap load + update in one op
- `delete_in_op`: load via `_in_op`; agent listing for the cascade now
  routes through the new `Agents::list_for_workspace_in_op`; final
  `update_in_op` + `delete_in_op` both go through the cascade op

### `workspace_secret::WorkspaceSecrets`
- `update_value`, `delete`: wrap in single op

### `mcp_creds::McpCredentials`
- `revoke`: wrap load + update in one op
- `revoke_in_op`: load via `find_by_id_in_op`

## Patterns deferred / not touched

- **`note::Notes`** — already correct; every mutation method begins an
  op (via the workspace-context-bump-aware `begin_op` helper) and uses
  `_in_op` variants throughout
- **`skill::Skills`** — already correct; the only mutation
  (`upsert_from_library_in_op`) is op-aware by signature. All other
  methods are read-only
- **`library::Library`** — only exposes `_in_op` mutation methods;
  callers are responsible for the op
- **`user::Users`** — only single-round-trip methods
- **`skill::job`** — already op-aware

No public API removed. `_in_op` variants were already on every repo
because they're generated by `EsRepo`; the only new public-ish method
is `Agents::list_for_workspace_in_op` (pub(crate)).

## Test plan

- [x] `cargo fmt && git add -A && nix flake check` — passes
- [x] `cargo nextest run -p drua-core` — 191 / 191 pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)