### PR TITLE
feat(compose): make workspace admin tools accessible from compose scripts

### DIFF
--- a/core/src/toolset/top_level/agent.rs
+++ b/core/src/toolset/top_level/agent.rs
@@ -107,7 +107,7 @@ impl TopLevelTool for WorkspaceAgent {
     }
 
     fn composable(&self) -> bool {
-        false
+        true
     }
 
     async fn call(

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -488,6 +488,81 @@ mod tests {
         assert!(ts.contains("\"done\""), "{ts}");
     }
 
+    /// Workspace-admin tools (`agent`, `skill`, `workflow`, `sandbox`,
+    /// `spaces`, `notes`, `log`) MUST be reachable from compose so admins
+    /// can script-automate them. Stub `TopLevelTool` impls mirror the
+    /// real tools' names and `composable() == true`; `generate_dts` then
+    /// declares each one as a callable function on the `tools` namespace.
+    #[test]
+    fn admin_tools_appear_in_compose_dts() {
+        struct StubAdminTool {
+            name: &'static str,
+            composable: bool,
+        }
+
+        #[async_trait::async_trait]
+        impl TopLevelTool for StubAdminTool {
+            fn name(&self) -> &str {
+                self.name
+            }
+            fn description(&self) -> &str {
+                "stub admin tool"
+            }
+            fn input_schema(&self) -> &serde_json::Value {
+                static EMPTY: LazyLock<serde_json::Value> =
+                    LazyLock::new(|| serde_json::json!({"type": "object"}));
+                &EMPTY
+            }
+            fn composable(&self) -> bool {
+                self.composable
+            }
+            async fn call(
+                &self,
+                _subject: &AuthSubject,
+                _arguments: Option<JsonObject>,
+            ) -> Result<CallToolResult, ToolSetsError> {
+                unreachable!("stub: not invoked in this test")
+            }
+        }
+
+        let mut top: HashMap<String, Arc<dyn TopLevelTool>> = HashMap::new();
+        for name in [
+            "agent", "skill", "workflow", "sandbox", "spaces", "notes", "log",
+        ] {
+            top.insert(
+                name.to_string(),
+                Arc::new(StubAdminTool {
+                    name,
+                    composable: true,
+                }) as Arc<dyn TopLevelTool>,
+            );
+        }
+        // A non-composable meta tool should NOT leak into dts.
+        top.insert(
+            "compose".to_string(),
+            Arc::new(StubAdminTool {
+                name: "compose",
+                composable: false,
+            }) as Arc<dyn TopLevelTool>,
+        );
+
+        let sets: Vec<Arc<dyn SearchableToolSet>> = Vec::new();
+        let dts = generate_dts(&AuthSubject::Anonymous, &sets, &top);
+
+        for name in [
+            "agent", "skill", "workflow", "sandbox", "spaces", "notes", "log",
+        ] {
+            assert!(
+                dts.contains(&format!("function {name}(")),
+                "expected `function {name}(` in dts, got:\n{dts}"
+            );
+        }
+        assert!(
+            !dts.contains("function compose("),
+            "non-composable tool leaked into dts:\n{dts}"
+        );
+    }
+
     /// Strict MCP clients (e.g. Claude Code) reject boolean schemas inside
     /// `properties`. The dynamic `result` field must serialize as `{}`, not
     /// `true`.

--- a/core/src/toolset/top_level/skill.rs
+++ b/core/src/toolset/top_level/skill.rs
@@ -161,7 +161,7 @@ impl TopLevelTool for SkillTool {
     }
 
     fn composable(&self) -> bool {
-        false
+        true
     }
 
     async fn call(

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -436,7 +436,7 @@ impl TopLevelTool for WorkflowTool {
     }
 
     fn composable(&self) -> bool {
-        false
+        true
     }
 
     async fn call(

--- a/core/src/toolset/traits.rs
+++ b/core/src/toolset/traits.rs
@@ -45,8 +45,13 @@ pub trait TopLevelTool: Send + Sync {
         true
     }
 
-    /// Default `true`. Override to `false` to prevent recursive dispatch
-    /// (compose itself) or for tools incompatible with compose (agent, use_skill, sandbox).
+    /// Default `true`. Override to `false` only for meta-tools whose
+    /// semantics don't fit a JS bridge — `compose` (recursion),
+    /// `compose_types` (introspection-only), and `use_skill` (spawns a
+    /// nested agent). Workspace-admin tools (`agent`, `sandbox`,
+    /// `skill`, `workflow`, ...) ARE composable: their service methods
+    /// run `subject.can(...)` themselves and the dispatcher passes the
+    /// caller's subject through unchanged, so authz is preserved.
     fn composable(&self) -> bool {
         true
     }


### PR DESCRIPTION
## Summary

Flip `composable()` from `false` to `true` on the workspace-admin top-level tools `agent`, `skill`, and `workflow` so admins can script automation via compose:

```js
const agents = await tools.agent({ command: "list" });
const skill = await tools.skill({ command: "create", name: "x", description: "...", body: "..." });
await tools.workflow({ command: "trigger", definition_id: id });
```

`sandbox`, `spaces`, `notes`, and `log` were already composable (default or explicit). This PR closes the gap on the remaining workspace-admin surface.

## Tools flipped

| Tool | Before | After |
|------|--------|-------|
| `agent` | `false` | `true` |
| `skill` | `false` | `true` |
| `workflow` | `false` | `true` |

## Why this is now safe

These tools were originally excluded in #213 (`composable()` trait method replacing `COMPOSE_EXCLUDED`) under a blanket *"incompatible with compose"* rationale. The exclusion no longer holds:

- **Authorization** — #222 consolidated authz to the service layer; every admin command runs `subject.can(...)` itself. The compose `CatalogDispatcher` passes the caller's `AuthSubject` through unchanged, so a non-admin compose script that calls `tools.agent({...})` fails with the same error as a direct `agent` call.
- **Audit** — each inner dispatch records its own action via `Audit::record_action(format!("compose > top_level: {name}"))` (`compose.rs:273`), so admin mutations invoked from compose still produce per-call audit entries.
- **Schemas** — `agent` returns `Content::text` (typed as `any` in the dts); `skill` and `workflow` already declare `output_schema`. All three appear in `generate_dts` once `composable() == true`.

## Excluded by design (still `false`)

The genuine meta-tools remain non-composable:
- `compose` — recursion
- `compose_types` — introspection only
- `use_skill` — spawns a nested agent
- `whoami` — session/identity meta-tool

## Tests

Added `admin_tools_appear_in_compose_dts` in `core/src/toolset/top_level/compose.rs`:
- registers stub tools named `agent`, `skill`, `workflow`, `sandbox`, `spaces`, `notes`, `log` with `composable() == true`
- registers a stub `compose` tool with `composable() == false`
- asserts `generate_dts` declares each admin tool as `function <name>(args: {...}): Promise<...>`
- asserts the non-composable `compose` tool is filtered out

## Test plan

- [x] `cargo build -p drua-core`
- [x] `cargo test -p drua-core --lib toolset::top_level::compose` (7/7 pass)
- [x] `nix flake check`
- [ ] Manual: from a compose script, `await tools.agent({command:"list"})` returns the workspace's agents
- [ ] Manual: a non-admin subject's compose call to `tools.skill({command:"create", ...})` fails with the same authz error as a direct call

🤖 Generated with [Claude Code](https://claude.com/claude-code)