### PR TITLE
feat(images): concourse-drua-resource — Concourse → drua workflow trigger

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,6 +13,7 @@ groups:
   - build-edge-image
   - build-sandbox-image
   - build-tunnel-connector-image
+  - build-concourse-drua-resource-image
   - bump-galoy-charts-tunnel-connector-image
   - deploy-to-prod
   - train-classifier
@@ -400,6 +401,40 @@ jobs:
     get_params:
       skip_download: true
 
+#! Builds the OCI image used as a Concourse `resource_type` to fire
+#! drua workflow runs from any pipeline's `on_failure:` (or anywhere
+#! else). Image source lives in `images/concourse-drua-resource/`.
+- name: build-concourse-drua-resource-image
+  serial: true
+  plan:
+  - get: repo-concourse-drua-resource
+    trigger: true
+  - task: build-image
+    config:
+      platform: linux
+      image_resource: #@ nix_flake_image_config()
+      inputs:
+      - name: repo-concourse-drua-resource
+        path: repo
+      outputs:
+      - name: image
+      caches:
+      - path: /nix-cache
+      run:
+        path: repo/ci/tasks/with-nix-cache.sh
+        args:
+          - sh
+          - -exc
+          - |
+            cd repo
+            nix build .#concourse-drua-resource-image
+            gunzip -c result > ../image/image.tar
+  - put: concourse-drua-resource-edge-image
+    params:
+      image: image/image.tar
+    get_params:
+      skip_download: true
+
 #! After `build-tunnel-connector-image` publishes a fresh digest, open
 #! (or force-update) a PR on GaloyMoney/galoy-charts that pins
 #! `tunnelConnector.image.digest` in `charts/galoy-deps/values.yaml`.
@@ -512,6 +547,16 @@ resources:
     - Cargo.toml
     - Cargo.lock
 
+- name: repo-concourse-drua-resource
+  type: git
+  source:
+    uri: #@ data.values.git_uri
+    branch: #@ data.values.git_branch
+    private_key: #@ data.values.github_private_key
+    paths:
+    - images/concourse-drua-resource/
+    - flake.nix
+
 #! Read-only clone of galoy-charts main. The `bump-galoy-charts-
 #! tunnel-connector-image` job uses this to build the commit that gets
 #! force-pushed to the bot branch below.
@@ -609,6 +654,14 @@ resources:
     username: #@ data.values.gar_registry_user
     password: #@ data.values.gar_registry_password
     repository: #@ data.values.gar_registry + "/tunnel-connector"
+
+- name: concourse-drua-resource-edge-image
+  type: registry-image
+  source:
+    tag: edge
+    username: #@ data.values.gar_registry_user
+    password: #@ data.values.gar_registry_password
+    repository: #@ data.values.gar_registry + "/concourse-drua-resource"
 
 - name: tf-galoy-agents-prod
   type: terraform

--- a/flake.nix
+++ b/flake.nix
@@ -436,6 +436,10 @@
           tunnel-connector = self.packages.${system}.tunnel-connector;
         };
 
+        packages.concourse-drua-resource-image = import ./images/concourse-drua-resource/default.nix {
+          inherit pkgs;
+        };
+
         devShells.training = pkgs.mkShell {
           buildInputs = [ pythonEnv ];
           shellHook = ''

--- a/images/concourse-drua-resource/check.sh
+++ b/images/concourse-drua-resource/check.sh
@@ -1,0 +1,5 @@
+# No upstream version stream — drua workflows are triggered, not polled.
+# Concourse calls `check` periodically; returning a static singleton
+# version means the resource never accumulates new versions in the
+# pipeline UI.
+echo '[{"ref":"none"}]'

--- a/images/concourse-drua-resource/default.nix
+++ b/images/concourse-drua-resource/default.nix
@@ -1,0 +1,53 @@
+{ pkgs }:
+# Concourse resource for triggering drua workflow runs from a pipeline.
+# Mirrors github.com/GaloyMoney/concourse-zenduty-resource in shape:
+# - `out` POSTs to drua's `/webhooks/{definition_id}` (the receiver in
+#   server/src/webhook.rs) with a Concourse build-context payload
+# - `check` and `in` are stubs (no upstream version stream, no fetch)
+#
+# Image is published from this repo's CI as
+# `<gar>/concourse-drua-resource:edge`. Pipelines reference it via a
+# registry-image resource_type.
+let
+  runtimeInputs = with pkgs; [
+    bashInteractive
+    coreutils
+    curl
+    cacert
+    jq
+  ];
+
+  mkResourceScript = name: source: pkgs.writeShellApplication {
+    inherit name runtimeInputs;
+    text = builtins.readFile source;
+  };
+
+  checkScript = mkResourceScript "check" ./check.sh;
+  inScript = mkResourceScript "in" ./in.sh;
+  outScript = mkResourceScript "out" ./out.sh;
+
+  # Concourse invokes `/opt/resource/{check,in,out}` directly. The
+  # `writeShellApplication` derivations carry Nix-store shebangs and
+  # the runtime inputs on PATH, so we just stage them at the canonical
+  # paths.
+  resourceDir = pkgs.runCommand "concourse-drua-resource-tree" { } ''
+    mkdir -p $out/opt/resource
+    cp ${checkScript}/bin/check $out/opt/resource/check
+    cp ${inScript}/bin/in       $out/opt/resource/in
+    cp ${outScript}/bin/out     $out/opt/resource/out
+    chmod 0755 $out/opt/resource/check $out/opt/resource/in $out/opt/resource/out
+  '';
+in
+pkgs.dockerTools.buildLayeredImage {
+  name = "concourse-drua-resource";
+  tag = "latest";
+  contents = [
+    pkgs.cacert
+    resourceDir
+  ];
+  config = {
+    Env = [
+      "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+    ];
+  };
+}

--- a/images/concourse-drua-resource/in.sh
+++ b/images/concourse-drua-resource/in.sh
@@ -1,0 +1,5 @@
+# Stub: this resource has no fetchable artefact. A future v2 may poll
+# `GET /webhooks/{def}/runs/{run}` and write the run state into the
+# input dir; until then we drain stdin and return the static version.
+cat > /dev/null
+echo '{"version":{"ref":"none"}}'

--- a/images/concourse-drua-resource/out.sh
+++ b/images/concourse-drua-resource/out.sh
@@ -1,0 +1,86 @@
+PAYLOAD=$(cat)
+
+URL=$(echo "$PAYLOAD" | jq -r '.source.url // empty')
+WORKFLOW_ID=$(echo "$PAYLOAD" | jq -r '.source.workflow_id // empty')
+SECRET=$(echo "$PAYLOAD" | jq -r '.source.secret // empty')
+
+if [ -z "$URL" ] || [ -z "$WORKFLOW_ID" ] || [ -z "$SECRET" ]; then
+  echo "concourse-drua-resource: source.url, source.workflow_id and source.secret are required" >&2
+  exit 1
+fi
+
+ALERT_TYPE=$(echo "$PAYLOAD" | jq -r '.params.alert_type // "ci_failure"')
+EXTRA=$(echo "$PAYLOAD" | jq -c '.params.extra // {}')
+
+ATC_EXTERNAL_URL=${ATC_EXTERNAL_URL:-}
+BUILD_TEAM_NAME=${BUILD_TEAM_NAME:-}
+BUILD_PIPELINE_NAME=${BUILD_PIPELINE_NAME:-}
+BUILD_JOB_NAME=${BUILD_JOB_NAME:-}
+BUILD_NAME=${BUILD_NAME:-}
+
+JOB_URL="${ATC_EXTERNAL_URL%/}/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}"
+CORRELATION_ID="concourse-${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-${BUILD_NAME}"
+
+BODY=$(jq -n \
+  --arg alert_type "$ALERT_TYPE" \
+  --arg team "$BUILD_TEAM_NAME" \
+  --arg pipeline "$BUILD_PIPELINE_NAME" \
+  --arg job "$BUILD_JOB_NAME" \
+  --arg build "$BUILD_NAME" \
+  --arg url "$JOB_URL" \
+  --arg correlation_id "$CORRELATION_ID" \
+  --argjson extra "$EXTRA" \
+  '{
+    source: "concourse",
+    alert_type: $alert_type,
+    team: $team,
+    pipeline: $pipeline,
+    job: $job,
+    build: $build,
+    build_url: $url,
+    correlation_id: $correlation_id,
+    extra: $extra
+  }')
+
+RESP_FILE=$(mktemp)
+trap 'rm -f "$RESP_FILE"' EXIT
+
+# `-w '%{http_code}'` writes only the status to stdout (captured into
+# HTTP_CODE); the response body lands in $RESP_FILE. Diagnostics flow
+# to stderr below so the version JSON on stdout stays clean.
+HTTP_CODE=$(curl --silent --show-error \
+  --output "$RESP_FILE" \
+  --write-out '%{http_code}' \
+  --request POST "${URL%/}/webhooks/${WORKFLOW_ID}" \
+  --header "Authorization: Bearer ${SECRET}" \
+  --header 'Content-Type: application/json' \
+  --data "$BODY")
+
+RUN_ID=$(cat "$RESP_FILE" 2>/dev/null || true)
+if [ -z "$RUN_ID" ]; then
+  RUN_ID="unknown"
+fi
+
+echo "concourse-drua-resource: POST ${URL%/}/webhooks/${WORKFLOW_ID} -> ${HTTP_CODE} (run_id=${RUN_ID})" >&2
+
+# Loud failure when the trigger itself is broken. Concourse marks the
+# `put` step failed and the operator sees the diagnostic above.
+case "$HTTP_CODE" in
+  2*) ;;
+  *) exit 1 ;;
+esac
+
+jq -n \
+  --arg ref "$RUN_ID" \
+  --arg code "$HTTP_CODE" \
+  --arg url "$JOB_URL" \
+  --arg correlation_id "$CORRELATION_ID" \
+  '{
+    version: { ref: $ref },
+    metadata: [
+      { name: "http_code", value: $code },
+      { name: "run_id", value: $ref },
+      { name: "build_url", value: $url },
+      { name: "correlation_id", value: $correlation_id }
+    ]
+  }'

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -1,4 +1,12 @@
 //! Outside the auth middleware — authn via the trigger's stored secret.
+//!
+//! Recognised `provider` values on `WorkflowTrigger::Webhook`:
+//! - `None` / `Some("concourse")` — `Authorization: Bearer <secret>`.
+//!   The `concourse` arm is documentation-only; it tags workflows
+//!   meant to be fired by the `concourse-drua-resource` so the
+//!   dashboard and library YAML carry intent.
+//! - `Some("honeycomb")` — `X-Honeycomb-Webhook-Token: <secret>`
+//!   (Honeycomb's non-standard header, no `Bearer` prefix).
 
 use axum::{
     body::Bytes,
@@ -48,18 +56,10 @@ pub async fn handle_webhook(
         }
     };
 
-    let header_name = match provider.as_deref() {
-        Some("honeycomb") => "x-honeycomb-webhook-token",
-        _ => "authorization",
-    };
+    let header_name = header_name_for_provider(provider.as_deref());
 
     let presented = match headers.get(header_name).and_then(|v| v.to_str().ok()) {
-        Some(value) => match provider.as_deref() {
-            // Generic provider strips the `Bearer ` prefix; named
-            // providers carry the raw secret.
-            None => value.strip_prefix("Bearer ").unwrap_or(value).to_string(),
-            _ => value.to_string(),
-        },
+        Some(value) => extract_secret(value, provider.as_deref()),
         None => {
             tracing::warn!(header_name, "webhook: missing verification header");
             return StatusCode::UNAUTHORIZED.into_response();
@@ -97,5 +97,82 @@ pub async fn handle_webhook(
             tracing::error!(error = %e, "webhook: failed to trigger run");
             StatusCode::INTERNAL_SERVER_ERROR.into_response()
         }
+    }
+}
+
+fn header_name_for_provider(provider: Option<&str>) -> &'static str {
+    match provider {
+        Some("honeycomb") => "x-honeycomb-webhook-token",
+        // `concourse` is documentation-only — same wire shape as `None`.
+        Some("concourse") | None => "authorization",
+        _ => "authorization",
+    }
+}
+
+fn extract_secret(header_value: &str, provider: Option<&str>) -> String {
+    match provider {
+        Some("concourse") | None => header_value
+            .strip_prefix("Bearer ")
+            .unwrap_or(header_value)
+            .to_string(),
+        _ => header_value.to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn header_name_default_is_authorization() {
+        assert_eq!(header_name_for_provider(None), "authorization");
+    }
+
+    #[test]
+    fn header_name_honeycomb_uses_custom_header() {
+        assert_eq!(
+            header_name_for_provider(Some("honeycomb")),
+            "x-honeycomb-webhook-token"
+        );
+    }
+
+    #[test]
+    fn header_name_concourse_uses_authorization() {
+        assert_eq!(header_name_for_provider(Some("concourse")), "authorization");
+    }
+
+    #[test]
+    fn header_name_unknown_provider_falls_back_to_authorization() {
+        assert_eq!(
+            header_name_for_provider(Some("not-a-known-provider")),
+            "authorization"
+        );
+    }
+
+    #[test]
+    fn extract_secret_strips_bearer_for_default_provider() {
+        assert_eq!(extract_secret("Bearer whsec_abc", None), "whsec_abc");
+    }
+
+    #[test]
+    fn extract_secret_strips_bearer_for_concourse() {
+        assert_eq!(
+            extract_secret("Bearer whsec_abc", Some("concourse")),
+            "whsec_abc"
+        );
+    }
+
+    #[test]
+    fn extract_secret_passes_raw_for_honeycomb() {
+        assert_eq!(
+            extract_secret("whsec_abc", Some("honeycomb")),
+            "whsec_abc"
+        );
+    }
+
+    #[test]
+    fn extract_secret_returns_value_unchanged_when_no_bearer_prefix() {
+        assert_eq!(extract_secret("whsec_abc", None), "whsec_abc");
+        assert_eq!(extract_secret("whsec_abc", Some("concourse")), "whsec_abc");
     }
 }


### PR DESCRIPTION
## Summary

- Adds a Concourse `resource_type` (built and published from this repo as `<gar>/concourse-drua-resource:edge`) for triggering drua workflow runs from any pipeline's `on_failure:` step. Mirrors the shape of `GaloyMoney/concourse-zenduty-resource`: `out` POSTs to drua's existing `/webhooks/{id}` receiver; `check` and `in` are stubs.
- Wires a `build-concourse-drua-resource-image` job into `ci/pipeline.yml`, paths-filtered to `images/concourse-drua-resource/` + `flake.nix` (matching the existing `build-sandbox-image` / `build-tunnel-connector-image` pattern).
- Recognises `provider: concourse` on `WorkflowTrigger::Webhook` as a documentation-only twin of the default arm (same `Authorization: Bearer <secret>` wire format) so workflow YAML and the dashboard can tag triggers meant to be fired by this resource.
- Extracts `header_name_for_provider` and `extract_secret` from `handle_webhook` as pure helpers and adds 8 unit tests covering all (provider, header) combinations.

## Why in this repo, not a sibling

Keeps the `out` script's wire format coupled to `server/src/webhook.rs` — schema or auth changes are one PR, not two. No new public repo, no new cachix wiring, no new `repipe`. Image is still independently consumable from any pipeline via its registry-image URL.

## Out of scope (deferred to follow-ups)

- A drua-side workflow YAML with `trigger: { type: webhook, provider: concourse }` for the first consumer pipeline.
- `GET /webhooks/{def_id}/runs/{run_id}` JSON endpoint to make `in:` a real polling step (v2).
- Wiring this into `ci/pipeline.yml`'s own `on_failure:` blocks (needs a real workflow_id + vault secret first).
- Idempotency-by-correlation_id on `Workflows::trigger_run_for_definition`.

Background and the full proposal are in clat memory `019df2db` (research report) and `019df2fd` (decisions).

## Test plan

- [x] `cargo check -p drua-server`
- [x] `cargo nextest run -p drua-server --lib webhook` → 8/8 pass
- [x] `cargo clippy -p drua-server --all-targets -- -D warnings` clean
- [x] `nix build .#concourse-drua-resource-image` succeeds (shellcheck runs at build time and passes for all three scripts)
- [x] Layer inspection of the resulting image confirms `/opt/resource/{check,in,out}` present with Nix-store bash shebangs
- [x] `nix flake show` lists the new output across all four systems
- [ ] First successful `build-concourse-drua-resource-image` run in Concourse after merge
- [ ] Smoke test: a real Concourse `put: drua-on-…-failure` against a test workflow yields `200 <run_id>` and a spawned `WorkflowRun`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new Concourse resource image and CI publishing flow, and tweaks webhook auth header parsing via refactored helpers; misconfiguration could break webhook triggering for existing providers.
> 
> **Overview**
> Adds a new `concourse-drua-resource` OCI image (with Concourse `/opt/resource/{check,in,out}` scripts) that triggers drua workflow runs by POSTing build context to `/webhooks/{definition_id}`.
> 
> Wires this image into `ci/pipeline.yml` with a new paths-filtered build-and-push job and registry resource, and exposes it as `.#concourse-drua-resource-image` in `flake.nix`.
> 
> Updates `server/src/webhook.rs` to explicitly recognize `provider: concourse` (same `Authorization: Bearer ...` behavior as the default), factoring header selection/secret extraction into helpers and adding unit tests for provider/header combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1fd1e76e847917f2cb8a5d3d13cf6eecf613e6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->