### PR TITLE
fix(agent): skills block per-agent + refresh on sandbox attach/detach

### DIFF
--- a/core/src/agent/entity.rs
+++ b/core/src/agent/entity.rs
@@ -327,4 +327,34 @@ mod tests {
         assert_eq!(agent.workflow_id, Some(wf));
         assert_eq!(agent.workflow_run_id, Some(run));
     }
+
+    #[test]
+    fn attached_sandbox_id_tracks_attach_and_detach() {
+        let mut agent = build(None, None);
+        assert!(agent.attached_sandbox_id().is_none());
+
+        let sandbox_id = SandboxId::new();
+        let outcome = agent
+            .sandbox_attached(sandbox_id, SandboxAgentMode::Read)
+            .expect("attach");
+        assert!(matches!(outcome, Idempotent::Executed(())));
+        assert_eq!(agent.attached_sandbox_id(), Some(sandbox_id));
+
+        let outcome = agent.sandbox_detached(sandbox_id);
+        assert!(matches!(outcome, Idempotent::Executed(())));
+        assert!(agent.attached_sandbox_id().is_none());
+    }
+
+    #[test]
+    fn sandbox_attached_same_mode_is_idempotent() {
+        let mut agent = build(None, None);
+        let sandbox_id = SandboxId::new();
+        let _ = agent
+            .sandbox_attached(sandbox_id, SandboxAgentMode::Write)
+            .expect("first attach");
+        let outcome = agent
+            .sandbox_attached(sandbox_id, SandboxAgentMode::Write)
+            .expect("re-attach");
+        assert!(matches!(outcome, Idempotent::AlreadyApplied));
+    }
 }

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -37,14 +37,16 @@ use session::Sessions;
 
 /// Snapshot of dynamic system blocks (notes + skills), keyed by
 /// `ContextGeneration` at fetch time. Skips DB round-trips on the hot path.
+/// Skills are scoped to `(workspace_id, attached_sandbox_id)` because each
+/// agent's exported sandbox skills depend on its own attachment.
 #[derive(Clone)]
-struct CachedWorkspaceContext {
+struct CachedAgentContext {
     generation: u64,
     notes_block: Option<session::message::SystemBlock>,
     skills_block: Option<session::message::SystemBlock>,
 }
 
-impl CachedWorkspaceContext {
+impl CachedAgentContext {
     fn to_blocks(&self) -> Vec<session::message::SystemBlock> {
         let mut out = Vec::with_capacity(2);
         if let Some(b) = &self.notes_block {
@@ -68,9 +70,12 @@ pub struct Agents {
     toolsets: Arc<ToolSets>,
     prompt_requests: llm::PromptRequestChannel,
     context_generation: ContextGeneration,
-    context_cache:
-        Arc<std::sync::RwLock<std::collections::HashMap<WorkspaceId, CachedWorkspaceContext>>>,
+    context_cache: ContextCache,
 }
+
+type ContextCacheKey = (WorkspaceId, Option<SandboxId>);
+type ContextCache =
+    Arc<std::sync::RwLock<std::collections::HashMap<ContextCacheKey, CachedAgentContext>>>;
 
 impl Agents {
     #[allow(clippy::too_many_arguments)]
@@ -99,16 +104,20 @@ impl Agents {
     }
 
     /// Hot-path lookup of dynamic system blocks. Reads `ContextGeneration`
-    /// atomically; only hits DB when the generation has bumped.
+    /// atomically; only hits DB when the generation has bumped. Skills are
+    /// scoped to the agent's attached sandbox so two agents in the same
+    /// workspace with different sandboxes don't share an entry.
     async fn cached_dynamic_blocks(
         &self,
         workspace_id: WorkspaceId,
+        sandbox_id: Option<SandboxId>,
     ) -> Vec<session::message::SystemBlock> {
         let current_gen = self.context_generation.current();
+        let key = (workspace_id, sandbox_id);
 
         {
             let cache = self.context_cache.read().expect("context_cache poisoned");
-            if let Some(cached) = cache.get(&workspace_id) {
+            if let Some(cached) = cache.get(&key) {
                 if cached.generation == current_gen {
                     return cached.to_blocks();
                 }
@@ -126,20 +135,20 @@ impl Agents {
         };
         let skills_block = self
             .skills
-            .skills_context_for_workspace(workspace_id)
+            .skills_context_for_agent(workspace_id, sandbox_id)
             .await
             .ok()
             .flatten()
             .map(|text| session::message::SystemBlock::Skills { text });
 
-        let entry = CachedWorkspaceContext {
+        let entry = CachedAgentContext {
             generation: current_gen,
             notes_block: notes_block.clone(),
             skills_block: skills_block.clone(),
         };
         let result = entry.to_blocks();
         if let Ok(mut cache) = self.context_cache.write() {
-            cache.insert(workspace_id, entry);
+            cache.insert(key, entry);
         }
         result
     }
@@ -369,8 +378,22 @@ impl Agents {
             }
         }
 
-        if let Ok(Some(skills_content)) =
-            self.skills.skills_context_for_workspace(workspace_id).await
+        // Apply attach to the entity first so the initial skills block can
+        // reflect the attached sandbox's exported skills.
+        let initial_sandbox_id = if let Some((sandbox_id, mode)) = attach_sandbox {
+            // Rejects WorkspaceLead before the sandbox round-trip.
+            if agent.sandbox_attached(sandbox_id, mode)?.did_execute() {
+                self.repo.update_in_op(op, &mut agent).await?;
+            }
+            Some(sandbox_id)
+        } else {
+            None
+        };
+
+        if let Ok(Some(skills_content)) = self
+            .skills
+            .skills_context_for_agent(workspace_id, initial_sandbox_id)
+            .await
         {
             system_blocks.push(session::message::SystemBlock::Skills {
                 text: skills_content,
@@ -394,10 +417,6 @@ impl Agents {
             .await?;
 
         if let Some((sandbox_id, mode)) = attach_sandbox {
-            // Agent side first: rejects WorkspaceLead before the sandbox round-trip.
-            if agent.sandbox_attached(sandbox_id, mode)?.did_execute() {
-                self.repo.update_in_op(op, &mut agent).await?;
-            }
             let sandbox = self
                 .sandboxes
                 .attach_to_agent_in_op(op, workspace_id, sandbox_id, agent.id, mode)
@@ -580,6 +599,9 @@ impl Agents {
             )
             .await?;
 
+        self.refresh_skills_block_in_op(&mut op, agent_id, workspace_id, Some(sandbox_id))
+            .await;
+
         op.commit().await?;
 
         Ok(agent)
@@ -623,9 +645,50 @@ impl Agents {
             )
             .await?;
 
+        self.refresh_skills_block_in_op(&mut op, agent_id, agent.workspace_id, None)
+            .await;
+
         op.commit().await?;
 
         Ok(agent)
+    }
+
+    /// Recomputes the `Skills` system block for `agent_id` scoped to
+    /// `sandbox_id` and pushes it. Idempotent: when the block content matches
+    /// the latest persisted skills block, no event is emitted. Errors from
+    /// the skills service or session push are logged and swallowed — sandbox
+    /// attach/detach must not fail because of a transient skills-context
+    /// problem.
+    async fn refresh_skills_block_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        agent_id: AgentId,
+        workspace_id: WorkspaceId,
+        sandbox_id: Option<SandboxId>,
+    ) {
+        let skills_text = match self
+            .skills
+            .skills_context_for_agent(workspace_id, sandbox_id)
+            .await
+        {
+            Ok(Some(text)) => text,
+            Ok(None) => return,
+            Err(e) => {
+                tracing::warn!(error = %e, "skills_context_for_agent failed during refresh");
+                return;
+            }
+        };
+        if let Err(e) = self
+            .sessions
+            .push_system_block_in_op(
+                op,
+                agent_id,
+                session::message::SystemBlock::Skills { text: skills_text },
+            )
+            .await
+        {
+            tracing::warn!(error = %e, "push_system_block_in_op failed during skills refresh");
+        }
     }
 
     #[instrument(name = "domain.agent.chat_history", skip(self, sub))]
@@ -763,7 +826,9 @@ impl Agents {
 
         // Pass blocks into `add_user_input` so diff + user-input share a single
         // repo round-trip; `next_prompt` later spawns a new thread if changed.
-        let dynamic_blocks = self.cached_dynamic_blocks(agent.workspace_id).await;
+        let dynamic_blocks = self
+            .cached_dynamic_blocks(agent.workspace_id, agent.attached_sandbox_id())
+            .await;
         let mut proposed_system_blocks = system_prompt::system_blocks_for_role(
             agent.agent_role,
             &self.toolsets,

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -214,6 +214,24 @@ impl Sessions {
         Ok(response)
     }
 
+    /// Pushes a `SystemBlock` to the agent's session in `op`. Idempotent —
+    /// when `block`'s content equals the latest persisted block of the same
+    /// kind no event is emitted.
+    #[instrument(name = "domain.agent_session.push_system_block_in_op", skip(self, op))]
+    pub async fn push_system_block_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        agent_id: AgentId,
+        block: message::SystemBlock,
+    ) -> Result<es_entity::Idempotent<()>, AgentSessionError> {
+        let mut session = self.repo.find_by_agent_id_in_op(op, agent_id).await?;
+        let outcome = session.push_system_block(block);
+        if outcome.did_execute() {
+            self.repo.update_in_op(op, &mut session).await?;
+        }
+        Ok(outcome)
+    }
+
     #[instrument(name = "domain.agent_session.chat_history", skip(self))]
     pub async fn chat_history(
         &self,

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -477,27 +477,23 @@ impl Sandboxes {
     }
 
     /// `pub(crate)` helper used by the skills context builder; no auth check.
-    #[instrument(name = "domain.sandbox.exported_skills_for_workspace", skip(self))]
-    pub(crate) async fn exported_skills_for_workspace(
+    /// `None` (unattached agent) → empty Vec. `Some` → that one sandbox's
+    /// `exported_skills` (only when Ready); other states return empty.
+    #[instrument(name = "domain.sandbox.exported_skills_for_sandbox", skip(self))]
+    pub(crate) async fn exported_skills_for_sandbox(
         &self,
-        workspace_id: WorkspaceId,
+        sandbox_id: Option<SandboxId>,
     ) -> Result<Vec<sandbox::instance_client::ExportedSkill>, SandboxError> {
-        let query = PaginatedQueryArgs {
-            first: 100,
-            after: None,
+        let Some(id) = sandbox_id else {
+            return Ok(Vec::new());
         };
-        let result = self
-            .repo
-            .list_for_workspace_id_by_created_at(workspace_id, query, ListDirection::Descending)
-            .await?;
-        let mut skills = Vec::new();
-        for sandbox in &result.entities {
-            if sandbox.state != SandboxState::Ready {
-                continue;
-            }
-            skills.extend(sandbox.exported_skills.iter().cloned());
+        let Some(sandbox) = self.repo.maybe_find_by_id(id).await? else {
+            return Ok(Vec::new());
+        };
+        if sandbox.state != SandboxState::Ready {
+            return Ok(Vec::new());
         }
-        Ok(skills)
+        Ok(sandbox.exported_skills.clone())
     }
 
     /// Returns `NotReady` unless `state == Ready` (only state with `base_url`).

--- a/core/src/skill/mod.rs
+++ b/core/src/skill/mod.rs
@@ -239,25 +239,22 @@ impl Skills {
             .map_err(SkillError::from)
     }
 
-    /// Build skills context for system prompt injection.
+    /// Build skills context for system prompt injection, scoped to a single
+    /// agent's attached sandbox (or none).
     ///
-    /// Returns an `<available_skills>` block listing workspace + global +
-    /// sandbox-exported skills with their descriptions, truncated to fit the
-    /// character budget. DB skills shadow sandbox skills of the same name.
-    /// Returns `None` if there are no skills.
-    #[instrument(name = "skill.skills_context_for_workspace", skip(self))]
-    pub async fn skills_context_for_workspace(
+    /// Returns an `<available_skills>` block listing workspace + global skills
+    /// plus the attached sandbox's exported skills (when `sandbox_id` is
+    /// `Some` and the sandbox is `Ready`). DB skills shadow sandbox skills of
+    /// the same name. Returns `None` if there are no skills.
+    #[instrument(name = "skill.skills_context_for_agent", skip(self))]
+    pub async fn skills_context_for_agent(
         &self,
         workspace_id: WorkspaceId,
+        sandbox_id: Option<SandboxId>,
     ) -> Result<Option<String>, SkillError> {
         let db_skills = self.list_for_workspace_inner(workspace_id).await?;
 
-        // Collect sandbox-exported skills, dedup against DB skills.
-        let sandbox_skills = match self
-            .sandboxes
-            .exported_skills_for_workspace(workspace_id)
-            .await
-        {
+        let sandbox_skills = match self.sandboxes.exported_skills_for_sandbox(sandbox_id).await {
             Ok(skills) => skills,
             Err(e) => {
                 tracing::warn!(error = %e, "failed to fetch sandbox exported skills");
@@ -265,7 +262,6 @@ impl Skills {
             }
         };
 
-        // Build a unified listing: (name, scope_tag, description)
         let mut seen_names = std::collections::HashSet::new();
         let mut entries: Vec<(&str, &str, String)> = Vec::new();
 
@@ -284,7 +280,7 @@ impl Skills {
             }
             seen_names.insert(&skill.name);
             let desc = skill.description.clone().unwrap_or_default();
-            entries.push((&skill.name, " [sandbox]", desc));
+            entries.push((&skill.name, "", desc));
         }
 
         if entries.is_empty() {

--- a/core/tests/skills_per_agent.rs
+++ b/core/tests/skills_per_agent.rs
@@ -1,0 +1,158 @@
+#![recursion_limit = "256"]
+
+use std::sync::Arc;
+
+use drua_core::primitives::{AuthSubject, SandboxId, UserId, WorkspaceId};
+use drua_core::sandbox::{SandboxConfig, Sandboxes};
+use drua_core::skill::Skills;
+
+const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
+
+async fn pool() -> sqlx::PgPool {
+    let url = std::env::var("DATABASE_URL").unwrap_or_else(|_| PG_CON.to_string());
+    sqlx::PgPool::connect(&url).await.expect("connect to pg")
+}
+
+async fn build_skills(pool: &sqlx::PgPool) -> Skills {
+    let sandboxes = Arc::new(
+        Sandboxes::init(pool, SandboxConfig::default(), None)
+            .await
+            .expect("init sandboxes"),
+    );
+    Skills::new_without_library(pool, sandboxes)
+}
+
+/// Inserts a row into `workspaces` so the `skills.workspace_id` FK can be
+/// satisfied without spinning up the full `Workspaces` service stack.
+async fn seed_workspace(pool: &sqlx::PgPool, id: WorkspaceId, name_prefix: &str) {
+    let unique_name = format!("{name_prefix}-{}", uuid::Uuid::from(id));
+    sqlx::query("INSERT INTO workspaces (id, name, created_at) VALUES ($1, $2, NOW())")
+        .bind(uuid::Uuid::from(id))
+        .bind(unique_name)
+        .execute(pool)
+        .await
+        .expect("insert workspace");
+}
+
+/// Unattached agents (no sandbox) get only workspace + global DB skills,
+/// and the rendered block must not carry the legacy `[sandbox]` tag.
+#[tokio::test]
+async fn skills_context_unattached_excludes_sandbox_tag() {
+    let pool = pool().await;
+    let skills = build_skills(&pool).await;
+    let sub = AuthSubject::User(UserId::new());
+    let ws = WorkspaceId::new();
+    seed_workspace(&pool, ws, "ws-a").await;
+
+    skills
+        .create(
+            &sub,
+            ws,
+            "ws-a",
+            "alpha-skill".into(),
+            "alpha description".into(),
+            "echo alpha".into(),
+        )
+        .await
+        .expect("create skill");
+
+    let context = skills
+        .skills_context_for_agent(ws, None)
+        .await
+        .expect("skills_context_for_agent")
+        .expect("expected Some block");
+
+    assert!(
+        context.contains("alpha-skill"),
+        "workspace skill should appear: {context}"
+    );
+    assert!(
+        !context.contains("[sandbox]"),
+        "no sandbox tag in unattached agent block: {context}"
+    );
+}
+
+/// Two workspaces in the same DB must not bleed skills into each other,
+/// and an unknown sandbox id resolves to no exported skills (so it is
+/// equivalent to passing `None`).
+#[tokio::test]
+async fn skills_context_isolates_workspaces_and_unknown_sandbox() {
+    let pool = pool().await;
+    let skills = build_skills(&pool).await;
+    let sub = AuthSubject::User(UserId::new());
+    let ws_a = WorkspaceId::new();
+    let ws_b = WorkspaceId::new();
+    seed_workspace(&pool, ws_a, "ws-a").await;
+    seed_workspace(&pool, ws_b, "ws-b").await;
+
+    skills
+        .create(
+            &sub,
+            ws_a,
+            "ws-a",
+            "alpha-only".into(),
+            "alpha-only desc".into(),
+            "echo alpha".into(),
+        )
+        .await
+        .expect("create alpha");
+    skills
+        .create(
+            &sub,
+            ws_b,
+            "ws-b",
+            "beta-only".into(),
+            "beta-only desc".into(),
+            "echo beta".into(),
+        )
+        .await
+        .expect("create beta");
+
+    let ctx_a = skills
+        .skills_context_for_agent(ws_a, None)
+        .await
+        .expect("ws_a context")
+        .expect("ws_a Some");
+    assert!(ctx_a.contains("alpha-only"));
+    assert!(!ctx_a.contains("beta-only"));
+
+    let ctx_b = skills
+        .skills_context_for_agent(ws_b, None)
+        .await
+        .expect("ws_b context")
+        .expect("ws_b Some");
+    assert!(ctx_b.contains("beta-only"));
+    assert!(!ctx_b.contains("alpha-only"));
+
+    // Passing an unknown sandbox id is a no-op for the sandbox-skills source.
+    let ctx_a_with_unknown = skills
+        .skills_context_for_agent(ws_a, Some(SandboxId::new()))
+        .await
+        .expect("ctx with unknown sandbox")
+        .expect("Some");
+    assert_eq!(
+        ctx_a, ctx_a_with_unknown,
+        "unknown sandbox must not change the rendered block"
+    );
+}
+
+/// With no DB skills and no real sandbox skills available, the context is
+/// `None` regardless of which sandbox id is passed — proving that the
+/// per-agent renderer never invents content.
+#[tokio::test]
+async fn skills_context_none_when_no_skills_anywhere() {
+    let pool = pool().await;
+    let skills = build_skills(&pool).await;
+    let ws = WorkspaceId::new();
+
+    let unattached = skills
+        .skills_context_for_agent(ws, None)
+        .await
+        .expect("call");
+    let with_sandbox = skills
+        .skills_context_for_agent(ws, Some(SandboxId::new()))
+        .await
+        .expect("call");
+    assert!(unattached.is_none(), "unattached: {unattached:?}");
+    assert!(with_sandbox.is_none(), "with-sandbox: {with_sandbox:?}");
+}


### PR DESCRIPTION
## Bug shape

The `<available_skills>` system block was built per-**workspace**, not per-agent. Every agent received the union of every Ready sandbox's `exported_skills` — even from sandboxes it wasn't attached to.

Confirmed against DB on 2026-04-29 (memory `019ddaca`): three agents (`scratch-agent`, `repo-agent`, `space-agent`) in the same workspace had **identical** `system_blocks[5]` listing the three drua skills exported by `repo-sandbox`, even though only `repo-agent` was attached to it. Skills were tagged `[sandbox]` regardless of which sandbox they came from.

This caused two problems:
1. **Behavioral**: agents were told they had skills they couldn't invoke. `Skills::find_by_name` correctly gates sandbox-exported skills on the *caller's* `sandbox_id`, so `use_skill <name>` returned `None` and failed.
2. **Cross-tenant info leak**: every agent learned of every other sandbox's exported skill names + descriptions purely from the system prompt.

## Validated behavior

The user's intent (per task brief): the skills block must be **per-agent**, and attach/detach during the session must update it. The original memory's "Fix shape" suggested deferring the dynamic-refresh part as a separate concern; the user explicitly asked us to include it. Both are in this PR.

## Code changes

### Per-agent scoping
- `Sandboxes::exported_skills_for_workspace(WorkspaceId)` → `exported_skills_for_sandbox(Option<SandboxId>)`. `None` (unattached agent) → empty Vec. `Some(id)` → that one sandbox's exports when Ready.
- `Skills::skills_context_for_workspace(WorkspaceId)` → `skills_context_for_agent(WorkspaceId, Option<SandboxId>)`.
- `CachedWorkspaceContext` → `CachedAgentContext`, keyed on `(WorkspaceId, Option<SandboxId>)` so two agents in the same workspace with different sandboxes don't share a cache entry.
- The `[sandbox]` tag is dropped; once the block is scoped to the agent's own sandbox the tag is redundant.
- `Agents::create_in_op` now applies attach to the entity *before* building the initial Skills block, so the very first `system_blocks` reflect the attached sandbox's exports.

### Dynamic refresh on attach/detach
- New `Sessions::push_system_block_in_op(op, agent_id, block)` — idempotent wrapper over `AgentSession::push_system_block` (no event when content equals the latest persisted block of the same kind).
- `Agents::attach_sandbox` and `Agents::detach_sandbox` recompute the Skills block scoped to the new attachment and push it via the new method, alongside the existing `<sandbox>` notification.
- Errors from the recompute are logged and swallowed — sandbox attach/detach must not fail because of a transient skills-context lookup.

## Before / after

Before (workspace `019ddab4`, three agents):
```
system_blocks[5] (kind=skills) on every agent:
  <available_skills>
  - best-practices-check [sandbox] — ...
  - inspect-conversation [sandbox] — ...
  - monitor-pr-actions [sandbox] — ...
  </available_skills>
```

After:
- `scratch-agent` (no sandbox) → no Skills block (or workspace+global skills only).
- `repo-agent` (attached to `repo-sandbox`) → block lists the three skills, no `[sandbox]` tag.
- `space-agent` (attached to a `space-sandbox` exporting nothing) → no Skills block (or workspace+global skills only).
- Re-attaching `repo-agent` to a different sandbox emits a `SystemBlockUpdated { Skills }` event reflecting the new attachment; detaching emits another reflecting the unattached state.

## Tests

- `core/tests/skills_per_agent.rs`:
  - `skills_context_unattached_excludes_sandbox_tag` — workspace skill appears, no `[sandbox]` literal in the block.
  - `skills_context_isolates_workspaces_and_unknown_sandbox` — cross-workspace isolation; passing an unknown `SandboxId` is equivalent to `None`.
  - `skills_context_none_when_no_skills_anywhere` — agent with no skills + nonexistent sandbox renders no block.
- `core/src/agent/entity.rs::tests`:
  - `attached_sandbox_id_tracks_attach_and_detach` — entity-level invariant that drives the per-agent scoping.
  - `sandbox_attached_same_mode_is_idempotent` — backstops the idempotent refresh path.

All 241 `drua-core` tests pass; `nix flake check` (fmt + clippy + nextest + graphql + default-config) is green.

## Coordination

- PR #221 (idempotent commands): the new `push_system_block_in_op` returns `Idempotent<()>` and is gated by `AgentSession::push_system_block`'s existing equality check (no `idempotency_guard!` macro needed because the entity-level guard already covers it).
- PR #222 (authz consolidation): no new public service methods need authz — `attach_sandbox`/`detach_sandbox` already have `subject.can(...)` checks and the new helper is a private method called within those flows.

## Test plan

- [x] `cargo nextest run -p drua-core` — 241/241 pass
- [x] `nix flake check` — clean
- [x] Inline entity tests for attach/detach
- [x] Integration tests for cross-workspace + unknown-sandbox scoping
- [ ] Manual TUI verification of inspect-conversation against fresh workspace with multiple sandboxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)