### PR TITLE
ci(deploy): bump sandbox-gvisor pool to e2-standard-8

### DIFF
--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -109,11 +109,11 @@ resource "google_container_node_pool" "gvisor" {
   }
 
   node_config {
-    # 4 vCPU / 16 GiB to fit a single largeish sandbox per node with
-    # headroom; gvisor adds ~10-15% overhead. Was e2-standard-2 (2 vCPU /
-    # 8 GiB) which couldn't fit non-trivial sandboxes alongside system
-    # daemons.
-    machine_type = "e2-standard-4"
+    # 8 vCPU / 32 GiB to fit a 4 vCPU / 8 GiB sandbox (e.g. full lana-bank
+    # dev stack) with headroom for system daemons and gvisor overhead
+    # (~10-15%). Was e2-standard-4, but a 4-CPU pod cannot schedule on a
+    # 4-CPU node — system daemonsets reserve ~80m before any workload.
+    machine_type = "e2-standard-8"
 
     sandbox_config {
       sandbox_type = "gvisor"


### PR DESCRIPTION
## Summary
- Bumps `sandbox-gvisor` node pool machine type from `e2-standard-4` (4 vCPU / 16 GiB) to `e2-standard-8` (8 vCPU / 32 GiB) in `ci/deploy/drua/main.tf` so sandboxes requesting 4 vCPU / 8 GiB can actually schedule.
- Updates the inline rationale comment.

## Why
The current `sandbox-gvisor` pool runs `e2-standard-4`, which exposes only ~3920m allocatable CPU per node — GKE reserves ~80m for system processes before any DaemonSets run. A sandbox pod requesting `cpu: "4"` (e.g. enough headroom to host the full lana-bank dev stack: Keycloak + 2 Postgres + Oathkeeper + Jaeger/otelcol + lana server + admin-panel) is therefore unschedulable on any node of this type, regardless of pool size. Live state showed exactly this: two sandboxes stuck in `Pending` with `0/3 nodes are available: 1 Insufficient cpu` and the autoscaler refusing to grow the pool because the pod wouldn't fit on a fresh node either.

`e2-standard-8` gives ~7.9 allocatable CPU and ~29 GiB allocatable RAM — comfortable for one 4 vCPU / 8 GiB sandbox plus gVisor's ~10–15% overhead, with room for a smaller sidecar workload.

## Cost note
On-demand price roughly doubles per active node (~\$0.13/hr → ~\$0.27/hr in us-east1). With `min_node_count = 0` unchanged, idle cost is still \$0.

## Apply notes
- `machine_type` change forces a node-pool rebuild; pending sandboxes will reschedule onto fresh nodes.
- Left `min_node_count = 0` / `max_node_count = 2` unchanged — bump max if concurrency becomes the bottleneck.

## Test plan
- [ ] Concourse `tf-plan` for `drua` shows only the node-pool machine_type change (and the implied recreate).
- [ ] After apply, confirm the new sandbox pool nodes report `instance-type=e2-standard-8` and ~7920m allocatable CPU.
- [ ] Re-create a 4 vCPU / 8 GiB sandbox and verify it transitions `Pending` → `Running`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)