### PR TITLE
feat(toolset): provider-aware edit-tool adapters (Anthropic identity, OpenAI V4A, Gemini, Fallback)

### DIFF
--- a/core/src/toolset/edit/adapter.rs
+++ b/core/src/toolset/edit/adapter.rs
@@ -1,0 +1,60 @@
+//! [`ProviderEditAdapter`] — translates between a provider's preferred
+//! file-edit tool schema and the canonical [`EditOp`](super::canonical::EditOp).
+//!
+//! Each adapter owns three things:
+//! 1. [`declare_tools`](ProviderEditAdapter::declare_tools) — the tool
+//!    declarations the model expects (`apply_patch` for OpenAI, three tools for
+//!    Gemini, the schema-less server tool for Anthropic, etc.);
+//! 2. [`parse_call`](ProviderEditAdapter::parse_call) — turn a model-emitted
+//!    tool-call payload into one or more [`EditOp`]s;
+//! 3. [`format_result`](ProviderEditAdapter::format_result) — serialise the
+//!    canonical [`EditOpResult`] / [`EditExecError`] into the wire shape the
+//!    provider expects on the next turn.
+
+use serde::{Deserialize, Serialize};
+
+use super::canonical::{EditExecError, EditOp, EditOpResult, EditParseError};
+
+/// One advertised tool. Several adapters declare > 1 (e.g. Gemini: `replace`,
+/// `write_file`, `read_file`; OpenAI: `apply_patch` + `read_file`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolDeclaration {
+    pub name: String,
+    pub description: String,
+    /// JSON Schema for the tool's input. Empty `{}` for schema-less server
+    /// tools (Anthropic's `text_editor_*`).
+    pub input_schema: serde_json::Value,
+    /// Set for Anthropic's schema-less server tool. When `Some`, the LLM
+    /// caller should emit a `{"type": <provider_type>, "name": <name>}`
+    /// envelope instead of declaring `input_schema` over the wire.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_type: Option<String>,
+}
+
+pub trait ProviderEditAdapter: Send + Sync {
+    /// Stable name for tracing / debugging.
+    fn provider_name(&self) -> &'static str;
+
+    /// Tools to advertise to the model. Multiple entries are valid — Gemini's
+    /// adapter exposes three; OpenAI's exposes two; Anthropic's exposes one.
+    fn declare_tools(&self) -> Vec<ToolDeclaration>;
+
+    /// Translate a provider-emitted tool-call into 1+ canonical [`EditOp`]s.
+    /// `tool_name` lets adapters with multiple tools (Gemini, OpenAI) dispatch.
+    /// V4A `apply_patch` returns a `Vec` because one patch can touch many files.
+    fn parse_call(
+        &self,
+        tool_name: &str,
+        raw_input: &serde_json::Value,
+    ) -> Result<Vec<EditOp>, EditParseError>;
+
+    /// Serialise an executed batch's outcome back into the provider's
+    /// expected tool-result envelope. `tool_use_id` is the model's id for
+    /// the call (echoed back per the Anthropic / OpenAI conventions).
+    fn format_result(
+        &self,
+        tool_use_id: &str,
+        results: &[EditOpResult],
+        errors: &[EditExecError],
+    ) -> serde_json::Value;
+}

--- a/core/src/toolset/edit/adapters/anthropic.rs
+++ b/core/src/toolset/edit/adapters/anthropic.rs
@@ -1,0 +1,284 @@
+//! Anthropic adapter — identity passthrough on the canonical [`EditOp`].
+//!
+//! Anthropic ships `text_editor_*` as a server tool: the model already knows
+//! the schema, so the request payload only needs `{"type": "...", "name": "..."}`.
+//! Concretely we still emit a JSON-Schema in [`ToolDeclaration::input_schema`]
+//! for adapters that fall back to a regular function-tool envelope (e.g. when
+//! the provider does not understand the server-tool shorthand).
+
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use super::super::adapter::{ProviderEditAdapter, ToolDeclaration};
+use super::super::canonical::{EditExecError, EditOp, EditOpResult, EditParseError};
+
+/// Per-version constants from the official Anthropic text-editor docs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum AnthropicTextEditorVersion {
+    /// Claude Sonnet 3.5 — original release.
+    V20241022,
+    /// Claude Sonnet 3.7 — same capabilities, renamed `type`.
+    V20250124,
+    /// Claude 4.x — `undo_edit` removed, tool renamed.
+    V20250429,
+    /// Claude 4.x — adds optional `max_characters`. Default.
+    V20250728,
+}
+
+impl AnthropicTextEditorVersion {
+    pub fn provider_type(self) -> &'static str {
+        match self {
+            Self::V20241022 => "text_editor_20241022",
+            Self::V20250124 => "text_editor_20250124",
+            Self::V20250429 => "text_editor_20250429",
+            Self::V20250728 => "text_editor_20250728",
+        }
+    }
+
+    pub fn tool_name(self) -> &'static str {
+        match self {
+            Self::V20241022 | Self::V20250124 => "str_replace_editor",
+            Self::V20250429 | Self::V20250728 => "str_replace_based_edit_tool",
+        }
+    }
+
+    pub fn supports_undo_edit(self) -> bool {
+        matches!(self, Self::V20241022 | Self::V20250124)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct AnthropicAdapter {
+    version: AnthropicTextEditorVersion,
+}
+
+impl AnthropicAdapter {
+    pub fn new(version: AnthropicTextEditorVersion) -> Self {
+        Self { version }
+    }
+
+    pub fn latest() -> Self {
+        Self::new(AnthropicTextEditorVersion::V20250728)
+    }
+}
+
+impl ProviderEditAdapter for AnthropicAdapter {
+    fn provider_name(&self) -> &'static str {
+        "anthropic"
+    }
+
+    fn declare_tools(&self) -> Vec<ToolDeclaration> {
+        vec![ToolDeclaration {
+            name: self.version.tool_name().to_string(),
+            description: "Anthropic-compatible text editor. Commands: \
+                view, create, str_replace, insert."
+                .to_string(),
+            input_schema: edit_input_schema(self.version),
+            provider_type: Some(self.version.provider_type().to_string()),
+        }]
+    }
+
+    fn parse_call(
+        &self,
+        tool_name: &str,
+        raw_input: &serde_json::Value,
+    ) -> Result<Vec<EditOp>, EditParseError> {
+        if tool_name != self.version.tool_name() {
+            return Err(EditParseError::UnknownCommand(format!(
+                "expected {}, got {tool_name}",
+                self.version.tool_name()
+            )));
+        }
+        let op: EditOp = serde_json::from_value(raw_input.clone())
+            .map_err(|e| EditParseError::InvalidShape(e.to_string()))?;
+        Ok(vec![op])
+    }
+
+    fn format_result(
+        &self,
+        tool_use_id: &str,
+        results: &[EditOpResult],
+        errors: &[EditExecError],
+    ) -> serde_json::Value {
+        let is_error = !errors.is_empty();
+        let text = if is_error {
+            errors
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        } else {
+            results
+                .iter()
+                .map(EditOpResult::human_summary)
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        json!({
+            "type": "tool_result",
+            "tool_use_id": tool_use_id,
+            "is_error": is_error,
+            "content": [{"type": "text", "text": text}],
+        })
+    }
+}
+
+/// Schema for the canonical edit tool — union of the four core commands plus
+/// `view_range` / `file_text` / `old_str` / `new_str` / `insert_line`. Used
+/// by the [`AnthropicAdapter`] (when a fallback function-tool envelope is
+/// required) and re-exported for the existing MCP-side tool registration.
+pub(crate) fn edit_input_schema(version: AnthropicTextEditorVersion) -> serde_json::Value {
+    let mut commands = vec!["view", "create", "str_replace", "insert"];
+    if version.supports_undo_edit() {
+        commands.push("undo_edit");
+    }
+    json!({
+        "type": "object",
+        "properties": {
+            "command": {
+                "type": "string",
+                "enum": commands,
+                "description": "Which editor operation to perform."
+            },
+            "path": {
+                "type": "string",
+                "description": "Absolute path to the file or directory inside the sandbox workspace."
+            },
+            "view_range": {
+                "type": "array",
+                "items": { "type": "integer" },
+                "minItems": 2,
+                "maxItems": 2,
+                "description": "[start, end] line range for `view`. -1 for end means EOF. Optional."
+            },
+            "file_text": {
+                "type": "string",
+                "description": "Full file contents for `create`."
+            },
+            "old_str": {
+                "type": "string",
+                "description": "Substring to replace for `str_replace`. Must appear exactly once."
+            },
+            "new_str": {
+                "type": "string",
+                "description": "Replacement text for `str_replace`, or text to insert for `insert`."
+            },
+            "insert_line": {
+                "type": "integer",
+                "minimum": 0,
+                "description": "Line number after which to insert text for `insert`. 0 = beginning of file."
+            }
+        },
+        "required": ["command", "path"],
+        "additionalProperties": false
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn version_envelopes_match_docs() {
+        assert_eq!(
+            AnthropicTextEditorVersion::V20241022.provider_type(),
+            "text_editor_20241022"
+        );
+        assert_eq!(
+            AnthropicTextEditorVersion::V20241022.tool_name(),
+            "str_replace_editor"
+        );
+        assert_eq!(
+            AnthropicTextEditorVersion::V20250728.provider_type(),
+            "text_editor_20250728"
+        );
+        assert_eq!(
+            AnthropicTextEditorVersion::V20250728.tool_name(),
+            "str_replace_based_edit_tool"
+        );
+    }
+
+    #[test]
+    fn undo_edit_only_on_legacy_versions() {
+        assert!(AnthropicTextEditorVersion::V20241022.supports_undo_edit());
+        assert!(AnthropicTextEditorVersion::V20250124.supports_undo_edit());
+        assert!(!AnthropicTextEditorVersion::V20250429.supports_undo_edit());
+        assert!(!AnthropicTextEditorVersion::V20250728.supports_undo_edit());
+    }
+
+    #[test]
+    fn declare_tools_emits_provider_type() {
+        let adapter = AnthropicAdapter::latest();
+        let decl = adapter.declare_tools();
+        assert_eq!(decl.len(), 1);
+        assert_eq!(decl[0].name, "str_replace_based_edit_tool");
+        assert_eq!(
+            decl[0].provider_type.as_deref(),
+            Some("text_editor_20250728")
+        );
+    }
+
+    #[test]
+    fn parse_call_round_trip_str_replace() {
+        let adapter = AnthropicAdapter::latest();
+        let raw = serde_json::json!({
+            "command": "str_replace",
+            "path": "/w/a.rs",
+            "old_str": "let x = 1;",
+            "new_str": "let x = 2;",
+        });
+        let ops = adapter
+            .parse_call("str_replace_based_edit_tool", &raw)
+            .unwrap();
+        assert_eq!(ops.len(), 1);
+        match &ops[0] {
+            EditOp::StrReplace {
+                path,
+                old_str,
+                new_str,
+            } => {
+                assert_eq!(path, "/w/a.rs");
+                assert_eq!(old_str, "let x = 1;");
+                assert_eq!(new_str, "let x = 2;");
+            }
+            _ => panic!("expected str_replace"),
+        }
+    }
+
+    #[test]
+    fn parse_call_rejects_wrong_tool_name() {
+        let adapter = AnthropicAdapter::latest();
+        let raw = serde_json::json!({"command": "view", "path": "/w/a.rs"});
+        assert!(adapter.parse_call("apply_patch", &raw).is_err());
+    }
+
+    #[test]
+    fn format_result_emits_anthropic_envelope() {
+        let adapter = AnthropicAdapter::latest();
+        let v = adapter.format_result(
+            "toolu_01",
+            &[EditOpResult::Replaced {
+                path: "/w/a.rs".to_string(),
+                occurrences: 1,
+            }],
+            &[],
+        );
+        assert_eq!(v["type"], "tool_result");
+        assert_eq!(v["tool_use_id"], "toolu_01");
+        assert_eq!(v["is_error"], false);
+    }
+
+    #[test]
+    fn format_result_marks_errors() {
+        let adapter = AnthropicAdapter::latest();
+        let v = adapter.format_result(
+            "toolu_01",
+            &[],
+            &[EditExecError::NonUniqueMatch {
+                path: "/w/a.rs".to_string(),
+                actual: 3,
+            }],
+        );
+        assert_eq!(v["is_error"], true);
+    }
+}

--- a/core/src/toolset/edit/adapters/fallback.rs
+++ b/core/src/toolset/edit/adapters/fallback.rs
@@ -1,0 +1,134 @@
+//! Fallback adapter — single mega-tool `edit_file` for tool-schema-agnostic
+//! models (Llama, DeepSeek, Grok, OpenRouter passthrough). Mirrors Anthropic's
+//! canonical four-command shape but is declared as a regular function tool
+//! with a thorough description and inline examples.
+
+use serde_json::json;
+
+use super::super::adapter::{ProviderEditAdapter, ToolDeclaration};
+use super::super::canonical::{EditExecError, EditOp, EditOpResult, EditParseError};
+
+pub const EDIT_FILE: &str = "edit_file";
+
+#[derive(Debug, Clone, Default)]
+pub struct FallbackAdapter;
+
+impl FallbackAdapter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ProviderEditAdapter for FallbackAdapter {
+    fn provider_name(&self) -> &'static str {
+        "fallback"
+    }
+
+    fn declare_tools(&self) -> Vec<ToolDeclaration> {
+        let description = "View, create, edit, or insert into files.\n\
+            Choose `command` based on need:\n\
+            - view: read file or list directory; returns numbered lines\n\
+            - create: create new file with `file_text`\n\
+            - str_replace: replace exactly-once-matching `old_str` with \
+              `new_str` (include 3+ lines of context to ensure uniqueness)\n\
+            - insert: insert `new_str` after `insert_line` (0 = start of file)\n\
+            \n\
+            Example calls:\n\
+            {\"command\": \"view\", \"path\": \"src/lib.rs\"}\n\
+            {\"command\": \"str_replace\", \"path\": \"src/lib.rs\", \
+            \"old_str\": \"    let x = 1;\", \
+            \"new_str\": \"    let x = 10;\"}";
+
+        vec![ToolDeclaration {
+            name: EDIT_FILE.to_string(),
+            description: description.to_string(),
+            input_schema: json!({
+                "type": "object",
+                "properties": {
+                    "command":     {"type": "string", "enum": ["view", "create", "str_replace", "insert"]},
+                    "path":        {"type": "string"},
+                    "view_range":  {
+                        "type": "array",
+                        "items": {"type": "integer"},
+                        "minItems": 2,
+                        "maxItems": 2
+                    },
+                    "old_str":     {"type": "string"},
+                    "new_str":     {"type": "string"},
+                    "file_text":   {"type": "string"},
+                    "insert_line": {"type": "integer", "minimum": 0}
+                },
+                "required": ["command", "path"],
+                "additionalProperties": false
+            }),
+            provider_type: None,
+        }]
+    }
+
+    fn parse_call(
+        &self,
+        tool_name: &str,
+        raw_input: &serde_json::Value,
+    ) -> Result<Vec<EditOp>, EditParseError> {
+        if tool_name != EDIT_FILE {
+            return Err(EditParseError::UnknownCommand(tool_name.to_string()));
+        }
+        let op: EditOp = serde_json::from_value(raw_input.clone())
+            .map_err(|e| EditParseError::InvalidShape(e.to_string()))?;
+        Ok(vec![op])
+    }
+
+    fn format_result(
+        &self,
+        tool_use_id: &str,
+        results: &[EditOpResult],
+        errors: &[EditExecError],
+    ) -> serde_json::Value {
+        let is_error = !errors.is_empty();
+        let text = if is_error {
+            errors
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        } else {
+            results
+                .iter()
+                .map(EditOpResult::human_summary)
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        json!({
+            "tool_call_id": tool_use_id,
+            "is_error": is_error,
+            "output": text,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn declares_single_tool() {
+        let adapter = FallbackAdapter::new();
+        let decl = adapter.declare_tools();
+        assert_eq!(decl.len(), 1);
+        assert_eq!(decl[0].name, "edit_file");
+    }
+
+    #[test]
+    fn parse_view_round_trip() {
+        let adapter = FallbackAdapter::new();
+        let raw = json!({"command": "view", "path": "/w/a.rs"});
+        let ops = adapter.parse_call(EDIT_FILE, &raw).unwrap();
+        assert!(matches!(&ops[0], EditOp::View { .. }));
+    }
+
+    #[test]
+    fn parse_unknown_tool_errors() {
+        let adapter = FallbackAdapter::new();
+        assert!(adapter.parse_call("apply_patch", &json!({})).is_err());
+    }
+}

--- a/core/src/toolset/edit/adapters/gemini.rs
+++ b/core/src/toolset/edit/adapters/gemini.rs
@@ -1,0 +1,227 @@
+//! Gemini adapter — three separate tools matching the Gemini CLI muscle
+//! memory: `replace`, `write_file`, `read_file`. No `insert` analog.
+//!
+//! `replace` defaults to `expected_replacements = 1`. Setting it > 1 is
+//! reflected in the canonical [`EditOp::StrReplace`] only insofar as the
+//! executor is expected to refuse if the actual count differs (uniqueness
+//! invariant matches Anthropic's `str_replace`).
+
+use serde_json::json;
+
+use super::super::adapter::{ProviderEditAdapter, ToolDeclaration};
+use super::super::canonical::{EditExecError, EditOp, EditOpResult, EditParseError};
+
+pub const REPLACE: &str = "replace";
+pub const WRITE_FILE: &str = "write_file";
+pub const READ_FILE: &str = "read_file";
+
+#[derive(Debug, Clone, Default)]
+pub struct GeminiAdapter;
+
+impl GeminiAdapter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ProviderEditAdapter for GeminiAdapter {
+    fn provider_name(&self) -> &'static str {
+        "gemini"
+    }
+
+    fn declare_tools(&self) -> Vec<ToolDeclaration> {
+        vec![
+            ToolDeclaration {
+                name: REPLACE.to_string(),
+                description: "Replace exactly one occurrence of `old_string` with \
+                     `new_string` in `file_path`. `old_string` must be unique \
+                     in the file (include 3+ lines of surrounding context to \
+                     ensure uniqueness). Set `expected_replacements > 1` to \
+                     replace multiple matches."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "file_path":  {"type": "string"},
+                        "old_string": {"type": "string"},
+                        "new_string": {"type": "string"},
+                        "expected_replacements": {"type": "integer", "default": 1, "minimum": 1}
+                    },
+                    "required": ["file_path", "old_string", "new_string"],
+                    "additionalProperties": false
+                }),
+                provider_type: None,
+            },
+            ToolDeclaration {
+                name: WRITE_FILE.to_string(),
+                description: "Create or completely overwrite a file with the \
+                              given content."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string"},
+                        "content":   {"type": "string"}
+                    },
+                    "required": ["file_path", "content"],
+                    "additionalProperties": false
+                }),
+                provider_type: None,
+            },
+            ToolDeclaration {
+                name: READ_FILE.to_string(),
+                description: "Read a file with 1-indexed line numbers \
+                              prepended. Optional [start, end] line range; \
+                              -1 for EOF."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "view_range": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "minItems": 2,
+                            "maxItems": 2
+                        }
+                    },
+                    "required": ["path"],
+                    "additionalProperties": false
+                }),
+                provider_type: None,
+            },
+        ]
+    }
+
+    fn parse_call(
+        &self,
+        tool_name: &str,
+        raw_input: &serde_json::Value,
+    ) -> Result<Vec<EditOp>, EditParseError> {
+        match tool_name {
+            REPLACE => {
+                let path = req_str(raw_input, "file_path")?;
+                let old_str = req_str(raw_input, "old_string")?;
+                let new_str = req_str(raw_input, "new_string")?;
+                Ok(vec![EditOp::StrReplace {
+                    path,
+                    old_str,
+                    new_str,
+                }])
+            }
+            WRITE_FILE => {
+                let path = req_str(raw_input, "file_path")?;
+                let file_text = req_str(raw_input, "content")?;
+                Ok(vec![EditOp::Create { path, file_text }])
+            }
+            READ_FILE => {
+                let path = req_str(raw_input, "path")?;
+                let view_range = raw_input
+                    .get("view_range")
+                    .map(|v| {
+                        serde_json::from_value::<[i64; 2]>(v.clone())
+                            .map_err(|e| EditParseError::InvalidShape(format!("view_range: {e}")))
+                    })
+                    .transpose()?;
+                Ok(vec![EditOp::View { path, view_range }])
+            }
+            other => Err(EditParseError::UnknownCommand(other.to_string())),
+        }
+    }
+
+    fn format_result(
+        &self,
+        tool_use_id: &str,
+        results: &[EditOpResult],
+        errors: &[EditExecError],
+    ) -> serde_json::Value {
+        let is_error = !errors.is_empty();
+        let text = if is_error {
+            errors
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("\n")
+        } else {
+            results
+                .iter()
+                .map(EditOpResult::human_summary)
+                .collect::<Vec<_>>()
+                .join("\n")
+        };
+        json!({
+            "tool_call_id": tool_use_id,
+            "is_error": is_error,
+            "output": text,
+        })
+    }
+}
+
+fn req_str(raw: &serde_json::Value, field: &'static str) -> Result<String, EditParseError> {
+    raw.get(field)
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .ok_or(EditParseError::MissingField(field))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn declares_three_tools() {
+        let adapter = GeminiAdapter::new();
+        let names: Vec<_> = adapter
+            .declare_tools()
+            .into_iter()
+            .map(|t| t.name)
+            .collect();
+        assert_eq!(names, vec!["replace", "write_file", "read_file"]);
+    }
+
+    #[test]
+    fn parse_replace() {
+        let adapter = GeminiAdapter::new();
+        let raw = json!({
+            "file_path": "/w/a.rs",
+            "old_string": "let x = 1;",
+            "new_string": "let x = 2;",
+        });
+        let ops = adapter.parse_call(REPLACE, &raw).unwrap();
+        assert!(matches!(&ops[0], EditOp::StrReplace { path, .. } if path == "/w/a.rs"));
+    }
+
+    #[test]
+    fn parse_write_file() {
+        let adapter = GeminiAdapter::new();
+        let raw = json!({"file_path": "x", "content": "y"});
+        let ops = adapter.parse_call(WRITE_FILE, &raw).unwrap();
+        match &ops[0] {
+            EditOp::Create { path, file_text } => {
+                assert_eq!(path, "x");
+                assert_eq!(file_text, "y");
+            }
+            _ => panic!("expected Create"),
+        }
+    }
+
+    #[test]
+    fn parse_read_file_without_range() {
+        let adapter = GeminiAdapter::new();
+        let raw = json!({"path": "x"});
+        let ops = adapter.parse_call(READ_FILE, &raw).unwrap();
+        assert!(matches!(
+            &ops[0],
+            EditOp::View {
+                view_range: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn missing_field_errors() {
+        let adapter = GeminiAdapter::new();
+        assert!(adapter.parse_call(REPLACE, &json!({})).is_err());
+    }
+}

--- a/core/src/toolset/edit/adapters/mod.rs
+++ b/core/src/toolset/edit/adapters/mod.rs
@@ -1,0 +1,12 @@
+mod anthropic;
+mod fallback;
+mod gemini;
+mod openai;
+mod openai_v4a;
+
+pub use anthropic::{AnthropicAdapter, AnthropicTextEditorVersion};
+pub use fallback::FallbackAdapter;
+pub use gemini::GeminiAdapter;
+pub use openai::OpenAIAdapter;
+
+pub(crate) use anthropic::edit_input_schema;

--- a/core/src/toolset/edit/adapters/openai.rs
+++ b/core/src/toolset/edit/adapters/openai.rs
@@ -1,0 +1,228 @@
+//! OpenAI adapter — V4A `apply_patch` envelope plus a companion `read_file`
+//! tool (since `apply_patch` is write-only).
+//!
+//! GPT-4.1+/GPT-5/Codex were extensively trained on the V4A grammar, so this
+//! is the highest-leverage non-Anthropic adapter. The adapter declares
+//! tools as standard `function`-style entries; both Chat Completions and
+//! Responses APIs accept that shape.
+
+use serde_json::json;
+
+use super::super::adapter::{ProviderEditAdapter, ToolDeclaration};
+use super::super::canonical::{EditExecError, EditOp, EditOpResult, EditParseError};
+use super::openai_v4a::parse_v4a_patch;
+
+pub const APPLY_PATCH: &str = "apply_patch";
+pub const READ_FILE: &str = "read_file";
+
+#[derive(Debug, Clone, Default)]
+pub struct OpenAIAdapter;
+
+impl OpenAIAdapter {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl ProviderEditAdapter for OpenAIAdapter {
+    fn provider_name(&self) -> &'static str {
+        "openai"
+    }
+
+    fn declare_tools(&self) -> Vec<ToolDeclaration> {
+        vec![
+            ToolDeclaration {
+                name: APPLY_PATCH.to_string(),
+                description: "Apply a V4A patch to the working directory. Use the \
+                     `*** Begin Patch` / `*** End Patch` envelope. Supports \
+                     `*** Add File:`, `*** Update File:` (with `@@` hunks and \
+                     `+`/`-` lines plus surrounding context), `*** Move to:`, \
+                     and `*** Delete File:`."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "input": {
+                            "type": "string",
+                            "description": "The full V4A patch text, beginning \
+                                with `*** Begin Patch` and ending with \
+                                `*** End Patch`."
+                        }
+                    },
+                    "required": ["input"],
+                    "additionalProperties": false
+                }),
+                provider_type: None,
+            },
+            ToolDeclaration {
+                name: READ_FILE.to_string(),
+                description: "Read a file or list a directory. Returns 1-indexed \
+                              numbered lines."
+                    .to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"},
+                        "view_range": {
+                            "type": "array",
+                            "items": {"type": "integer"},
+                            "minItems": 2,
+                            "maxItems": 2,
+                            "description": "Optional [start, end] line numbers. \
+                                            -1 for end means EOF."
+                        }
+                    },
+                    "required": ["path"],
+                    "additionalProperties": false
+                }),
+                provider_type: None,
+            },
+        ]
+    }
+
+    fn parse_call(
+        &self,
+        tool_name: &str,
+        raw_input: &serde_json::Value,
+    ) -> Result<Vec<EditOp>, EditParseError> {
+        match tool_name {
+            APPLY_PATCH => {
+                let input = raw_input
+                    .get("input")
+                    .and_then(|v| v.as_str())
+                    .ok_or(EditParseError::MissingField("input"))?;
+                parse_v4a_patch(input)
+            }
+            READ_FILE => {
+                let path = raw_input
+                    .get("path")
+                    .and_then(|v| v.as_str())
+                    .ok_or(EditParseError::MissingField("path"))?
+                    .to_string();
+                let view_range = raw_input
+                    .get("view_range")
+                    .map(|v| {
+                        serde_json::from_value::<[i64; 2]>(v.clone())
+                            .map_err(|e| EditParseError::InvalidShape(format!("view_range: {e}")))
+                    })
+                    .transpose()?;
+                Ok(vec![EditOp::View { path, view_range }])
+            }
+            other => Err(EditParseError::UnknownCommand(other.to_string())),
+        }
+    }
+
+    fn format_result(
+        &self,
+        tool_use_id: &str,
+        results: &[EditOpResult],
+        errors: &[EditExecError],
+    ) -> serde_json::Value {
+        if errors.is_empty() {
+            let summary = if results.len() == 1 {
+                results[0].human_summary()
+            } else {
+                let n = results.len();
+                format!(
+                    "Successfully applied {n} operation(s):\n{}",
+                    results
+                        .iter()
+                        .map(EditOpResult::human_summary)
+                        .collect::<Vec<_>>()
+                        .join("\n")
+                )
+            };
+            json!({
+                "type": "apply_patch_call_output",
+                "call_id": tool_use_id,
+                "status": "completed",
+                "output": summary,
+            })
+        } else {
+            let detail = errors
+                .iter()
+                .map(|e| e.to_string())
+                .collect::<Vec<_>>()
+                .join("\n");
+            json!({
+                "type": "apply_patch_call_output",
+                "call_id": tool_use_id,
+                "status": "failed",
+                "output": detail,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn declares_apply_patch_and_read_file() {
+        let adapter = OpenAIAdapter::new();
+        let decl = adapter.declare_tools();
+        assert_eq!(decl.len(), 2);
+        assert_eq!(decl[0].name, "apply_patch");
+        assert_eq!(decl[1].name, "read_file");
+    }
+
+    #[test]
+    fn parse_apply_patch_round_trips_through_v4a() {
+        let adapter = OpenAIAdapter::new();
+        let raw = json!({
+            "input": "*** Begin Patch\n*** Add File: a.txt\n+hi\n*** End Patch"
+        });
+        let ops = adapter.parse_call(APPLY_PATCH, &raw).unwrap();
+        assert!(matches!(&ops[0], EditOp::Create { path, .. } if path == "a.txt"));
+    }
+
+    #[test]
+    fn parse_read_file_with_range() {
+        let adapter = OpenAIAdapter::new();
+        let raw = json!({"path": "/w/a.rs", "view_range": [1, -1]});
+        let ops = adapter.parse_call(READ_FILE, &raw).unwrap();
+        match &ops[0] {
+            EditOp::View { path, view_range } => {
+                assert_eq!(path, "/w/a.rs");
+                assert_eq!(view_range, &Some([1, -1]));
+            }
+            _ => panic!("expected View"),
+        }
+    }
+
+    #[test]
+    fn parse_read_file_missing_path_errors() {
+        let adapter = OpenAIAdapter::new();
+        let raw = json!({});
+        assert!(adapter.parse_call(READ_FILE, &raw).is_err());
+    }
+
+    #[test]
+    fn unknown_tool_name_errors() {
+        let adapter = OpenAIAdapter::new();
+        assert!(adapter.parse_call("not_a_tool", &json!({})).is_err());
+    }
+
+    #[test]
+    fn format_result_uses_apply_patch_call_output_envelope() {
+        let adapter = OpenAIAdapter::new();
+        let v = adapter.format_result(
+            "call_01",
+            &[EditOpResult::Created {
+                path: "x".to_string(),
+            }],
+            &[],
+        );
+        assert_eq!(v["type"], "apply_patch_call_output");
+        assert_eq!(v["call_id"], "call_01");
+        assert_eq!(v["status"], "completed");
+    }
+
+    #[test]
+    fn format_result_marks_failure() {
+        let adapter = OpenAIAdapter::new();
+        let v = adapter.format_result("call_01", &[], &[EditExecError::NotFound("x".to_string())]);
+        assert_eq!(v["status"], "failed");
+    }
+}

--- a/core/src/toolset/edit/adapters/openai_v4a/mod.rs
+++ b/core/src/toolset/edit/adapters/openai_v4a/mod.rs
@@ -1,0 +1,26 @@
+//! OpenAI V4A `apply_patch` envelope parser.
+//!
+//! Wire grammar (from the canonical
+//! [`apply_patch_tool_instructions.md`](https://github.com/openai/codex/blob/main/codex-rs/apply-patch/apply_patch_tool_instructions.md)):
+//!
+//! ```text
+//! *** Begin Patch
+//! *** Add File: <path>
+//! +<content lines>...
+//! *** Update File: <path>
+//! *** Move to: <new-path>          (optional, after Update File)
+//! @@ <hunk header>                 (optional disambiguator)
+//!  <unchanged context>
+//! -<removed line>
+//! +<added line>
+//! *** End of File                  (optional, marks EOF inside hunk)
+//! *** Delete File: <path>
+//! *** End Patch
+//! ```
+
+mod parser;
+
+#[cfg(test)]
+mod tests;
+
+pub use parser::parse_v4a_patch;

--- a/core/src/toolset/edit/adapters/openai_v4a/parser.rs
+++ b/core/src/toolset/edit/adapters/openai_v4a/parser.rs
@@ -1,0 +1,211 @@
+//! Line-by-line V4A patch parser → `Vec<EditOp>`.
+//!
+//! Translation rules:
+//! - `*** Add File: <path>` + `+`-prefixed lines → [`EditOp::Create`].
+//! - `*** Delete File: <path>` → [`EditOp::Delete`].
+//! - `*** Update File: <path>` with `@@` hunks → one [`EditOp::StrReplace`]
+//!   per hunk; `old_str` = context + `-` lines, `new_str` = context + `+` lines.
+//! - `*** Move to: <new-path>` after Update File → emits a trailing
+//!   [`EditOp::Rename`] (after the StrReplace ops on the source path).
+
+use super::super::super::canonical::{EditOp, EditParseError};
+
+const BEGIN: &str = "*** Begin Patch";
+const END: &str = "*** End Patch";
+
+pub fn parse_v4a_patch(raw: &str) -> Result<Vec<EditOp>, EditParseError> {
+    let normalised = raw.replace("\r\n", "\n");
+    let trimmed = normalised.trim_matches(['\n', ' ', '\t']);
+    let lines: Vec<&str> = trimmed.split('\n').collect();
+
+    if lines.is_empty() || lines[0].trim() != BEGIN {
+        return Err(EditParseError::MalformedPatch(
+            "missing `*** Begin Patch` header".into(),
+        ));
+    }
+    if lines
+        .iter()
+        .rev()
+        .find(|l| !l.trim().is_empty())
+        .map(|l| l.trim())
+        != Some(END)
+    {
+        return Err(EditParseError::MalformedPatch(
+            "missing `*** End Patch` footer".into(),
+        ));
+    }
+
+    let mut ops = Vec::new();
+    let mut i = 1usize;
+
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed_line = line.trim_end();
+
+        if trimmed_line.is_empty() {
+            i += 1;
+            continue;
+        }
+        if trimmed_line == END {
+            break;
+        }
+
+        if let Some(path) = trimmed_line.strip_prefix("*** Add File: ") {
+            i += 1;
+            let (content, next) = collect_added_lines(&lines, i)?;
+            ops.push(EditOp::Create {
+                path: path.trim().to_string(),
+                file_text: content,
+            });
+            i = next;
+        } else if let Some(path) = trimmed_line.strip_prefix("*** Delete File: ") {
+            ops.push(EditOp::Delete {
+                path: path.trim().to_string(),
+            });
+            i += 1;
+        } else if let Some(path) = trimmed_line.strip_prefix("*** Update File: ") {
+            let path = path.trim().to_string();
+            i += 1;
+
+            let mut move_to: Option<String> = None;
+            if i < lines.len() {
+                if let Some(target) = lines[i].trim_end().strip_prefix("*** Move to: ") {
+                    move_to = Some(target.trim().to_string());
+                    i += 1;
+                }
+            }
+
+            let (replacements, next) = collect_update_hunks(&lines, i, &path)?;
+            ops.extend(replacements);
+            i = next;
+
+            if let Some(to) = move_to {
+                ops.push(EditOp::Rename { from: path, to });
+            }
+        } else {
+            return Err(EditParseError::MalformedPatch(format!(
+                "unexpected line outside file section: {trimmed_line:?}"
+            )));
+        }
+    }
+
+    if ops.is_empty() {
+        return Err(EditParseError::MalformedPatch(
+            "patch contained no file operations".into(),
+        ));
+    }
+
+    Ok(ops)
+}
+
+/// Collect `+`-prefixed body lines of an `*** Add File:` section. Stops at the
+/// next `*** ` directive or `*** End Patch`.
+fn collect_added_lines(lines: &[&str], start: usize) -> Result<(String, usize), EditParseError> {
+    let mut out = Vec::new();
+    let mut i = start;
+    while i < lines.len() {
+        let line = lines[i];
+        if line.trim_end().starts_with("*** ") {
+            break;
+        }
+        if let Some(rest) = line.strip_prefix('+') {
+            out.push(rest.to_string());
+        } else if line.is_empty() {
+            out.push(String::new());
+        } else {
+            return Err(EditParseError::MalformedPatch(format!(
+                "Add File body line must start with `+`: {line:?}"
+            )));
+        }
+        i += 1;
+    }
+    Ok((out.join("\n"), i))
+}
+
+/// Collect `@@`-delimited hunks for an `*** Update File:` section. Each hunk
+/// becomes one `StrReplace`. Stops at the next `*** ` directive.
+fn collect_update_hunks(
+    lines: &[&str],
+    start: usize,
+    path: &str,
+) -> Result<(Vec<EditOp>, usize), EditParseError> {
+    let mut ops = Vec::new();
+    let mut i = start;
+    let mut current_old: Vec<String> = Vec::new();
+    let mut current_new: Vec<String> = Vec::new();
+    let mut in_hunk = false;
+
+    let flush = |old: &mut Vec<String>, new: &mut Vec<String>, ops: &mut Vec<EditOp>| {
+        if !old.is_empty() || !new.is_empty() {
+            ops.push(EditOp::StrReplace {
+                path: path.to_string(),
+                old_str: old.join("\n"),
+                new_str: new.join("\n"),
+            });
+        }
+        old.clear();
+        new.clear();
+    };
+
+    while i < lines.len() {
+        let line = lines[i];
+        let trimmed = line.trim_end();
+
+        if trimmed.starts_with("*** ") && trimmed != "*** End of File" {
+            break;
+        }
+
+        if let Some(_header) = trimmed.strip_prefix("@@") {
+            if in_hunk {
+                flush(&mut current_old, &mut current_new, &mut ops);
+            }
+            in_hunk = true;
+            i += 1;
+            continue;
+        }
+
+        if !in_hunk {
+            if trimmed.is_empty() {
+                i += 1;
+                continue;
+            }
+            return Err(EditParseError::MalformedPatch(format!(
+                "Update File body must begin with `@@`: {trimmed:?}"
+            )));
+        }
+
+        if trimmed == "*** End of File" {
+            i += 1;
+            continue;
+        }
+
+        if let Some(rest) = line.strip_prefix('+') {
+            current_new.push(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix('-') {
+            current_old.push(rest.to_string());
+        } else if let Some(rest) = line.strip_prefix(' ') {
+            current_old.push(rest.to_string());
+            current_new.push(rest.to_string());
+        } else if line.is_empty() {
+            current_old.push(String::new());
+            current_new.push(String::new());
+        } else {
+            return Err(EditParseError::MalformedPatch(format!(
+                "hunk line must begin with ` `, `+`, or `-`: {line:?}"
+            )));
+        }
+        i += 1;
+    }
+
+    if in_hunk {
+        flush(&mut current_old, &mut current_new, &mut ops);
+    }
+
+    if ops.is_empty() {
+        return Err(EditParseError::MalformedPatch(format!(
+            "Update File `{path}` contained no hunks"
+        )));
+    }
+
+    Ok((ops, i))
+}

--- a/core/src/toolset/edit/adapters/openai_v4a/tests.rs
+++ b/core/src/toolset/edit/adapters/openai_v4a/tests.rs
@@ -1,0 +1,290 @@
+//! V4A apply_patch parser corpus.
+//!
+//! Each test case mirrors a real shape from the OpenAI Codex documentation
+//! or one of the well-known parser bug reports (codex GH issues #2030, #15003).
+
+use super::super::super::canonical::EditOp;
+use super::parser::parse_v4a_patch;
+
+#[test]
+fn add_file_simple() {
+    let patch = "\
+*** Begin Patch
+*** Add File: foo.py
++def f():
++    return 1
+*** End Patch";
+    let ops = parse_v4a_patch(patch).expect("should parse");
+    assert_eq!(ops.len(), 1);
+    match &ops[0] {
+        EditOp::Create { path, file_text } => {
+            assert_eq!(path, "foo.py");
+            assert_eq!(file_text, "def f():\n    return 1");
+        }
+        other => panic!("expected Create, got {other:?}"),
+    }
+}
+
+#[test]
+fn delete_file_simple() {
+    let patch = "\
+*** Begin Patch
+*** Delete File: old.py
+*** End Patch";
+    let ops = parse_v4a_patch(patch).unwrap();
+    assert_eq!(ops.len(), 1);
+    assert!(matches!(&ops[0], EditOp::Delete { path } if path == "old.py"));
+}
+
+#[test]
+fn update_file_single_hunk_with_context() {
+    let patch = "\
+*** Begin Patch
+*** Update File: bar.py
+@@ class Greeter
+     def hello(self):
+-        print(\"hi\")
++        print(\"hello\")
+*** End Patch";
+    let ops = parse_v4a_patch(patch).unwrap();
+    assert_eq!(ops.len(), 1);
+    match &ops[0] {
+        EditOp::StrReplace {
+            path,
+            old_str,
+            new_str,
+        } => {
+            assert_eq!(path, "bar.py");
+            assert_eq!(old_str, "    def hello(self):\n        print(\"hi\")");
+            assert_eq!(new_str, "    def hello(self):\n        print(\"hello\")");
+        }
+        other => panic!("expected StrReplace, got {other:?}"),
+    }
+}
+
+#[test]
+fn update_file_multiple_hunks() {
+    let patch = "\
+*** Begin Patch
+*** Update File: lib.rs
+@@ fn one
+-    let x = 1;
++    let x = 10;
+@@ fn two
+-    let y = 2;
++    let y = 20;
+*** End Patch";
+    let ops = parse_v4a_patch(patch).unwrap();
+    assert_eq!(ops.len(), 2);
+    match (&ops[0], &ops[1]) {
+        (
+            EditOp::StrReplace {
+                path: p1,
+                old_str: o1,
+                new_str: n1,
+            },
+            EditOp::StrReplace {
+                path: p2,
+                old_str: o2,
+                new_str: n2,
+            },
+        ) => {
+            assert_eq!(p1, "lib.rs");
+            assert_eq!(p2, "lib.rs");
+            assert_eq!(o1, "    let x = 1;");
+            assert_eq!(n1, "    let x = 10;");
+            assert_eq!(o2, "    let y = 2;");
+            assert_eq!(n2, "    let y = 20;");
+        }
+        _ => panic!("expected two StrReplace"),
+    }
+}
+
+#[test]
+fn update_with_move_emits_rename() {
+    let patch = "\
+*** Begin Patch
+*** Update File: src/old.py
+*** Move to: src/new.py
+@@ def f
+-    return 1
++    return 2
+*** End Patch";
+    let ops = parse_v4a_patch(patch).unwrap();
+    assert_eq!(ops.len(), 2);
+    match &ops[0] {
+        EditOp::StrReplace { path, .. } => assert_eq!(path, "src/old.py"),
+        other => panic!("expected StrReplace first, got {other:?}"),
+    }
+    match &ops[1] {
+        EditOp::Rename { from, to } => {
+            assert_eq!(from, "src/old.py");
+            assert_eq!(to, "src/new.py");
+        }
+        other => panic!("expected Rename last, got {other:?}"),
+    }
+}
+
+#[test]
+fn mixed_add_update_delete() {
+    let patch = "\
+*** Begin Patch
+*** Add File: a.py
++x = 1
+*** Update File: b.py
+@@ def f
+-    return 1
++    return 2
+*** Delete File: c.py
+*** End Patch";
+    let ops = parse_v4a_patch(patch).unwrap();
+    assert_eq!(ops.len(), 3);
+    assert!(matches!(&ops[0], EditOp::Create { path, .. } if path == "a.py"));
+    assert!(matches!(&ops[1], EditOp::StrReplace { path, .. } if path == "b.py"));
+    assert!(matches!(&ops[2], EditOp::Delete { path } if path == "c.py"));
+}
+
+#[test]
+fn end_of_file_marker_is_handled() {
+    let patch = "\
+*** Begin Patch
+*** Update File: tail.py
+@@ def main
+     pass
+-    return None
++    return 0
+*** End of File
+*** End Patch";
+    let ops = parse_v4a_patch(patch).unwrap();
+    assert_eq!(ops.len(), 1);
+    match &ops[0] {
+        EditOp::StrReplace {
+            old_str, new_str, ..
+        } => {
+            assert!(old_str.contains("return None"));
+            assert!(new_str.contains("return 0"));
+            assert!(!old_str.contains("End of File"));
+        }
+        _ => panic!("expected StrReplace"),
+    }
+}
+
+#[test]
+fn crlf_line_endings_are_normalised() {
+    let patch = "*** Begin Patch\r\n*** Add File: x.txt\r\n+hello\r\n*** End Patch\r\n";
+    let ops = parse_v4a_patch(patch).unwrap();
+    match &ops[0] {
+        EditOp::Create { file_text, .. } => assert_eq!(file_text, "hello"),
+        _ => panic!("expected Create"),
+    }
+}
+
+#[test]
+fn leading_and_trailing_whitespace_tolerated() {
+    let patch = "\n\n  *** Begin Patch\n*** Add File: x\n+y\n*** End Patch  \n\n";
+    parse_v4a_patch(patch).unwrap();
+}
+
+#[test]
+fn missing_begin_envelope_errors() {
+    let patch = "*** Add File: foo\n+bar\n*** End Patch";
+    assert!(parse_v4a_patch(patch).is_err());
+}
+
+#[test]
+fn missing_end_envelope_errors() {
+    let patch = "*** Begin Patch\n*** Add File: foo\n+bar\n";
+    assert!(parse_v4a_patch(patch).is_err());
+}
+
+#[test]
+fn add_file_body_must_be_prefixed_with_plus() {
+    let patch = "\
+*** Begin Patch
+*** Add File: foo
+not prefixed
+*** End Patch";
+    assert!(parse_v4a_patch(patch).is_err());
+}
+
+#[test]
+fn update_file_without_hunk_header_errors() {
+    let patch = "\
+*** Begin Patch
+*** Update File: bar.py
+-    return 1
++    return 2
+*** End Patch";
+    assert!(parse_v4a_patch(patch).is_err());
+}
+
+#[test]
+fn update_file_without_hunks_errors() {
+    let patch = "\
+*** Begin Patch
+*** Update File: bar.py
+*** End Patch";
+    assert!(parse_v4a_patch(patch).is_err());
+}
+
+#[test]
+fn empty_patch_errors() {
+    let patch = "*** Begin Patch\n*** End Patch";
+    assert!(parse_v4a_patch(patch).is_err());
+}
+
+#[test]
+fn unexpected_line_outside_file_section_errors() {
+    let patch = "\
+*** Begin Patch
+random text
+*** Add File: x
++y
+*** End Patch";
+    assert!(parse_v4a_patch(patch).is_err());
+}
+
+#[test]
+fn add_file_preserves_blank_lines_in_body() {
+    let patch = "\
+*** Begin Patch
+*** Add File: x.py
++a
+
++b
+*** End Patch";
+    let ops = parse_v4a_patch(patch).unwrap();
+    match &ops[0] {
+        EditOp::Create { file_text, .. } => assert_eq!(file_text, "a\n\nb"),
+        _ => panic!("expected Create"),
+    }
+}
+
+#[test]
+fn hunk_with_multiple_context_and_changes() {
+    let patch = "\
+*** Begin Patch
+*** Update File: f.py
+@@ def f
+     a = 1
+     b = 2
+-    c = 3
++    c = 30
++    d = 4
+     e = 5
+*** End Patch";
+    let ops = parse_v4a_patch(patch).unwrap();
+    assert_eq!(ops.len(), 1);
+    match &ops[0] {
+        EditOp::StrReplace {
+            old_str, new_str, ..
+        } => {
+            assert_eq!(old_str, "    a = 1\n    b = 2\n    c = 3\n    e = 5");
+            assert_eq!(
+                new_str,
+                "    a = 1\n    b = 2\n    c = 30\n    d = 4\n    e = 5"
+            );
+        }
+        _ => panic!("expected StrReplace"),
+    }
+}

--- a/core/src/toolset/edit/canonical.rs
+++ b/core/src/toolset/edit/canonical.rs
@@ -1,0 +1,217 @@
+//! Canonical edit-operation types — the lingua franca that every
+//! [`ProviderEditAdapter`](super::adapter::ProviderEditAdapter) parses model
+//! tool-calls into. Wire-compatible with Anthropic's `text_editor_*` tool for
+//! the four overlapping commands (`view`, `create`, `str_replace`, `insert`)
+//! so a serialized [`EditOp`] can be forwarded verbatim to the
+//! sandbox-tool-server's `/execute` endpoint.
+//!
+//! Two extras (`delete`, `rename`) are required to losslessly model
+//! OpenAI V4A `apply_patch` and Gemini-style file moves; the Anthropic
+//! adapter never emits them.
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "command", rename_all = "snake_case")]
+pub enum EditOp {
+    View {
+        path: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        view_range: Option<[i64; 2]>,
+    },
+    Create {
+        path: String,
+        file_text: String,
+    },
+    StrReplace {
+        path: String,
+        old_str: String,
+        new_str: String,
+    },
+    Insert {
+        path: String,
+        insert_line: u64,
+        new_str: String,
+    },
+    Delete {
+        path: String,
+    },
+    Rename {
+        from: String,
+        to: String,
+    },
+}
+
+impl EditOp {
+    /// Stable name for the discriminator used in tracing / audit.
+    pub fn command(&self) -> &'static str {
+        match self {
+            EditOp::View { .. } => "view",
+            EditOp::Create { .. } => "create",
+            EditOp::StrReplace { .. } => "str_replace",
+            EditOp::Insert { .. } => "insert",
+            EditOp::Delete { .. } => "delete",
+            EditOp::Rename { .. } => "rename",
+        }
+    }
+
+    /// Path the op reads/writes. For [`EditOp::Rename`] this is the
+    /// destination path (the canonical "target" of the operation).
+    pub fn path(&self) -> &str {
+        match self {
+            EditOp::View { path, .. }
+            | EditOp::Create { path, .. }
+            | EditOp::StrReplace { path, .. }
+            | EditOp::Insert { path, .. }
+            | EditOp::Delete { path } => path,
+            EditOp::Rename { to, .. } => to,
+        }
+    }
+
+    /// Read-only ops can run on read-only sandbox attachments.
+    pub fn is_read_only(&self) -> bool {
+        matches!(self, EditOp::View { .. })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum EditOpResult {
+    /// Numbered-line file contents or directory listing.
+    View {
+        output: String,
+    },
+    Created {
+        path: String,
+    },
+    Replaced {
+        path: String,
+        occurrences: usize,
+    },
+    Inserted {
+        path: String,
+        line: u64,
+    },
+    Deleted {
+        path: String,
+    },
+    Renamed {
+        from: String,
+        to: String,
+    },
+}
+
+impl EditOpResult {
+    pub fn human_summary(&self) -> String {
+        match self {
+            EditOpResult::View { output } => output.clone(),
+            EditOpResult::Created { path } => format!("Created {path}"),
+            EditOpResult::Replaced { path, occurrences } => {
+                format!("Replaced {occurrences} occurrence(s) in {path}")
+            }
+            EditOpResult::Inserted { path, line } => {
+                format!("Inserted at line {line} in {path}")
+            }
+            EditOpResult::Deleted { path } => format!("Deleted {path}"),
+            EditOpResult::Renamed { from, to } => format!("Renamed {from} → {to}"),
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EditParseError {
+    #[error("missing required field: {0}")]
+    MissingField(&'static str),
+    #[error("unknown command: {0}")]
+    UnknownCommand(String),
+    #[error("invalid argument shape: {0}")]
+    InvalidShape(String),
+    #[error("malformed V4A patch: {0}")]
+    MalformedPatch(String),
+    #[error("ambiguous hunk: {0}")]
+    AmbiguousHunk(String),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum EditExecError {
+    #[error("file not found: {0}")]
+    NotFound(String),
+    #[error("`old_str` matched {actual} times in {path}; expected exactly 1")]
+    NonUniqueMatch { path: String, actual: usize },
+    #[error("sandbox execution error: {0}")]
+    Sandbox(String),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn view_serialises_with_anthropic_field_names() {
+        let op = EditOp::View {
+            path: "/w/a.rs".to_string(),
+            view_range: Some([10, -1]),
+        };
+        let v = serde_json::to_value(&op).unwrap();
+        assert_eq!(v["command"], "view");
+        assert_eq!(v["path"], "/w/a.rs");
+        assert_eq!(v["view_range"], serde_json::json!([10, -1]));
+    }
+
+    #[test]
+    fn str_replace_round_trips() {
+        let op = EditOp::StrReplace {
+            path: "/w/a.rs".to_string(),
+            old_str: "let x = 1;".to_string(),
+            new_str: "let x = 2;".to_string(),
+        };
+        let v = serde_json::to_value(&op).unwrap();
+        let back: EditOp = serde_json::from_value(v).unwrap();
+        assert_eq!(op, back);
+    }
+
+    #[test]
+    fn insert_uses_new_str_field() {
+        let op = EditOp::Insert {
+            path: "/w/a.rs".to_string(),
+            insert_line: 0,
+            new_str: "// header\n".to_string(),
+        };
+        let v = serde_json::to_value(&op).unwrap();
+        assert_eq!(v["new_str"], "// header\n");
+        assert_eq!(v["insert_line"], 0);
+    }
+
+    #[test]
+    fn delete_and_rename_serialise() {
+        let d = EditOp::Delete {
+            path: "old.rs".to_string(),
+        };
+        let r = EditOp::Rename {
+            from: "a.rs".to_string(),
+            to: "b.rs".to_string(),
+        };
+        assert_eq!(serde_json::to_value(&d).unwrap()["command"], "delete");
+        assert_eq!(serde_json::to_value(&r).unwrap()["command"], "rename");
+    }
+
+    #[test]
+    fn unknown_command_errors() {
+        let v = serde_json::json!({"command": "exec", "path": "/w/a.rs"});
+        let r: Result<EditOp, _> = serde_json::from_value(v);
+        assert!(r.is_err());
+    }
+
+    #[test]
+    fn is_read_only_only_for_view() {
+        let view = EditOp::View {
+            path: "p".to_string(),
+            view_range: None,
+        };
+        let create = EditOp::Create {
+            path: "p".to_string(),
+            file_text: String::new(),
+        };
+        assert!(view.is_read_only());
+        assert!(!create.is_read_only());
+    }
+}

--- a/core/src/toolset/edit/mod.rs
+++ b/core/src/toolset/edit/mod.rs
@@ -1,0 +1,144 @@
+//! Provider-aware schema translation for the in-sandbox file editor.
+//!
+//! drua's executor (the sandbox-tool-server's `/execute` endpoint) speaks the
+//! Anthropic `text_editor_*` wire format; the canonical [`EditOp`] is its
+//! one-to-one Rust mirror. Every provider adapter translates a model's
+//! preferred schema into one or more [`EditOp`]s on the way *in*, and back
+//! into the provider's expected tool-result envelope on the way *out*.
+//!
+//! - [`AnthropicAdapter`]   — identity (server tool, schema-less)
+//! - [`OpenAIAdapter`]      — V4A `apply_patch` envelope + `read_file`
+//! - [`GeminiAdapter`]      — `replace` / `write_file` / `read_file`
+//! - [`FallbackAdapter`]    — single `edit_file` mega-tool
+//!
+//! [`adapter_for`] picks the right adapter from a model identifier
+//! (e.g. `"claude-sonnet-4-20250514"`, `"gpt-5-codex"`, `"gemini-2.5-pro"`).
+
+pub mod adapter;
+mod adapters;
+pub mod canonical;
+
+pub use adapter::{ProviderEditAdapter, ToolDeclaration};
+pub use adapters::{
+    AnthropicAdapter, AnthropicTextEditorVersion, FallbackAdapter, GeminiAdapter, OpenAIAdapter,
+};
+pub use canonical::{EditExecError, EditOp, EditOpResult, EditParseError};
+
+pub(crate) use adapters::edit_input_schema;
+
+/// Pick the right [`ProviderEditAdapter`] for a model identifier.
+///
+/// Uses prefix sniffing on the model name — drua does not currently maintain
+/// a structured `ModelId` enum (see open question #4 in the spec). The match
+/// order matters: more specific prefixes first, fallback last.
+pub fn adapter_for(model_id: &str) -> Box<dyn ProviderEditAdapter> {
+    let lower = model_id.to_ascii_lowercase();
+
+    if lower.starts_with("claude") || lower.starts_with("anthropic/") {
+        return Box::new(AnthropicAdapter::new(anthropic_version_for(&lower)));
+    }
+    if lower.starts_with("gpt-")
+        || lower.starts_with("o1")
+        || lower.starts_with("o3")
+        || lower.starts_with("o4")
+        || lower.starts_with("codex")
+        || lower.starts_with("openai/")
+    {
+        return Box::new(OpenAIAdapter::new());
+    }
+    if lower.starts_with("gemini") || lower.starts_with("google/") {
+        return Box::new(GeminiAdapter::new());
+    }
+    Box::new(FallbackAdapter::new())
+}
+
+/// Map a Claude model identifier to the right `text_editor_*` revision.
+/// Defaults to the latest (`20250728`) on unknown Claude variants.
+fn anthropic_version_for(lower_model_id: &str) -> AnthropicTextEditorVersion {
+    if lower_model_id.contains("claude-3-5") || lower_model_id.contains("claude-sonnet-3-5") {
+        AnthropicTextEditorVersion::V20241022
+    } else if lower_model_id.contains("claude-3-7") || lower_model_id.contains("claude-sonnet-3-7")
+    {
+        AnthropicTextEditorVersion::V20250124
+    } else {
+        AnthropicTextEditorVersion::V20250728
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn routes_claude_to_anthropic() {
+        let a = adapter_for("claude-sonnet-4-20250514");
+        assert_eq!(a.provider_name(), "anthropic");
+    }
+
+    #[test]
+    fn routes_openrouter_anthropic_alias() {
+        let a = adapter_for("anthropic/claude-opus-4");
+        assert_eq!(a.provider_name(), "anthropic");
+    }
+
+    #[test]
+    fn routes_gpt_to_openai() {
+        assert_eq!(adapter_for("gpt-5-codex").provider_name(), "openai");
+        assert_eq!(adapter_for("gpt-4.1").provider_name(), "openai");
+        assert_eq!(adapter_for("o3-mini").provider_name(), "openai");
+        assert_eq!(adapter_for("codex-mini").provider_name(), "openai");
+    }
+
+    #[test]
+    fn routes_gemini_to_gemini() {
+        assert_eq!(adapter_for("gemini-2.5-pro").provider_name(), "gemini");
+        assert_eq!(
+            adapter_for("google/gemini-2.5-flash").provider_name(),
+            "gemini"
+        );
+    }
+
+    #[test]
+    fn unknown_falls_back() {
+        assert_eq!(adapter_for("llama-3.3-70b").provider_name(), "fallback");
+        assert_eq!(adapter_for("deepseek-v3").provider_name(), "fallback");
+        assert_eq!(adapter_for("grok-2").provider_name(), "fallback");
+    }
+
+    #[test]
+    fn anthropic_version_matrix() {
+        match adapter_for("claude-3-5-sonnet-20241022")
+            .declare_tools()
+            .into_iter()
+            .next()
+            .unwrap()
+            .provider_type
+            .as_deref()
+        {
+            Some("text_editor_20241022") => {}
+            other => panic!("expected text_editor_20241022, got {other:?}"),
+        }
+        match adapter_for("claude-3-7-sonnet-latest")
+            .declare_tools()
+            .into_iter()
+            .next()
+            .unwrap()
+            .provider_type
+            .as_deref()
+        {
+            Some("text_editor_20250124") => {}
+            other => panic!("expected text_editor_20250124, got {other:?}"),
+        }
+        match adapter_for("claude-sonnet-4-20250514")
+            .declare_tools()
+            .into_iter()
+            .next()
+            .unwrap()
+            .provider_type
+            .as_deref()
+        {
+            Some("text_editor_20250728") => {}
+            other => panic!("expected text_editor_20250728, got {other:?}"),
+        }
+    }
+}

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -1,4 +1,5 @@
 mod config;
+pub mod edit;
 mod error;
 mod filter;
 pub mod searchable;

--- a/core/src/toolset/top_level/text_editor.rs
+++ b/core/src/toolset/top_level/text_editor.rs
@@ -4,6 +4,12 @@
 //! same field names. Forwards the request body verbatim to the
 //! sandbox-tool-server's `/execute` endpoint.
 //!
+//! Argument parsing goes through
+//! [`AnthropicAdapter`](crate::toolset::edit::AnthropicAdapter) (identity
+//! passthrough for the canonical schema) so the command/auth split stays in
+//! sync with the canonical [`EditOp`](crate::toolset::edit::EditOp) used by
+//! every non-Anthropic provider adapter.
+//!
 //! Visibility / authz mirrors [`super::Bash`]:
 //! - Visible only to [`AuthSubject::Agent`] / [`AuthSubject::AgentOnBehalfOfUser`].
 //! - `view` is read-only → executable with either `SandboxUse` *or*
@@ -23,6 +29,9 @@ use crate::audit::Audit;
 use crate::auth::AuthSubject;
 use crate::primitives::{AuthScope, SandboxId};
 use crate::sandbox::Sandboxes;
+use crate::toolset::edit::{
+    AnthropicAdapter, AnthropicTextEditorVersion, EditOp, ProviderEditAdapter,
+};
 
 use super::super::error::ToolSetsError;
 use super::super::traits::TopLevelTool;
@@ -30,11 +39,15 @@ use super::{schema_for, TextOutput};
 
 pub struct TextEditor {
     sandboxes: Arc<Sandboxes>,
+    adapter: AnthropicAdapter,
 }
 
 impl TextEditor {
     pub fn new(sandboxes: Arc<Sandboxes>) -> Self {
-        Self { sandboxes }
+        Self {
+            sandboxes,
+            adapter: AnthropicAdapter::new(AnthropicTextEditorVersion::V20250728),
+        }
     }
 }
 
@@ -42,49 +55,10 @@ static TEXT_EDITOR_OUTPUT_SCHEMA: LazyLock<serde_json::Value> =
     LazyLock::new(schema_for::<TextOutput>);
 
 static TEXT_EDITOR_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
-    // Union of fields across all commands; `command` discriminates and
-    // the server validates per-command requirements.
-    serde_json::json!({
-    "type": "object",
-    "properties": {
-            "command": {
-                "type": "string",
-                "enum": ["view", "create", "str_replace", "insert"],
-                "description": "Which editor operation to perform."
-            },
-            "path": {
-                "type": "string",
-                "description": "Absolute path to the file or directory inside the sandbox workspace."
-            },
-            "view_range": {
-                "type": "array",
-                "items": { "type": "integer" },
-                "minItems": 2,
-                "maxItems": 2,
-                "description": "[start, end] line range for `view`. -1 for end means EOF. Optional."
-            },
-            "file_text": {
-                "type": "string",
-                "description": "Full file contents for `create`."
-            },
-            "old_str": {
-                "type": "string",
-                "description": "Substring to replace for `str_replace`. Must appear exactly once."
-            },
-            "new_str": {
-                "type": "string",
-                "description": "Replacement text for `str_replace`, or text to insert for `insert`."
-            },
-            "insert_line": {
-                "type": "integer",
-                "minimum": 0,
-                "description": "Line number after which to insert text for `insert`. 0 = beginning of file."
-            }
-        },
-        "required": ["command", "path"],
-        "additionalProperties": false,
-    })
+    crate::toolset::edit::edit_input_schema(AnthropicTextEditorVersion::V20250728)
 });
+
+const TOOL_NAME: &str = "str_replace_based_edit_tool";
 
 fn writable_sandbox_id(subject: &AuthSubject) -> Option<SandboxId> {
     subject.scopes().iter().find_map(|s| match s {
@@ -93,15 +67,10 @@ fn writable_sandbox_id(subject: &AuthSubject) -> Option<SandboxId> {
     })
 }
 
-/// `view` is the only read-only operation; everything else mutates.
-fn command_is_mutating(command: &str) -> bool {
-    !matches!(command, "view")
-}
-
 #[async_trait::async_trait]
 impl TopLevelTool for TextEditor {
     fn name(&self) -> &str {
-        "str_replace_based_edit_tool"
+        TOOL_NAME
     }
 
     fn description(&self) -> &str {
@@ -130,37 +99,40 @@ impl TopLevelTool for TextEditor {
         subject: &AuthSubject,
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
-        let args = arguments.unwrap_or_default();
-        let command = args
-            .get("command")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| ToolSetsError::MissingArgument("command".to_string()))?;
+        let args_value = serde_json::Value::Object(arguments.unwrap_or_default());
+        let mut ops = self
+            .adapter
+            .parse_call(TOOL_NAME, &args_value)
+            .map_err(|e| ToolSetsError::InvalidArgument(e.to_string()))?;
+        let op = ops
+            .pop()
+            .ok_or_else(|| ToolSetsError::InvalidArgument("empty edit op batch".into()))?;
 
-        // Mutating commands require SandboxUse; `view` falls back to SandboxRead.
-        let sandbox_id = if command_is_mutating(command) {
-            writable_sandbox_id(subject).ok_or(ToolSetsError::Unauthorized)?
-        } else {
+        // Mutating ops require SandboxUse; `view` falls back to SandboxRead.
+        let sandbox_id = if op.is_read_only() {
             subject
                 .readable_sandbox_id()
                 .ok_or(ToolSetsError::Unauthorized)?
+        } else {
+            writable_sandbox_id(subject).ok_or(ToolSetsError::Unauthorized)?
         };
         Audit::record_action("text_editor");
         Audit::record_sandbox_id(sandbox_id);
 
-        let client = if command_is_mutating(command) {
+        let client = if op.is_read_only() {
             self.sandboxes
-                .instance_client_for(subject, sandbox_id)
+                .instance_client_for_read(subject, sandbox_id)
                 .await
         } else {
             self.sandboxes
-                .instance_client_for_read(subject, sandbox_id)
+                .instance_client_for(subject, sandbox_id)
                 .await
         }
         .map_err(|e| ToolSetsError::Sandbox(e.to_string()))?;
 
         let req = ExecuteRequest {
-            tool: "str_replace_based_edit_tool".to_string(),
-            input: serde_json::Value::Object(args),
+            tool: TOOL_NAME.to_string(),
+            input: edit_op_to_sandbox_input(&op),
         };
 
         match client.execute(&req).await {
@@ -182,5 +154,57 @@ impl TopLevelTool for TextEditor {
                 "sandbox /execute call failed: {e}"
             ))])),
         }
+    }
+}
+
+/// The sandbox executor speaks the Anthropic `text_editor_*` wire format,
+/// so the canonical [`EditOp`] serialises straight through. The two extra
+/// canonical variants ([`EditOp::Delete`] / [`EditOp::Rename`]) cannot
+/// reach this path — Anthropic's schema-less server tool can only emit the
+/// four core commands, and [`AnthropicAdapter::parse_call`] enforces that.
+fn edit_op_to_sandbox_input(op: &EditOp) -> serde_json::Value {
+    serde_json::to_value(op).expect("EditOp is always serializable")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_view_to_sandbox_input() {
+        let op = EditOp::View {
+            path: "/w/a.rs".to_string(),
+            view_range: Some([1, -1]),
+        };
+        let v = edit_op_to_sandbox_input(&op);
+        assert_eq!(v["command"], "view");
+        assert_eq!(v["path"], "/w/a.rs");
+        assert_eq!(v["view_range"], serde_json::json!([1, -1]));
+    }
+
+    #[test]
+    fn round_trip_str_replace_to_sandbox_input() {
+        let op = EditOp::StrReplace {
+            path: "/w/a.rs".to_string(),
+            old_str: "let x = 1;".into(),
+            new_str: "let x = 2;".into(),
+        };
+        let v = edit_op_to_sandbox_input(&op);
+        assert_eq!(v["command"], "str_replace");
+        assert_eq!(v["old_str"], "let x = 1;");
+        assert_eq!(v["new_str"], "let x = 2;");
+    }
+
+    #[test]
+    fn round_trip_insert_uses_new_str_field() {
+        let op = EditOp::Insert {
+            path: "/w/a.rs".to_string(),
+            insert_line: 0,
+            new_str: "header\n".into(),
+        };
+        let v = edit_op_to_sandbox_input(&op);
+        assert_eq!(v["command"], "insert");
+        assert_eq!(v["new_str"], "header\n");
+        assert_eq!(v["insert_line"], 0);
     }
 }


### PR DESCRIPTION
## Summary

Introduces a canonical `EditOp` + `ProviderEditAdapter` trait so each LLM provider gets the file-edit schema it was trained on, while the executor (sandbox `/execute` endpoint) still speaks the single Anthropic-compatible wire format end-to-end.

This is a **scaffold + Phase 1 refactor** in one PR. Phases 2–4 (the OpenAI / Gemini / Fallback adapters) are implemented but **not yet wired into the LLM call path** — they ship ready for opt-in adoption. See \"Out of scope\" below.

## Architecture

```
core/src/toolset/edit/
├── canonical.rs        EditOp / EditOpResult / EditParseError / EditExecError
├── adapter.rs          ProviderEditAdapter trait + ToolDeclaration
├── adapters/
│   ├── anthropic.rs    identity (text_editor_*)
│   ├── openai.rs       apply_patch (V4A) + read_file
│   ├── openai_v4a/     V4A parser submodule + 18-case corpus
│   ├── gemini.rs       replace / write_file / read_file
│   └── fallback.rs     edit_file mega-tool (Llama, DeepSeek, Grok, …)
└── mod.rs              adapter_for(model_id) router
```

`EditOp` is a strict superset of Anthropic's commands — adds `Delete` and `Rename` so OpenAI V4A patches with `*** Delete File:` and `*** Move to:` round-trip losslessly. The Anthropic adapter never emits those variants.

## The four adapters

| Adapter | Tools declared | Output envelope |
|---|---|---|
| **Anthropic** | `str_replace_based_edit_tool` (or legacy name per version) with `provider_type: text_editor_*` | `{type: tool_result, tool_use_id, is_error, content}` |
| **OpenAI** | `apply_patch` + `read_file` | `{type: apply_patch_call_output, call_id, status, output}` |
| **Gemini** | `replace`, `write_file`, `read_file` | `{tool_call_id, is_error, output}` |
| **Fallback** | `edit_file` (rich description, mirrors canonical shape) | `{tool_call_id, is_error, output}` |

The Anthropic adapter is version-aware: `text_editor_20241022` (Claude 3.5), `_20250124` (3.7), `_20250429` (Claude 4 — drops `undo_edit`), `_20250728` (default — adds `max_characters`). Tool name flips between `str_replace_editor` and `str_replace_based_edit_tool` accordingly.

The OpenAI V4A parser handles `Add File`, `Update File` (with `@@` hunks, multi-hunk per file, `+`/`-`/context lines, optional `*** End of File`), `*** Move to:` (emits `Rename`), and `Delete File`. CRLF normalisation and leading/trailing whitespace are tolerated. Malformed envelopes return a structured `EditParseError::MalformedPatch`.

## Open questions — decisions

1. **Which providers does drua route through?** drua's `prompt_executor.rs` configures Anthropic + OpenAI Chat Completions + OpenAI Responses. Anthropic & OpenAI are P0; Gemini is forward-looking; Fallback covers OpenRouter passthrough. **All four shipped.**
2. **Chat Completions vs Responses?** Both. The `apply_patch` declaration uses the `function`-tool shape that both APIs accept; Responses-API users can later swap to the first-class `{type: \"apply_patch\"}` shorthand without changing the adapter contract.
3. **Numbered `view` output?** The sandbox `/execute` endpoint owns this — outside this PR's scope. Existing tool description claims numbered output; trusting the existing impl per the spec's \"Phase 1 = pure refactor, no behaviour change\" rule.
4. **`ModelId` enum?** None exists. Used prefix-sniffing in `adapter_for(&str)` (`claude*` / `anthropic/*` → Anthropic; `gpt-*` / `o[1-4]*` / `codex*` / `openai/*` → OpenAI; `gemini*` / `google/*` → Gemini; else Fallback). Lightweight and easy to migrate to a structured `ModelId` later.
5. **Error envelopes per provider?** Each adapter's `format_result` owns its provider-shaped envelope. Existing `text_editor.rs` keeps emitting MCP `CallToolResult` (no behaviour change).
6. **Add `Delete` / `Rename` to canonical?** **Yes.** Required for V4A round-trip. Additive — Anthropic adapter rejects them at parse time (impossible from the schema-less server tool anyway).

## Test coverage

- **52 new unit tests** covering: canonical type round-trips, all four adapters' `declare_tools` / `parse_call` / `format_result`, version matrix, routing.
- **V4A corpus** (`adapters/openai_v4a/tests.rs`, 18 cases): simple add/delete/update, multi-hunk, move-to-rename, mixed batches, `*** End of File`, CRLF, multi-context hunks, plus failure cases (missing envelope, bad prefix, no hunks, empty patch, unexpected lines).
- **Existing `text_editor.rs` tests** (3) ensure the canonical → sandbox-input serialisation preserves the Anthropic wire format bit-for-bit.
- **No live-model smoke tests** in this PR. The spec calls them \"gated, optional, require API keys\" — they should land alongside the actual Phase-5 LLM-call-site wiring.

`nix flake check` passes (fmt, clippy `-D warnings`, nextest, graphql-schema, default-config).

## Out of scope

- **Phase 5 wiring into the LLM call path.** Hooking `adapter_for(model)` into `lib/anthropic-client` / `lib/openai-client`'s `Prompt`-→-wire conversion is intentionally deferred to keep this PR truly behaviour-neutral. The adapters are ready; a follow-up can rewrite `Prompt.tools` per-provider before each call and translate tool-call results back through `parse_call`.
- **Aider-style `<<<<<<< SEARCH / >>>>>>> REPLACE` editblock textual fallback** (spec's optional Phase 5 in the original numbering). Trivial to add to `FallbackAdapter` later.
- **Sandbox executor semantics.** Untouched. The four core commands continue to forward verbatim to `/execute`.

## Test plan

- [x] `cargo test -p drua-core --lib toolset::edit` — 52 / 52 pass
- [x] `cargo test -p drua-core --lib toolset::top_level::text_editor` — 3 / 3 pass
- [x] `nix flake check` — fmt / clippy / nextest / graphql-schema / default-config all pass
- [ ] Manual smoke test against Claude / GPT-5 / Gemini once Phase 5 wiring lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)