### PR TITLE
feat(admin): add spaces tool to admin MCP toolset

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -257,6 +257,7 @@ impl App {
             Arc::clone(&sandboxes),
             Arc::clone(&audit),
             Arc::clone(&workspaces),
+            Arc::clone(&library),
         ));
 
         // Reverse-sync (file → entity) for every service that implements

--- a/core/src/library/mod.rs
+++ b/core/src/library/mod.rs
@@ -319,6 +319,46 @@ impl Library {
         Ok(space)
     }
 
+    /// Lists every space, paginated. Authorized for admin / workspace-admin
+    /// subjects; the workspace-membership ACL on `Space` is intentionally
+    /// bypassed so admins can audit the full set.
+    #[tracing::instrument(name = "library.list_all_spaces", skip(self, sub))]
+    pub async fn list_all_spaces(
+        &self,
+        sub: &crate::auth::AuthSubject,
+    ) -> Result<Vec<Space>, LibraryError> {
+        sub.can(
+            crate::auth::AuthVerb::Read,
+            crate::auth::AuthResource::Space(None),
+        )?;
+        crate::audit::Audit::record_action_if_unset("space.list_all");
+        Ok(self.space_repo.list_all().await?)
+    }
+
+    /// Slug → `Space` lookup that enforces `Read` on the resolved space
+    /// but skips the workspace-membership check. Intended for admin tools
+    /// that need to inspect any space regardless of `authorized_workspaces`.
+    #[tracing::instrument(name = "library.find_space_by_slug_admin", skip(self, sub))]
+    pub async fn find_space_by_slug_admin(
+        &self,
+        sub: &crate::auth::AuthSubject,
+        slug: &str,
+    ) -> Result<Space, LibraryError> {
+        let space = self
+            .space_repo
+            .maybe_find_by_slug(slug)
+            .await?
+            .ok_or_else(|| SpaceError::NotFound {
+                slug: slug.to_string(),
+            })?;
+        sub.can(
+            crate::auth::AuthVerb::Read,
+            crate::auth::AuthResource::Space(Some(space.id)),
+        )?;
+        crate::audit::Audit::record_action_if_unset("space.find_by_slug");
+        Ok(space)
+    }
+
     /// Internal access to the search/upstream/embedder primitives so
     /// `space::file_sync` can drive its index job without leaking
     /// `Library`'s privates to the rest of the crate.

--- a/core/src/library/space/repo.rs
+++ b/core/src/library/space/repo.rs
@@ -21,4 +21,26 @@ impl SpaceRepo {
     pub fn new(pool: &PgPool) -> Self {
         Self { pool: pool.clone() }
     }
+
+    pub async fn list_all(&self) -> Result<Vec<Space>, SpaceQueryError> {
+        const PAGE_SIZE: usize = 100;
+        let mut all = Vec::new();
+        let mut query = PaginatedQueryArgs {
+            first: PAGE_SIZE,
+            after: None,
+        };
+
+        loop {
+            let mut result = self
+                .list_by_created_at(query, ListDirection::Descending)
+                .await?;
+            all.append(&mut result.entities);
+            match result.into_next_query() {
+                Some(next) => query = next,
+                None => break,
+            }
+        }
+
+        Ok(all)
+    }
 }

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -1,8 +1,8 @@
 //! `AdminToolSet` — admin-only tools exposed exclusively through the
 //! searchable catalog (`search_tools` → `describe_tool` → `call_tool`).
 //!
-//! Consolidated into 4 tools with command discriminators:
-//! `agent`, `sandbox`, `log`, `workspace`.
+//! Consolidated into 5 tools with command discriminators:
+//! `agent`, `sandbox`, `log`, `workspace`, `spaces`.
 //! Prefixed as `drua_admin_agent`, `drua_admin_sandbox`, etc.
 
 use std::sync::{Arc, LazyLock};
@@ -14,6 +14,7 @@ use serde::Deserialize;
 use crate::agent::{Agent, AgentRole, Agents};
 use crate::audit::{Audit, AuditEntry, AuditLogQuery};
 use crate::auth::AuthSubject;
+use crate::library::{Library, Space};
 use crate::primitives::{AgentId, SandboxId, UserId, WorkspaceId};
 use crate::sandbox::{Sandbox, SandboxAgentMode, SandboxMode, SandboxSpecs, Sandboxes};
 use crate::workspace::{Workspace, Workspaces};
@@ -206,10 +207,29 @@ struct WorkspaceParams {
     description: Option<String>,
 }
 
+#[derive(Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum SpacesCommand {
+    Create,
+    List,
+    Get,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct SpacesParams {
+    command: SpacesCommand,
+    /// Slug for `create` and `get`. Must match `[a-z0-9-]+` with no
+    /// leading / trailing / double hyphens.
+    slug: Option<String>,
+    /// Optional human-readable summary, used by `create`.
+    description: Option<String>,
+}
+
 static AGENT_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<AgentParams>);
 static SANDBOX_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<SandboxParams>);
 static LOG_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<LogParams>);
 static WORKSPACE_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<WorkspaceParams>);
+static SPACES_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<SpacesParams>);
 
 struct ToolDef {
     name: &'static str,
@@ -246,6 +266,16 @@ static TOOLS: &[ToolDef] = &[
                        `description`; also seeds a WorkspaceLead agent), `list`.",
         schema: &WORKSPACE_SCHEMA,
     },
+    ToolDef {
+        name: "spaces",
+        description: "Manage library spaces — bounded collaborative folders under \
+                       `spaces/<slug>/` in the knowledge-base repo. Commands: \
+                       `create` (requires `slug`, optional `description`; the calling \
+                       subject's workspace is auto-added to the authorized list), \
+                       `list` (no args), \
+                       `get` (requires `slug`; bypasses workspace ACL for admins).",
+        schema: &SPACES_SCHEMA,
+    },
 ];
 
 pub struct AdminToolSet {
@@ -254,6 +284,7 @@ pub struct AdminToolSet {
     sandboxes: Arc<Sandboxes>,
     audit: Arc<Audit>,
     workspaces: Arc<Workspaces>,
+    library: Arc<Library>,
 }
 
 impl AdminToolSet {
@@ -262,6 +293,7 @@ impl AdminToolSet {
         sandboxes: Arc<Sandboxes>,
         audit: Arc<Audit>,
         workspaces: Arc<Workspaces>,
+        library: Arc<Library>,
     ) -> Self {
         let entries = TOOLS
             .iter()
@@ -282,6 +314,7 @@ impl AdminToolSet {
             sandboxes,
             audit,
             workspaces,
+            library,
         }
     }
 }
@@ -319,6 +352,7 @@ impl SearchableToolSet for AdminToolSet {
             "sandbox" => self.sandbox(subject, arguments).await,
             "log" => self.log(arguments).await,
             "workspace" => self.workspace(subject, arguments).await,
+            "spaces" => self.spaces(subject, arguments).await,
             _ => Err(ToolSetsError::ToolNotFound(tool_name.to_string())),
         }
     }
@@ -551,6 +585,53 @@ impl AdminToolSet {
                 Ok(CallToolResult::success(vec![Content::text(
                     format_workspaces(&all),
                 )]))
+            }
+        }
+    }
+
+    async fn spaces(
+        &self,
+        subject: &AuthSubject,
+        arguments: Option<JsonObject>,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        let params: SpacesParams = parse_params(arguments)?;
+
+        match params.command {
+            SpacesCommand::Create => {
+                let slug = params.slug.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("slug is required for create".to_string())
+                })?;
+                let description = params.description.filter(|s| !s.is_empty());
+                Audit::record_action("spaces.create");
+                let space = self
+                    .library
+                    .create_space(subject, slug, description)
+                    .await?;
+                Ok(CallToolResult::success(vec![Content::text(format_space(
+                    &space, true,
+                ))]))
+            }
+
+            SpacesCommand::List => {
+                Audit::record_action("spaces.list");
+                let all = self.library.list_all_spaces(subject).await?;
+                Ok(CallToolResult::success(vec![Content::text(format_spaces(
+                    &all,
+                ))]))
+            }
+
+            SpacesCommand::Get => {
+                let slug = params.slug.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("slug is required for get".to_string())
+                })?;
+                Audit::record_action("spaces.get");
+                let space = self
+                    .library
+                    .find_space_by_slug_admin(subject, &slug)
+                    .await?;
+                Ok(CallToolResult::success(vec![Content::text(format_space(
+                    &space, false,
+                ))]))
             }
         }
     }
@@ -830,4 +911,130 @@ fn format_workspaces(ws: &[Workspace]) -> String {
         lines.push(format!("{:<38} {:<30} {}", w.id, w.name, description));
     }
     lines.join("\n")
+}
+
+fn format_space(s: &Space, created: bool) -> String {
+    let authorized: Vec<String> = s
+        .authorized_workspaces
+        .iter()
+        .map(ToString::to_string)
+        .collect();
+    let auth_str = if authorized.is_empty() {
+        "none".to_string()
+    } else {
+        authorized.join(", ")
+    };
+    let description = s.description.as_deref().unwrap_or("\u{2014}");
+    let header = if created { "Space created." } else { "Space:" };
+    format!(
+        "{header}\n  id: {}\n  slug: {}\n  description: {}\n  authorized_workspaces: {}",
+        s.id, s.slug, description, auth_str,
+    )
+}
+
+fn format_spaces(spaces: &[Space]) -> String {
+    if spaces.is_empty() {
+        return "No spaces found.".to_string();
+    }
+
+    let mut lines = Vec::with_capacity(spaces.len() + 2);
+    lines.push(format!(
+        "{:<38} {:<24} {:<6} {}",
+        "ID", "SLUG", "WS#", "DESCRIPTION"
+    ));
+    lines.push("-".repeat(100));
+
+    for s in spaces {
+        let description = s.description.as_deref().unwrap_or("\u{2014}");
+        lines.push(format!(
+            "{:<38} {:<24} {:<6} {}",
+            s.id,
+            truncate(&s.slug, 24),
+            s.authorized_workspaces.len(),
+            description,
+        ));
+    }
+
+    lines.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(json: serde_json::Value) -> Option<JsonObject> {
+        match json {
+            serde_json::Value::Object(obj) => Some(obj),
+            _ => panic!("expected object"),
+        }
+    }
+
+    #[test]
+    fn spaces_create_parses_full_args() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "create",
+            "slug": "oncall",
+            "description": "On-call rotation",
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, SpacesCommand::Create));
+        assert_eq!(p.slug.as_deref(), Some("oncall"));
+        assert_eq!(p.description.as_deref(), Some("On-call rotation"));
+    }
+
+    #[test]
+    fn spaces_create_parses_without_description() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "create",
+            "slug": "incidents",
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, SpacesCommand::Create));
+        assert_eq!(p.slug.as_deref(), Some("incidents"));
+        assert!(p.description.is_none());
+    }
+
+    #[test]
+    fn spaces_list_parses_no_args() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "list",
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, SpacesCommand::List));
+        assert!(p.slug.is_none());
+        assert!(p.description.is_none());
+    }
+
+    #[test]
+    fn spaces_get_parses_slug() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "get",
+            "slug": "oncall",
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, SpacesCommand::Get));
+        assert_eq!(p.slug.as_deref(), Some("oncall"));
+    }
+
+    #[test]
+    fn spaces_rejects_unknown_command() {
+        let res: Result<SpacesParams, _> = parse_params(args(serde_json::json!({
+            "command": "destroy",
+        })));
+        assert!(res.is_err());
+    }
+
+    #[test]
+    fn spaces_schema_includes_command_enum() {
+        let schema = &*SPACES_SCHEMA;
+        let s = serde_json::to_string(schema).unwrap();
+        assert!(s.contains("\"create\""));
+        assert!(s.contains("\"list\""));
+        assert!(s.contains("\"get\""));
+    }
+
+    #[test]
+    fn tools_includes_spaces() {
+        assert!(TOOLS.iter().any(|t| t.name == "spaces"));
+    }
 }


### PR DESCRIPTION
## Summary

Adds a `spaces` entry to the `AdminToolSet` mirroring the existing `agent`, `sandbox`, `workspace`, and `log` admin tools (command discriminator + admin-only visibility + `search_tools` / `describe_tool` / `call_tool` flow).

## Command surface

- `create { slug, description? }` — reuses `Library::create_space` (same path as the spaces TopLevelTool)
- `list` — new `Library::list_all_spaces`, paginated wrapper over `SpaceRepo::list_all`
- `get { slug }` — new `Library::find_space_by_slug_admin`, slug→`Space` that enforces `Read` on the resolved space but bypasses the workspace-membership ACL that gates `find_space_by_slug_authorized`

## Auth + audit

- Visibility: `AdminToolSet::is_visible = subject.is_admin()` — non-admins see no entries
- Service-layer authz on every command via `sub.can(verb, AuthResource::Space(_))` (PR #222)
- `Audit::record_action("spaces.{create,list,get}")` set in the dispatcher; service methods record action keys via `record_action_if_unset`
- All errors flow through `ToolSetsError::Library` (`#[from] LibraryError`)

## Constraints honored

- `SpacesTool` (TopLevelTool) is unchanged — purely additive registration in admin
- Schemars-derived input schema (PR #208 baseline)
- `Idempotent<T>` semantics on `create_space` are preserved (handled inside `Library`)
- Matches existing admin toolset patterns: `ToolDef` array, `LazyLock<serde_json::Value>` schema cache, plain-text formatter helpers

## Test plan

- [x] Unit tests in `core/src/toolset/searchable/admin.rs` cover `SpacesParams` parsing for every command, schema enum exposure, `TOOLS` registration, and unknown-command rejection
- [x] `cargo clippy --all-targets -p drua-core -- -D warnings` clean
- [x] `cargo nextest run -p drua-core --lib` — 251/251 passing
- [x] `nix flake check` passes (fmt + clippy + nextest + graphql-schema + default-config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)