### PR TITLE
fix(sandbox): setsid persistent shell so it can't steal TTY foreground

### DIFF
--- a/images/sandbox/server/src/session.rs
+++ b/images/sandbox/server/src/session.rs
@@ -124,6 +124,26 @@ fn try_spawn(
         }
     };
 
+    // Detach the spawned shell from the parent's controlling terminal.
+    // Without this, `bash -i` calls `tcsetpgrp` and steals the user's TTY
+    // foreground pgroup, causing Ctrl-C on the dev server to be delivered
+    // to bash (which ignores SIGINT) instead of the server. The Bwrap layer
+    // already gets this via `--new-session`; the UidOnly/Plain fallbacks
+    // need an explicit `setsid()`.
+    #[cfg(unix)]
+    if !matches!(layer, IsolationLayer::Bwrap) {
+        // SAFETY: setsid(2) is async-signal-safe and only mutates the
+        // child's session/pgroup state. No allocations, no locks.
+        unsafe {
+            cmd.pre_exec(|| {
+                if libc::setsid() < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
     cmd.stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
@@ -709,5 +729,43 @@ mod tests {
         assert!(r.unwrap().output.contains("still-alive"));
 
         let _ = tokio::fs::remove_file(&tmp).await;
+    }
+
+    /// Regression test for the Ctrl-C-swallowed bug: the persistent
+    /// `bash -i` must NOT inherit the parent's session. Without
+    /// `setsid()` in `try_spawn`'s pre_exec, interactive bash takes over
+    /// the controlling TTY's foreground pgroup and Ctrl-C on the dev
+    /// server stops being delivered.
+    ///
+    /// Asserts the spawned shell is in its own session
+    /// (`getsid(child) != getsid(self)`) — Plain/UidOnly layers run
+    /// `setsid()`, Bwrap uses `--new-session`, so this invariant holds
+    /// for whichever layer was selected.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn session_shell_is_in_a_separate_session() {
+        init_test_workspace();
+        let session = BashSession::new();
+
+        let _ = session
+            .execute("echo trigger-spawn", DEFAULT_TIMEOUT_MS)
+            .await
+            .expect("spawn shell");
+
+        let inner = session.inner.lock().await;
+        let inner = inner.as_ref().expect("session should be live");
+        let child_pid = inner.child.id().expect("child has pid") as libc::pid_t;
+
+        // SAFETY: getsid is a pure read of kernel state for a known PID.
+        let child_sid = unsafe { libc::getsid(child_pid) };
+        let self_sid = unsafe { libc::getsid(0) };
+
+        assert!(child_sid > 0, "getsid(child) failed: {child_sid}");
+        assert_ne!(
+            child_sid, self_sid,
+            "shell session must be detached from the parent's session, \
+             otherwise interactive bash steals the controlling TTY's \
+             foreground pgroup and Ctrl-C is swallowed"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes a regression where pressing **Ctrl-C on the local dev server is silently swallowed** once any sandbox has run a `bash` tool call.

### Root cause

The persistent shell in `images/sandbox/server/src/session.rs` is spawned as `bash --noediting --noprofile --norc -i`. Interactive bash unconditionally:

1. opens `/dev/tty` (it inherits the dev server's session, so the user's terminal is reachable),
2. calls `setpgid(0, getpid())` to put itself in its own pgroup,
3. calls `tcsetpgrp(/dev/tty, getpgrp())` to make its pgroup the **foreground pgroup of the user's terminal**.

After that, every Ctrl-C goes to bash's pgroup. Bash interactive treats SIGINT as "abort current command, redraw prompt" — it does not exit. `drua-cli` never sees the signal and stays alive. From the user's perspective, **Ctrl-C is ineffective**.

The `Bwrap` layer already escaped this via `--new-session`; the `UidOnly` and `Plain` fallbacks did not. Those fallbacks are what runs whenever bwrap is unavailable (Linux without bwrap, all of macOS dev).

Empirically reproduced with a Python pty harness that mimics the spawn (all three stdio piped, controlling tty inherited):
```
BEFORE: fg_pgroup=29161, my_pgroup=29161
AFTER:  fg_pgroup=29162, bash_pid=29162, bash_pgroup=29162
*** bash grabbed TTY foreground pgroup ***
```

### Fix

Add a `pre_exec(libc::setsid)` to the `UidOnly` and `Plain` arms of `try_spawn` in `images/sandbox/server/src/session.rs`. This puts the shell in a fresh session with no controlling tty — `/dev/tty` open fails, bash silently disables job control, no `tcsetpgrp` call, no foreground theft. This matches exactly what `--new-session` already does for the Bwrap layer.

### Regression introduced by

[`f1b9b6e7`](https://github.com/GaloyMoney/drua/commit/f1b9b6e7) — feat(sandbox): persistent bash session for backing service survival (#148). Pre-PR the fallback used ephemeral non-interactive `bash -c <cmd>` which never enabled job control, so this couldn't surface.

### Triggering condition

The persistent shell is created lazily on the first `bash`-tool `/execute` call. Sandbox creation, `/initialize`, and `/attach` do not spawn the shell. So the bug arms only after an agent in a sandbox has actually run a bash command.

## Test plan

- [x] `cargo check -p sandbox-tool-server` — clean
- [x] `cargo clippy -p sandbox-tool-server --all-targets -- -D warnings` — clean
- [x] `cargo fmt -p sandbox-tool-server -- --check` — clean
- [x] `cargo test -p sandbox-tool-server session::` — 13/13 pass, including new regression test:
  - `session_shell_is_in_a_separate_session` — asserts `getsid(child) != getsid(self)` so any future regression that drops `setsid` (or the bwrap `--new-session`) trips the test
- [x] All existing session tests still pass: `session_executes_echo`, `session_captures_exit_code`, `session_preserves_state_between_commands`, `session_background_process_survives` (validates `&` still works without `-i`'s job control), `session_restart_works`, `session_recovers_after_shell_death`, `session_timeout_returns_error_and_recovers`, `session_timeout_preserves_session_via_sigint` (validates user-space `trap` still works)
- [ ] Manual repro on macOS dev: `make start` → spawn a sandbox → run a bash tool call → Ctrl-C should now actually kill the dev server

## Follow-ups (out of scope, tracked separately)

The full root-cause report (memory `019dde61`) lists structural improvements worth picking up later:

- Wire `tokio::signal::ctrl_c()` into `run_server` to call the existing-but-unused `App::shutdown()` for orderly drain of jobs / sandboxes / library / OTel.
- Capture sandbox-tool-server stdout/stderr into per-sandbox log files instead of inheriting the dev-server's terminal (`lib/sandbox/src/admin_client/local/mod.rs`).
- On Linux, set `PR_SET_PDEATHSIG` so sandbox children die with the parent even when `kill_on_drop` doesn't run (SIGINT path skips `Drop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)