### PR TITLE
fix(mcp-gateway): wrap concourse list outputs in named records

### DIFF
--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -24,6 +24,34 @@ use rmcp::model::{CallToolResult, JsonObject};
 use crate::audit::Audit;
 use crate::auth::AuthSubject;
 
+/// schemars 0.8 emits boolean `true` for `serde_json::Value` fields, which
+/// strict JSON-Schema validators (notably Claude Code's MCP client) reject
+/// inside `properties`. Use via `#[schemars(schema_with = "...")]` on a field
+/// whose runtime type is `serde_json::Value` and whose contents are arbitrary
+/// — emits the equivalent empty-object schema `{}`.
+pub(crate) fn any_json_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
+    schemars::schema::Schema::Object(Default::default())
+}
+
+/// Companion to [`any_json_schema`] for `Vec<serde_json::Value>` fields —
+/// emits `{ "type": "array", "items": {} }` so the items schema is an
+/// object, not the boolean shorthand schemars defaults to.
+pub(crate) fn array_of_any_schema(
+    _: &mut schemars::gen::SchemaGenerator,
+) -> schemars::schema::Schema {
+    use schemars::schema::{ArrayValidation, InstanceType, Schema, SchemaObject, SingleOrVec};
+    Schema::Object(SchemaObject {
+        instance_type: Some(InstanceType::Array.into()),
+        array: Some(Box::new(ArrayValidation {
+            items: Some(SingleOrVec::Single(Box::new(Schema::Object(
+                Default::default(),
+            )))),
+            ..Default::default()
+        })),
+        ..Default::default()
+    })
+}
+
 pub struct ToolSets {
     sets: Arc<RwLock<Vec<Arc<dyn SearchableToolSet>>>>,
     top_level: Arc<RwLock<HashMap<String, Arc<dyn TopLevelTool>>>>,

--- a/core/src/toolset/searchable/concourse.rs
+++ b/core/src/toolset/searchable/concourse.rs
@@ -253,26 +253,24 @@ mod schema_tests {
     #[test]
     fn no_boolean_schemas_in_concourse_outputs() {
         fn assert_no_bool_schemas(value: &serde_json::Value, path: &str) {
-            match value {
-                serde_json::Value::Object(map) => {
-                    if let Some(props) = map.get("properties").and_then(|v| v.as_object()) {
-                        for (k, v) in props {
-                            assert!(
-                                !matches!(v, serde_json::Value::Bool(_)),
-                                "boolean schema at {path}.properties.{k}"
-                            );
-                            assert_no_bool_schemas(v, &format!("{path}.properties.{k}"));
-                        }
-                    }
-                    if let Some(items) = map.get("items") {
-                        assert!(
-                            !matches!(items, serde_json::Value::Bool(_)),
-                            "boolean schema at {path}.items"
-                        );
-                        assert_no_bool_schemas(items, &format!("{path}.items"));
-                    }
+            let Some(map) = value.as_object() else {
+                return;
+            };
+            if let Some(props) = map.get("properties").and_then(|v| v.as_object()) {
+                for (k, v) in props {
+                    assert!(
+                        !matches!(v, serde_json::Value::Bool(_)),
+                        "boolean schema at {path}.properties.{k}"
+                    );
+                    assert_no_bool_schemas(v, &format!("{path}.properties.{k}"));
                 }
-                _ => {}
+            }
+            if let Some(items) = map.get("items") {
+                assert!(
+                    !matches!(items, serde_json::Value::Bool(_)),
+                    "boolean schema at {path}.items"
+                );
+                assert_no_bool_schemas(items, &format!("{path}.items"));
             }
         }
         for (name, schema) in [

--- a/core/src/toolset/searchable/concourse.rs
+++ b/core/src/toolset/searchable/concourse.rs
@@ -125,6 +125,7 @@ struct JobOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     last_status: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "crate::toolset::any_json_schema")]
     current_build: Option<serde_json::Value>,
 }
 
@@ -160,6 +161,7 @@ struct TriggerBuildOutput {
 #[derive(serde::Serialize, schemars::JsonSchema)]
 struct PipelineConfigJobOutput {
     name: String,
+    #[schemars(schema_with = "crate::toolset::array_of_any_schema")]
     inputs: Vec<serde_json::Value>,
 }
 
@@ -214,29 +216,127 @@ mod schema_tests {
         assert!(description_for(&schema, "start_time").contains("seconds"));
         assert!(description_for(&schema, "end_time").contains("seconds"));
     }
+
+    /// MCP `structuredContent` must be a JSON object — list-style outputs
+    /// have to be wrapped in a named-field record, not a top-level array.
+    /// Each `(static, field)` is the advertised `outputSchema` and the
+    /// expected wrapper field name.
+    #[test]
+    fn list_outputs_are_object_wrapped_records() {
+        for (schema, field) in [
+            (&*OUT_LIST_PIPELINES, "pipelines"),
+            (&*OUT_LIST_JOBS, "jobs"),
+            (&*OUT_PIPELINE_CONFIG, "jobs"),
+            (&*OUT_LIST_BUILDS, "builds"),
+            (&*OUT_BUILD_RESOURCES, "resources"),
+        ] {
+            assert_eq!(
+                schema.get("type").and_then(|v| v.as_str()),
+                Some("object"),
+                "list outputSchema must be type:object, got: {schema:#}"
+            );
+            let prop = schema
+                .get("properties")
+                .and_then(|p| p.get(field))
+                .unwrap_or_else(|| panic!("missing wrapper field `{field}` in: {schema:#}"));
+            assert_eq!(
+                prop.get("type").and_then(|v| v.as_str()),
+                Some("array"),
+                "wrapper field `{field}` should be an array, got: {prop:#}"
+            );
+        }
+    }
+
+    /// Strict MCP clients reject boolean schemas inside `properties` /
+    /// `items`. `serde_json::Value` fields must serialize as `{}` — and
+    /// `Vec<serde_json::Value>` as `array of {}` — never `true`.
+    #[test]
+    fn no_boolean_schemas_in_concourse_outputs() {
+        fn assert_no_bool_schemas(value: &serde_json::Value, path: &str) {
+            match value {
+                serde_json::Value::Object(map) => {
+                    if let Some(props) = map.get("properties").and_then(|v| v.as_object()) {
+                        for (k, v) in props {
+                            assert!(
+                                !matches!(v, serde_json::Value::Bool(_)),
+                                "boolean schema at {path}.properties.{k}"
+                            );
+                            assert_no_bool_schemas(v, &format!("{path}.properties.{k}"));
+                        }
+                    }
+                    if let Some(items) = map.get("items") {
+                        assert!(
+                            !matches!(items, serde_json::Value::Bool(_)),
+                            "boolean schema at {path}.items"
+                        );
+                        assert_no_bool_schemas(items, &format!("{path}.items"));
+                    }
+                }
+                _ => {}
+            }
+        }
+        for (name, schema) in [
+            ("OUT_LIST_PIPELINES", &*OUT_LIST_PIPELINES),
+            ("OUT_LIST_JOBS", &*OUT_LIST_JOBS),
+            ("OUT_PIPELINE_CONFIG", &*OUT_PIPELINE_CONFIG),
+            ("OUT_LIST_BUILDS", &*OUT_LIST_BUILDS),
+            ("OUT_BUILD_RESOURCES", &*OUT_BUILD_RESOURCES),
+        ] {
+            assert_no_bool_schemas(schema, name);
+        }
+    }
 }
 
 #[derive(serde::Serialize, schemars::JsonSchema)]
 struct BuildResourceOutput {
     resource: String,
+    #[schemars(schema_with = "crate::toolset::any_json_schema")]
     version: serde_json::Value,
     first_occurrence: bool,
 }
 
+// List-shaped outputs are wrapped in a named-field object so that
+// `structuredContent` is a JSON object (per the MCP spec) rather than a
+// top-level array.
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct PipelineListOutput {
+    pipelines: Vec<PipelineOutput>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct JobListOutput {
+    jobs: Vec<JobOutput>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct PipelineConfigOutput {
+    jobs: Vec<PipelineConfigJobOutput>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct BuildListOutput {
+    builds: Vec<BuildSummaryOutput>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct BuildResourceListOutput {
+    resources: Vec<BuildResourceOutput>,
+}
+
 static OUT_LIST_PIPELINES: LazyLock<serde_json::Value> =
-    LazyLock::new(schema_for::<Vec<PipelineOutput>>);
-static OUT_LIST_JOBS: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<Vec<JobOutput>>);
+    LazyLock::new(schema_for::<PipelineListOutput>);
+static OUT_LIST_JOBS: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<JobListOutput>);
 static OUT_BUILD_STATUS: LazyLock<serde_json::Value> =
     LazyLock::new(schema_for::<BuildStatusOutput>);
 static OUT_BUILD_LOGS: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<BuildLogsOutput>);
 static OUT_TRIGGER_BUILD: LazyLock<serde_json::Value> =
     LazyLock::new(schema_for::<TriggerBuildOutput>);
 static OUT_PIPELINE_CONFIG: LazyLock<serde_json::Value> =
-    LazyLock::new(schema_for::<Vec<PipelineConfigJobOutput>>);
-static OUT_LIST_BUILDS: LazyLock<serde_json::Value> =
-    LazyLock::new(schema_for::<Vec<BuildSummaryOutput>>);
+    LazyLock::new(schema_for::<PipelineConfigOutput>);
+static OUT_LIST_BUILDS: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<BuildListOutput>);
 static OUT_BUILD_RESOURCES: LazyLock<serde_json::Value> =
-    LazyLock::new(schema_for::<Vec<BuildResourceOutput>>);
+    LazyLock::new(schema_for::<BuildResourceListOutput>);
 
 pub struct ConcourseToolSet {
     client: Arc<ConcourseClient>,
@@ -334,35 +434,39 @@ impl SearchableToolSet for ConcourseToolSet {
         match tool_name {
             "list_pipelines" => {
                 let pipelines = self.client.list_all_pipelines().await?;
-                let out: Vec<PipelineOutput> = pipelines
-                    .iter()
-                    .map(|p| PipelineOutput {
-                        name: p.name.clone(),
-                        paused: p.paused,
-                        public: p.public,
-                        archived: p.archived,
-                        team: p.team_name.clone(),
-                    })
-                    .collect();
-                Ok(typed_array_result(&out))
+                let out = PipelineListOutput {
+                    pipelines: pipelines
+                        .iter()
+                        .map(|p| PipelineOutput {
+                            name: p.name.clone(),
+                            paused: p.paused,
+                            public: p.public,
+                            archived: p.archived,
+                            team: p.team_name.clone(),
+                        })
+                        .collect(),
+                };
+                Ok(typed_result(&out))
             }
             "list_jobs" => {
                 let params: PipelineParams = parse_params(arguments)?;
                 let jobs = self.client.list_jobs(&params.pipeline).await?;
-                let out: Vec<JobOutput> = jobs
-                    .iter()
-                    .map(|j| JobOutput {
-                        name: j.name.clone(),
-                        paused: j.paused,
-                        pipeline: j.pipeline_name.clone(),
-                        last_status: j.finished_build.as_ref().map(|b| b.status.clone()),
-                        current_build: j
-                            .next_build
-                            .as_ref()
-                            .map(|b| serde_json::json!({"id": b.id, "status": b.status})),
-                    })
-                    .collect();
-                Ok(typed_array_result(&out))
+                let out = JobListOutput {
+                    jobs: jobs
+                        .iter()
+                        .map(|j| JobOutput {
+                            name: j.name.clone(),
+                            paused: j.paused,
+                            pipeline: j.pipeline_name.clone(),
+                            last_status: j.finished_build.as_ref().map(|b| b.status.clone()),
+                            current_build: j
+                                .next_build
+                                .as_ref()
+                                .map(|b| serde_json::json!({"id": b.id, "status": b.status})),
+                        })
+                        .collect(),
+                };
+                Ok(typed_result(&out))
             }
             "get_build_status" => {
                 let params: PipelineJobParams = parse_params(arguments)?;
@@ -420,20 +524,22 @@ impl SearchableToolSet for ConcourseToolSet {
             "get_pipeline_config" => {
                 let params: PipelineParams = parse_params(arguments)?;
                 let config = self.client.get_pipeline_config(&params.pipeline).await?;
-                let out: Vec<PipelineConfigJobOutput> = config
-                    .config
-                    .jobs
-                    .iter()
-                    .map(|j| {
-                        let mut inputs = Vec::new();
-                        extract_get_steps(&j.plan, &mut inputs);
-                        PipelineConfigJobOutput {
-                            name: j.name.clone(),
-                            inputs,
-                        }
-                    })
-                    .collect();
-                Ok(typed_array_result(&out))
+                let out = PipelineConfigOutput {
+                    jobs: config
+                        .config
+                        .jobs
+                        .iter()
+                        .map(|j| {
+                            let mut inputs = Vec::new();
+                            extract_get_steps(&j.plan, &mut inputs);
+                            PipelineConfigJobOutput {
+                                name: j.name.clone(),
+                                inputs,
+                            }
+                        })
+                        .collect(),
+                };
+                Ok(typed_result(&out))
             }
             "list_builds_for_job" => {
                 let params: ListBuildsParams = parse_params(arguments)?;
@@ -442,31 +548,35 @@ impl SearchableToolSet for ConcourseToolSet {
                     .client
                     .list_job_builds(&params.pipeline, &params.job, Some(limit))
                     .await?;
-                let out: Vec<BuildSummaryOutput> = builds
-                    .iter()
-                    .map(|b| BuildSummaryOutput {
-                        build_id: b.id,
-                        name: b.name.clone(),
-                        status: b.status.clone(),
-                        start_time: b.start_time,
-                        end_time: b.end_time,
-                    })
-                    .collect();
-                Ok(typed_array_result(&out))
+                let out = BuildListOutput {
+                    builds: builds
+                        .iter()
+                        .map(|b| BuildSummaryOutput {
+                            build_id: b.id,
+                            name: b.name.clone(),
+                            status: b.status.clone(),
+                            start_time: b.start_time,
+                            end_time: b.end_time,
+                        })
+                        .collect(),
+                };
+                Ok(typed_result(&out))
             }
             "get_build_resources" => {
                 let params: BuildIdParams = parse_params(arguments)?;
                 let resources = self.client.get_build_resources(params.build_id).await?;
-                let out: Vec<BuildResourceOutput> = resources
-                    .inputs
-                    .iter()
-                    .map(|i| BuildResourceOutput {
-                        resource: i.name.clone(),
-                        version: i.version.clone(),
-                        first_occurrence: i.first_occurrence,
-                    })
-                    .collect();
-                Ok(typed_array_result(&out))
+                let out = BuildResourceListOutput {
+                    resources: resources
+                        .inputs
+                        .iter()
+                        .map(|i| BuildResourceOutput {
+                            resource: i.name.clone(),
+                            version: i.version.clone(),
+                            first_occurrence: i.first_occurrence,
+                        })
+                        .collect(),
+                };
+                Ok(typed_result(&out))
             }
             _ => Err(ToolSetsError::ToolNotFound(tool_name.to_string())),
         }
@@ -510,14 +620,6 @@ fn tool_entry_with_filter(
 }
 
 fn typed_result<T: serde::Serialize>(value: &T) -> CallToolResult {
-    let structured = serde_json::to_value(value).expect("serialization");
-    let text = serde_json::to_string_pretty(&structured).unwrap_or_default();
-    let mut result = CallToolResult::success(vec![Content::text(text)]);
-    result.structured_content = Some(structured);
-    result
-}
-
-fn typed_array_result<T: serde::Serialize>(value: &[T]) -> CallToolResult {
     let structured = serde_json::to_value(value).expect("serialization");
     let text = serde_json::to_string_pretty(&structured).unwrap_or_default();
     let mut result = CallToolResult::success(vec![Content::text(text)]);

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -163,10 +163,10 @@ struct DescribeToolOutput {
     upstream: String,
     category: String,
     description: String,
-    #[schemars(schema_with = "super::any_json_schema")]
+    #[schemars(schema_with = "crate::toolset::any_json_schema")]
     input_schema: serde_json::Value,
     #[serde(skip_serializing_if = "Option::is_none")]
-    #[schemars(schema_with = "super::any_json_schema")]
+    #[schemars(schema_with = "crate::toolset::any_json_schema")]
     output_schema: Option<serde_json::Value>,
     default_output_filter: String,
 }

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -55,7 +55,7 @@ static COMPOSE_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<
 
 #[derive(serde::Serialize, schemars::JsonSchema)]
 struct ComposeOutput {
-    #[schemars(schema_with = "super::any_json_schema")]
+    #[schemars(schema_with = "crate::toolset::any_json_schema")]
     result: serde_json::Value,
     console: Vec<String>,
     tool_calls: usize,

--- a/core/src/toolset/top_level/mod.rs
+++ b/core/src/toolset/top_level/mod.rs
@@ -49,15 +49,6 @@ pub(super) fn parse_params<T: serde::de::DeserializeOwned>(
     serde_json::from_value(value).map_err(|e| ToolSetsError::InvalidArgument(e.to_string()))
 }
 
-/// schemars 0.8 emits boolean `true` for `serde_json::Value` fields, which
-/// strict JSON-Schema validators (notably Claude Code's MCP client) reject in
-/// `properties`. Use via `#[schemars(schema_with = "super::any_json_schema")]`
-/// on a field whose runtime type is `serde_json::Value` and whose contents are
-/// arbitrary — emits the equivalent empty-object schema `{}`.
-pub(super) fn any_json_schema(_: &mut schemars::gen::SchemaGenerator) -> schemars::schema::Schema {
-    schemars::schema::Schema::Object(Default::default())
-}
-
 /// Draft-07, inlined sub-schemas, `additionalProperties: false` (avoids
 /// `#[serde(deny_unknown_fields)]` which conflicts with `#[serde(flatten)]`).
 /// `definitions` is **kept** so the compose TS generator can resolve `$ref`s


### PR DESCRIPTION
## Summary

Five concourse tools were emitting MCP-spec-violating responses: top-level JSON arrays in `structuredContent` with `outputSchema: { type: array, ... }`. Per the MCP spec, `structuredContent` MUST be a JSON object. Strict clients (Claude Code's MCP client) reject these with:

```
{
  \"expected\": \"record\",
  \"code\": \"invalid_type\",
  \"path\": [\"structuredContent\"],
  \"message\": \"Invalid input: expected record, received array\"
}
```

Replaces the bare `Vec<T>` outputs with per-tool named wrapper structs that align with the existing per-tool-output-struct pattern in the file:

| Tool | New wrapper |
|---|---|
| `concourse_list_pipelines` | `{ pipelines: [...] }` |
| `concourse_list_jobs` | `{ jobs: [...] }` |
| `concourse_get_pipeline_config` | `{ jobs: [...] }` |
| `concourse_list_builds_for_job` | `{ builds: [...] }` |
| `concourse_get_build_resources` | `{ resources: [...] }` |

Self-documenting field names show up in `compose_types` TS output (`Promise<{pipelines: PipelineOutput[]}>`) — readable without consulting the schema. `typed_array_result` is deleted; every tool now uses `typed_result`.

## Related fix in the same PR

Three `serde_json::Value` fields (`JobOutput.current_build`, `PipelineConfigJobOutput.inputs`, `BuildResourceOutput.version`) were emitting boolean schemas (`true` / `items: true`) that strict validators also reject. They didn't show up in earlier testing because the outer array bug fired first and short-circuited validation. Annotated with `any_json_schema` / `array_of_any_schema` (the helpers from #230) — promoted to `crate::toolset::` so `searchable/` can reach them.

## Why this approach

- **Per-tool named wrappers > a generic `ItemsOutput<T>`.** Field names tell the reader what's inside (`pipelines`, `jobs`, `builds`) without a schema lookup, and TS signatures stay grep-able.
- **Drops `typed_array_result` rather than wrapping it.** One result-construction path for all concourse tools, fewer helpers.
- **`schema_with` over field-type changes.** Same pattern as #230, no runtime semantic change.

## Compatibility note

This **does change the wire format** for the five list tools — callers previously parsing `structuredContent` as a top-level array now need to reach into `.pipelines` / `.jobs` / etc. Lenient clients (e.g. plain HTTP probes) that worked against the old shape will need to update. Strict clients (which were rejecting the old shape entirely) are net better off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)