### PR TITLE
fix(mcp-gateway): emit object schemas for arbitrary JSON fields

### DIFF
--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -163,8 +163,10 @@ struct DescribeToolOutput {
     upstream: String,
     category: String,
     description: String,
+    #[schemars(schema_with = "super::any_json_schema")]
     input_schema: serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "super::any_json_schema")]
     output_schema: Option<serde_json::Value>,
     default_output_filter: String,
 }
@@ -729,5 +731,22 @@ mod tests {
         assert_eq!(SearchCatalog::normalize("list-pipelines"), "list pipelines");
         assert_eq!(SearchCatalog::normalize("Search_Code"), "search code");
         assert_eq!(SearchCatalog::normalize("no changes"), "no changes");
+    }
+
+    /// Strict MCP clients (e.g. Claude Code) reject boolean schemas inside
+    /// `properties`. `serde_json::Value` fields must serialize as `{}`, not
+    /// `true`.
+    #[test]
+    fn describe_output_schema_has_no_boolean_properties() {
+        let props = DESCRIBE_OUTPUT_SCHEMA
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .expect("describe outputSchema has properties");
+        for (name, schema) in props {
+            assert!(
+                !matches!(schema, serde_json::Value::Bool(_)),
+                "property `{name}` is a boolean schema, MCP validators reject it"
+            );
+        }
     }
 }

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -55,6 +55,7 @@ static COMPOSE_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<
 
 #[derive(serde::Serialize, schemars::JsonSchema)]
 struct ComposeOutput {
+    #[schemars(schema_with = "super::any_json_schema")]
     result: serde_json::Value,
     console: Vec<String>,
     tool_calls: usize,
@@ -485,5 +486,22 @@ mod tests {
         assert!(ts.contains("Record<string, number>"), "{ts}");
         assert!(ts.contains("\"pending\""), "{ts}");
         assert!(ts.contains("\"done\""), "{ts}");
+    }
+
+    /// Strict MCP clients (e.g. Claude Code) reject boolean schemas inside
+    /// `properties`. The dynamic `result` field must serialize as `{}`, not
+    /// `true`.
+    #[test]
+    fn compose_output_schema_has_no_boolean_properties() {
+        let props = COMPOSE_OUTPUT_SCHEMA
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .expect("compose outputSchema has properties");
+        for (name, schema) in props {
+            assert!(
+                !matches!(schema, serde_json::Value::Bool(_)),
+                "property `{name}` is a boolean schema, MCP validators reject it"
+            );
+        }
     }
 }

--- a/core/src/toolset/top_level/mod.rs
+++ b/core/src/toolset/top_level/mod.rs
@@ -49,6 +49,15 @@ pub(super) fn parse_params<T: serde::de::DeserializeOwned>(
     serde_json::from_value(value).map_err(|e| ToolSetsError::InvalidArgument(e.to_string()))
 }
 
+/// schemars 0.8 emits boolean `true` for `serde_json::Value` fields, which
+/// strict JSON-Schema validators (notably Claude Code's MCP client) reject in
+/// `properties`. Use via `#[schemars(schema_with = "super::any_json_schema")]`
+/// on a field whose runtime type is `serde_json::Value` and whose contents are
+/// arbitrary — emits the equivalent empty-object schema `{}`.
+pub(super) fn any_json_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    schemars::schema::Schema::Object(Default::default())
+}
+
 /// Draft-07, inlined sub-schemas, `additionalProperties: false` (avoids
 /// `#[serde(deny_unknown_fields)]` which conflicts with `#[serde(flatten)]`).
 /// `definitions` is **kept** so the compose TS generator can resolve `$ref`s


### PR DESCRIPTION
## Summary

- `schemars` 0.8 derives `JsonSchema` for `serde_json::Value` as the boolean shorthand `true`. Claude Code's MCP client validates `tools/list` against a Zod schema that rejects boolean values inside `properties`, so it drops the **entire** response — all 6 top-level tools (`search_tools`, `describe_tool`, `call_tool`, `compose`, `compose_types`, `whoami`) disappear from any agent.
- Added a `super::any_json_schema` helper (returns `{}`) and applied `#[schemars(schema_with = …)]` to the three offending fields:
  - `DescribeToolOutput::input_schema`
  - `DescribeToolOutput::output_schema` (`Option<Value>`)
  - `ComposeOutput::result`
- Added regression tests on `DESCRIBE_OUTPUT_SCHEMA` and `COMPOSE_OUTPUT_SCHEMA` that fail if any property serializes back to a boolean schema.

## Why this approach

The schemars-blessed escape hatch sits next to the offending fields, no runtime semantics change, and other `serde_json::Value` consumers in the codebase are unaffected. Alternatives considered (and rejected): swapping the field type to `Map<String, Value>` (would break `compose`'s non-object results), dropping `output_schema` entirely (loses typing for the well-formed siblings), or post-processing every `schema_for` result (more magic, less locality).

## Repro

```bash
# Pre-fix: server returns 6 tools, but Claude Code's debug log shows
#   [ERROR] MCP server "drua" Failed to fetch tools: [
#     { path: ["tools", 3, "outputSchema", "properties", "input_schema"],  message: "Invalid input" },
#     { path: ["tools", 3, "outputSchema", "properties", "output_schema"], message: "Invalid input" },
#     { path: ["tools", 5, "outputSchema", "properties", "result"],        message: "Invalid input" },
#   ]
# and 0 tools register.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)