### PR TITLE
feat(spaces): three-tier file ops mirroring sandbox model

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -258,7 +258,11 @@ impl App {
         toolsets.register_top_level(MoveFile::new(Arc::clone(&sandboxes), Arc::clone(&space_fs)));
         toolsets.register_top_level(Delete::new(Arc::clone(&sandboxes), Arc::clone(&space_fs)));
 
-        toolsets.register_top_level(SpacesTool::new(Arc::clone(&spaces), Arc::clone(&projects)));
+        toolsets.register_top_level(SpacesTool::new(
+            Arc::clone(&spaces),
+            Arc::clone(&projects),
+            Arc::clone(&space_fs),
+        ));
         toolsets.register_top_level(ProjectSandbox::new(Arc::clone(&sandboxes)));
         toolsets.register_top_level(NotesTool::new(Arc::clone(&notes), Arc::clone(&projects)));
         toolsets.register_top_level(UseSkillTool::new(Arc::clone(&skills)));
@@ -280,6 +284,7 @@ impl App {
             Arc::clone(&audit),
             Arc::clone(&projects),
             Arc::clone(&spaces),
+            Arc::clone(&space_fs),
         ));
 
         // Reverse-sync (file → entity) for skills + workflows runs

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -421,19 +421,17 @@ impl Projects {
     }
 
     /// Central authorization primitive for sandboxless space access.
-    /// Resolves `slug` via `Library`, asserts the calling subject's
-    /// project has it mounted, and returns the resolved `Space` for
-    /// downstream tracing/audit. Used by `SpaceFs` read ops.
+    /// Resolves `slug` via `Library` and returns the `Space`. For
+    /// project-bound subjects (`Agent` / `AgentOnBehalfOfUser`),
+    /// asserts the carrying project has the space mounted. Admin
+    /// subjects bypass the mount gate — they reach into any space
+    /// in the library by design.
     #[instrument(name = "domain.project.space_for_subject", skip(self, sub))]
     pub async fn space_for_subject(
         &self,
         sub: &AuthSubject,
         slug: &str,
     ) -> Result<Space, ProjectError> {
-        let project_id = sub
-            .project_id()
-            .ok_or(crate::auth::error::AuthorizationError::AuthenticationRequired)?;
-
         let space = self
             .spaces
             .find_by_slug(slug)
@@ -442,6 +440,14 @@ impl Projects {
                 slug: slug.to_string(),
             })?;
 
+        if sub.is_admin() {
+            Audit::record_space_id(space.id);
+            return Ok(space);
+        }
+
+        let project_id = sub
+            .project_id()
+            .ok_or(crate::auth::error::AuthorizationError::AuthenticationRequired)?;
         let project = self.repo.find_by_id(project_id).await?;
         if !project.is_space_mounted(space.id) {
             return Err(SpaceError::NotMounted {

--- a/core/src/space_fs.rs
+++ b/core/src/space_fs.rs
@@ -374,10 +374,7 @@ impl SpaceFs {
 
 /// Filter `blobs` (rel-path, bytes) by a glob pattern and return the
 /// matching paths, sorted.
-fn glob_blobs(
-    blobs: Vec<(String, Vec<u8>)>,
-    pattern: &str,
-) -> Result<Vec<String>, SpaceError> {
+fn glob_blobs(blobs: Vec<(String, Vec<u8>)>, pattern: &str) -> Result<Vec<String>, SpaceError> {
     let regex = glob_to_regex(pattern)
         .map_err(|e| io_err(format!("invalid glob pattern '{pattern}': {e}")))?;
     let mut out: Vec<String> = blobs
@@ -391,10 +388,7 @@ fn glob_blobs(
 
 /// Run `grep` over already-walked blobs. Mirrors the curated subset of
 /// flags the `Grep` top-level tool accepts.
-fn grep_blobs(
-    blobs: Vec<(String, Vec<u8>)>,
-    args: &Value,
-) -> Result<String, SpaceError> {
+fn grep_blobs(blobs: Vec<(String, Vec<u8>)>, args: &Value) -> Result<String, SpaceError> {
     let pattern = args
         .get("pattern")
         .and_then(|v| v.as_str())

--- a/core/src/space_fs.rs
+++ b/core/src/space_fs.rs
@@ -12,8 +12,9 @@
 //! `Result<Option<T>, ProjectError>`. `Ok(None)` signals "not a `space:`
 //! path — fall through to the existing sandbox dispatch"; `Ok(Some(_))`
 //! is a successful space-rooted op. Authorization runs once in
-//! `resolve` via `Projects::space_for_subject`; per-method docs only
-//! call out method-specific behaviour.
+//! `resolve` via `Projects::space_for_subject`, which gates project
+//! agents on the mount and lets admins reach any space; per-method
+//! docs only call out method-specific behaviour.
 
 use std::sync::Arc;
 
@@ -329,15 +330,7 @@ impl SpaceFs {
             .walk(&resolved.space.slug, &resolved.rel_path)
             .await
             .map_err(|e| -> ProjectError { e.into() })?;
-        let regex = glob_to_regex(pattern)
-            .map_err(|e| io_err(format!("invalid glob pattern '{pattern}': {e}")))?;
-        let mut out: Vec<String> = blobs
-            .into_iter()
-            .map(|(p, _)| p)
-            .filter(|p| regex.is_match(p))
-            .collect();
-        out.sort();
-        Ok(Some(out))
+        Ok(Some(glob_blobs(blobs, pattern)?))
     }
 
     /// Grep walk across the space's tree. Replicates the curated subset
@@ -353,114 +346,17 @@ impl SpaceFs {
         let Some(resolved) = self.resolve(sub, path).await? else {
             return Ok(None);
         };
-        let pattern = args
-            .get("pattern")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| io_err("grep: missing 'pattern'".to_string()))?;
-        let mode = args
-            .get("output_mode")
-            .and_then(|v| v.as_str())
-            .unwrap_or("files_with_matches");
-        let case_insensitive = args.get("-i").and_then(|v| v.as_bool()).unwrap_or(false);
-        let multiline = args
-            .get("multiline")
-            .and_then(|v| v.as_bool())
-            .unwrap_or(false);
-        let glob_filter = args
-            .get("glob")
-            .and_then(|v| v.as_str())
-            .map(glob_to_regex)
-            .transpose()
-            .map_err(|e| io_err(format!("invalid glob filter: {e}")))?;
-        let show_line_nums = args.get("-n").and_then(|v| v.as_bool()).unwrap_or(true);
-        let context_after = args.get("-A").and_then(|v| v.as_i64()).unwrap_or(0).max(0) as usize;
-        let context_before = args.get("-B").and_then(|v| v.as_i64()).unwrap_or(0).max(0) as usize;
-        let context_around = args.get("-C").and_then(|v| v.as_i64()).unwrap_or(0).max(0) as usize;
-        let head_limit = args
-            .get("head_limit")
-            .and_then(|v| v.as_i64())
-            .map(|n| n.max(0) as usize);
-
-        let regex = regex::RegexBuilder::new(pattern)
-            .case_insensitive(case_insensitive)
-            .multi_line(multiline)
-            .dot_matches_new_line(multiline)
-            .build()
-            .map_err(|e| io_err(format!("invalid regex '{pattern}': {e}")))?;
-
         let blobs = self
             .spaces
             .walk(&resolved.space.slug, &resolved.rel_path)
             .await
             .map_err(|e| -> ProjectError { e.into() })?;
-
-        let before = context_before.max(context_around);
-        let after = context_after.max(context_around);
-
-        let mut output_lines: Vec<String> = Vec::new();
-        for (rel, bytes) in blobs {
-            if let Some(g) = glob_filter.as_ref() {
-                if !g.is_match(&rel) {
-                    continue;
-                }
-            }
-            let Ok(content) = std::str::from_utf8(&bytes) else {
-                continue;
-            };
-
-            match mode {
-                "files_with_matches" => {
-                    if regex.is_match(content) {
-                        output_lines.push(rel);
-                    }
-                }
-                "count" => {
-                    let n = regex.find_iter(content).count();
-                    if n > 0 {
-                        output_lines.push(format!("{rel}:{n}"));
-                    }
-                }
-                _ => {
-                    let lines: Vec<&str> = content.lines().collect();
-                    let mut matched_idx: Vec<usize> = Vec::new();
-                    for (i, line) in lines.iter().enumerate() {
-                        if regex.is_match(line) {
-                            matched_idx.push(i);
-                        }
-                    }
-                    if matched_idx.is_empty() {
-                        continue;
-                    }
-                    // Build the context-window line set (deduped).
-                    let mut want: std::collections::BTreeSet<usize> =
-                        std::collections::BTreeSet::new();
-                    for i in &matched_idx {
-                        let lo = i.saturating_sub(before);
-                        let hi = (*i + after).min(lines.len().saturating_sub(1));
-                        for j in lo..=hi {
-                            want.insert(j);
-                        }
-                    }
-                    for idx in want {
-                        if show_line_nums {
-                            output_lines.push(format!("{rel}:{}:{}", idx + 1, lines[idx]));
-                        } else {
-                            output_lines.push(format!("{rel}:{}", lines[idx]));
-                        }
-                    }
-                }
-            }
-        }
-
-        if let Some(cap) = head_limit {
-            output_lines.truncate(cap);
-        }
-        Ok(Some(output_lines.join("\n")))
+        Ok(Some(grep_blobs(blobs, args)?))
     }
 
     /// Rejects path-traversal, absolute paths, NUL bytes, and leading `/`.
     /// Empty `rel` is allowed (means "the space root").
-    fn validate_rel_path(rel: &str) -> Result<(), SpaceError> {
+    pub(crate) fn validate_rel_path(rel: &str) -> Result<(), SpaceError> {
         if rel.is_empty() {
             return Ok(());
         }
@@ -474,6 +370,127 @@ impl SpaceFs {
         }
         Ok(())
     }
+}
+
+/// Filter `blobs` (rel-path, bytes) by a glob pattern and return the
+/// matching paths, sorted.
+fn glob_blobs(
+    blobs: Vec<(String, Vec<u8>)>,
+    pattern: &str,
+) -> Result<Vec<String>, SpaceError> {
+    let regex = glob_to_regex(pattern)
+        .map_err(|e| io_err(format!("invalid glob pattern '{pattern}': {e}")))?;
+    let mut out: Vec<String> = blobs
+        .into_iter()
+        .map(|(p, _)| p)
+        .filter(|p| regex.is_match(p))
+        .collect();
+    out.sort();
+    Ok(out)
+}
+
+/// Run `grep` over already-walked blobs. Mirrors the curated subset of
+/// flags the `Grep` top-level tool accepts.
+fn grep_blobs(
+    blobs: Vec<(String, Vec<u8>)>,
+    args: &Value,
+) -> Result<String, SpaceError> {
+    let pattern = args
+        .get("pattern")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| io_err("grep: missing 'pattern'".to_string()))?;
+    let mode = args
+        .get("output_mode")
+        .and_then(|v| v.as_str())
+        .unwrap_or("files_with_matches");
+    let case_insensitive = args.get("-i").and_then(|v| v.as_bool()).unwrap_or(false);
+    let multiline = args
+        .get("multiline")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    let glob_filter = args
+        .get("glob")
+        .and_then(|v| v.as_str())
+        .map(glob_to_regex)
+        .transpose()
+        .map_err(|e| io_err(format!("invalid glob filter: {e}")))?;
+    let show_line_nums = args.get("-n").and_then(|v| v.as_bool()).unwrap_or(true);
+    let context_after = args.get("-A").and_then(|v| v.as_i64()).unwrap_or(0).max(0) as usize;
+    let context_before = args.get("-B").and_then(|v| v.as_i64()).unwrap_or(0).max(0) as usize;
+    let context_around = args.get("-C").and_then(|v| v.as_i64()).unwrap_or(0).max(0) as usize;
+    let head_limit = args
+        .get("head_limit")
+        .and_then(|v| v.as_i64())
+        .map(|n| n.max(0) as usize);
+
+    let regex = regex::RegexBuilder::new(pattern)
+        .case_insensitive(case_insensitive)
+        .multi_line(multiline)
+        .dot_matches_new_line(multiline)
+        .build()
+        .map_err(|e| io_err(format!("invalid regex '{pattern}': {e}")))?;
+
+    let before = context_before.max(context_around);
+    let after = context_after.max(context_around);
+
+    let mut output_lines: Vec<String> = Vec::new();
+    for (rel, bytes) in blobs {
+        if let Some(g) = glob_filter.as_ref() {
+            if !g.is_match(&rel) {
+                continue;
+            }
+        }
+        let Ok(content) = std::str::from_utf8(&bytes) else {
+            continue;
+        };
+
+        match mode {
+            "files_with_matches" => {
+                if regex.is_match(content) {
+                    output_lines.push(rel);
+                }
+            }
+            "count" => {
+                let n = regex.find_iter(content).count();
+                if n > 0 {
+                    output_lines.push(format!("{rel}:{n}"));
+                }
+            }
+            _ => {
+                let lines: Vec<&str> = content.lines().collect();
+                let mut matched_idx: Vec<usize> = Vec::new();
+                for (i, line) in lines.iter().enumerate() {
+                    if regex.is_match(line) {
+                        matched_idx.push(i);
+                    }
+                }
+                if matched_idx.is_empty() {
+                    continue;
+                }
+                // Build the context-window line set (deduped).
+                let mut want: std::collections::BTreeSet<usize> = std::collections::BTreeSet::new();
+                for i in &matched_idx {
+                    let lo = i.saturating_sub(before);
+                    let hi = (*i + after).min(lines.len().saturating_sub(1));
+                    for j in lo..=hi {
+                        want.insert(j);
+                    }
+                }
+                for idx in want {
+                    if show_line_nums {
+                        output_lines.push(format!("{rel}:{}:{}", idx + 1, lines[idx]));
+                    } else {
+                        output_lines.push(format!("{rel}:{}", lines[idx]));
+                    }
+                }
+            }
+        }
+    }
+
+    if let Some(cap) = head_limit {
+        output_lines.truncate(cap);
+    }
+    Ok(output_lines.join("\n"))
 }
 
 fn invalid_rel_path(rel: &str) -> SpaceError {

--- a/core/src/toolset/inspect.rs
+++ b/core/src/toolset/inspect.rs
@@ -1,7 +1,11 @@
-//! Shared helpers for space file-ops dispatch from the tool layer
-//! (top-level `spaces` and admin `drua_admin_spaces`). The actual auth
-//! gate lives in `Projects::space_for_subject` (called via `SpaceFs`);
-//! this module just adapts request shapes and formats responses.
+//! Shared helpers for inspect-style tool dispatch:
+//! - `InspectTool` enum (Read|Ls|Grep|Glob), shared by sandbox and
+//!   space inspect commands across top-level and admin toolsets.
+//! - `parse_view_range`: zero-based `{offset, limit}` → 1-based
+//!   `(start, end)` view-range conversion. Also reused by sandbox
+//!   `build_read_request` to construct the editor `view_range` arg.
+//! - `dispatch_inspect` / `require_space_op`: space-specific helpers
+//!   that funnel through `SpaceFs`.
 
 use rmcp::model::{CallToolResult, Content, JsonObject};
 use serde::Deserialize;

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -1,8 +1,8 @@
 mod config;
 mod error;
 mod filter;
+mod inspect;
 pub mod searchable;
-mod space_inspect;
 pub mod top_level;
 mod traits;
 

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -2,6 +2,7 @@ mod config;
 mod error;
 mod filter;
 pub mod searchable;
+mod space_inspect;
 pub mod top_level;
 mod traits;
 

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -23,7 +23,7 @@ use crate::sandbox::{Sandbox, SandboxAgentMode, SandboxMode, SandboxSpecs, Sandb
 use crate::space_fs::SpaceFs;
 
 use super::super::error::ToolSetsError;
-use super::super::space_inspect::{dispatch_inspect, require_space_op, InspectTool};
+use super::super::inspect::{dispatch_inspect, parse_view_range, require_space_op, InspectTool};
 use super::super::traits::{SearchableToolSet, ToolSetEntry};
 
 fn parse_params<T: serde::de::DeserializeOwned>(
@@ -846,19 +846,7 @@ fn build_read_request(args: &JsonObject) -> Result<ExecuteRequest, ToolSetsError
         "path": path,
     });
 
-    let offset = args
-        .get("offset")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
-    let limit = args
-        .get("limit")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
-
-    if offset.is_some() || limit.is_some() {
-        let start = offset.unwrap_or(0) + 1;
-        let end = match limit {
-            Some(l) => start + l - 1,
-            None => -1,
-        };
+    if let Some((start, end)) = parse_view_range(args) {
         input["view_range"] = serde_json::json!([start, end]);
     }
 

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -20,9 +20,10 @@ use crate::library::AuthedSpaces;
 use crate::primitives::{AgentId, ProjectId, SandboxId, UserId};
 use crate::project::{Project, Projects};
 use crate::sandbox::{Sandbox, SandboxAgentMode, SandboxMode, SandboxSpecs, Sandboxes};
-use crate::space_fs::{FileView, SpaceFs};
+use crate::space_fs::SpaceFs;
 
 use super::super::error::ToolSetsError;
+use super::super::space_inspect::{dispatch_inspect, require_space_op, InspectTool};
 use super::super::traits::{SearchableToolSet, ToolSetEntry};
 
 fn parse_params<T: serde::de::DeserializeOwned>(
@@ -109,15 +110,6 @@ enum SandboxCommand {
 enum SandboxCreateMode {
     Scratch,
     Repo,
-}
-
-#[derive(Deserialize, schemars::JsonSchema)]
-#[serde(rename_all = "snake_case")]
-enum InspectTool {
-    Grep,
-    Glob,
-    Read,
-    Ls,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -712,8 +704,7 @@ impl AdminToolSet {
                 })?;
                 let tool_args = params.tool_args.unwrap_or_default();
                 Audit::record_action("spaces.inspect");
-                self.execute_space_inspect(subject, &slug, tool, tool_args)
-                    .await
+                dispatch_inspect(&self.space_fs, subject, &slug, tool, tool_args).await
             }
 
             SpacesCommand::Write => {
@@ -728,9 +719,11 @@ impl AdminToolSet {
                 })?;
                 Audit::record_action("spaces.write");
                 let space_path = format!("space:{slug}/{path}");
-                self.space_fs
+                let result = self
+                    .space_fs
                     .write_file(subject, &space_path, content)
                     .await?;
+                require_space_op(result, "write")?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "Wrote {space_path}"
                 ))]))
@@ -745,7 +738,8 @@ impl AdminToolSet {
                 })?;
                 Audit::record_action("spaces.delete");
                 let space_path = format!("space:{slug}/{path}");
-                self.space_fs.delete_file(subject, &space_path).await?;
+                let result = self.space_fs.delete_file(subject, &space_path).await?;
+                require_space_op(result, "delete")?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "Deleted {space_path}"
                 ))]))
@@ -764,109 +758,17 @@ impl AdminToolSet {
                 Audit::record_action("spaces.move");
                 let from_path = format!("space:{slug}/{from}");
                 let to_path = format!("space:{slug}/{to}");
-                self.space_fs
+                let result = self
+                    .space_fs
                     .move_file(subject, &from_path, &to_path)
                     .await?;
+                require_space_op(result, "move")?;
                 Ok(CallToolResult::success(vec![Content::text(format!(
                     "Moved {from_path} -> {to_path}"
                 ))]))
             }
         }
     }
-
-    async fn execute_space_inspect(
-        &self,
-        subject: &AuthSubject,
-        slug: &str,
-        tool: InspectTool,
-        tool_args: JsonObject,
-    ) -> Result<CallToolResult, ToolSetsError> {
-        let path = tool_args.get("path").and_then(|v| v.as_str()).unwrap_or("");
-        let space_path = format!("space:{slug}/{path}");
-
-        match tool {
-            InspectTool::Read => {
-                let view_range = parse_view_range(&tool_args);
-                let view = self
-                    .space_fs
-                    .view_file(subject, &space_path, view_range)
-                    .await?
-                    .ok_or_else(|| {
-                        ToolSetsError::Library(
-                            SpaceError::Io(format!("invalid space path: {space_path}")).into(),
-                        )
-                    })?;
-                let text = match view {
-                    FileView::File(text) => text,
-                    FileView::Dir(entries) => entries.join("\n"),
-                };
-                Ok(CallToolResult::success(vec![Content::text(text)]))
-            }
-            InspectTool::Ls => {
-                let entries = self
-                    .space_fs
-                    .view_dir(subject, &space_path)
-                    .await?
-                    .ok_or_else(|| {
-                        ToolSetsError::Library(
-                            SpaceError::Io(format!("invalid space path: {space_path}")).into(),
-                        )
-                    })?;
-                Ok(CallToolResult::success(vec![Content::text(
-                    entries.join("\n"),
-                )]))
-            }
-            InspectTool::Glob => {
-                let pattern = tool_args
-                    .get("pattern")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| ToolSetsError::MissingArgument("pattern".to_string()))?;
-                let matches = self
-                    .space_fs
-                    .glob(subject, &space_path, pattern)
-                    .await?
-                    .ok_or_else(|| {
-                        ToolSetsError::Library(
-                            SpaceError::Io(format!("invalid space path: {space_path}")).into(),
-                        )
-                    })?;
-                Ok(CallToolResult::success(vec![Content::text(
-                    matches.join("\n"),
-                )]))
-            }
-            InspectTool::Grep => {
-                let args = serde_json::Value::Object(tool_args);
-                let out = self
-                    .space_fs
-                    .grep(subject, &space_path, &args)
-                    .await?
-                    .ok_or_else(|| {
-                        ToolSetsError::Library(
-                            SpaceError::Io(format!("invalid space path: {space_path}")).into(),
-                        )
-                    })?;
-                Ok(CallToolResult::success(vec![Content::text(out)]))
-            }
-        }
-    }
-}
-
-fn parse_view_range(args: &JsonObject) -> Option<(i64, i64)> {
-    let offset = args
-        .get("offset")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
-    let limit = args
-        .get("limit")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
-    if offset.is_none() && limit.is_none() {
-        return None;
-    }
-    let start = offset.unwrap_or(0) + 1;
-    let end = match limit {
-        Some(l) => start + l - 1,
-        None => -1,
-    };
-    Some((start, end))
 }
 
 async fn execute_inspect(

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -15,12 +15,12 @@ use drua_library::{Space, SpaceError};
 
 use crate::agent::{Agent, AgentRole, Agents};
 use crate::audit::{Audit, AuditEntry, AuditLogQuery};
-use crate::auth::AuthSubject;
-use crate::auth::{AuthResource, AuthVerb};
+use crate::auth::{AuthResource, AuthSubject, AuthVerb};
 use crate::library::AuthedSpaces;
 use crate::primitives::{AgentId, ProjectId, SandboxId, UserId};
 use crate::project::{Project, Projects};
 use crate::sandbox::{Sandbox, SandboxAgentMode, SandboxMode, SandboxSpecs, Sandboxes};
+use crate::space_fs::{FileView, SpaceFs};
 
 use super::super::error::ToolSetsError;
 use super::super::traits::{SearchableToolSet, ToolSetEntry};
@@ -223,13 +223,23 @@ enum SpacesCommand {
     /// top-level `spaces` tool instead; this admin variant lets you
     /// reach into any project.
     Unmount,
+    /// Read-only file ops on a space. Mirrors sandbox admin's
+    /// `inspect`: pass `tool` (read|ls|grep|glob) and `tool_args`.
+    Inspect,
+    /// Blind overwrite of `space:<slug>/<path>` with `content`.
+    Write,
+    /// Delete `space:<slug>/<path>`.
+    Delete,
+    /// Rename / move `space:<slug>/<from>` → `space:<slug>/<to>`.
+    Move,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
 struct SpacesParams {
     command: SpacesCommand,
-    /// Slug for `create`, `get`, `mount`, `unmount`. Must match
-    /// `[a-z0-9-]+` with no leading / trailing / double hyphens.
+    /// Slug for `create`, `get`, `mount`, `unmount`, `inspect`,
+    /// `write`, `delete`, `move`. Must match `[a-z0-9-]+` with no
+    /// leading / trailing / double hyphens.
     slug: Option<String>,
     /// Optional human-readable summary, used by `create`.
     description: Option<String>,
@@ -237,6 +247,23 @@ struct SpacesParams {
     /// space to (or detach from).
     #[schemars(with = "Option<uuid::Uuid>")]
     project_id: Option<ProjectId>,
+
+    /// Required for `inspect`. Selects the read-only sub-op.
+    tool: Option<InspectTool>,
+    /// Op-specific arguments for `inspect`. Shape mirrors the
+    /// equivalent top-level tool (`Read` / `LS` / `Grep` / `Glob`).
+    #[serde(default)]
+    tool_args: Option<JsonObject>,
+
+    /// Path required for `write` and `delete`; relative to
+    /// `spaces/<slug>/`.
+    path: Option<String>,
+    /// Required for `write`.
+    content: Option<String>,
+    /// Required for `move` (source path within the space).
+    from: Option<String>,
+    /// Required for `move` (destination path within the space).
+    to: Option<String>,
 }
 
 static AGENT_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<AgentParams>);
@@ -289,7 +316,12 @@ static TOOLS: &[ToolDef] = &[
                        `list` (no args; every space in the library), \
                        `get` (requires `slug`), \
                        `mount` (requires `slug` and `project_id`; idempotent), \
-                       `unmount` (requires `slug` and `project_id`; idempotent).",
+                       `unmount` (requires `slug` and `project_id`; idempotent), \
+                       `inspect` (read-only file ops; requires `slug`, `tool` \
+                       (read|ls|grep|glob), `tool_args`), \
+                       `write` (requires `slug`, `path`, `content`), \
+                       `delete` (requires `slug`, `path`), \
+                       `move` (requires `slug`, `from`, `to`).",
         schema: &SPACES_SCHEMA,
     },
 ];
@@ -301,6 +333,7 @@ pub struct AdminToolSet {
     audit: Arc<Audit>,
     projects: Arc<Projects>,
     spaces: Arc<AuthedSpaces>,
+    space_fs: Arc<SpaceFs>,
 }
 
 impl AdminToolSet {
@@ -310,6 +343,7 @@ impl AdminToolSet {
         audit: Arc<Audit>,
         projects: Arc<Projects>,
         spaces: Arc<AuthedSpaces>,
+        space_fs: Arc<SpaceFs>,
     ) -> Self {
         let entries = TOOLS
             .iter()
@@ -331,6 +365,7 @@ impl AdminToolSet {
             audit,
             projects,
             spaces,
+            space_fs,
         }
     }
 }
@@ -667,8 +702,171 @@ impl AdminToolSet {
                     space.slug, space.id,
                 ))]))
             }
+
+            SpacesCommand::Inspect => {
+                let slug = params.slug.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("slug is required for inspect".to_string())
+                })?;
+                let tool = params.tool.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("tool is required for inspect".to_string())
+                })?;
+                let tool_args = params.tool_args.unwrap_or_default();
+                Audit::record_action("spaces.inspect");
+                self.execute_space_inspect(subject, &slug, tool, tool_args)
+                    .await
+            }
+
+            SpacesCommand::Write => {
+                let slug = params.slug.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("slug is required for write".to_string())
+                })?;
+                let path = params.path.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("path is required for write".to_string())
+                })?;
+                let content = params.content.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("content is required for write".to_string())
+                })?;
+                Audit::record_action("spaces.write");
+                let space_path = format!("space:{slug}/{path}");
+                self.space_fs
+                    .write_file(subject, &space_path, content)
+                    .await?;
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Wrote {space_path}"
+                ))]))
+            }
+
+            SpacesCommand::Delete => {
+                let slug = params.slug.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("slug is required for delete".to_string())
+                })?;
+                let path = params.path.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("path is required for delete".to_string())
+                })?;
+                Audit::record_action("spaces.delete");
+                let space_path = format!("space:{slug}/{path}");
+                self.space_fs.delete_file(subject, &space_path).await?;
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Deleted {space_path}"
+                ))]))
+            }
+
+            SpacesCommand::Move => {
+                let slug = params.slug.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("slug is required for move".to_string())
+                })?;
+                let from = params.from.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("from is required for move".to_string())
+                })?;
+                let to = params.to.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("to is required for move".to_string())
+                })?;
+                Audit::record_action("spaces.move");
+                let from_path = format!("space:{slug}/{from}");
+                let to_path = format!("space:{slug}/{to}");
+                self.space_fs
+                    .move_file(subject, &from_path, &to_path)
+                    .await?;
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Moved {from_path} -> {to_path}"
+                ))]))
+            }
         }
     }
+
+    async fn execute_space_inspect(
+        &self,
+        subject: &AuthSubject,
+        slug: &str,
+        tool: InspectTool,
+        tool_args: JsonObject,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        let path = tool_args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let space_path = format!("space:{slug}/{path}");
+
+        match tool {
+            InspectTool::Read => {
+                let view_range = parse_view_range(&tool_args);
+                let view = self
+                    .space_fs
+                    .view_file(subject, &space_path, view_range)
+                    .await?
+                    .ok_or_else(|| {
+                        ToolSetsError::Library(
+                            SpaceError::Io(format!("invalid space path: {space_path}")).into(),
+                        )
+                    })?;
+                let text = match view {
+                    FileView::File(text) => text,
+                    FileView::Dir(entries) => entries.join("\n"),
+                };
+                Ok(CallToolResult::success(vec![Content::text(text)]))
+            }
+            InspectTool::Ls => {
+                let entries = self
+                    .space_fs
+                    .view_dir(subject, &space_path)
+                    .await?
+                    .ok_or_else(|| {
+                        ToolSetsError::Library(
+                            SpaceError::Io(format!("invalid space path: {space_path}")).into(),
+                        )
+                    })?;
+                Ok(CallToolResult::success(vec![Content::text(
+                    entries.join("\n"),
+                )]))
+            }
+            InspectTool::Glob => {
+                let pattern = tool_args
+                    .get("pattern")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| ToolSetsError::MissingArgument("pattern".to_string()))?;
+                let matches = self
+                    .space_fs
+                    .glob(subject, &space_path, pattern)
+                    .await?
+                    .ok_or_else(|| {
+                        ToolSetsError::Library(
+                            SpaceError::Io(format!("invalid space path: {space_path}")).into(),
+                        )
+                    })?;
+                Ok(CallToolResult::success(vec![Content::text(
+                    matches.join("\n"),
+                )]))
+            }
+            InspectTool::Grep => {
+                let args = serde_json::Value::Object(tool_args);
+                let out = self
+                    .space_fs
+                    .grep(subject, &space_path, &args)
+                    .await?
+                    .ok_or_else(|| {
+                        ToolSetsError::Library(
+                            SpaceError::Io(format!("invalid space path: {space_path}")).into(),
+                        )
+                    })?;
+                Ok(CallToolResult::success(vec![Content::text(out)]))
+            }
+        }
+    }
+}
+
+fn parse_view_range(args: &JsonObject) -> Option<(i64, i64)> {
+    let offset = args
+        .get("offset")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
+    if offset.is_none() && limit.is_none() {
+        return None;
+    }
+    let start = offset.unwrap_or(0) + 1;
+    let end = match limit {
+        Some(l) => start + l - 1,
+        None => -1,
+    };
+    Some((start, end))
 }
 
 async fn execute_inspect(
@@ -1077,6 +1275,107 @@ mod tests {
         assert!(s.contains("\"get\""));
         assert!(s.contains("\"mount\""));
         assert!(s.contains("\"unmount\""));
+        assert!(s.contains("\"inspect\""));
+        assert!(s.contains("\"write\""));
+        assert!(s.contains("\"delete\""));
+        assert!(s.contains("\"move\""));
+    }
+
+    #[test]
+    fn spaces_inspect_parses_full_args() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "inspect",
+            "slug": "oncall",
+            "tool": "read",
+            "tool_args": { "path": "runbooks/foo.md" },
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, SpacesCommand::Inspect));
+        assert_eq!(p.slug.as_deref(), Some("oncall"));
+        assert!(matches!(p.tool, Some(InspectTool::Read)));
+        assert_eq!(
+            p.tool_args
+                .as_ref()
+                .and_then(|a| a.get("path").and_then(|v| v.as_str())),
+            Some("runbooks/foo.md")
+        );
+    }
+
+    #[test]
+    fn spaces_inspect_parses_grep_tool() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "inspect",
+            "slug": "oncall",
+            "tool": "grep",
+            "tool_args": { "pattern": "TODO", "output_mode": "content", "-n": true },
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, SpacesCommand::Inspect));
+        assert!(matches!(p.tool, Some(InspectTool::Grep)));
+    }
+
+    #[test]
+    fn spaces_inspect_parses_glob_tool() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "inspect",
+            "slug": "oncall",
+            "tool": "glob",
+            "tool_args": { "pattern": "**/*.md" },
+        })))
+        .expect("parse");
+        assert!(matches!(p.tool, Some(InspectTool::Glob)));
+    }
+
+    #[test]
+    fn spaces_inspect_parses_ls_tool() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "inspect",
+            "slug": "oncall",
+            "tool": "ls",
+            "tool_args": { "path": "" },
+        })))
+        .expect("parse");
+        assert!(matches!(p.tool, Some(InspectTool::Ls)));
+    }
+
+    #[test]
+    fn spaces_write_parses_args() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "write",
+            "slug": "oncall",
+            "path": "notes/x.md",
+            "content": "hello",
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, SpacesCommand::Write));
+        assert_eq!(p.path.as_deref(), Some("notes/x.md"));
+        assert_eq!(p.content.as_deref(), Some("hello"));
+    }
+
+    #[test]
+    fn spaces_delete_parses_args() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "delete",
+            "slug": "oncall",
+            "path": "notes/x.md",
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, SpacesCommand::Delete));
+        assert_eq!(p.path.as_deref(), Some("notes/x.md"));
+    }
+
+    #[test]
+    fn spaces_move_parses_args() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "move",
+            "slug": "oncall",
+            "from": "a.md",
+            "to": "b.md",
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, SpacesCommand::Move));
+        assert_eq!(p.from.as_deref(), Some("a.md"));
+        assert_eq!(p.to.as_deref(), Some("b.md"));
     }
 
     #[test]

--- a/core/src/toolset/space_inspect.rs
+++ b/core/src/toolset/space_inspect.rs
@@ -1,0 +1,120 @@
+//! Shared helpers for space file-ops dispatch from the tool layer
+//! (top-level `spaces` and admin `drua_admin_spaces`). The actual auth
+//! gate lives in `Projects::space_for_subject` (called via `SpaceFs`);
+//! this module just adapts request shapes and formats responses.
+
+use rmcp::model::{CallToolResult, Content, JsonObject};
+use serde::Deserialize;
+
+use drua_library::SpaceError;
+
+use crate::auth::AuthSubject;
+use crate::space_fs::{FileView, SpaceFs};
+
+use super::error::ToolSetsError;
+
+#[derive(Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum InspectTool {
+    Read,
+    Ls,
+    Grep,
+    Glob,
+}
+
+/// Translates `{offset, limit}` (zero-based) into the 1-based,
+/// inclusive `(start, end)` range the file view layer expects.
+/// `end == -1` means EOF.
+pub(crate) fn parse_view_range(args: &JsonObject) -> Option<(i64, i64)> {
+    let offset = args
+        .get("offset")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
+    if offset.is_none() && limit.is_none() {
+        return None;
+    }
+    let start = offset.unwrap_or(0) + 1;
+    let end = match limit {
+        Some(l) => start + l - 1,
+        None => -1,
+    };
+    Some((start, end))
+}
+
+/// Runs an `InspectTool` against `space:<slug>/<tool_args.path>`,
+/// formatting the response as plain text. `Ok(None)` from `SpaceFs`
+/// (only reachable for an empty slug, since callers always prefix
+/// `space:`) is converted to an error so callers never see a silent
+/// success.
+pub(crate) async fn dispatch_inspect(
+    space_fs: &SpaceFs,
+    subject: &AuthSubject,
+    slug: &str,
+    tool: InspectTool,
+    tool_args: JsonObject,
+) -> Result<CallToolResult, ToolSetsError> {
+    let path = tool_args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+    let space_path = format!("space:{slug}/{path}");
+    let invalid = || -> ToolSetsError {
+        ToolSetsError::Library(SpaceError::Io(format!("invalid space path: {space_path}")).into())
+    };
+
+    match tool {
+        InspectTool::Read => {
+            let view_range = parse_view_range(&tool_args);
+            let view = space_fs
+                .view_file(subject, &space_path, view_range)
+                .await?
+                .ok_or_else(invalid)?;
+            let text = match view {
+                FileView::File(text) => text,
+                FileView::Dir(entries) => entries.join("\n"),
+            };
+            Ok(CallToolResult::success(vec![Content::text(text)]))
+        }
+        InspectTool::Ls => {
+            let entries = space_fs
+                .view_dir(subject, &space_path)
+                .await?
+                .ok_or_else(invalid)?;
+            Ok(CallToolResult::success(vec![Content::text(
+                entries.join("\n"),
+            )]))
+        }
+        InspectTool::Glob => {
+            let pattern = tool_args
+                .get("pattern")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| ToolSetsError::MissingArgument("pattern".to_string()))?;
+            let matches = space_fs
+                .glob(subject, &space_path, pattern)
+                .await?
+                .ok_or_else(invalid)?;
+            Ok(CallToolResult::success(vec![Content::text(
+                matches.join("\n"),
+            )]))
+        }
+        InspectTool::Grep => {
+            let args = serde_json::Value::Object(tool_args);
+            let out = space_fs
+                .grep(subject, &space_path, &args)
+                .await?
+                .ok_or_else(invalid)?;
+            Ok(CallToolResult::success(vec![Content::text(out)]))
+        }
+    }
+}
+
+/// Errors `Ok(None)` (empty slug → `parse_space_path` returns None)
+/// as `InvalidArgument` so write/delete/move callers can't silently
+/// no-op. Successful ops just propagate.
+pub(crate) fn require_space_op(result: Option<()>, what: &str) -> Result<(), ToolSetsError> {
+    if result.is_none() {
+        return Err(ToolSetsError::InvalidArgument(format!(
+            "slug must be non-empty for {what}"
+        )));
+    }
+    Ok(())
+}

--- a/core/src/toolset/top_level/sandbox.rs
+++ b/core/src/toolset/top_level/sandbox.rs
@@ -371,19 +371,7 @@ fn build_read_request(args: &JsonObject) -> Result<ExecuteRequest, ToolSetsError
         "path": path,
     });
 
-    let offset = args
-        .get("offset")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
-    let limit = args
-        .get("limit")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
-
-    if offset.is_some() || limit.is_some() {
-        let start = offset.unwrap_or(0) + 1; // 0-based → 1-based
-        let end = match limit {
-            Some(l) => start + l - 1,
-            None => -1, // EOF
-        };
+    if let Some((start, end)) = super::super::inspect::parse_view_range(args) {
         input["view_range"] = serde_json::json!([start, end]);
     }
 

--- a/core/src/toolset/top_level/spaces.rs
+++ b/core/src/toolset/top_level/spaces.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, LazyLock};
 
-use rmcp::model::{CallToolResult, JsonObject};
+use rmcp::model::{CallToolResult, Content, JsonObject};
 use serde::Deserialize;
 
 use drua_library::Space;
@@ -9,10 +9,20 @@ use crate::audit::Audit;
 use crate::auth::{AuthResource, AuthSubject, AuthVerb};
 use crate::library::AuthedSpaces;
 use crate::project::Projects;
+use crate::space_fs::{FileView, SpaceFs};
 
 use super::super::error::ToolSetsError;
 use super::super::traits::TopLevelTool;
 use super::{parse_params, OutputSchema};
+
+#[derive(Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "snake_case")]
+enum InspectTool {
+    Read,
+    Ls,
+    Grep,
+    Glob,
+}
 
 #[derive(Deserialize)]
 #[serde(tag = "command", rename_all = "snake_case")]
@@ -36,6 +46,32 @@ enum SpacesParams {
         #[serde(default)]
         all: bool,
     },
+    /// Read-only file ops on a space mounted on the caller's project.
+    /// Mirrors `sandbox`'s `inspect`: pass `tool` (read|ls|grep|glob)
+    /// and `tool_args`.
+    Inspect {
+        slug: String,
+        tool: InspectTool,
+        #[serde(default)]
+        tool_args: Option<JsonObject>,
+    },
+    /// Blind overwrite of `space:<slug>/<path>` with `content`. Slug
+    /// must be mounted on the caller's project.
+    Write {
+        slug: String,
+        path: String,
+        content: String,
+    },
+    /// Delete `space:<slug>/<path>`. Slug must be mounted on the
+    /// caller's project.
+    Delete { slug: String, path: String },
+    /// Rename / move `space:<slug>/<from>` → `space:<slug>/<to>`.
+    /// Slug must be mounted on the caller's project.
+    Move {
+        slug: String,
+        from: String,
+        to: String,
+    },
 }
 
 impl SpacesParams {
@@ -45,6 +81,10 @@ impl SpacesParams {
             Self::Mount { .. } => "mount",
             Self::Unmount { .. } => "unmount",
             Self::List { .. } => "list",
+            Self::Inspect { .. } => "inspect",
+            Self::Write { .. } => "write",
+            Self::Delete { .. } => "delete",
+            Self::Move { .. } => "move",
         }
     }
 }
@@ -84,12 +124,12 @@ static SPACES_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
         "properties": {
             "command": {
                 "type": "string",
-                "enum": ["create", "mount", "unmount", "list"],
+                "enum": ["create", "mount", "unmount", "list", "inspect", "write", "delete", "move"],
                 "description": "Which spaces operation to perform."
             },
             "slug": {
                 "type": "string",
-                "description": "Directory-safe identifier ([a-z0-9-]+, no leading/trailing hyphens). Becomes spaces/<slug>/ in the library repo. Required for create, mount, and unmount."
+                "description": "Directory-safe identifier ([a-z0-9-]+, no leading/trailing hyphens). Becomes spaces/<slug>/ in the library repo. Required for create, mount, unmount, inspect, write, delete, and move."
             },
             "description": {
                 "type": "string",
@@ -98,6 +138,31 @@ static SPACES_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
             "all": {
                 "type": "boolean",
                 "description": "List flag: true returns every space in the library (for discovery before mount); false (default) returns only spaces mounted on this project."
+            },
+            "tool": {
+                "type": "string",
+                "enum": ["read", "ls", "grep", "glob"],
+                "description": "Inspect sub-tool. Required for inspect."
+            },
+            "tool_args": {
+                "type": "object",
+                "description": "Inspect sub-tool arguments. Shape mirrors the equivalent top-level tool: ls/read take {path, ...}; grep/glob take {pattern, path?, ...}."
+            },
+            "path": {
+                "type": "string",
+                "description": "Path relative to spaces/<slug>/. Required for write and delete."
+            },
+            "content": {
+                "type": "string",
+                "description": "File contents. Required for write."
+            },
+            "from": {
+                "type": "string",
+                "description": "Source path relative to spaces/<slug>/. Required for move."
+            },
+            "to": {
+                "type": "string",
+                "description": "Destination path relative to spaces/<slug>/. Required for move."
             }
         },
         "required": ["command"],
@@ -108,11 +173,20 @@ static SPACES_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
 pub struct SpacesTool {
     spaces: Arc<AuthedSpaces>,
     projects: Arc<Projects>,
+    space_fs: Arc<SpaceFs>,
 }
 
 impl SpacesTool {
-    pub fn new(spaces: Arc<AuthedSpaces>, projects: Arc<Projects>) -> Self {
-        Self { spaces, projects }
+    pub fn new(
+        spaces: Arc<AuthedSpaces>,
+        projects: Arc<Projects>,
+        space_fs: Arc<SpaceFs>,
+    ) -> Self {
+        Self {
+            spaces,
+            projects,
+            space_fs,
+        }
     }
 }
 
@@ -132,7 +206,14 @@ impl TopLevelTool for SpacesTool {
          `unmount` (requires `slug`; drops a previously-mounted space \
          — the space itself is unaffected), \
          `list` (defaults to spaces mounted by the caller's project; \
-         pass `all: true` to discover every space in the library)."
+         pass `all: true` to discover every space in the library), \
+         `inspect` (read-only file ops on a mounted space; requires \
+         `slug`, `tool` (read|ls|grep|glob), `tool_args`), \
+         `write` (requires `slug`, `path`, `content`), \
+         `delete` (requires `slug`, `path`), \
+         `move` (requires `slug`, `from`, `to`). \
+         File ops are gated on the slug being mounted on the caller's \
+         project."
     }
 
     fn input_schema(&self) -> &serde_json::Value {
@@ -167,6 +248,45 @@ impl TopLevelTool for SpacesTool {
         Audit::record_action(format!("spaces.{}", params.command_name()));
 
         let (text, out) = match params {
+            SpacesParams::Inspect {
+                slug,
+                tool,
+                tool_args,
+            } => {
+                return self
+                    .execute_inspect(subject, &slug, tool, tool_args.unwrap_or_default())
+                    .await;
+            }
+            SpacesParams::Write {
+                slug,
+                path,
+                content,
+            } => {
+                let space_path = format!("space:{slug}/{path}");
+                self.space_fs
+                    .write_file(subject, &space_path, content)
+                    .await?;
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Wrote {space_path}"
+                ))]));
+            }
+            SpacesParams::Delete { slug, path } => {
+                let space_path = format!("space:{slug}/{path}");
+                self.space_fs.delete_file(subject, &space_path).await?;
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Deleted {space_path}"
+                ))]));
+            }
+            SpacesParams::Move { slug, from, to } => {
+                let from_path = format!("space:{slug}/{from}");
+                let to_path = format!("space:{slug}/{to}");
+                self.space_fs
+                    .move_file(subject, &from_path, &to_path)
+                    .await?;
+                return Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Moved {from_path} -> {to_path}"
+                ))]));
+            }
             SpacesParams::Create { slug, description } => {
                 let space = self
                     .projects
@@ -261,4 +381,112 @@ impl TopLevelTool for SpacesTool {
 
         Ok(SPACES_OUTPUT.success(text, &out))
     }
+}
+
+impl SpacesTool {
+    async fn execute_inspect(
+        &self,
+        subject: &AuthSubject,
+        slug: &str,
+        tool: InspectTool,
+        tool_args: JsonObject,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        let path = tool_args.get("path").and_then(|v| v.as_str()).unwrap_or("");
+        let space_path = format!("space:{slug}/{path}");
+
+        match tool {
+            InspectTool::Read => {
+                let view_range = parse_view_range(&tool_args);
+                let view = self
+                    .space_fs
+                    .view_file(subject, &space_path, view_range)
+                    .await?
+                    .ok_or_else(|| {
+                        ToolSetsError::Library(
+                            drua_library::SpaceError::Io(format!(
+                                "invalid space path: {space_path}"
+                            ))
+                            .into(),
+                        )
+                    })?;
+                let text = match view {
+                    FileView::File(text) => text,
+                    FileView::Dir(entries) => entries.join("\n"),
+                };
+                Ok(CallToolResult::success(vec![Content::text(text)]))
+            }
+            InspectTool::Ls => {
+                let entries = self
+                    .space_fs
+                    .view_dir(subject, &space_path)
+                    .await?
+                    .ok_or_else(|| {
+                        ToolSetsError::Library(
+                            drua_library::SpaceError::Io(format!(
+                                "invalid space path: {space_path}"
+                            ))
+                            .into(),
+                        )
+                    })?;
+                Ok(CallToolResult::success(vec![Content::text(
+                    entries.join("\n"),
+                )]))
+            }
+            InspectTool::Glob => {
+                let pattern = tool_args
+                    .get("pattern")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| ToolSetsError::MissingArgument("pattern".to_string()))?;
+                let matches = self
+                    .space_fs
+                    .glob(subject, &space_path, pattern)
+                    .await?
+                    .ok_or_else(|| {
+                        ToolSetsError::Library(
+                            drua_library::SpaceError::Io(format!(
+                                "invalid space path: {space_path}"
+                            ))
+                            .into(),
+                        )
+                    })?;
+                Ok(CallToolResult::success(vec![Content::text(
+                    matches.join("\n"),
+                )]))
+            }
+            InspectTool::Grep => {
+                let args = serde_json::Value::Object(tool_args);
+                let out = self
+                    .space_fs
+                    .grep(subject, &space_path, &args)
+                    .await?
+                    .ok_or_else(|| {
+                        ToolSetsError::Library(
+                            drua_library::SpaceError::Io(format!(
+                                "invalid space path: {space_path}"
+                            ))
+                            .into(),
+                        )
+                    })?;
+                Ok(CallToolResult::success(vec![Content::text(out)]))
+            }
+        }
+    }
+}
+
+fn parse_view_range(args: &JsonObject) -> Option<(i64, i64)> {
+    let offset = args
+        .get("offset")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
+    let limit = args
+        .get("limit")
+        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
+    if offset.is_none() && limit.is_none() {
+        return None;
+    }
+    let start = offset.unwrap_or(0) + 1;
+    let end = match limit {
+        Some(l) => start + l - 1,
+        None => -1,
+    };
+    Some((start, end))
 }

--- a/core/src/toolset/top_level/spaces.rs
+++ b/core/src/toolset/top_level/spaces.rs
@@ -12,7 +12,7 @@ use crate::project::Projects;
 use crate::space_fs::SpaceFs;
 
 use super::super::error::ToolSetsError;
-use super::super::space_inspect::{dispatch_inspect, require_space_op, InspectTool};
+use super::super::inspect::{dispatch_inspect, require_space_op, InspectTool};
 use super::super::traits::TopLevelTool;
 use super::{parse_params, OutputSchema};
 
@@ -169,11 +169,7 @@ pub struct SpacesTool {
 }
 
 impl SpacesTool {
-    pub fn new(
-        spaces: Arc<AuthedSpaces>,
-        projects: Arc<Projects>,
-        space_fs: Arc<SpaceFs>,
-    ) -> Self {
+    pub fn new(spaces: Arc<AuthedSpaces>, projects: Arc<Projects>, space_fs: Arc<SpaceFs>) -> Self {
         Self {
             spaces,
             projects,
@@ -384,4 +380,3 @@ impl TopLevelTool for SpacesTool {
         Ok(SPACES_OUTPUT.success(text, &out))
     }
 }
-

--- a/core/src/toolset/top_level/spaces.rs
+++ b/core/src/toolset/top_level/spaces.rs
@@ -9,20 +9,12 @@ use crate::audit::Audit;
 use crate::auth::{AuthResource, AuthSubject, AuthVerb};
 use crate::library::AuthedSpaces;
 use crate::project::Projects;
-use crate::space_fs::{FileView, SpaceFs};
+use crate::space_fs::SpaceFs;
 
 use super::super::error::ToolSetsError;
+use super::super::space_inspect::{dispatch_inspect, require_space_op, InspectTool};
 use super::super::traits::TopLevelTool;
 use super::{parse_params, OutputSchema};
-
-#[derive(Deserialize, schemars::JsonSchema)]
-#[serde(rename_all = "snake_case")]
-enum InspectTool {
-    Read,
-    Ls,
-    Grep,
-    Glob,
-}
 
 #[derive(Deserialize)]
 #[serde(tag = "command", rename_all = "snake_case")]
@@ -253,9 +245,14 @@ impl TopLevelTool for SpacesTool {
                 tool,
                 tool_args,
             } => {
-                return self
-                    .execute_inspect(subject, &slug, tool, tool_args.unwrap_or_default())
-                    .await;
+                return dispatch_inspect(
+                    &self.space_fs,
+                    subject,
+                    &slug,
+                    tool,
+                    tool_args.unwrap_or_default(),
+                )
+                .await;
             }
             SpacesParams::Write {
                 slug,
@@ -263,16 +260,19 @@ impl TopLevelTool for SpacesTool {
                 content,
             } => {
                 let space_path = format!("space:{slug}/{path}");
-                self.space_fs
+                let result = self
+                    .space_fs
                     .write_file(subject, &space_path, content)
                     .await?;
+                require_space_op(result, "write")?;
                 return Ok(CallToolResult::success(vec![Content::text(format!(
                     "Wrote {space_path}"
                 ))]));
             }
             SpacesParams::Delete { slug, path } => {
                 let space_path = format!("space:{slug}/{path}");
-                self.space_fs.delete_file(subject, &space_path).await?;
+                let result = self.space_fs.delete_file(subject, &space_path).await?;
+                require_space_op(result, "delete")?;
                 return Ok(CallToolResult::success(vec![Content::text(format!(
                     "Deleted {space_path}"
                 ))]));
@@ -280,9 +280,11 @@ impl TopLevelTool for SpacesTool {
             SpacesParams::Move { slug, from, to } => {
                 let from_path = format!("space:{slug}/{from}");
                 let to_path = format!("space:{slug}/{to}");
-                self.space_fs
+                let result = self
+                    .space_fs
                     .move_file(subject, &from_path, &to_path)
                     .await?;
+                require_space_op(result, "move")?;
                 return Ok(CallToolResult::success(vec![Content::text(format!(
                     "Moved {from_path} -> {to_path}"
                 ))]));
@@ -383,110 +385,3 @@ impl TopLevelTool for SpacesTool {
     }
 }
 
-impl SpacesTool {
-    async fn execute_inspect(
-        &self,
-        subject: &AuthSubject,
-        slug: &str,
-        tool: InspectTool,
-        tool_args: JsonObject,
-    ) -> Result<CallToolResult, ToolSetsError> {
-        let path = tool_args.get("path").and_then(|v| v.as_str()).unwrap_or("");
-        let space_path = format!("space:{slug}/{path}");
-
-        match tool {
-            InspectTool::Read => {
-                let view_range = parse_view_range(&tool_args);
-                let view = self
-                    .space_fs
-                    .view_file(subject, &space_path, view_range)
-                    .await?
-                    .ok_or_else(|| {
-                        ToolSetsError::Library(
-                            drua_library::SpaceError::Io(format!(
-                                "invalid space path: {space_path}"
-                            ))
-                            .into(),
-                        )
-                    })?;
-                let text = match view {
-                    FileView::File(text) => text,
-                    FileView::Dir(entries) => entries.join("\n"),
-                };
-                Ok(CallToolResult::success(vec![Content::text(text)]))
-            }
-            InspectTool::Ls => {
-                let entries = self
-                    .space_fs
-                    .view_dir(subject, &space_path)
-                    .await?
-                    .ok_or_else(|| {
-                        ToolSetsError::Library(
-                            drua_library::SpaceError::Io(format!(
-                                "invalid space path: {space_path}"
-                            ))
-                            .into(),
-                        )
-                    })?;
-                Ok(CallToolResult::success(vec![Content::text(
-                    entries.join("\n"),
-                )]))
-            }
-            InspectTool::Glob => {
-                let pattern = tool_args
-                    .get("pattern")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| ToolSetsError::MissingArgument("pattern".to_string()))?;
-                let matches = self
-                    .space_fs
-                    .glob(subject, &space_path, pattern)
-                    .await?
-                    .ok_or_else(|| {
-                        ToolSetsError::Library(
-                            drua_library::SpaceError::Io(format!(
-                                "invalid space path: {space_path}"
-                            ))
-                            .into(),
-                        )
-                    })?;
-                Ok(CallToolResult::success(vec![Content::text(
-                    matches.join("\n"),
-                )]))
-            }
-            InspectTool::Grep => {
-                let args = serde_json::Value::Object(tool_args);
-                let out = self
-                    .space_fs
-                    .grep(subject, &space_path, &args)
-                    .await?
-                    .ok_or_else(|| {
-                        ToolSetsError::Library(
-                            drua_library::SpaceError::Io(format!(
-                                "invalid space path: {space_path}"
-                            ))
-                            .into(),
-                        )
-                    })?;
-                Ok(CallToolResult::success(vec![Content::text(out)]))
-            }
-        }
-    }
-}
-
-fn parse_view_range(args: &JsonObject) -> Option<(i64, i64)> {
-    let offset = args
-        .get("offset")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
-    let limit = args
-        .get("limit")
-        .and_then(|v| v.as_i64().or_else(|| v.as_str()?.parse().ok()));
-    if offset.is_none() && limit.is_none() {
-        return None;
-    }
-    let start = offset.unwrap_or(0) + 1;
-    let end = match limit {
-        Some(l) => start + l - 1,
-        None => -1,
-    };
-    Some((start, end))
-}


### PR DESCRIPTION
## Summary

- Centralizes space file-op auth in `Projects::space_for_subject` by branching on `sub.is_admin()` — global admins bypass the project mount gate, project-bound subjects keep the existing mount check
- Mirrors the sandbox three-tier model for spaces:
  - `ProjectMember` — top-level Read/LS/Glob/Grep/Edit/Move/Delete on `space:<slug>/...` (already wired)
  - `ProjectAdmin` — top-level `spaces` tool gains `inspect/write/delete/move` alongside `create/mount/unmount/list`, scoped to spaces mounted on their project
  - global `Admin` — `drua_admin_spaces` gets the same file ops with cross-project reach
- All space file paths now flow through `SpaceFs` with the same interface as the agent-facing file tools; `admin.rs` no longer reaches into `AuthedSpaces::inner()` for file ops, and the previously-extracted helpers (`MAX_VIEW_FILE_BYTES`, `apply_view_range`, `format_dir`, `glob_blobs`, `grep_blobs`) are re-privatised inside `space_fs.rs`

## Test plan

- [x] `cargo check -p drua-core`
- [x] `cargo test -p drua-core --lib` (244/244)
- [x] `cargo clippy --workspace --all-targets`
- [ ] Verify a `ProjectAdmin` agent can `spaces inspect|write|delete|move` against a space mounted on its project
- [ ] Verify a `ProjectAdmin` cannot reach a space mounted on a different project (NotMounted error)
- [ ] Verify a global Admin can reach any space cross-project via `drua_admin_spaces`
- [ ] Verify `ProjectMember` agents are unchanged (still only the top-level file tools on `space:<slug>/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new space file write/delete/move capabilities and changes authorization to let admin subjects bypass project mount checks, which could widen access if misconfigured. Most logic is routed through `SpaceFs` with path validation, reducing but not eliminating risk of unintended cross-space edits.
> 
> **Overview**
> Adds a three-tier space file-ops surface that mirrors the sandbox model: the top-level `spaces` tool now supports `inspect` (read/ls/grep/glob) plus `write`, `delete`, and `move` for spaces mounted on the caller’s project, and the admin `spaces` tool gains the same ops with cross-project reach.
> 
> Centralizes sandboxless space authorization in `Projects::space_for_subject` by allowing `sub.is_admin()` to bypass the mounted-space gate, and routes the new tool operations through `SpaceFs` (including shared `inspect` dispatch/helpers and refactored `glob`/`grep` blob handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 023a65f10f899d8d6bb1d72ed9f0fd442b0b2f12. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->