### PR TITLE
feat(zenduty): MCP wrapper for incidents and schedules

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,6 +52,13 @@ OPENAI_API_KEY=
 # CONCOURSE_USERNAME=
 # CONCOURSE_PASSWORD=
 
+# ── Optional — Zenduty ───────────────────────────────────────────────────────
+
+# API token for the Zenduty toolset. Only needed when
+# `toolsets.zenduty.enabled: true` in the config file. Sent as
+# `Authorization: Token <api_key>` per Zenduty's docs.
+# ZENDUTY_API_TOKEN=
+
 # ── Optional — MCP Upstream Auth Headers ─────────────────────────────────────
 # Each MCP upstream defined in the config file can have its auth header
 # injected via an env var named `{NAME}_AUTH_HEADER` (name uppercased).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1428,6 +1428,7 @@ dependencies = [
  "tracing",
  "tracing-opentelemetry",
  "uuid",
+ "zenduty-client",
 ]
 
 [[package]]
@@ -7219,6 +7220,19 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zenduty-client"
+version = "0.1.0"
+dependencies = [
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
   "client",
   "server",
   "lib/concourse-client",
+  "lib/zenduty-client",
   "core",
   "core/crates/library",
   "mcp-gateway",
@@ -47,6 +48,7 @@ name = "drua"
 [workspace.dependencies]
 # Internal crates
 concourse-client = { path = "lib/concourse-client" }
+zenduty-client = { path = "lib/zenduty-client" }
 sandbox = { path = "lib/sandbox" }
 js-engine = { path = "lib/js-engine" }
 json-schema-ts = { path = "lib/json-schema-ts" }

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ A complete `.env.example` is provided at the repo root.
 | `GITHUB_ALLOWED_TEAMS` | No | `""` (all users) | Comma-separated GitHub teams allowed to log in (`org/team-slug`). |
 | `CONCOURSE_USERNAME` | No | — | Concourse CI basic-auth username (when concourse toolset is enabled). |
 | `CONCOURSE_PASSWORD` | No | — | Concourse CI basic-auth password. |
+| `ZENDUTY_API_TOKEN` | No | — | Zenduty API token (sent as `Authorization: Token <token>`). Required when the zenduty toolset is enabled. |
 | `{UPSTREAM}_AUTH_HEADER` | No | — | Auth header for each MCP upstream. Name is uppercased from the config, e.g. `HONEYCOMB_AUTH_HEADER`, `GITHUB_AUTH_HEADER`, `LINGO_AUTH_HEADER`. |
 | `GITHUB_APP_PRIVATE_KEY_PATH` | No | — | Filesystem path to the GitHub App PEM private key (for sandbox token auto-provisioning). Requires `github_app` section in config. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | `http://localhost:4317` | OpenTelemetry OTLP gRPC endpoint. |
@@ -99,6 +100,7 @@ the included `drua.yml` for a complete local-dev example. Key sections:
 | `oauth` | GitHub OAuth client ID, redirect URI, allowed teams |
 | `agents.builtin_roles` | Per-role LLM model, system prompt, max tokens, auto-reset timer |
 | `toolsets.concourse` | Concourse CI URL, team, enabled flag |
+| `toolsets.zenduty` | Zenduty API URL override, default team, enabled flag |
 | `toolsets.mcp_upstreams[]` | MCP upstream services (name, URL, category, allowed tools, auth header name) |
 | `toolsets.code_assistant` | Path to the code-assistant SQLite DB |
 | `sandbox.backend` | `local` (child process) or `k8s` (namespace + template) |

--- a/charts/drua/templates/deployment.yaml
+++ b/charts/drua/templates/deployment.yaml
@@ -154,6 +154,12 @@ spec:
               name: {{ template "galoyAgents.fullname" . }}
               key: "concourse-password"
               optional: true
+        - name: ZENDUTY_API_TOKEN
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "galoyAgents.fullname" . }}
+              key: "zenduty-api-token"
+              optional: true
         {{- range .Values.galoyAgents.config.mcpUpstreams }}
         - name: {{ .name | upper }}_AUTH_HEADER
           valueFrom:

--- a/charts/drua/templates/secret.yaml
+++ b/charts/drua/templates/secret.yaml
@@ -25,6 +25,9 @@ data:
   {{- if .Values.galoyAgents.secrets.concoursePassword }}
   concourse-password: {{ .Values.galoyAgents.secrets.concoursePassword | trim | b64enc | trim }}
   {{- end }}
+  {{- if .Values.galoyAgents.secrets.zendutyApiToken }}
+  zenduty-api-token: {{ .Values.galoyAgents.secrets.zendutyApiToken | trim | b64enc | trim }}
+  {{- end }}
   {{- if .Values.galoyAgents.codeAssistant.gcsCreds }}
   gcs-creds: {{ .Values.galoyAgents.codeAssistant.gcsCreds | trim | b64enc | trim }}
   {{- end }}

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -173,6 +173,7 @@ galoyAgents:
     githubClientSecret: ""
     concourseUsername: ""
     concoursePassword: ""
+    zendutyApiToken: ""
     anthropicApiKey: ""
     openaiApiKey: ""
     annotations:

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -20,6 +20,7 @@ async-trait = "0.1"
 base64 = "0.22"
 chacha20poly1305 = "0.10"
 concourse-client = { workspace = true }
+zenduty-client = { workspace = true }
 chrono = { version = "0.4", features = ["clock", "serde"], default-features = false }
 derive_builder = "0.20"
 es-entity = "0.10"

--- a/core/src/toolset/config.rs
+++ b/core/src/toolset/config.rs
@@ -9,6 +9,8 @@ pub struct ToolSetsConfig {
     #[serde(default)]
     pub concourse: ConcourseToolSetConfig,
     #[serde(default)]
+    pub zenduty: ZendutyToolSetConfig,
+    #[serde(default)]
     pub code_assistant: CodeAssistantToolSetConfig,
     #[serde(default)]
     pub compose: ComposeConfig,
@@ -145,4 +147,20 @@ pub struct ConcourseToolSetConfig {
     pub username: String,
     #[serde(skip)]
     pub password: String,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct ZendutyToolSetConfig {
+    #[serde(default)]
+    pub enabled: bool,
+    /// Optional override for the API base URL. Defaults to
+    /// `https://www.zenduty.com/` when empty.
+    #[serde(default)]
+    pub url: String,
+    /// Default team unique_id used by schedule endpoints when none is
+    /// supplied at call time.
+    #[serde(default)]
+    pub default_team: String,
+    #[serde(skip)]
+    pub api_token: String,
 }

--- a/core/src/toolset/error.rs
+++ b/core/src/toolset/error.rs
@@ -16,6 +16,8 @@ pub enum ToolSetsError {
     MissingArgument(String),
     #[error("ToolSetsError - Concourse: {0}")]
     Concourse(#[from] concourse_client::ConcourseError),
+    #[error("ToolSetsError - Zenduty: {0}")]
+    Zenduty(#[from] zenduty_client::ZendutyError),
     #[error("ToolSetsError - InvalidArgument: {0}")]
     InvalidArgument(String),
     #[error("ToolSetsError - CodeAssistant: {0}")]

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -90,6 +90,27 @@ impl ToolSets {
             tracing::info!(url = %config.concourse.url, "Concourse toolset initialized");
         }
 
+        if config.zenduty.enabled && !config.zenduty.api_token.is_empty() {
+            match zenduty_client::ZendutyClient::new(&config.zenduty.url, &config.zenduty.api_token)
+            {
+                Ok(client) => {
+                    let default_team = if config.zenduty.default_team.is_empty() {
+                        None
+                    } else {
+                        Some(config.zenduty.default_team.clone())
+                    };
+                    sets.push(Arc::new(ZendutyToolSet::new(client, default_team)));
+                    tracing::info!(
+                        url = %config.zenduty.url,
+                        "Zenduty toolset initialized"
+                    );
+                }
+                Err(e) => {
+                    init_errors.push(("zenduty".to_string(), e.to_string()));
+                }
+            }
+        }
+
         let sets = Arc::new(RwLock::new(sets));
         let top_level: Arc<RwLock<HashMap<String, Arc<dyn TopLevelTool>>>> =
             Arc::new(RwLock::new(HashMap::new()));

--- a/core/src/toolset/searchable/mod.rs
+++ b/core/src/toolset/searchable/mod.rs
@@ -8,9 +8,11 @@ pub mod code_assistant;
 pub mod concourse;
 pub mod library;
 pub mod upstream;
+pub mod zenduty;
 
 pub use admin::AdminToolSet;
 pub use code_assistant::CodeAssistantToolSet;
 pub use concourse::ConcourseToolSet;
 pub use library::LibraryToolSet;
 pub use upstream::*;
+pub use zenduty::ZendutyToolSet;

--- a/core/src/toolset/searchable/zenduty.rs
+++ b/core/src/toolset/searchable/zenduty.rs
@@ -1,0 +1,516 @@
+use std::sync::{Arc, LazyLock};
+
+use rmcp::model::{CallToolResult, Content, JsonObject, Tool};
+use serde::Deserialize;
+use zenduty_client::{IncidentStatus, ListIncidentsParams, ZendutyClient};
+
+use crate::auth::AuthSubject;
+
+use super::super::{SearchableToolSet, ToolSetEntry, ToolSetsError};
+
+fn parse_params<T: serde::de::DeserializeOwned>(
+    arguments: Option<JsonObject>,
+) -> Result<T, ToolSetsError> {
+    let value = serde_json::Value::Object(arguments.unwrap_or_default());
+    serde_json::from_value(value).map_err(|e| ToolSetsError::InvalidArgument(e.to_string()))
+}
+
+fn schema_for<T: schemars::JsonSchema>() -> serde_json::Value {
+    let settings = schemars::gen::SchemaSettings::draft07().with(|s| {
+        s.inline_subschemas = true;
+        s.meta_schema = None;
+    });
+    let generator = settings.into_generator();
+    let schema = generator.into_root_schema_for::<T>();
+    let mut value = serde_json::to_value(schema).expect("schema serialization");
+    if let Some(obj) = value.as_object_mut() {
+        obj.remove("title");
+        obj.insert(
+            "additionalProperties".into(),
+            serde_json::Value::Bool(false),
+        );
+    }
+    value
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct ListIncidentsArgs {
+    /// Filter by status names: "triggered", "acknowledged", "resolved".
+    /// Defaults to triggered + acknowledged (i.e. ongoing) when omitted.
+    #[serde(default)]
+    statuses: Option<Vec<String>>,
+    #[serde(default)]
+    team_id: Option<String>,
+    #[serde(default)]
+    service_id: Option<String>,
+    #[serde(default)]
+    page: Option<u32>,
+    #[serde(default)]
+    page_size: Option<u32>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct IncidentIdArgs {
+    /// Zenduty incident `unique_id` (the string id used in URL paths).
+    incident_id: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct AddNoteArgs {
+    /// Zenduty incident `unique_id`.
+    incident_id: String,
+    /// Note body (markdown supported by Zenduty).
+    note: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct UpdateStatusArgs {
+    incident_id: String,
+    /// One of "acknowledged" or "resolved". "triggered" is rarely useful.
+    status: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct ListSchedulesArgs {
+    /// Defaults to `toolsets.zenduty.default_team` when omitted.
+    #[serde(default)]
+    team_id: Option<String>,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+struct GetScheduleArgs {
+    #[serde(default)]
+    team_id: Option<String>,
+    schedule_id: String,
+}
+
+static LIST_INCIDENTS_SCHEMA: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<ListIncidentsArgs>);
+static INCIDENT_ID_SCHEMA: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<IncidentIdArgs>);
+static ADD_NOTE_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<AddNoteArgs>);
+static UPDATE_STATUS_SCHEMA: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<UpdateStatusArgs>);
+static LIST_SCHEDULES_SCHEMA: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<ListSchedulesArgs>);
+static GET_SCHEDULE_SCHEMA: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<GetScheduleArgs>);
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct IncidentSummaryOutput {
+    unique_id: Option<String>,
+    incident_number: Option<u64>,
+    title: String,
+    status: Option<String>,
+    urgency: Option<u8>,
+    creation_date: Option<String>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct IncidentListOutput {
+    incidents: Vec<IncidentSummaryOutput>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct IncidentDetailOutput {
+    unique_id: Option<String>,
+    incident_number: Option<u64>,
+    title: String,
+    summary: Option<String>,
+    status: Option<String>,
+    urgency: Option<u8>,
+    creation_date: Option<String>,
+    acknowledged_date: Option<String>,
+    resolved_date: Option<String>,
+    #[schemars(schema_with = "crate::toolset::any_json_schema")]
+    service: Option<serde_json::Value>,
+    #[schemars(schema_with = "crate::toolset::any_json_schema")]
+    assigned_to: Option<serde_json::Value>,
+    #[schemars(schema_with = "crate::toolset::any_json_schema")]
+    team: Option<serde_json::Value>,
+    #[schemars(schema_with = "crate::toolset::any_json_schema")]
+    escalation_policy: Option<serde_json::Value>,
+    #[schemars(schema_with = "crate::toolset::array_of_any_schema")]
+    tags: Vec<serde_json::Value>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct NoteOutput {
+    unique_id: Option<String>,
+    note: String,
+    time_created: Option<String>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct ScheduleSummaryOutput {
+    unique_id: Option<String>,
+    name: String,
+    summary: Option<String>,
+    time_zone: Option<String>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct ScheduleListOutput {
+    schedules: Vec<ScheduleSummaryOutput>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct ScheduleDetailOutput {
+    unique_id: Option<String>,
+    name: String,
+    summary: Option<String>,
+    time_zone: Option<String>,
+    #[schemars(schema_with = "crate::toolset::array_of_any_schema")]
+    layers: Vec<serde_json::Value>,
+    #[schemars(schema_with = "crate::toolset::array_of_any_schema")]
+    overrides: Vec<serde_json::Value>,
+    #[schemars(schema_with = "crate::toolset::array_of_any_schema")]
+    on_call_now: Vec<serde_json::Value>,
+}
+
+static OUT_LIST_INCIDENTS: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<IncidentListOutput>);
+static OUT_INCIDENT_DETAIL: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<IncidentDetailOutput>);
+static OUT_NOTE: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<NoteOutput>);
+static OUT_LIST_SCHEDULES: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<ScheduleListOutput>);
+static OUT_SCHEDULE_DETAIL: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<ScheduleDetailOutput>);
+
+fn status_name(code: Option<u8>) -> Option<String> {
+    code.and_then(|c| IncidentStatus::try_from(c).ok())
+        .map(|s| s.as_str().to_string())
+}
+
+fn parse_status_name(s: &str) -> Result<IncidentStatus, ToolSetsError> {
+    match s.to_ascii_lowercase().as_str() {
+        "triggered" => Ok(IncidentStatus::Triggered),
+        "acknowledged" | "ack" => Ok(IncidentStatus::Acknowledged),
+        "resolved" | "resolve" => Ok(IncidentStatus::Resolved),
+        other => Err(ToolSetsError::InvalidArgument(format!(
+            "unknown status '{other}' (expected triggered|acknowledged|resolved)"
+        ))),
+    }
+}
+
+pub struct ZendutyToolSet {
+    client: Arc<ZendutyClient>,
+    default_team: Option<String>,
+    tools: Vec<ToolSetEntry>,
+}
+
+impl ZendutyToolSet {
+    pub fn new(client: ZendutyClient, default_team: Option<String>) -> Self {
+        let tools = vec![
+            tool_entry(
+                "list_incidents",
+                "List Zenduty incidents. Defaults to ongoing (triggered + acknowledged). Optionally filter by team_id, service_id, or status names.",
+                (*LIST_INCIDENTS_SCHEMA).clone(),
+                (*OUT_LIST_INCIDENTS).clone(),
+            ),
+            tool_entry(
+                "get_incident",
+                "Get full detail for a Zenduty incident by unique_id, including status, urgency, assignees, service, and team.",
+                (*INCIDENT_ID_SCHEMA).clone(),
+                (*OUT_INCIDENT_DETAIL).clone(),
+            ),
+            tool_entry(
+                "add_incident_note",
+                "Attach a note (comment) to a Zenduty incident. Use this to record context like a CI build URL on an ongoing incident.",
+                (*ADD_NOTE_SCHEMA).clone(),
+                (*OUT_NOTE).clone(),
+            ),
+            tool_entry(
+                "list_incident_notes",
+                "List notes attached to a Zenduty incident.",
+                (*INCIDENT_ID_SCHEMA).clone(),
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "notes": {
+                            "type": "array",
+                            "items": (*OUT_NOTE).clone(),
+                        }
+                    },
+                    "additionalProperties": false,
+                }),
+            ),
+            tool_entry(
+                "update_incident_status",
+                "Update an incident's status (acknowledged or resolved).",
+                (*UPDATE_STATUS_SCHEMA).clone(),
+                (*OUT_INCIDENT_DETAIL).clone(),
+            ),
+            tool_entry(
+                "list_schedules",
+                "List on-call schedules for a Zenduty team. Falls back to the configured default team when team_id is omitted.",
+                (*LIST_SCHEDULES_SCHEMA).clone(),
+                (*OUT_LIST_SCHEDULES).clone(),
+            ),
+            tool_entry(
+                "get_schedule",
+                "Get a Zenduty schedule's detail including layers, overrides, and the current on-call list.",
+                (*GET_SCHEDULE_SCHEMA).clone(),
+                (*OUT_SCHEDULE_DETAIL).clone(),
+            ),
+        ];
+
+        Self {
+            client: Arc::new(client),
+            default_team,
+            tools,
+        }
+    }
+
+    fn resolve_team(&self, team_id: Option<String>) -> Result<String, ToolSetsError> {
+        match team_id.or_else(|| self.default_team.clone()) {
+            Some(t) if !t.is_empty() => Ok(t),
+            _ => Err(ToolSetsError::MissingArgument(
+                "team_id (no default_team configured)".to_string(),
+            )),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl SearchableToolSet for ZendutyToolSet {
+    fn name(&self) -> &str {
+        "zenduty"
+    }
+
+    fn category(&self) -> &str {
+        "incident-response"
+    }
+
+    fn category_description(&self) -> &str {
+        "Zenduty incidents, notes, and on-call schedules"
+    }
+
+    fn tools(&self) -> &[ToolSetEntry] {
+        &self.tools
+    }
+
+    async fn call(
+        &self,
+        _subject: &AuthSubject,
+        tool_name: &str,
+        arguments: Option<JsonObject>,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        match tool_name {
+            "list_incidents" => {
+                let args: ListIncidentsArgs = parse_params(arguments)?;
+                let status_codes: Vec<u8> = match args.statuses {
+                    Some(names) => names
+                        .iter()
+                        .map(|s| parse_status_name(s).map(|st| st.as_u8()))
+                        .collect::<Result<Vec<_>, _>>()?,
+                    None => vec![
+                        IncidentStatus::Triggered.as_u8(),
+                        IncidentStatus::Acknowledged.as_u8(),
+                    ],
+                };
+                let params = ListIncidentsParams {
+                    status: Some(&status_codes),
+                    team_id: args.team_id.as_deref(),
+                    service_id: args.service_id.as_deref(),
+                    page: args.page,
+                    page_size: args.page_size,
+                };
+                let incidents = self.client.list_incidents(&params).await?;
+                let out = IncidentListOutput {
+                    incidents: incidents
+                        .iter()
+                        .map(|i| IncidentSummaryOutput {
+                            unique_id: i.unique_id.clone(),
+                            incident_number: i.incident_number,
+                            title: i.title.clone(),
+                            status: status_name(i.status),
+                            urgency: i.urgency,
+                            creation_date: i.creation_date.clone(),
+                        })
+                        .collect(),
+                };
+                Ok(typed_result(&out))
+            }
+            "get_incident" => {
+                let args: IncidentIdArgs = parse_params(arguments)?;
+                let i = self.client.get_incident(&args.incident_id).await?;
+                let out = IncidentDetailOutput {
+                    unique_id: i.unique_id,
+                    incident_number: i.incident_number,
+                    title: i.title,
+                    summary: i.summary,
+                    status: status_name(i.status),
+                    urgency: i.urgency,
+                    creation_date: i.creation_date,
+                    acknowledged_date: i.acknowledged_date,
+                    resolved_date: i.resolved_date,
+                    service: i.service_object.or(i.service),
+                    assigned_to: i.assigned_to,
+                    team: i.team,
+                    escalation_policy: i.escalation_policy,
+                    tags: i.tags,
+                };
+                Ok(typed_result(&out))
+            }
+            "add_incident_note" => {
+                let args: AddNoteArgs = parse_params(arguments)?;
+                let note = self
+                    .client
+                    .add_incident_note(&args.incident_id, &args.note)
+                    .await?;
+                let out = NoteOutput {
+                    unique_id: note.unique_id,
+                    note: note.note,
+                    time_created: note.time_created,
+                };
+                Ok(typed_result(&out))
+            }
+            "list_incident_notes" => {
+                let args: IncidentIdArgs = parse_params(arguments)?;
+                let notes = self.client.list_incident_notes(&args.incident_id).await?;
+                let mapped: Vec<NoteOutput> = notes
+                    .into_iter()
+                    .map(|n| NoteOutput {
+                        unique_id: n.unique_id,
+                        note: n.note,
+                        time_created: n.time_created,
+                    })
+                    .collect();
+                let out = serde_json::json!({ "notes": mapped });
+                let text = serde_json::to_string_pretty(&out).unwrap_or_default();
+                let mut result = CallToolResult::success(vec![Content::text(text)]);
+                result.structured_content = Some(out);
+                Ok(result)
+            }
+            "update_incident_status" => {
+                let args: UpdateStatusArgs = parse_params(arguments)?;
+                let status = parse_status_name(&args.status)?;
+                let i = self
+                    .client
+                    .update_incident_status(&args.incident_id, status)
+                    .await?;
+                let out = IncidentDetailOutput {
+                    unique_id: i.unique_id,
+                    incident_number: i.incident_number,
+                    title: i.title,
+                    summary: i.summary,
+                    status: status_name(i.status),
+                    urgency: i.urgency,
+                    creation_date: i.creation_date,
+                    acknowledged_date: i.acknowledged_date,
+                    resolved_date: i.resolved_date,
+                    service: i.service_object.or(i.service),
+                    assigned_to: i.assigned_to,
+                    team: i.team,
+                    escalation_policy: i.escalation_policy,
+                    tags: i.tags,
+                };
+                Ok(typed_result(&out))
+            }
+            "list_schedules" => {
+                let args: ListSchedulesArgs = parse_params(arguments)?;
+                let team = self.resolve_team(args.team_id)?;
+                let schedules = self.client.list_schedules(&team).await?;
+                let out = ScheduleListOutput {
+                    schedules: schedules
+                        .iter()
+                        .map(|s| ScheduleSummaryOutput {
+                            unique_id: s.unique_id.clone(),
+                            name: s.name.clone(),
+                            summary: s.summary.clone(),
+                            time_zone: s.time_zone.clone(),
+                        })
+                        .collect(),
+                };
+                Ok(typed_result(&out))
+            }
+            "get_schedule" => {
+                let args: GetScheduleArgs = parse_params(arguments)?;
+                let team = self.resolve_team(args.team_id)?;
+                let s = self.client.get_schedule(&team, &args.schedule_id).await?;
+                let out = ScheduleDetailOutput {
+                    unique_id: s.unique_id,
+                    name: s.name,
+                    summary: s.summary,
+                    time_zone: s.time_zone,
+                    layers: s.layers,
+                    overrides: s.overrides,
+                    on_call_now: s.on_call_now,
+                };
+                Ok(typed_result(&out))
+            }
+            _ => Err(ToolSetsError::ToolNotFound(tool_name.to_string())),
+        }
+    }
+}
+
+fn tool_entry(
+    name: &str,
+    description: &str,
+    schema: serde_json::Value,
+    output_schema: serde_json::Value,
+) -> ToolSetEntry {
+    let input_schema: JsonObject = match schema {
+        serde_json::Value::Object(m) => m,
+        _ => Default::default(),
+    };
+    let out_schema = match output_schema {
+        serde_json::Value::Object(m) => Some(Arc::new(m)),
+        _ => None,
+    };
+    let mut tool = Tool::default();
+    tool.name = name.to_string().into();
+    tool.description = Some(description.to_string().into());
+    tool.input_schema = Arc::new(input_schema);
+    tool.output_schema = out_schema;
+    ToolSetEntry {
+        name: name.to_string(),
+        description: tool,
+        default_output_filter: None,
+    }
+}
+
+fn typed_result<T: serde::Serialize>(value: &T) -> CallToolResult {
+    let structured = serde_json::to_value(value).expect("serialization");
+    let text = serde_json::to_string_pretty(&structured).unwrap_or_default();
+    let mut result = CallToolResult::success(vec![Content::text(text)]);
+    result.structured_content = Some(structured);
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_status_accepts_canonical_names() {
+        assert_eq!(
+            parse_status_name("triggered").unwrap(),
+            IncidentStatus::Triggered
+        );
+        assert_eq!(
+            parse_status_name("ACKNOWLEDGED").unwrap(),
+            IncidentStatus::Acknowledged
+        );
+        assert_eq!(
+            parse_status_name("Resolved").unwrap(),
+            IncidentStatus::Resolved
+        );
+    }
+
+    #[test]
+    fn parse_status_rejects_unknown() {
+        assert!(parse_status_name("closed").is_err());
+    }
+
+    #[test]
+    fn status_name_round_trips() {
+        assert_eq!(status_name(Some(1)).as_deref(), Some("triggered"));
+        assert_eq!(status_name(Some(2)).as_deref(), Some("acknowledged"));
+        assert_eq!(status_name(Some(3)).as_deref(), Some("resolved"));
+        assert_eq!(status_name(Some(99)), None);
+        assert_eq!(status_name(None), None);
+    }
+}

--- a/core/src/toolset/searchable/zenduty.rs
+++ b/core/src/toolset/searchable/zenduty.rs
@@ -64,6 +64,14 @@ struct AddNoteArgs {
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
+struct DeleteNoteArgs {
+    /// Zenduty incident `unique_id`.
+    incident_id: String,
+    /// Note `unique_id` (returned by `add_incident_note` / `list_incident_notes`).
+    note_id: String,
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
 struct UpdateStatusArgs {
     incident_id: String,
     /// One of "acknowledged" or "resolved". "triggered" is rarely useful.
@@ -89,6 +97,8 @@ static LIST_INCIDENTS_SCHEMA: LazyLock<serde_json::Value> =
 static INCIDENT_ID_SCHEMA: LazyLock<serde_json::Value> =
     LazyLock::new(schema_for::<IncidentIdArgs>);
 static ADD_NOTE_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<AddNoteArgs>);
+static DELETE_NOTE_SCHEMA: LazyLock<serde_json::Value> =
+    LazyLock::new(schema_for::<DeleteNoteArgs>);
 static UPDATE_STATUS_SCHEMA: LazyLock<serde_json::Value> =
     LazyLock::new(schema_for::<UpdateStatusArgs>);
 static LIST_SCHEDULES_SCHEMA: LazyLock<serde_json::Value> =
@@ -174,6 +184,17 @@ static OUT_LIST_INCIDENTS: LazyLock<serde_json::Value> =
 static OUT_INCIDENT_DETAIL: LazyLock<serde_json::Value> =
     LazyLock::new(schema_for::<IncidentDetailOutput>);
 static OUT_NOTE: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<NoteOutput>);
+static OUT_DELETED: LazyLock<serde_json::Value> = LazyLock::new(|| {
+    serde_json::json!({
+        "type": "object",
+        "properties": {
+            "deleted": { "type": "boolean" },
+            "incident_id": { "type": "string" },
+            "note_id": { "type": "string" },
+        },
+        "additionalProperties": false,
+    })
+});
 static OUT_LIST_SCHEDULES: LazyLock<serde_json::Value> =
     LazyLock::new(schema_for::<ScheduleListOutput>);
 static OUT_SCHEDULE_DETAIL: LazyLock<serde_json::Value> =
@@ -236,6 +257,12 @@ impl ZendutyToolSet {
                     },
                     "additionalProperties": false,
                 }),
+            ),
+            tool_entry(
+                "delete_incident_note",
+                "Delete a note from a Zenduty incident by its unique_id.",
+                (*DELETE_NOTE_SCHEMA).clone(),
+                (*OUT_DELETED).clone(),
             ),
             tool_entry(
                 "update_incident_status",
@@ -382,6 +409,21 @@ impl SearchableToolSet for ZendutyToolSet {
                     })
                     .collect();
                 let out = serde_json::json!({ "notes": mapped });
+                let text = serde_json::to_string_pretty(&out).unwrap_or_default();
+                let mut result = CallToolResult::success(vec![Content::text(text)]);
+                result.structured_content = Some(out);
+                Ok(result)
+            }
+            "delete_incident_note" => {
+                let args: DeleteNoteArgs = parse_params(arguments)?;
+                self.client
+                    .delete_incident_note(&args.incident_id, &args.note_id)
+                    .await?;
+                let out = serde_json::json!({
+                    "deleted": true,
+                    "incident_id": args.incident_id,
+                    "note_id": args.note_id,
+                });
                 let text = serde_json::to_string_pretty(&out).unwrap_or_default();
                 let mut result = CallToolResult::success(vec![Content::text(text)]);
                 result.structured_content = Some(out);

--- a/core/src/toolset/searchable/zenduty.rs
+++ b/core/src/toolset/searchable/zenduty.rs
@@ -138,7 +138,8 @@ struct IncidentDetailOutput {
 struct NoteOutput {
     unique_id: Option<String>,
     note: String,
-    time_created: Option<String>,
+    user_name: Option<String>,
+    creation_date: Option<String>,
 }
 
 #[derive(serde::Serialize, schemars::JsonSchema)]
@@ -349,7 +350,7 @@ impl SearchableToolSet for ZendutyToolSet {
                     service: i.service_object.or(i.service),
                     assigned_to: i.assigned_to,
                     team: i.team,
-                    escalation_policy: i.escalation_policy,
+                    escalation_policy: i.escalation_policy_object.or(i.escalation_policy),
                     tags: i.tags,
                 };
                 Ok(typed_result(&out))
@@ -363,7 +364,8 @@ impl SearchableToolSet for ZendutyToolSet {
                 let out = NoteOutput {
                     unique_id: note.unique_id,
                     note: note.note,
-                    time_created: note.time_created,
+                    user_name: note.user_name,
+                    creation_date: note.creation_date,
                 };
                 Ok(typed_result(&out))
             }
@@ -375,7 +377,8 @@ impl SearchableToolSet for ZendutyToolSet {
                     .map(|n| NoteOutput {
                         unique_id: n.unique_id,
                         note: n.note,
-                        time_created: n.time_created,
+                        user_name: n.user_name,
+                        creation_date: n.creation_date,
                     })
                     .collect();
                 let out = serde_json::json!({ "notes": mapped });
@@ -404,7 +407,7 @@ impl SearchableToolSet for ZendutyToolSet {
                     service: i.service_object.or(i.service),
                     assigned_to: i.assigned_to,
                     team: i.team,
-                    escalation_policy: i.escalation_policy,
+                    escalation_policy: i.escalation_policy_object.or(i.escalation_policy),
                     tags: i.tags,
                 };
                 Ok(typed_result(&out))

--- a/dev/drua.default.yml
+++ b/dev/drua.default.yml
@@ -21,6 +21,10 @@ toolsets:
     enabled: false
     url: ''
     team: ''
+  zenduty:
+    enabled: false
+    url: ''
+    default_team: ''
   code_assistant:
     db_path: ''
   compose:

--- a/drua.yml
+++ b/drua.yml
@@ -55,7 +55,7 @@ toolsets:
     url: https://ci.galoy.io
     team: dev
   zenduty:
-    enabled: true
+    enabled: false
     url: ''
     default_team: 'c634c1cb-405d-451f-a83b-23fa06475e89'
   mcp_upstreams:

--- a/drua.yml
+++ b/drua.yml
@@ -54,6 +54,10 @@ toolsets:
     enabled: true
     url: https://ci.galoy.io
     team: dev
+  zenduty:
+    enabled: false
+    url: ''
+    default_team: ''
   mcp_upstreams:
     - name: honeycomb
       url: https://mcp.honeycomb.io/mcp

--- a/drua.yml
+++ b/drua.yml
@@ -55,9 +55,9 @@ toolsets:
     url: https://ci.galoy.io
     team: dev
   zenduty:
-    enabled: false
+    enabled: true
     url: ''
-    default_team: ''
+    default_team: 'c634c1cb-405d-451f-a83b-23fa06475e89'
   mcp_upstreams:
     - name: honeycomb
       url: https://mcp.honeycomb.io/mcp

--- a/lib/zenduty-client/Cargo.toml
+++ b/lib/zenduty-client/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "zenduty-client"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+url = "2"
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/lib/zenduty-client/README.md
+++ b/lib/zenduty-client/README.md
@@ -1,0 +1,45 @@
+# zenduty-client
+
+Async Rust client for the [Zenduty REST API](https://apidocs.zenduty.com/).
+Used by `drua-core` to expose Zenduty incidents and on-call schedules as
+MCP tools (see `core/src/toolset/searchable/zenduty.rs`).
+
+## Auth
+
+Zenduty uses static API tokens. The client sends them as
+`Authorization: Token <api_key>`.
+
+```rust
+let client = ZendutyClient::new("https://www.zenduty.com/", &api_token)?;
+```
+
+The MCP gateway sources the token from the `ZENDUTY_API_TOKEN` env var.
+
+## Scope (v1)
+
+**Incidents** (read + minimal write):
+- `list_incidents` — filter by status / team / service
+- `get_incident` — full detail by `unique_id`
+- `add_incident_note` — primary write for the concourse-trigger workflow
+- `list_incident_notes`
+- `update_incident_status` — acknowledge / resolve / re-trigger
+- helpers: `acknowledge_incident`, `resolve_incident`
+
+**Schedules** (read-only):
+- `list_schedules` (per team)
+- `get_schedule` — layers, overrides, current on-call
+
+**Intentionally out of scope** (extend in a follow-up):
+- users / teams CRUD
+- postmortems
+- escalation policy editing
+- service / integration management
+- alert rules
+- maintenance windows
+
+## Pagination
+
+List endpoints handle either DRF-paginated envelopes
+(`{count, next, previous, results}`) or bare arrays via `Page<T>`. v1 only
+returns the first page; add cursor/page args at the call site if you need
+more.

--- a/lib/zenduty-client/src/client.rs
+++ b/lib/zenduty-client/src/client.rs
@@ -74,13 +74,13 @@ impl ZendutyClient {
         Self::handle_response(resp).await
     }
 
-    async fn put_json<T, B>(&self, path: &str, body: &B) -> Result<T, ZendutyError>
+    async fn patch_json<T, B>(&self, path: &str, body: &B) -> Result<T, ZendutyError>
     where
         T: serde::de::DeserializeOwned,
         B: Serialize + ?Sized,
     {
         let url = self.api_url(path)?;
-        let resp = self.http.put(url).json(body).send().await?;
+        let resp = self.http.patch(url).json(body).send().await?;
         Self::handle_response(resp).await
     }
 
@@ -127,14 +127,13 @@ impl ZendutyClient {
         if let Some(page_size) = params.page_size {
             q.push(("page_size", page_size.to_string()));
         }
-        let page: Page<Incident> = self.get_with_query("/api/account/incidents/", &q).await?;
+        let page: Page<Incident> = self.get_with_query("/api/incidents/", &q).await?;
         Ok(page.into_results())
     }
 
     #[tracing::instrument(name = "zenduty_client.get_incident", skip_all)]
     pub async fn get_incident(&self, incident_id: &str) -> Result<Incident, ZendutyError> {
-        self.get(&format!("/api/account/incidents/{incident_id}/"))
-            .await
+        self.get(&format!("/api/incidents/{incident_id}/")).await
     }
 
     #[tracing::instrument(name = "zenduty_client.add_incident_note", skip_all)]
@@ -144,11 +143,8 @@ impl ZendutyClient {
         note: &str,
     ) -> Result<IncidentNote, ZendutyError> {
         let body = NewIncidentNote { note };
-        self.post_json(
-            &format!("/api/account/incidents/{incident_id}/notes/"),
-            &body,
-        )
-        .await
+        self.post_json(&format!("/api/incidents/{incident_id}/note/"), &body)
+            .await
     }
 
     #[tracing::instrument(name = "zenduty_client.list_incident_notes", skip_all)]
@@ -157,7 +153,7 @@ impl ZendutyClient {
         incident_id: &str,
     ) -> Result<Vec<IncidentNote>, ZendutyError> {
         let page: Page<IncidentNote> = self
-            .get(&format!("/api/account/incidents/{incident_id}/notes/"))
+            .get(&format!("/api/incidents/{incident_id}/note/"))
             .await?;
         Ok(page.into_results())
     }
@@ -171,7 +167,7 @@ impl ZendutyClient {
         let body = IncidentStatusUpdate {
             status: Some(status.as_u8()),
         };
-        self.put_json(&format!("/api/account/incidents/{incident_id}/"), &body)
+        self.patch_json(&format!("/api/incidents/{incident_id}/"), &body)
             .await
     }
 

--- a/lib/zenduty-client/src/client.rs
+++ b/lib/zenduty-client/src/client.rs
@@ -91,9 +91,21 @@ impl ZendutyClient {
         if status.is_success() {
             return Ok(resp.json::<T>().await?);
         }
-        let code = status.as_u16();
+        Err(Self::error_for_status(resp).await)
+    }
+
+    /// DELETE returns 204 No Content — no body to deserialize.
+    async fn handle_no_content(resp: reqwest::Response) -> Result<(), ZendutyError> {
+        if resp.status().is_success() {
+            return Ok(());
+        }
+        Err(Self::error_for_status(resp).await)
+    }
+
+    async fn error_for_status(resp: reqwest::Response) -> ZendutyError {
+        let code = resp.status().as_u16();
         let body = resp.text().await.unwrap_or_default();
-        Err(match code {
+        match code {
             401 | 403 => ZendutyError::Unauthorized(body),
             404 => ZendutyError::NotFound(body),
             429 => ZendutyError::RateLimited(body),
@@ -101,7 +113,7 @@ impl ZendutyClient {
                 status: code,
                 message: body,
             },
-        })
+        }
     }
 
     #[tracing::instrument(name = "zenduty_client.list_incidents", skip_all)]
@@ -156,6 +168,17 @@ impl ZendutyClient {
             .get(&format!("/api/incidents/{incident_id}/note/"))
             .await?;
         Ok(page.into_results())
+    }
+
+    #[tracing::instrument(name = "zenduty_client.delete_incident_note", skip_all)]
+    pub async fn delete_incident_note(
+        &self,
+        incident_id: &str,
+        note_id: &str,
+    ) -> Result<(), ZendutyError> {
+        let url = self.api_url(&format!("/api/incidents/{incident_id}/note/{note_id}/"))?;
+        let resp = self.http.delete(url).send().await?;
+        Self::handle_no_content(resp).await
     }
 
     #[tracing::instrument(name = "zenduty_client.update_incident_status", skip_all)]

--- a/lib/zenduty-client/src/client.rs
+++ b/lib/zenduty-client/src/client.rs
@@ -1,0 +1,207 @@
+use reqwest::header::{HeaderMap, HeaderValue, ACCEPT, AUTHORIZATION, CONTENT_TYPE};
+use serde::Serialize;
+use url::Url;
+
+use crate::error::ZendutyError;
+use crate::types::*;
+
+/// Async client for the Zenduty REST API.
+pub struct ZendutyClient {
+    http: reqwest::Client,
+    base_url: Url,
+}
+
+impl ZendutyClient {
+    /// `base_url` defaults to `https://www.zenduty.com/` if empty.
+    /// `api_token` is sent as `Authorization: Token <token>` per Zenduty's docs.
+    pub fn new(base_url: &str, api_token: &str) -> Result<Self, ZendutyError> {
+        let base = if base_url.trim().is_empty() {
+            "https://www.zenduty.com/"
+        } else {
+            base_url
+        };
+        let mut base_url = Url::parse(base)?;
+        // Ensure trailing slash so `Url::join` keeps the prefix.
+        if !base_url.path().ends_with('/') {
+            base_url.set_path(&format!("{}/", base_url.path()));
+        }
+
+        let mut headers = HeaderMap::new();
+        let auth = format!("Token {}", api_token.trim());
+        headers.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str(&auth).map_err(|e| ZendutyError::InvalidHeader(e.to_string()))?,
+        );
+        headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        let http = reqwest::Client::builder()
+            .user_agent("zenduty-client-rs/0.1")
+            .default_headers(headers)
+            .build()?;
+
+        Ok(Self { http, base_url })
+    }
+
+    fn api_url(&self, path: &str) -> Result<Url, ZendutyError> {
+        let trimmed = path.trim_start_matches('/');
+        Ok(self.base_url.join(trimmed)?)
+    }
+
+    async fn get<T: serde::de::DeserializeOwned>(&self, path: &str) -> Result<T, ZendutyError> {
+        let url = self.api_url(path)?;
+        let resp = self.http.get(url).send().await?;
+        Self::handle_response(resp).await
+    }
+
+    async fn get_with_query<T, Q>(&self, path: &str, query: &Q) -> Result<T, ZendutyError>
+    where
+        T: serde::de::DeserializeOwned,
+        Q: Serialize + ?Sized,
+    {
+        let url = self.api_url(path)?;
+        let resp = self.http.get(url).query(query).send().await?;
+        Self::handle_response(resp).await
+    }
+
+    async fn post_json<T, B>(&self, path: &str, body: &B) -> Result<T, ZendutyError>
+    where
+        T: serde::de::DeserializeOwned,
+        B: Serialize + ?Sized,
+    {
+        let url = self.api_url(path)?;
+        let resp = self.http.post(url).json(body).send().await?;
+        Self::handle_response(resp).await
+    }
+
+    async fn put_json<T, B>(&self, path: &str, body: &B) -> Result<T, ZendutyError>
+    where
+        T: serde::de::DeserializeOwned,
+        B: Serialize + ?Sized,
+    {
+        let url = self.api_url(path)?;
+        let resp = self.http.put(url).json(body).send().await?;
+        Self::handle_response(resp).await
+    }
+
+    async fn handle_response<T: serde::de::DeserializeOwned>(
+        resp: reqwest::Response,
+    ) -> Result<T, ZendutyError> {
+        let status = resp.status();
+        if status.is_success() {
+            return Ok(resp.json::<T>().await?);
+        }
+        let code = status.as_u16();
+        let body = resp.text().await.unwrap_or_default();
+        Err(match code {
+            401 | 403 => ZendutyError::Unauthorized(body),
+            404 => ZendutyError::NotFound(body),
+            429 => ZendutyError::RateLimited(body),
+            _ => ZendutyError::Api {
+                status: code,
+                message: body,
+            },
+        })
+    }
+
+    #[tracing::instrument(name = "zenduty_client.list_incidents", skip_all)]
+    pub async fn list_incidents(
+        &self,
+        params: &ListIncidentsParams<'_>,
+    ) -> Result<Vec<Incident>, ZendutyError> {
+        let mut q: Vec<(&str, String)> = Vec::new();
+        if let Some(statuses) = params.status {
+            for s in statuses {
+                q.push(("status", s.to_string()));
+            }
+        }
+        if let Some(team) = params.team_id {
+            q.push(("team", team.to_string()));
+        }
+        if let Some(service) = params.service_id {
+            q.push(("service", service.to_string()));
+        }
+        if let Some(page) = params.page {
+            q.push(("page", page.to_string()));
+        }
+        if let Some(page_size) = params.page_size {
+            q.push(("page_size", page_size.to_string()));
+        }
+        let page: Page<Incident> = self.get_with_query("/api/account/incidents/", &q).await?;
+        Ok(page.into_results())
+    }
+
+    #[tracing::instrument(name = "zenduty_client.get_incident", skip_all)]
+    pub async fn get_incident(&self, incident_id: &str) -> Result<Incident, ZendutyError> {
+        self.get(&format!("/api/account/incidents/{incident_id}/"))
+            .await
+    }
+
+    #[tracing::instrument(name = "zenduty_client.add_incident_note", skip_all)]
+    pub async fn add_incident_note(
+        &self,
+        incident_id: &str,
+        note: &str,
+    ) -> Result<IncidentNote, ZendutyError> {
+        let body = NewIncidentNote { note };
+        self.post_json(
+            &format!("/api/account/incidents/{incident_id}/notes/"),
+            &body,
+        )
+        .await
+    }
+
+    #[tracing::instrument(name = "zenduty_client.list_incident_notes", skip_all)]
+    pub async fn list_incident_notes(
+        &self,
+        incident_id: &str,
+    ) -> Result<Vec<IncidentNote>, ZendutyError> {
+        let page: Page<IncidentNote> = self
+            .get(&format!("/api/account/incidents/{incident_id}/notes/"))
+            .await?;
+        Ok(page.into_results())
+    }
+
+    #[tracing::instrument(name = "zenduty_client.update_incident_status", skip_all)]
+    pub async fn update_incident_status(
+        &self,
+        incident_id: &str,
+        status: IncidentStatus,
+    ) -> Result<Incident, ZendutyError> {
+        let body = IncidentStatusUpdate {
+            status: Some(status.as_u8()),
+        };
+        self.put_json(&format!("/api/account/incidents/{incident_id}/"), &body)
+            .await
+    }
+
+    pub async fn acknowledge_incident(&self, incident_id: &str) -> Result<Incident, ZendutyError> {
+        self.update_incident_status(incident_id, IncidentStatus::Acknowledged)
+            .await
+    }
+
+    pub async fn resolve_incident(&self, incident_id: &str) -> Result<Incident, ZendutyError> {
+        self.update_incident_status(incident_id, IncidentStatus::Resolved)
+            .await
+    }
+
+    #[tracing::instrument(name = "zenduty_client.list_schedules", skip_all)]
+    pub async fn list_schedules(&self, team_id: &str) -> Result<Vec<Schedule>, ZendutyError> {
+        let page: Page<Schedule> = self
+            .get(&format!("/api/account/teams/{team_id}/schedules/"))
+            .await?;
+        Ok(page.into_results())
+    }
+
+    #[tracing::instrument(name = "zenduty_client.get_schedule", skip_all)]
+    pub async fn get_schedule(
+        &self,
+        team_id: &str,
+        schedule_id: &str,
+    ) -> Result<Schedule, ZendutyError> {
+        self.get(&format!(
+            "/api/account/teams/{team_id}/schedules/{schedule_id}/"
+        ))
+        .await
+    }
+}

--- a/lib/zenduty-client/src/error.rs
+++ b/lib/zenduty-client/src/error.rs
@@ -1,0 +1,29 @@
+use thiserror::Error;
+
+/// Errors returned by the Zenduty client.
+#[derive(Debug, Error)]
+pub enum ZendutyError {
+    #[error("HTTP request failed: {0}")]
+    Http(#[from] reqwest::Error),
+
+    #[error("failed to parse URL: {0}")]
+    Url(#[from] url::ParseError),
+
+    #[error("JSON serialization/deserialization error: {0}")]
+    Json(#[from] serde_json::Error),
+
+    #[error("invalid header value: {0}")]
+    InvalidHeader(String),
+
+    #[error("unauthorized — check ZENDUTY_API_TOKEN: {0}")]
+    Unauthorized(String),
+
+    #[error("not found: {0}")]
+    NotFound(String),
+
+    #[error("rate limited (HTTP 429): {0}")]
+    RateLimited(String),
+
+    #[error("API error (HTTP {status}): {message}")]
+    Api { status: u16, message: String },
+}

--- a/lib/zenduty-client/src/lib.rs
+++ b/lib/zenduty-client/src/lib.rs
@@ -1,0 +1,7 @@
+mod client;
+mod error;
+mod types;
+
+pub use client::ZendutyClient;
+pub use error::ZendutyError;
+pub use types::*;

--- a/lib/zenduty-client/src/types.rs
+++ b/lib/zenduty-client/src/types.rs
@@ -80,6 +80,8 @@ pub struct Incident {
     #[serde(default)]
     pub escalation_policy: Option<serde_json::Value>,
     #[serde(default)]
+    pub escalation_policy_object: Option<serde_json::Value>,
+    #[serde(default)]
     pub tags: Vec<serde_json::Value>,
     #[serde(default)]
     pub merged_with: Option<serde_json::Value>,
@@ -92,15 +94,17 @@ pub struct Incident {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct IncidentNote {
     #[serde(default)]
-    pub id: Option<u64>,
-    #[serde(default)]
     pub unique_id: Option<String>,
     #[serde(default)]
     pub note: String,
     #[serde(default)]
-    pub user: Option<serde_json::Value>,
+    pub user: Option<String>,
     #[serde(default)]
-    pub time_created: Option<String>,
+    pub user_name: Option<String>,
+    #[serde(default)]
+    pub incident: Option<u64>,
+    #[serde(default)]
+    pub creation_date: Option<String>,
     #[serde(flatten, default)]
     pub extra: serde_json::Map<String, serde_json::Value>,
 }

--- a/lib/zenduty-client/src/types.rs
+++ b/lib/zenduty-client/src/types.rs
@@ -1,0 +1,210 @@
+use serde::{Deserialize, Serialize};
+
+/// Zenduty incident statuses are integer-coded on the wire.
+/// See <https://apidocs.zenduty.com/>.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(into = "u8", try_from = "u8")]
+pub enum IncidentStatus {
+    Triggered,
+    Acknowledged,
+    Resolved,
+}
+
+impl IncidentStatus {
+    pub fn as_u8(self) -> u8 {
+        match self {
+            Self::Triggered => 1,
+            Self::Acknowledged => 2,
+            Self::Resolved => 3,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Triggered => "triggered",
+            Self::Acknowledged => "acknowledged",
+            Self::Resolved => "resolved",
+        }
+    }
+}
+
+impl From<IncidentStatus> for u8 {
+    fn from(value: IncidentStatus) -> Self {
+        value.as_u8()
+    }
+}
+
+impl TryFrom<u8> for IncidentStatus {
+    type Error = String;
+    fn try_from(value: u8) -> Result<Self, Self::Error> {
+        match value {
+            1 => Ok(Self::Triggered),
+            2 => Ok(Self::Acknowledged),
+            3 => Ok(Self::Resolved),
+            other => Err(format!("unknown incident status code: {other}")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Incident {
+    #[serde(default)]
+    pub id: Option<u64>,
+    /// Zenduty's stable string id used in URL paths (e.g. notes endpoint).
+    #[serde(default)]
+    pub unique_id: Option<String>,
+    #[serde(default)]
+    pub incident_number: Option<u64>,
+    #[serde(default)]
+    pub title: String,
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub status: Option<u8>,
+    #[serde(default)]
+    pub urgency: Option<u8>,
+    #[serde(default)]
+    pub creation_date: Option<String>,
+    #[serde(default)]
+    pub acknowledged_date: Option<String>,
+    #[serde(default)]
+    pub resolved_date: Option<String>,
+    #[serde(default)]
+    pub service: Option<serde_json::Value>,
+    #[serde(default)]
+    pub service_object: Option<serde_json::Value>,
+    #[serde(default)]
+    pub assigned_to: Option<serde_json::Value>,
+    #[serde(default)]
+    pub team: Option<serde_json::Value>,
+    #[serde(default)]
+    pub escalation_policy: Option<serde_json::Value>,
+    #[serde(default)]
+    pub tags: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub merged_with: Option<serde_json::Value>,
+    /// Catch-all for fields the schema evolves to add (alert_key, sla,
+    /// integration metadata) without forcing a client release.
+    #[serde(flatten, default)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IncidentNote {
+    #[serde(default)]
+    pub id: Option<u64>,
+    #[serde(default)]
+    pub unique_id: Option<String>,
+    #[serde(default)]
+    pub note: String,
+    #[serde(default)]
+    pub user: Option<serde_json::Value>,
+    #[serde(default)]
+    pub time_created: Option<String>,
+    #[serde(flatten, default)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct NewIncidentNote<'a> {
+    pub note: &'a str,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct IncidentStatusUpdate {
+    /// Integer status code: 1=triggered, 2=acknowledged, 3=resolved.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<u8>,
+}
+
+#[derive(Debug, Clone, Default, Serialize)]
+pub struct ListIncidentsParams<'a> {
+    pub status: Option<&'a [u8]>,
+    pub team_id: Option<&'a str>,
+    pub service_id: Option<&'a str>,
+    pub page: Option<u32>,
+    pub page_size: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Schedule {
+    #[serde(default)]
+    pub unique_id: Option<String>,
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub summary: Option<String>,
+    #[serde(default)]
+    pub time_zone: Option<String>,
+    #[serde(default)]
+    pub team: Option<serde_json::Value>,
+    #[serde(default)]
+    pub layers: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub overrides: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub on_call_now: Vec<serde_json::Value>,
+    #[serde(flatten, default)]
+    pub extra: serde_json::Map<String, serde_json::Value>,
+}
+
+/// Zenduty list endpoints return either a bare array or a DRF-paginated
+/// envelope `{count, next, previous, results: [...]}`. This handles both.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum Page<T> {
+    Paginated {
+        #[serde(default)]
+        count: Option<u64>,
+        #[serde(default)]
+        next: Option<String>,
+        #[serde(default)]
+        previous: Option<String>,
+        results: Vec<T>,
+    },
+    Bare(Vec<T>),
+}
+
+impl<T> Page<T> {
+    pub fn into_results(self) -> Vec<T> {
+        match self {
+            Page::Paginated { results, .. } => results,
+            Page::Bare(v) => v,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn page_deserializes_bare_array() {
+        let raw = r#"[{"name":"a"},{"name":"b"}]"#;
+        let page: Page<Schedule> = serde_json::from_str(raw).unwrap();
+        let results = page.into_results();
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].name, "a");
+    }
+
+    #[test]
+    fn page_deserializes_drf_envelope() {
+        let raw = r#"{"count":1,"next":null,"previous":null,"results":[{"name":"x"}]}"#;
+        let page: Page<Schedule> = serde_json::from_str(raw).unwrap();
+        let results = page.into_results();
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "x");
+    }
+
+    #[test]
+    fn incident_status_round_trips() {
+        for s in [
+            IncidentStatus::Triggered,
+            IncidentStatus::Acknowledged,
+            IncidentStatus::Resolved,
+        ] {
+            let n = s.as_u8();
+            assert_eq!(IncidentStatus::try_from(n).unwrap(), s);
+        }
+    }
+}

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -251,6 +251,10 @@ impl Config {
             config.toolsets.concourse.password = val;
         }
 
+        if let Ok(val) = std::env::var("ZENDUTY_API_TOKEN") {
+            config.toolsets.zenduty.api_token = val.trim().to_string();
+        }
+
         // {NAME}_AUTH_HEADER env vars override upstream MCP auth headers.
         for upstream in &mut config.toolsets.mcp_upstreams {
             let env_key = format!("{}_AUTH_HEADER", upstream.name.to_uppercase());


### PR DESCRIPTION
## Summary

Adds a new `zenduty-client` crate plus a `ZendutyToolSet` exposing it
through the MCP gateway, mirroring the existing `concourse-client` /
`ConcourseToolSet` pattern. The end-state user story is:

> A Concourse `on_failure` step calls a drua workflow that finds the
> matching ongoing Zenduty incident (by service tag / alert key) and
> attaches a note with the failing build URL.

This PR builds the tool surface that makes that workflow possible
(searching ongoing incidents, then `add_incident_note`).

## Tools exposed

**Incidents** (read + minimal write):
- `list_incidents` — defaults to ongoing (triggered + acknowledged); filterable by `team_id`, `service_id`, status names
- `get_incident` — full detail by `unique_id`
- `add_incident_note` — primary write for the workflow
- `list_incident_notes`
- `update_incident_status` — `acknowledged` / `resolved`

**Schedules** (read-only v1):
- `list_schedules` — per team, falls back to `toolsets.zenduty.default_team`
- `get_schedule` — layers, overrides, current on-call

## Out of scope (extend in follow-ups)

users / teams CRUD, postmortems, escalation policy editing, service /
integration management, alert rules, maintenance windows. Noted in
`lib/zenduty-client/README.md`.

## Config

```yaml
toolsets:
  zenduty:
    enabled: true
    url: ""               # defaults to https://www.zenduty.com/
    default_team: "<team_unique_id>"
```

Env var: `ZENDUTY_API_TOKEN` (sent as `Authorization: Token <token>`).
Plumbed through `.env.example`, `dev/drua.default.yml`, the helm chart
(`values.yaml`, `secret.yaml`, `deployment.yaml`) the same way
`CONCOURSE_USERNAME`/`PASSWORD` are.

## Manual test

1. `export ZENDUTY_API_TOKEN=<your token>`
2. Set `toolsets.zenduty.enabled: true` in `drua.yml`
3. `make start` and connect via MCP client
4. `search_tools query=zenduty` should return the 7 tools
5. `call_tool tool_name=zenduty_list_incidents` should return ongoing incidents
6. `call_tool tool_name=zenduty_add_incident_note arguments='{"incident_id":"<unique_id>","note":"build https://ci.galoy.io/builds/123 failed"}'`

## Test plan

- [x] `cargo nextest run -p zenduty-client` (3 tests)
- [x] `cargo nextest run -p drua-core --lib zenduty` (3 tests, 249 skipped)
- [x] `cargo clippy -p zenduty-client --all-targets -- -D warnings` clean
- [x] `cargo clippy -p drua-core --all-targets -- -D warnings` clean
- [ ] Live smoke test against Zenduty (requires real token)
- [ ] `nix flake check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new external API integration with authenticated requests and incident write actions (notes/status), plus new config/env/Helm secret plumbing; errors or misconfiguration could impact incident workflows.
> 
> **Overview**
> Adds a new **Zenduty toolset** to the MCP gateway, backed by a new `lib/zenduty-client` crate, enabling agents to list/get incidents, add/list/delete incident notes, update incident status, and query on-call schedules.
> 
> Wires Zenduty into configuration and deployment: extends `ToolSetsConfig`/`ToolSetsError`, initializes the toolset when `toolsets.zenduty.enabled` and `ZENDUTY_API_TOKEN` are set, and updates `.env.example`, `README.md`, default YAML configs, and the Helm chart to supply the token via `values.yaml` → `secret.yaml` → `deployment.yaml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f8b1f4a0dabdb94f5f66ddccde82e5148edb7f6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->