### PR TITLE
refactor(authz): consolidate authorization to service-layer can() — remove toolset redundancy

### DIFF
--- a/core/src/auth/subject.rs
+++ b/core/src/auth/subject.rs
@@ -80,19 +80,6 @@ impl AuthSubject {
         self.has_scope(&AuthScope::Admin)
     }
 
-    /// `WorkspaceRead`/`WorkspaceWrite` were collapsed into
-    /// [`AuthScope::WorkspaceAdmin`]; this is the single workspace-level check.
-    pub fn can_read_workspace(&self) -> bool {
-        self.workspace_id()
-            .is_some_and(|ws| self.has_scope(&AuthScope::WorkspaceAdmin(ws)))
-    }
-
-    /// Currently identical to [`Self::can_read_workspace`]; kept distinct so
-    /// write-side call sites stay readable and can diverge later.
-    pub fn can_write_workspace(&self) -> bool {
-        self.can_read_workspace()
-    }
-
     /// Users implicitly have all scopes.
     pub fn has_scope(&self, scope: &AuthScope) -> bool {
         match self {
@@ -141,5 +128,109 @@ impl AuthSubject {
             },
             AuthSubject::Anonymous => panic!("Anonymous subject has no message source"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ws() -> WorkspaceId {
+        WorkspaceId::from(uuid::Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8").unwrap())
+    }
+
+    fn other_ws() -> WorkspaceId {
+        WorkspaceId::from(uuid::Uuid::parse_str("b1b2b3b4-c1c2-d1d2-e1e2-e3e4e5e6e7e8").unwrap())
+    }
+
+    fn member(ws: WorkspaceId) -> AuthSubject {
+        AuthSubject::Agent(ws, AgentId::new(), vec![AuthScope::WorkspaceMember(ws)])
+    }
+
+    fn admin(ws: WorkspaceId) -> AuthSubject {
+        AuthSubject::Agent(ws, AgentId::new(), vec![AuthScope::WorkspaceAdmin(ws)])
+    }
+
+    #[test]
+    fn user_is_omnipotent() {
+        let user = AuthSubject::User(UserId::new());
+        assert!(user
+            .can(AuthVerb::Delete, AuthResource::Sandbox(ws(), None))
+            .is_ok());
+    }
+
+    #[test]
+    fn anonymous_authentication_required() {
+        let err = AuthSubject::Anonymous
+            .can(AuthVerb::Read, AuthResource::Workspace(None))
+            .unwrap_err();
+        assert!(matches!(err, AuthorizationError::AuthenticationRequired));
+    }
+
+    #[test]
+    fn workspace_admin_permits_management_resources() {
+        let s = admin(ws());
+        for verb in [
+            AuthVerb::Read,
+            AuthVerb::Create,
+            AuthVerb::Update,
+            AuthVerb::Delete,
+        ] {
+            assert!(s.can(verb, AuthResource::Sandbox(ws(), None)).is_ok());
+            assert!(s.can(verb, AuthResource::Agent(ws(), None)).is_ok());
+            assert!(s.can(verb, AuthResource::Workflow(ws(), None)).is_ok());
+            assert!(s.can(verb, AuthResource::Skill(ws(), None)).is_ok());
+        }
+        assert!(s.can(AuthVerb::Read, AuthResource::AuditLog(ws())).is_ok());
+    }
+
+    /// Negative case: a `WorkspaceMember` cannot manage skills (or any
+    /// admin-only resource) — the privileged tool would be hidden via
+    /// visibility AND rejected at service entry. This is the consolidation
+    /// invariant the refactor guarantees.
+    #[test]
+    fn workspace_member_cannot_manage_admin_resources() {
+        let s = member(ws());
+        assert!(s
+            .can(AuthVerb::Update, AuthResource::Skill(ws(), None))
+            .is_err());
+        assert!(s
+            .can(AuthVerb::Create, AuthResource::Sandbox(ws(), None))
+            .is_err());
+        assert!(s
+            .can(AuthVerb::Read, AuthResource::Agent(ws(), None))
+            .is_err());
+        assert!(s
+            .can(AuthVerb::Read, AuthResource::Workflow(ws(), None))
+            .is_err());
+        assert!(s.can(AuthVerb::Read, AuthResource::AuditLog(ws())).is_err());
+    }
+
+    #[test]
+    fn workspace_member_can_use_skills_and_notes() {
+        let s = member(ws());
+        assert!(s
+            .can(AuthVerb::Use, AuthResource::Skill(ws(), None))
+            .is_ok());
+        assert!(s
+            .can(AuthVerb::Read, AuthResource::Skill(ws(), None))
+            .is_ok());
+        assert!(s
+            .can(AuthVerb::Create, AuthResource::Note(ws(), None))
+            .is_ok());
+        assert!(s
+            .can(AuthVerb::Update, AuthResource::Note(ws(), None))
+            .is_ok());
+    }
+
+    #[test]
+    fn cross_workspace_admin_cannot_access_other_workspace() {
+        let s = admin(ws());
+        assert!(s
+            .can(AuthVerb::Read, AuthResource::Sandbox(other_ws(), None))
+            .is_err());
+        assert!(s
+            .can(AuthVerb::Update, AuthResource::Skill(other_ws(), None))
+            .is_err());
     }
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -199,10 +199,7 @@ impl App {
             context_generation.clone(),
         ));
 
-        toolsets.register_top_level(WorkspaceAgent::new(
-            Arc::clone(&agents),
-            Arc::clone(&sandboxes),
-        ));
+        toolsets.register_top_level(WorkspaceAgent::new(Arc::clone(&agents)));
         toolsets.register_top_level(WorkspaceSandbox::new(Arc::clone(&sandboxes)));
 
         let execute_run_initializer = Workflows::execute_run_job_initializer(

--- a/core/src/toolset/top_level/agent.rs
+++ b/core/src/toolset/top_level/agent.rs
@@ -3,9 +3,9 @@
 //! Single tool with a `command` discriminator (like `text_editor`):
 //! `create`, `list`, `attach_sandbox`, `detach_sandbox`.
 //!
-//! Read commands (`list`) require `can_read_workspace`; write commands
-//! (`create`, `attach_sandbox`, `detach_sandbox`) enforce
-//! `can_write_workspace` inside `call()`.
+//! Authorization is delegated entirely to [`Agents`] / [`Sandboxes`]:
+//! every service method runs `subject.can(verb, resource)` itself, so
+//! this layer only routes parameters and surfaces errors.
 
 use std::sync::{Arc, LazyLock};
 
@@ -14,9 +14,9 @@ use serde::Deserialize;
 
 use crate::agent::{Agent, AgentRole, Agents};
 use crate::audit::Audit;
-use crate::auth::AuthSubject;
+use crate::auth::{AuthResource, AuthSubject, AuthVerb};
 use crate::primitives::{AgentId, SandboxId};
-use crate::sandbox::{SandboxAgentMode, Sandboxes};
+use crate::sandbox::SandboxAgentMode;
 
 use super::super::error::ToolSetsError;
 use super::super::traits::TopLevelTool;
@@ -55,12 +55,11 @@ impl WorkspaceAgentCommand {
 
 pub struct WorkspaceAgent {
     agents: Arc<Agents>,
-    sandboxes: Arc<Sandboxes>,
 }
 
 impl WorkspaceAgent {
-    pub fn new(agents: Arc<Agents>, sandboxes: Arc<Sandboxes>) -> Self {
-        Self { agents, sandboxes }
+    pub fn new(agents: Arc<Agents>) -> Self {
+        Self { agents }
     }
 }
 
@@ -100,7 +99,11 @@ impl TopLevelTool for WorkspaceAgent {
     }
 
     fn is_visible(&self, subject: &AuthSubject) -> bool {
-        subject.can_read_workspace()
+        subject.workspace_id().is_some_and(|ws| {
+            subject
+                .can(AuthVerb::Read, AuthResource::Agent(ws, None))
+                .is_ok()
+        })
     }
 
     fn composable(&self) -> bool {
@@ -119,9 +122,6 @@ impl TopLevelTool for WorkspaceAgent {
 
         match params.command {
             WorkspaceAgentCommand::Create => {
-                if !subject.can_write_workspace() {
-                    return Err(ToolSetsError::Unauthorized);
-                }
                 let name = params.name.ok_or_else(|| {
                     ToolSetsError::MissingArgument("name is required for create".to_string())
                 })?;
@@ -147,9 +147,6 @@ impl TopLevelTool for WorkspaceAgent {
             }
 
             WorkspaceAgentCommand::AttachSandbox => {
-                if !subject.can_write_workspace() {
-                    return Err(ToolSetsError::Unauthorized);
-                }
                 let agent_id = params.agent_id.ok_or_else(|| {
                     ToolSetsError::MissingArgument(
                         "agent_id is required for attach_sandbox".to_string(),
@@ -162,15 +159,6 @@ impl TopLevelTool for WorkspaceAgent {
                 })?;
                 let mode = params.mode.unwrap_or(SandboxAgentMode::Read);
 
-                let sandbox = self
-                    .sandboxes
-                    .find_by_id(subject, sandbox_id)
-                    .await
-                    .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
-                if sandbox.workspace_id != workspace_id {
-                    return Err(ToolSetsError::Unauthorized);
-                }
-
                 let agent = self
                     .agents
                     .attach_sandbox(subject, agent_id, sandbox_id, mode)
@@ -182,9 +170,6 @@ impl TopLevelTool for WorkspaceAgent {
             }
 
             WorkspaceAgentCommand::DetachSandbox => {
-                if !subject.can_write_workspace() {
-                    return Err(ToolSetsError::Unauthorized);
-                }
                 let agent_id = params.agent_id.ok_or_else(|| {
                     ToolSetsError::MissingArgument(
                         "agent_id is required for detach_sandbox".to_string(),
@@ -195,24 +180,6 @@ impl TopLevelTool for WorkspaceAgent {
                         "sandbox_id is required for detach_sandbox".to_string(),
                     )
                 })?;
-
-                let existing = self
-                    .agents
-                    .find_by_id(subject, agent_id)
-                    .await
-                    .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
-                if existing.workspace_id != workspace_id {
-                    return Err(ToolSetsError::Unauthorized);
-                }
-
-                let sandbox = self
-                    .sandboxes
-                    .find_by_id(subject, sandbox_id)
-                    .await
-                    .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
-                if sandbox.workspace_id != workspace_id {
-                    return Err(ToolSetsError::Unauthorized);
-                }
 
                 let agent = self
                     .agents

--- a/core/src/toolset/top_level/log.rs
+++ b/core/src/toolset/top_level/log.rs
@@ -15,7 +15,7 @@ use super::super::error::ToolSetsError;
 use super::super::traits::TopLevelTool;
 use super::{parse_params, schema_for};
 use crate::audit::{Audit, AuditEntry, AuditLogQuery};
-use crate::auth::AuthSubject;
+use crate::auth::{AuthResource, AuthSubject, AuthVerb};
 use crate::primitives::{AgentId, SandboxId, UserId};
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -164,7 +164,11 @@ impl TopLevelTool for WorkspaceLog {
     }
 
     fn is_visible(&self, subject: &AuthSubject) -> bool {
-        subject.can_read_workspace()
+        subject.workspace_id().is_some_and(|ws| {
+            subject
+                .can(AuthVerb::Read, AuthResource::AuditLog(ws))
+                .is_ok()
+        })
     }
 
     async fn call(
@@ -173,6 +177,10 @@ impl TopLevelTool for WorkspaceLog {
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
         let workspace_id = subject.workspace_id().ok_or(ToolSetsError::Unauthorized)?;
+        // `Audit` has no per-subject service API, so authz lives here.
+        subject
+            .can(AuthVerb::Read, AuthResource::AuditLog(workspace_id))
+            .map_err(|_| ToolSetsError::Unauthorized)?;
         Audit::record_action("audit.query");
         let params: AuditLogParams = parse_params(arguments)?;
 

--- a/core/src/toolset/top_level/notes.rs
+++ b/core/src/toolset/top_level/notes.rs
@@ -4,7 +4,7 @@ use rmcp::model::{CallToolResult, Content, JsonObject};
 use serde::Deserialize;
 
 use crate::audit::Audit;
-use crate::auth::AuthSubject;
+use crate::auth::{AuthResource, AuthSubject, AuthVerb};
 use crate::library::SearchResult;
 use crate::note::Notes;
 use crate::primitives::{NoteId, WorkflowDefinitionId};
@@ -198,7 +198,11 @@ impl TopLevelTool for NotesTool {
     }
 
     fn is_visible(&self, subject: &AuthSubject) -> bool {
-        subject.workspace_id().is_some()
+        subject.workspace_id().is_some_and(|ws| {
+            subject
+                .can(AuthVerb::Read, AuthResource::Note(ws, None))
+                .is_ok()
+        })
     }
 
     async fn call(

--- a/core/src/toolset/top_level/sandbox.rs
+++ b/core/src/toolset/top_level/sandbox.rs
@@ -3,8 +3,9 @@
 //! Single tool with a `command` discriminator (like `text_editor`):
 //! `create`, `list`, `get`, `inspect`.
 //!
-//! Read commands (`list`, `get`, `inspect`) require `can_read_workspace`;
-//! write commands (`create`) enforce `can_write_workspace` inside `call()`.
+//! Authorization is delegated entirely to [`Sandboxes`]: each service
+//! method runs `subject.can(verb, AuthResource::Sandbox(..))` itself, so
+//! this layer only routes parameters and surfaces errors.
 
 use std::sync::{Arc, LazyLock};
 
@@ -13,7 +14,7 @@ use sandbox::instance_client::ExecuteRequest;
 use serde::Deserialize;
 
 use crate::audit::Audit;
-use crate::auth::AuthSubject;
+use crate::auth::{AuthResource, AuthSubject, AuthVerb};
 use crate::primitives::SandboxId;
 use crate::sandbox::{Sandbox, Sandboxes};
 
@@ -144,7 +145,11 @@ impl TopLevelTool for WorkspaceSandbox {
     }
 
     fn is_visible(&self, subject: &AuthSubject) -> bool {
-        subject.can_read_workspace()
+        subject.workspace_id().is_some_and(|ws| {
+            subject
+                .can(AuthVerb::Read, AuthResource::Sandbox(ws, None))
+                .is_ok()
+        })
     }
 
     fn composable(&self) -> bool {
@@ -163,9 +168,6 @@ impl TopLevelTool for WorkspaceSandbox {
 
         match params.command {
             SandboxCommand::Create => {
-                if !subject.can_write_workspace() {
-                    return Err(ToolSetsError::Unauthorized);
-                }
                 let name = params.name.ok_or_else(|| {
                     ToolSetsError::MissingArgument("name is required for create".to_string())
                 })?;
@@ -228,10 +230,6 @@ impl TopLevelTool for WorkspaceSandbox {
                     .await
                     .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 
-                if sandbox.workspace_id != workspace_id {
-                    return Err(ToolSetsError::Unauthorized);
-                }
-
                 Ok(CallToolResult::success(vec![Content::text(
                     format_sandbox(&sandbox),
                 )]))
@@ -248,22 +246,16 @@ impl TopLevelTool for WorkspaceSandbox {
 
                 Audit::record_sandbox_id(sandbox_id);
 
-                let sandbox = self
+                let _ = self
                     .sandboxes
                     .find_by_id(subject, sandbox_id)
                     .await
                     .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
-                if sandbox.workspace_id != workspace_id {
-                    return Err(ToolSetsError::Unauthorized);
-                }
 
                 execute_inspect(subject, &self.sandboxes, sandbox_id, tool, tool_args).await
             }
 
             SandboxCommand::Restart => {
-                if !subject.can_write_workspace() {
-                    return Err(ToolSetsError::Unauthorized);
-                }
                 let sandbox_id = params.sandbox_id.ok_or_else(|| {
                     ToolSetsError::MissingArgument("sandbox_id is required for restart".to_string())
                 })?;
@@ -290,9 +282,6 @@ impl TopLevelTool for WorkspaceSandbox {
             }
 
             SandboxCommand::Suspend => {
-                if !subject.can_write_workspace() {
-                    return Err(ToolSetsError::Unauthorized);
-                }
                 let sandbox_id = params.sandbox_id.ok_or_else(|| {
                     ToolSetsError::MissingArgument("sandbox_id is required for suspend".to_string())
                 })?;

--- a/core/src/toolset/top_level/skill.rs
+++ b/core/src/toolset/top_level/skill.rs
@@ -7,7 +7,7 @@ use rmcp::model::{CallToolResult, Content, JsonObject};
 use serde::Deserialize;
 
 use crate::audit::Audit;
-use crate::auth::AuthSubject;
+use crate::auth::{AuthResource, AuthSubject, AuthVerb};
 use crate::primitives::SkillId;
 use crate::skill::{Skill, Skills};
 use crate::workspace::Workspaces;
@@ -152,7 +152,12 @@ impl TopLevelTool for SkillTool {
     }
 
     fn is_visible(&self, subject: &AuthSubject) -> bool {
-        subject.can_read_workspace()
+        // Management surface: visible iff subject can mutate skills (admin scope).
+        subject.workspace_id().is_some_and(|ws| {
+            subject
+                .can(AuthVerb::Update, AuthResource::Skill(ws, None))
+                .is_ok()
+        })
     }
 
     fn composable(&self) -> bool {
@@ -175,9 +180,6 @@ impl TopLevelTool for SkillTool {
                 description,
                 body,
             } => {
-                if !subject.can_write_workspace() {
-                    return Err(ToolSetsError::Unauthorized);
-                }
                 let workspace_name = self
                     .workspaces
                     .find_by_id(subject, workspace_id)
@@ -216,9 +218,6 @@ impl TopLevelTool for SkillTool {
                 description,
                 body,
             } => {
-                if !subject.can_write_workspace() {
-                    return Err(ToolSetsError::Unauthorized);
-                }
                 let skill = self
                     .skills
                     .update(subject, skill_id, workspace_id, name, description, body)
@@ -238,9 +237,6 @@ impl TopLevelTool for SkillTool {
             }
 
             SkillParams::Delete { skill_id } => {
-                if !subject.can_write_workspace() {
-                    return Err(ToolSetsError::Unauthorized);
-                }
                 self.skills
                     .delete(subject, skill_id, workspace_id)
                     .await

--- a/core/src/toolset/top_level/use_skill.rs
+++ b/core/src/toolset/top_level/use_skill.rs
@@ -3,7 +3,7 @@ use std::sync::{Arc, LazyLock};
 use rmcp::model::{CallToolResult, Content, JsonObject};
 use serde::Deserialize;
 
-use crate::auth::AuthSubject;
+use crate::auth::{AuthResource, AuthSubject, AuthVerb};
 use crate::skill::Skills;
 
 use super::super::error::ToolSetsError;
@@ -123,7 +123,11 @@ impl TopLevelTool for UseSkillTool {
     }
 
     fn is_visible(&self, subject: &AuthSubject) -> bool {
-        subject.workspace_id().is_some()
+        subject.workspace_id().is_some_and(|ws| {
+            subject
+                .can(AuthVerb::Use, AuthResource::Skill(ws, None))
+                .is_ok()
+        })
     }
 
     fn composable(&self) -> bool {

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -4,7 +4,7 @@ use rmcp::model::{CallToolResult, Content, JsonObject};
 use serde::Deserialize;
 
 use crate::audit::Audit;
-use crate::auth::AuthSubject;
+use crate::auth::{AuthResource, AuthSubject, AuthVerb};
 use crate::primitives::{WorkflowDefinitionId, WorkflowRunId};
 use crate::sandbox::{SandboxAgentMode, SandboxMode, SandboxSpecs};
 use crate::workflow::{
@@ -400,7 +400,11 @@ impl TopLevelTool for WorkflowTool {
     }
 
     fn is_visible(&self, subject: &AuthSubject) -> bool {
-        subject.can_read_workspace()
+        subject.workspace_id().is_some_and(|ws| {
+            subject
+                .can(AuthVerb::Read, AuthResource::Workflow(ws, None))
+                .is_ok()
+        })
     }
 
     fn composable(&self) -> bool {
@@ -430,10 +434,6 @@ impl TopLevelTool for WorkflowTool {
                 timeout_seconds,
                 sandboxes,
             } => {
-                if !subject.can_write_workspace() {
-                    return Err(ToolSetsError::Unauthorized);
-                }
-
                 let trigger = if manual {
                     WorkflowTrigger::Manual
                 } else {
@@ -535,9 +535,6 @@ impl TopLevelTool for WorkflowTool {
                 definition_id,
                 payload,
             } => {
-                if !subject.can_write_workspace() {
-                    return Err(ToolSetsError::Unauthorized);
-                }
                 let payload =
                     payload.unwrap_or_else(|| serde_json::Value::Object(Default::default()));
                 let run = self


### PR DESCRIPTION
## Summary

The toolset layer was running scope checks (`can_write_workspace`,
`can_read_workspace`, cross-workspace ID guards) that the underlying
service methods already enforce via `subject.can(verb, resource)`. The
policy was duplicated in two layers, easy to drift, and made it look
like authz lived in the tool. This PR pushes every decision down into
the service and reshapes visibility predicates to use `can()` so
there's one canonical authorization entry point.

## Existing topology (where authz lived)

Each domain service already runs `subject.can(verb, resource)` at the
top of every public method:

- `core/src/sandbox/mod.rs` — `Sandboxes` (`create:86`, `find_by_id:288`,
  `instance_client_*:471`, `list:497`, `restart:530`, `suspend:650`)
- `core/src/agent/mod.rs` — `Agents` (`create:164/196`, `find_by_id:429`,
  `list:447/477`, `attach_sandbox:548`, `detach_sandbox:597`,
  `chat_history:639`, `thread_*:656/674/692`)
- `core/src/skill/mod.rs` — `Skills` (`find_by_id:75`, `list:146/169`,
  `search:226`, `create:339`, `update:368`, `delete:395`)
- `core/src/workflow/mod.rs` — `Workflows` (`create:176`, `find_by_id:331`,
  `list:354`, `trigger_run:379`, `list_runs:428`, `find_run_by_id:454`)
- `core/src/workspace/mod.rs` — `Workspaces` (`create:70`, `find:109/122`,
  `list:129`, `update:142`, `delete:160`)
- `core/src/note/mod.rs`, `core/src/mcp_creds/mod.rs`,
  `core/src/workspace_secret/mod.rs` — same pattern

The redundancy lived in the tools — every privileged tool re-checked
the same scope before calling the service:

```rust
// Before — sandbox.rs:166
match params.command {
    SandboxCommand::Create => {
        if !subject.can_write_workspace() {
            return Err(ToolSetsError::Unauthorized);
        }
        let sandbox = self.sandboxes.create(subject, ws, ...).await?;
        //                                  ^^^^^^^ also runs `sub.can(Create, Sandbox(ws, None))`
```

Visibility lived in a parallel code path: `is_visible(subject)`
returned `subject.can_read_workspace()` /
`subject.workspace_id().is_some()` instead of feeding the same
`can()`.

## Methods cleaned up

| Crate | File | Redundant gates removed |
| --- | --- | --- |
| core | `toolset/top_level/sandbox.rs` | 3 `can_write_workspace()` + 2 cross-ws ID guards |
| core | `toolset/top_level/agent.rs` | 3 `can_write_workspace()` + 3 cross-ws ID guards (+ unused `Sandboxes` dep dropped) |
| core | `toolset/top_level/skill.rs` | 3 `can_write_workspace()` (Create/Update/Delete) |
| core | `toolset/top_level/workflow.rs` | 2 `can_write_workspace()` (Create/Trigger) |
| core | `auth/subject.rs` | `can_read_workspace` / `can_write_workspace` helpers deleted (no remaining callers) |

**Total: 16 redundant policy decisions eliminated.**

## Visibility checks consolidated

Every visibility predicate that wasn't already a thin shim over
`can()` is now exactly that. Seven tools updated:

| Tool | Before | After |
| --- | --- | --- |
| `WorkspaceSandbox` | `subject.can_read_workspace()` | `subject.can(Read, Sandbox(ws, None)).is_ok()` |
| `WorkspaceAgent` | `subject.can_read_workspace()` | `subject.can(Read, Agent(ws, None)).is_ok()` |
| `WorkflowTool` | `subject.can_read_workspace()` | `subject.can(Read, Workflow(ws, None)).is_ok()` |
| `SkillTool` | `subject.can_read_workspace()` | `subject.can(Update, Skill(ws, None)).is_ok()` (admin-only mgmt surface) |
| `WorkspaceLog` | `subject.can_read_workspace()` | `subject.can(Read, AuditLog(ws)).is_ok()` |
| `NotesTool` | `subject.workspace_id().is_some()` | `subject.can(Read, Note(ws, None)).is_ok()` |
| `UseSkillTool` | `subject.workspace_id().is_some()` | `subject.can(Use, Skill(ws, None)).is_ok()` |

### Before / after example

```rust
// Before
fn is_visible(&self, subject: &AuthSubject) -> bool {
    subject.can_read_workspace()
}

async fn call(&self, subject, args) -> ... {
    let workspace_id = subject.workspace_id().ok_or(Unauthorized)?;
    match params.command {
        SandboxCommand::Create => {
            if !subject.can_write_workspace() {
                return Err(ToolSetsError::Unauthorized);
            }
            self.sandboxes.create(subject, workspace_id, ...).await
        }
    }
}
```

```rust
// After — visibility AND invocation flow through the same can() answer.
fn is_visible(&self, subject: &AuthSubject) -> bool {
    subject
        .workspace_id()
        .is_some_and(|ws| subject.can(AuthVerb::Read, AuthResource::Sandbox(ws, None)).is_ok())
}

async fn call(&self, subject, args) -> ... {
    let workspace_id = subject.workspace_id().ok_or(Unauthorized)?;
    match params.command {
        SandboxCommand::Create => {
            self.sandboxes.create(subject, workspace_id, ...).await
            // service does sub.can(Create, Sandbox(ws, None)) — single source of truth
        }
    }
}
```

## Cases that needed bespoke logic beyond `can()`

A handful of predicates legitimately can't be a clean `can()` query;
each is left in place with a one-line rationale.

- **Sandbox-backed tools** (`bash`, `glob`, `grep`, `ls`, `read`,
  `text_editor`): visible to non-admin agents. The natural translation
  would be `can(Use, Sandbox(ws, Some(id)))`, but the sandbox ID isn't
  known at visibility time and the predicate is intentionally
  permissive (visible even before a sandbox is attached so the model
  can ask to attach). Invocation still runs through
  `Sandboxes::instance_client_for{,_read}`, which calls `sub.can(...)`.
- **`WhoAmI`**: visible only to `ExportedAgent`. Identity-introspection,
  no resource model.
- **`AdminToolSet`**: `subject.is_admin()` (i.e. `Admin` scope). No
  per-resource verb expresses "global admin".
- **`UpstreamToolSet`** (external MCP servers): scope-set match
  against the upstream's required scopes. Per the task brief, this is
  not merged into `can()` — those are external server scopes, not
  drua resources.
- **`WorkspaceLog::call()`**: `Audit` has no per-subject service API,
  so the explicit `subject.can(Read, AuditLog(ws))?` lives at the
  tool boundary. Same predicate as visibility — single source of
  truth, just enforced one layer up.

## Verification

- `nix flake check` passes (fmt, clippy `--deny warnings`, nextest)
- 193 existing lib tests green
- Added 6 negative/positive tests on `AuthSubject::can` covering
  admin permissions, member denial of admin-only resources, member
  positive paths (skills/notes), cross-workspace admin isolation, and
  Anonymous → `AuthenticationRequired`

## Test plan
- [x] `nix flake check`
- [x] Negative test: `WorkspaceMember` cannot `Update Skill` /
      `Create Sandbox` / `Read Agent` / `Read Workflow` / `Read AuditLog`
- [x] Positive test: `WorkspaceMember` can `Use`/`Read Skill`,
      `Create`/`Update Note`
- [x] Cross-workspace test: admin in workspace A cannot access
      workspace B resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)