### PR TITLE
feat(toolset): spaces.search with space-scoped library search

### DIFF
--- a/core/crates/library/src/lib.rs
+++ b/core/crates/library/src/lib.rs
@@ -21,7 +21,7 @@ pub use importer::{DocType, GitFileHash, LibraryImporter, UpsertError};
 pub use job::WriteOp;
 pub use primitives::SpaceId;
 pub use search::{SearchHit, SearchStore, SearchableFields};
-pub use space::{NewSpace, Space, SpaceError, SpaceEvent, Spaces};
+pub use space::{NewSpace, Space, SpaceError, SpaceEvent, Spaces, SPACE_DOC_TYPE};
 pub use synced::LibrarySynced;
 
 pub use self::git::DirEntry;

--- a/core/crates/library/src/space/mod.rs
+++ b/core/crates/library/src/space/mod.rs
@@ -12,7 +12,7 @@ use crate::git::GitEngine;
 use crate::importer::{DocType, GitFileHash, LibraryImporter, UpsertError};
 use crate::SearchableFields;
 
-const SPACE_DOC_TYPE: DocType = DocType::new("space_file");
+pub const SPACE_DOC_TYPE: DocType = DocType::new("space_file");
 
 /// UUID v5 namespace for deriving deterministic doc_ids from `<slug>/<rel_path>`.
 const SPACE_DOC_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -262,6 +262,7 @@ impl App {
             Arc::clone(&spaces),
             Arc::clone(&projects),
             Arc::clone(&space_fs),
+            Arc::clone(&search),
         ));
         toolsets.register_top_level(ProjectSandbox::new(Arc::clone(&sandboxes)));
         toolsets.register_top_level(NotesTool::new(Arc::clone(&notes), Arc::clone(&projects)));

--- a/core/src/library/mod.rs
+++ b/core/src/library/mod.rs
@@ -4,7 +4,7 @@ pub use error::LibraryError;
 
 pub use drua_library::{
     DirEntry, DocType, GitFileHash, NewSpace, SearchHit, SearchableFields, Space, SpaceError,
-    SpaceEvent, Spaces, WriteOp,
+    SpaceEvent, Spaces, WriteOp, SPACE_DOC_TYPE,
 };
 
 use crate::audit::Audit;

--- a/core/src/toolset/searchable/library.rs
+++ b/core/src/toolset/searchable/library.rs
@@ -1,6 +1,6 @@
 use std::sync::{Arc, LazyLock};
 
-use drua_library::{DocType, SearchHit, SearchableFields};
+use drua_library::{DocType, SearchHit, SearchableFields, SPACE_DOC_TYPE};
 use rmcp::model::{CallToolResult, Content, JsonObject, Tool};
 use serde::Deserialize;
 
@@ -12,8 +12,6 @@ use crate::skill::SKILL_DOC_TYPE;
 
 use super::super::error::ToolSetsError;
 use super::super::traits::{SearchableToolSet, ToolSetEntry};
-
-const SPACE_FILE_DOC_TYPE_STR: &str = "space_file";
 
 /// Tool-shaped global search hit. Translated from `drua_library::SearchHit`
 /// at the toolset boundary.
@@ -51,7 +49,7 @@ fn hit_to_global(hit: SearchHit) -> GlobalSearchHit {
 }
 
 fn fields_to_file(fields: SearchableFields) -> LibraryFile {
-    let is_space = fields.doc_type.as_str() == SPACE_FILE_DOC_TYPE_STR;
+    let is_space = fields.doc_type == SPACE_DOC_TYPE;
     let (space_slug, relative_path, project_id) = if is_space {
         (fields.scope_slug, fields.path, None)
     } else {
@@ -125,7 +123,7 @@ impl From<LibraryFileType> for DocType {
         match t {
             LibraryFileType::Skill => SKILL_DOC_TYPE,
             LibraryFileType::Note => NOTE_DOC_TYPE,
-            LibraryFileType::SpaceFile => DocType::new(SPACE_FILE_DOC_TYPE_STR),
+            LibraryFileType::SpaceFile => SPACE_DOC_TYPE,
         }
     }
 }
@@ -135,10 +133,12 @@ impl From<LibraryFileType> for DocType {
 /// fallback.
 impl From<DocType> for LibraryFileType {
     fn from(t: DocType) -> Self {
-        match t.as_str() {
-            "skill" => LibraryFileType::Skill,
-            "space_file" => LibraryFileType::SpaceFile,
-            _ => LibraryFileType::Note,
+        if t == SKILL_DOC_TYPE {
+            LibraryFileType::Skill
+        } else if t == SPACE_DOC_TYPE {
+            LibraryFileType::SpaceFile
+        } else {
+            LibraryFileType::Note
         }
     }
 }
@@ -329,11 +329,7 @@ impl LibraryToolSet {
         let doc_types: Vec<DocType> = if let Some(types) = params.types {
             types.into_iter().map(Into::into).collect()
         } else {
-            vec![
-                SKILL_DOC_TYPE,
-                NOTE_DOC_TYPE,
-                DocType::new(SPACE_FILE_DOC_TYPE_STR),
-            ]
+            vec![SKILL_DOC_TYPE, NOTE_DOC_TYPE, SPACE_DOC_TYPE]
         };
 
         let raw = self
@@ -607,7 +603,7 @@ mod tests {
     fn library_file_output_carries_space_metadata() {
         let f = LibraryFile {
             doc_id: uuid::Uuid::new_v4(),
-            doc_type: DocType::new(SPACE_FILE_DOC_TYPE_STR),
+            doc_type: SPACE_DOC_TYPE,
             project_id: None,
             title: "Incident playbook".into(),
             body: "body".into(),

--- a/core/src/toolset/top_level/spaces.rs
+++ b/core/src/toolset/top_level/spaces.rs
@@ -3,11 +3,11 @@ use std::sync::{Arc, LazyLock};
 use rmcp::model::{CallToolResult, JsonObject};
 use serde::Deserialize;
 
-use drua_library::Space;
+use drua_library::{Space, SPACE_DOC_TYPE};
 
 use crate::audit::Audit;
 use crate::auth::{AuthResource, AuthSubject, AuthVerb};
-use crate::library::AuthedSpaces;
+use crate::library::{AuthedSearch, AuthedSpaces};
 use crate::project::Projects;
 use crate::space_fs::SpaceFs;
 
@@ -15,6 +15,10 @@ use super::super::error::ToolSetsError;
 use super::super::inspect::{dispatch_edit, dispatch_view, EditOp, ReadOp};
 use super::super::traits::TopLevelTool;
 use super::{parse_params, OutputSchema};
+
+fn default_search_limit() -> usize {
+    10
+}
 
 #[derive(Deserialize)]
 #[serde(tag = "command", rename_all = "snake_case")]
@@ -54,6 +58,15 @@ enum SpacesParams {
         #[serde(default)]
         op_args: Option<JsonObject>,
     },
+    /// Hybrid FTS + semantic search restricted to a single mounted
+    /// space. Mirrors `notes.search` / skill `use_skill search`, but
+    /// scoped to `space_file` rows tagged with this space's id.
+    Search {
+        slug: String,
+        query: String,
+        #[serde(default = "default_search_limit")]
+        limit: usize,
+    },
 }
 
 impl SpacesParams {
@@ -65,6 +78,7 @@ impl SpacesParams {
             Self::List { .. } => "list",
             Self::View { .. } => "view",
             Self::Edit { .. } => "edit",
+            Self::Search { .. } => "search",
         }
     }
 }
@@ -94,6 +108,19 @@ struct SpacesOutput {
     space: Option<SpaceSummary>,
     #[serde(skip_serializing_if = "Option::is_none")]
     spaces: Option<Vec<SpaceSummary>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    results: Option<Vec<SpaceSearchHit>>,
+}
+
+#[derive(serde::Serialize, schemars::JsonSchema)]
+struct SpaceSearchHit {
+    doc_id: String,
+    title: String,
+    preview: String,
+    score: f64,
+    /// Path inside `spaces/<slug>/`, when known.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    relative_path: Option<String>,
 }
 
 static SPACES_OUTPUT: LazyLock<OutputSchema<SpacesOutput>> = LazyLock::new(OutputSchema::new);
@@ -104,7 +131,7 @@ static SPACES_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
         "properties": {
             "command": {
                 "type": "string",
-                "enum": ["create", "mount", "unmount", "list", "view", "edit"],
+                "enum": ["create", "mount", "unmount", "list", "view", "edit", "search"],
                 "description": "Which spaces operation to perform."
             },
             "slug": {
@@ -127,6 +154,15 @@ static SPACES_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
             "op_args": {
                 "type": "object",
                 "description": "Sub-op arguments. view: read/ls take {path, ...}; grep/glob take {pattern, path?, ...}. edit: write {path, content}; str_replace {path, old_str, new_str}; insert {path, line, text}; delete {path}; move {from, to}."
+            },
+            "query": {
+                "type": "string",
+                "description": "Search query — keywords or natural language (search command)."
+            },
+            "limit": {
+                "type": "integer",
+                "minimum": 1,
+                "description": "Maximum number of search results (search command, default 10)."
             }
         },
         "required": ["command"],
@@ -138,14 +174,21 @@ pub struct SpacesTool {
     spaces: Arc<AuthedSpaces>,
     projects: Arc<Projects>,
     space_fs: Arc<SpaceFs>,
+    search: Arc<AuthedSearch>,
 }
 
 impl SpacesTool {
-    pub fn new(spaces: Arc<AuthedSpaces>, projects: Arc<Projects>, space_fs: Arc<SpaceFs>) -> Self {
+    pub fn new(
+        spaces: Arc<AuthedSpaces>,
+        projects: Arc<Projects>,
+        space_fs: Arc<SpaceFs>,
+        search: Arc<AuthedSearch>,
+    ) -> Self {
         Self {
             spaces,
             projects,
             space_fs,
+            search,
         }
     }
 }
@@ -172,9 +215,12 @@ impl TopLevelTool for SpacesTool {
          op=write {path, content} (full overwrite), \
          str_replace {path, old_str, new_str} (old_str must occur once), \
          insert {path, line, text} (line is 1-based, insert AFTER; 0 prepends), \
-         delete {path}, move {from, to}). \
-         File ops are gated on the slug being mounted on the caller's \
-         project. Use path=\"\" for the space root."
+         delete {path}, move {from, to}), \
+         `search` (hybrid FTS + semantic search over the files in a \
+         single mounted space; requires `slug`, `query`; optional \
+         `limit` defaults to 10). \
+         File ops and search are gated on the slug being mounted on \
+         the caller's project. Use path=\"\" for the space root."
     }
 
     fn input_schema(&self) -> &serde_json::Value {
@@ -239,7 +285,7 @@ impl TopLevelTool for SpacesTool {
                 let out = SpacesOutput {
                     command: "create".to_string(),
                     space: Some(SpaceSummary::from(&space)),
-                    spaces: None,
+                    ..Default::default()
                 };
                 (text, out)
             }
@@ -256,7 +302,7 @@ impl TopLevelTool for SpacesTool {
                 let out = SpacesOutput {
                     command: "mount".to_string(),
                     space: Some(SpaceSummary::from(&space)),
-                    spaces: None,
+                    ..Default::default()
                 };
                 (text, out)
             }
@@ -277,7 +323,7 @@ impl TopLevelTool for SpacesTool {
                 let out = SpacesOutput {
                     command: "unmount".to_string(),
                     space: Some(SpaceSummary::from(&space)),
-                    spaces: None,
+                    ..Default::default()
                 };
                 (text, out)
             }
@@ -314,13 +360,122 @@ impl TopLevelTool for SpacesTool {
                 };
                 let out = SpacesOutput {
                     command: "list".to_string(),
-                    space: None,
                     spaces: Some(summaries),
+                    ..Default::default()
+                };
+                (text, out)
+            }
+            SpacesParams::Search { slug, query, limit } => {
+                let space = self.projects.space_for_subject(subject, &slug).await?;
+                let hits = self
+                    .search
+                    .search(
+                        subject,
+                        &[uuid::Uuid::from(space.id)],
+                        &query,
+                        &[SPACE_DOC_TYPE],
+                        limit,
+                    )
+                    .await?;
+
+                let total = hits.len();
+                let mut entries: Vec<String> = Vec::with_capacity(total);
+                let mut results: Vec<SpaceSearchHit> = Vec::with_capacity(total);
+                for hit in hits {
+                    let preview: String = hit.fields.content.chars().take(200).collect();
+                    let path = hit.fields.path.unwrap_or_default();
+                    entries.push(format!(
+                        "path: {path}\ntitle: {}\npreview: {preview}",
+                        hit.fields.name,
+                    ));
+                    results.push(SpaceSearchHit {
+                        doc_id: hit.fields.doc_id.to_string(),
+                        title: hit.fields.name,
+                        preview,
+                        score: hit.score,
+                        relative_path: (!path.is_empty()).then_some(path),
+                    });
+                }
+                let text = if total == 0 {
+                    format!("No matches in space '{}' for query.", space.slug)
+                } else {
+                    format!(
+                        "Found {total} hit(s) in space '{}':\n\n{}",
+                        space.slug,
+                        entries.join("\n---\n"),
+                    )
+                };
+                let out = SpacesOutput {
+                    command: "search".to_string(),
+                    space: Some(SpaceSummary::from(&space)),
+                    results: Some(results),
+                    ..Default::default()
                 };
                 (text, out)
             }
         };
 
         Ok(SPACES_OUTPUT.success(text, &out))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_search_minimal() {
+        let json = serde_json::json!({
+            "command": "search",
+            "slug": "ops",
+            "query": "deploy"
+        });
+        let params: SpacesParams = serde_json::from_value(json).unwrap();
+        match params {
+            SpacesParams::Search { slug, query, limit } => {
+                assert_eq!(slug, "ops");
+                assert_eq!(query, "deploy");
+                assert_eq!(limit, default_search_limit());
+            }
+            _ => panic!("expected Search variant"),
+        }
+    }
+
+    #[test]
+    fn parse_search_with_limit() {
+        let json = serde_json::json!({
+            "command": "search",
+            "slug": "ops",
+            "query": "deploy",
+            "limit": 25
+        });
+        let params: SpacesParams = serde_json::from_value(json).unwrap();
+        match params {
+            SpacesParams::Search { limit, .. } => assert_eq!(limit, 25),
+            _ => panic!("expected Search variant"),
+        }
+    }
+
+    #[test]
+    fn search_command_name_matches_audit_action() {
+        let p = SpacesParams::Search {
+            slug: "ops".into(),
+            query: "x".into(),
+            limit: 1,
+        };
+        assert_eq!(p.command_name(), "search");
+    }
+
+    #[test]
+    fn schema_advertises_search_command() {
+        let schema = &*SPACES_SCHEMA;
+        let cmd_enum = schema
+            .pointer("/properties/command/enum")
+            .expect("command.enum")
+            .as_array()
+            .expect("array");
+        assert!(cmd_enum.iter().any(|v| v == "search"));
+        assert!(schema.pointer("/properties/query").is_some());
+        assert!(schema.pointer("/properties/limit").is_some());
     }
 }


### PR DESCRIPTION
## Summary

Adds a `spaces.search` MCP subcommand that proxies to the library's hybrid
FTS + semantic search, scoped to a single mounted space via slug. Achieves
parity with the existing `notes.search` (notes tool) and `use_skill search`
patterns — same shape, same defaults, same precedent for inline construction.

## Tool surface

```
spaces { command: \"search\", slug: <space-slug>, query: <query>, limit?: 10 }
```

Returns text (\"Found N hit(s) in space '<slug>'\" + per-hit blocks) and
structured `results: SpaceSearchHit[]` with `doc_id`, `title`, `preview`,
`score`, optional `relative_path`.

## Library client

The library search store already supports `scope_ids` filtering — no
extension needed. The previously private `SPACE_DOC_TYPE` constant in
`drua_library::space` is promoted to `pub` and re-exported through
`core::library`, matching the existing `SKILL_DOC_TYPE` / `NOTE_DOC_TYPE`
pattern. The duplicate `SPACE_FILE_DOC_TYPE_STR` literal in
`toolset/searchable/library.rs` is removed in favour of the now-public
const, and the stringly-typed `match t.as_str()` decoder is collapsed
onto const equality.

## Authorization

Slug → space resolution + mount-gate goes through
`Projects::space_for_subject` (project-bound subjects must have the slug
mounted; admins bypass). Visibility inherits the existing `SpacesTool`
gate (project-lead `Update on Project`).

> Note: `notes.search` is broader (`Read on Note` — visible to task
> agents). Keeping `spaces.search` under the lead-only `SpacesTool` gate
> matches the user-requested placement (\"alongside the existing spaces
> tools\"). If we want task-agent-visible space search, that's a follow-up
> that splits the tool or relaxes the gate.

## Parity reference

- `core/src/toolset/top_level/notes.rs::NotesParams::Search` — same shape
- `core/src/toolset/top_level/use_skill.rs::UseSkillAction::Search` — same shape
- `core/src/note/mod.rs::Notes::search` / `core/src/skill/mod.rs::Skills::search`
  — same library-search-call pattern (this PR keeps the call inline at
  the toolset boundary since `AuthedSearch` already provides the auth
  gate; no `AuthedSpaces::search` method needed)

## Tests

+4 new unit tests in `core/src/toolset/top_level/spaces.rs::tests`:
- `parse_search_minimal` — default-limit deserialisation
- `parse_search_with_limit` — explicit limit
- `search_command_name_matches_audit_action`
- `schema_advertises_search_command` — schema enum + query/limit properties

`nix flake check` passes (fmt, clippy --deny warnings, nextest). All
existing 262+ library tests still pass.

## Test plan

- [ ] CI green
- [ ] Manual smoke: invoke \`spaces { command: \"search\", slug: \"x\", query: \"y\" }\` against a project with mounted space and confirm hits
- [ ] Confirm un-mounted slugs return SpaceError::NotMounted (auth gate works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new top-level `spaces.search` command that queries the library search index with scope filtering; incorrect gating or scope-id handling could expose or hide content unexpectedly.
> 
> **Overview**
> Adds a new `spaces.search` subcommand that performs hybrid FTS+semantic search **within a single mounted space** (by slug), returning both human-readable hit previews and structured `results`.
> 
> Promotes `SPACE_DOC_TYPE` to a public, re-exported constant and updates library search tooling to use it (removing stringly-typed `"space_file"` checks), and wires `AuthedSearch` into `SpacesTool` construction with schema + unit tests for the new command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ec1c2a8ada27a80286e93cce6668bbedf50acac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->