### PR TITLE
fix(library): keep sync job alive across graceful shutdowns

### DIFF
--- a/core/crates/library/src/job/sync.rs
+++ b/core/crates/library/src/job/sync.rs
@@ -95,10 +95,6 @@ impl JobRunner for LibrarySyncRunner {
             tokio::select! {
                 _ = current_job.shutdown_requested() => {
                     tracing::debug!("library.sync: shutdown requested");
-                    // RescheduleNow, not Complete: `spawn_unique` is a no-op
-                    // while a row exists, so Complete would mark this
-                    // long-lived consumer terminal forever and the next pod
-                    // boot would silently never re-attach.
                     return Ok(JobCompletion::RescheduleNow);
                 }
                 msg = rx.recv() => {

--- a/core/crates/library/src/job/sync.rs
+++ b/core/crates/library/src/job/sync.rs
@@ -95,7 +95,11 @@ impl JobRunner for LibrarySyncRunner {
             tokio::select! {
                 _ = current_job.shutdown_requested() => {
                     tracing::debug!("library.sync: shutdown requested");
-                    return Ok(JobCompletion::Complete);
+                    // RescheduleNow, not Complete: `spawn_unique` is a no-op
+                    // while a row exists, so Complete would mark this
+                    // long-lived consumer terminal forever and the next pod
+                    // boot would silently never re-attach.
+                    return Ok(JobCompletion::RescheduleNow);
                 }
                 msg = rx.recv() => {
                     match msg {

--- a/core/migrations/20260504160000_cleanup_dead_library_sync.sql
+++ b/core/migrations/20260504160000_cleanup_dead_library_sync.sql
@@ -1,0 +1,37 @@
+-- Cleanup of dead library.sync row + orphan job types.
+--
+-- The library.sync runner used to return JobCompletion::Complete on
+-- shutdown, marking the unique-per-type job terminal forever. Deleting
+-- the existing row lets `spawn_unique` recreate a fresh one at the next
+-- Library::init; on the first tick `changes_since(None, HEAD)` walks
+-- the full tree and re-indexes every space file.
+--
+-- The other three job_types are leftovers from a pre-2026-05-03
+-- deployment that have no current JobInitializer registered, so the
+-- poller can never execute their pending rows.
+DELETE FROM job_executions
+WHERE job_type IN (
+    'library.sync',
+    'library.sync-space-files',
+    'skill.sync-from-library',
+    'workflow.sync-from-library'
+);
+
+DELETE FROM job_events
+WHERE id IN (
+    SELECT id FROM jobs
+    WHERE job_type IN (
+        'library.sync',
+        'library.sync-space-files',
+        'skill.sync-from-library',
+        'workflow.sync-from-library'
+    )
+);
+
+DELETE FROM jobs
+WHERE job_type IN (
+    'library.sync',
+    'library.sync-space-files',
+    'skill.sync-from-library',
+    'workflow.sync-from-library'
+);


### PR DESCRIPTION
## Summary
- `LibrarySyncRunner::run` was returning `JobCompletion::Complete` on `shutdown_requested`, which marks the unique-per-type `library.sync` job terminal in `job_events`. Because `spawn_unique` is a no-op while a row exists, no subsequent pod boot ever re-attached.
- The fetcher kept pushing `CommitTick`s into the mpsc; with no consumer the buffer fills (cap 64) and the fetcher loop wedges on `send`. Skills/notes still index because they go through the entity-hook path (`LibrarySyncHook`), but **space files** only reach `library_documents` via the git-replay sync — so they silently stopped indexing after the first graceful shutdown.
- Fix: return `RescheduleNow` on shutdown so the same job row is picked up again on the next boot.
- Migration: wipe the already-completed `library.sync` row (and three orphan job_types from the pre-2026-05-03 deployment that have no current `JobInitializer`). On first tick after restart, `changes_since(None, HEAD)` walks the whole tree and re-indexes every space file.

## How it was found
Prod on-call space had files in git but `library_search(types=[space_file])` returned 0. PG showed 0 `space_file` rows in `library_documents`. `job_events` for the lone `library.sync` row showed `execution_completed` + `job_completed` at 2026-05-04 07:11 UTC — well before the on-call space was created at 12:07 UTC.

## Test plan
- [ ] CI / `nix flake check` green
- [ ] Apply migration in staging — confirm `jobs WHERE job_type='library.sync'` is empty pre-deploy
- [ ] Deploy → confirm `Library::init` creates a fresh `library.sync` row, runner attaches, first tick indexes every existing space file into `library_documents`
- [ ] Roll a pod (graceful shutdown) → confirm the row is **not** marked `job_completed`; next pod re-attaches and continues processing ticks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes background job lifecycle semantics and includes a migration that deletes job records for multiple `job_type`s; mistakes could cause missed processing or unexpected re-runs after deploy.
> 
> **Overview**
> Prevents `library.sync` from being permanently marked complete on graceful shutdown by returning `JobCompletion::RescheduleNow` when `shutdown_requested()` fires, so the unique job can be picked up again on the next boot.
> 
> Adds a SQL migration (`20260504160000_cleanup_dead_library_sync.sql`) that deletes existing `jobs`, `job_events`, and `job_executions` rows for `library.sync` and three orphaned legacy `job_type`s, allowing a fresh sync job to be spawned and executed after deployment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 279524648e9f5cc68718fb06977298ee66e3b6fb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->