### PR TITLE
fix(client): honor --server flag instead of silently ignoring it

### DIFF
--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -963,15 +963,29 @@ fn dispatch_stream_event(state: &mut ScreenState, evt: ChatStreamEvent) {
     }
 }
 
-/// Delegates to login flow when credentials are missing/stale.
+/// Delegates to login flow when credentials are missing/stale, or when the
+/// caller passed `--server <url>` that disagrees with the saved config.
 async fn ensure_authenticated(server: Option<String>) -> Result<(Config, GraphqlClient, String)> {
     if let Ok(config) = Config::load() {
-        let client = GraphqlClient::new(&config.server_url, &config.auth_token);
-        if let Ok(user_name) = fetch_user_name(&client).await {
-            return Ok((config, client, user_name));
+        let mismatch = server
+            .as_deref()
+            .is_some_and(|s| s.trim_end_matches('/') != config.server_url.trim_end_matches('/'));
+
+        if mismatch {
+            println!(
+                "--server {} differs from saved {} — re-authenticating…",
+                server.as_deref().unwrap_or(""),
+                config.server_url,
+            );
+            println!();
+        } else {
+            let client = GraphqlClient::new(&config.server_url, &config.auth_token);
+            if let Ok(user_name) = fetch_user_name(&client).await {
+                return Ok((config, client, user_name));
+            }
+            println!("Session expired — starting login flow…");
+            println!();
         }
-        println!("Session expired — starting login flow…");
-        println!();
     } else {
         println!("Not logged in — starting login flow…");
         println!();


### PR DESCRIPTION
## Summary

`drua tui --server <url>` was silently dropped whenever a saved session in `~/.drua/config.json` still validated. The `ensure_authenticated` function only consulted the `--server` argument in the not-logged-in / expired-session branch — when a saved token was valid, it returned the saved server unconditionally.

The failure mode was invisible: with a valid prod token cached, `drua tui --server http://localhost:4200` would happily return prod data with no log line indicating the flag had been ignored. We hit this during local dev (the error in the chat looked like a local-config bug; it was actually prod's OpenRouter rate-limit on a model we'd never configured locally).

## Change

In `client/src/commands/dashboard.rs::ensure_authenticated`:
- Compare `--server` (when present) against `config.server_url`, trailing-slash insensitive.
- If they disagree, print a one-line notice and fall through to the login flow against the requested server.
- `login::run` already overwrites `~/.drua/config.json` with the new URL + token, so subsequent invocations without the flag use the new server.

## What this does NOT change

- Storage shape of `~/.drua/config.json` — still single `{ server_url, auth_token }`.
- Any other CLI subcommand (`status`, `workspace`, `export`) — they still read whatever is saved.
- Behavior when the saved session is expired or missing — unchanged.
- Server, web dashboard, or any deployed surface — pure client-side change.

## Trade-off accepted

Switching prod ↔ local re-auths each direction (token isn't cached per server). This is fine for current usage; if it becomes painful, a follow-up can move to a URL-keyed token map (`~/.drua/config.json` → `{ tokens: { url: token } }`).

## Test plan

- [ ] `drua login --server http://localhost:4200` (or have any saved session)
- [ ] `drua tui --server https://dashboard.agents.galoy.io` — observe the "differs from saved … re-authenticating…" line, follow login flow, land on prod
- [ ] `drua tui` — uses the new saved server (prod) as before
- [ ] `drua tui --server http://localhost:4200` again — re-auth back to local
- [ ] `drua tui` with no flag and a valid saved session — no re-auth, behaves exactly as before