### PR TITLE
feat(commits): rich attribution for library/repo writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1469,6 +1469,7 @@ dependencies = [
  "job",
  "pgvector",
  "serde",
+ "serde_json",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",

--- a/core/crates/library/Cargo.toml
+++ b/core/crates/library/Cargo.toml
@@ -23,3 +23,4 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 
 [dev-dependencies]
 tokio = { workspace = true }
+serde_json = { workspace = true }

--- a/core/crates/library/src/attribution.rs
+++ b/core/crates/library/src/attribution.rs
@@ -1,0 +1,301 @@
+//! Commit attribution attached to every library/repo write.
+//!
+//! Plain serializable data so it survives the persisted-job round trip
+//! (see [`crate::WriteOp`]). Rendered into a `git2::Signature` and a
+//! trailer block by [`crate::git::GitEngine::commit_one`].
+//!
+//! Constructors live both here (library defaults: [`Self::library_default`],
+//! [`Self::system`]) and in `drua-core::audit::Audit::commit_attribution`,
+//! which builds a richer value from the request's `AuditContextData` plus a
+//! JIT user lookup for the `Co-Authored-By:` line.
+
+use es_entity::context::EventContext;
+use serde::{Deserialize, Serialize};
+
+const ATTRIBUTION_CONTEXT_KEY: &str = "commit_attribution";
+
+/// Domain used for synthetic agent / bot identities. Real humans appear
+/// in `Co-Authored-By:` via `<github_id>+<username>@users.noreply.github.com`.
+pub const AGENT_DOMAIN: &str = "agent.galoy.io";
+
+pub const LIBRARY_BOT_NAME: &str = "drua-library[bot]";
+pub const LIBRARY_BOT_EMAIL: &str = "library@agent.galoy.io";
+pub const SYSTEM_BOT_NAME: &str = "drua-system[bot]";
+pub const SYSTEM_BOT_EMAIL: &str = "system@agent.galoy.io";
+pub const ADMIN_BOT_NAME: &str = "drua-admin[bot]";
+pub const ADMIN_BOT_EMAIL: &str = "admin@agent.galoy.io";
+pub const AGENT_BOT_NAME: &str = "drua-agent[bot]";
+pub const AGENT_BOT_EMAIL: &str = "agent@agent.galoy.io";
+pub const WORKFLOW_BOT_NAME: &str = "drua-workflow[bot]";
+pub const WORKFLOW_BOT_EMAIL: &str = "workflow@agent.galoy.io";
+
+/// Stable subject-type tag rendered into the `Drua-Subject-Type:` trailer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CommitSubjectKind {
+    /// Importer canonical rewrites and other unattributed system writes.
+    System,
+    /// Library default — used as the fallback when no attribution was
+    /// captured at the call site (e.g. tests, internal tooling).
+    Library,
+    /// Direct user mutation (e.g. admin via MCP).
+    User,
+    /// Bearer-token-driven mutation by a credential issued to a user.
+    ExportedAgent,
+    /// Autonomous agent (cron / webhook / manual workflow run).
+    WorkflowAgent,
+    /// Agent acting on behalf of a human user (chat session).
+    AgentOnBehalfOfUser,
+}
+
+impl CommitSubjectKind {
+    pub fn as_trailer_value(self) -> &'static str {
+        match self {
+            Self::System => "system",
+            Self::Library => "library",
+            Self::User => "user",
+            Self::ExportedAgent => "exported_agent",
+            Self::WorkflowAgent => "workflow_agent",
+            Self::AgentOnBehalfOfUser => "agent_on_behalf_of_user",
+        }
+    }
+}
+
+/// Plain serializable attribution data attached to every library commit.
+///
+/// `trailers` are rendered alphabetically after any `Co-Authored-By:`
+/// lines, separated from the user-provided commit message by a blank
+/// line so trailers form a valid Git trailer block.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CommitAttribution {
+    pub author_name: String,
+    pub author_email: String,
+    pub committer_name: String,
+    pub committer_email: String,
+    pub kind: CommitSubjectKind,
+    #[serde(default)]
+    pub trailers: Vec<(String, String)>,
+    /// `(display_name, email)` rendered as `Co-Authored-By:` lines.
+    #[serde(default)]
+    pub co_authored_by: Vec<(String, String)>,
+}
+
+impl Default for CommitAttribution {
+    fn default() -> Self {
+        Self::library_default()
+    }
+}
+
+impl CommitAttribution {
+    /// Pre-MVP fallback signature; matches `drua-library@local`.
+    /// Used when no audit context is available (tests, bare library
+    /// crate consumers, post_persist_hook with no captured context).
+    pub fn library_default() -> Self {
+        Self {
+            author_name: LIBRARY_BOT_NAME.to_owned(),
+            author_email: LIBRARY_BOT_EMAIL.to_owned(),
+            committer_name: LIBRARY_BOT_NAME.to_owned(),
+            committer_email: LIBRARY_BOT_EMAIL.to_owned(),
+            kind: CommitSubjectKind::Library,
+            trailers: vec![("Drua-Subject-Type".to_owned(), "library".to_owned())],
+            co_authored_by: Vec::new(),
+        }
+    }
+
+    /// Importer canonical-rewrite path and other unattributed system writes.
+    pub fn system() -> Self {
+        Self {
+            author_name: SYSTEM_BOT_NAME.to_owned(),
+            author_email: SYSTEM_BOT_EMAIL.to_owned(),
+            committer_name: SYSTEM_BOT_NAME.to_owned(),
+            committer_email: SYSTEM_BOT_EMAIL.to_owned(),
+            kind: CommitSubjectKind::System,
+            trailers: vec![("Drua-Subject-Type".to_owned(), "system".to_owned())],
+            co_authored_by: Vec::new(),
+        }
+    }
+
+    /// Append a `Drua-*` trailer (de-duplicates by exact key+value match).
+    pub fn add_trailer(&mut self, key: impl Into<String>, value: impl Into<String>) {
+        let entry = (key.into(), value.into());
+        if !self.trailers.contains(&entry) {
+            self.trailers.push(entry);
+        }
+    }
+
+    pub fn add_co_authored_by(&mut self, name: impl Into<String>, email: impl Into<String>) {
+        let entry = (name.into(), email.into());
+        if !self.co_authored_by.contains(&entry) {
+            self.co_authored_by.push(entry);
+        }
+    }
+
+    /// Render the trailer block appended after the commit message body.
+    /// Returns the empty string if there are no trailers or co-authors,
+    /// otherwise a leading blank-line + key/value lines suitable for
+    /// `git interpret-trailers --parse`.
+    pub fn render_message_suffix(&self) -> String {
+        if self.trailers.is_empty() && self.co_authored_by.is_empty() {
+            return String::new();
+        }
+
+        let mut out = String::from("\n\n");
+
+        for (name, email) in &self.co_authored_by {
+            out.push_str("Co-Authored-By: ");
+            out.push_str(name);
+            out.push_str(" <");
+            out.push_str(email);
+            out.push_str(">\n");
+        }
+
+        let mut sorted = self.trailers.clone();
+        sorted.sort_by(|a, b| a.0.cmp(&b.0));
+        for (key, value) in &sorted {
+            out.push_str(key);
+            out.push_str(": ");
+            out.push_str(value);
+            out.push('\n');
+        }
+
+        out.truncate(out.trim_end_matches('\n').len());
+        out
+    }
+
+    /// Read the most-recently-stored value from the request's
+    /// [`EventContext`]. Falls back to [`Self::library_default`] when
+    /// no caller has populated it (tests, importer paths, etc.).
+    pub fn from_event_context() -> Self {
+        let ec = EventContext::current();
+        ec.data()
+            .lookup::<Self>(ATTRIBUTION_CONTEXT_KEY)
+            .ok()
+            .flatten()
+            .unwrap_or_else(Self::library_default)
+    }
+
+    /// Stash this value in the request's [`EventContext`] so downstream
+    /// post-persist hooks (e.g. `LibrarySynced` for Notes / Skills /
+    /// Workflows) can pick it up without a `&Users` resolver in scope.
+    pub fn put_in_event_context(&self) {
+        let mut ec = EventContext::current();
+        let _ = ec.insert(ATTRIBUTION_CONTEXT_KEY, self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn library_default_has_minimal_subject_type() {
+        let a = CommitAttribution::library_default();
+        assert_eq!(a.kind, CommitSubjectKind::Library);
+        assert_eq!(
+            a.trailers,
+            vec![("Drua-Subject-Type".to_owned(), "library".to_owned())]
+        );
+        assert!(a.co_authored_by.is_empty());
+    }
+
+    #[test]
+    fn system_uses_dedicated_bot_identity() {
+        let a = CommitAttribution::system();
+        assert_eq!(a.author_name, SYSTEM_BOT_NAME);
+        assert_eq!(a.author_email, SYSTEM_BOT_EMAIL);
+        assert_eq!(a.committer_name, SYSTEM_BOT_NAME);
+        assert_eq!(a.committer_email, SYSTEM_BOT_EMAIL);
+        assert_eq!(a.kind, CommitSubjectKind::System);
+    }
+
+    #[test]
+    fn render_suffix_is_empty_when_no_trailers_or_co_authors() {
+        let mut a = CommitAttribution::library_default();
+        a.trailers.clear();
+        assert_eq!(a.render_message_suffix(), "");
+    }
+
+    #[test]
+    fn render_suffix_orders_co_authors_first_then_alpha_trailers() {
+        let mut a = CommitAttribution::system();
+        a.trailers.clear();
+        a.add_trailer("Drua-Workflow-Run", "019df3a1");
+        a.add_trailer("Drua-Subject-Type", "workflow_agent");
+        a.add_trailer("Drua-Action", "space.write_file");
+        a.add_co_authored_by("Alice", "12345+alice@users.noreply.github.com");
+
+        let suffix = a.render_message_suffix();
+        let expected = "\n\nCo-Authored-By: Alice <12345+alice@users.noreply.github.com>\n\
+                       Drua-Action: space.write_file\n\
+                       Drua-Subject-Type: workflow_agent\n\
+                       Drua-Workflow-Run: 019df3a1";
+        assert_eq!(suffix, expected);
+    }
+
+    #[test]
+    fn add_trailer_dedupes_exact_matches() {
+        let mut a = CommitAttribution::system();
+        a.trailers.clear();
+        a.add_trailer("Drua-Action", "space.write_file");
+        a.add_trailer("Drua-Action", "space.write_file");
+        a.add_trailer("Drua-Action", "space.delete_file");
+        assert_eq!(a.trailers.len(), 2);
+    }
+
+    #[test]
+    fn add_co_authored_by_dedupes_exact_matches() {
+        let mut a = CommitAttribution::system();
+        a.add_co_authored_by("Alice", "alice@example.com");
+        a.add_co_authored_by("Alice", "alice@example.com");
+        assert_eq!(a.co_authored_by.len(), 1);
+    }
+
+    #[test]
+    fn render_human_on_behalf_of_workflow() {
+        let mut a = CommitAttribution {
+            author_name: "Alice (via drua)".to_owned(),
+            author_email: "12345+alice@users.noreply.github.com".to_owned(),
+            committer_name: AGENT_BOT_NAME.to_owned(),
+            committer_email: AGENT_BOT_EMAIL.to_owned(),
+            kind: CommitSubjectKind::AgentOnBehalfOfUser,
+            trailers: Vec::new(),
+            co_authored_by: Vec::new(),
+        };
+        a.add_trailer("Drua-Subject-Type", "agent_on_behalf_of_user");
+        a.add_trailer("Drua-Acting-User", "5f1c8b3a");
+        a.add_trailer("Drua-Project", "a1b2c3d4");
+        a.add_trailer("Drua-Agent", "019df3aa");
+        a.add_co_authored_by("Alice", "12345+alice@users.noreply.github.com");
+
+        let suffix = a.render_message_suffix();
+        assert!(
+            suffix.starts_with("\n\nCo-Authored-By: Alice <12345+alice@users.noreply.github.com>")
+        );
+        assert!(suffix.contains("Drua-Acting-User: 5f1c8b3a"));
+        assert!(suffix.contains("Drua-Subject-Type: agent_on_behalf_of_user"));
+        let acting_pos = suffix.find("Drua-Acting-User").unwrap();
+        let agent_pos = suffix.find("Drua-Agent").unwrap();
+        let project_pos = suffix.find("Drua-Project").unwrap();
+        let subject_pos = suffix.find("Drua-Subject-Type").unwrap();
+        assert!(acting_pos < agent_pos);
+        assert!(agent_pos < project_pos);
+        assert!(project_pos < subject_pos);
+    }
+
+    #[test]
+    fn subject_kind_serializes_snake_case() {
+        let json = serde_json::to_string(&CommitSubjectKind::AgentOnBehalfOfUser).unwrap();
+        assert_eq!(json, "\"agent_on_behalf_of_user\"");
+    }
+
+    #[test]
+    fn round_trip_serde() {
+        let mut a = CommitAttribution::system();
+        a.add_trailer("Drua-Action", "space.write_file");
+        a.add_co_authored_by("Bob", "67890+bob@users.noreply.github.com");
+
+        let json = serde_json::to_string(&a).unwrap();
+        let back: CommitAttribution = serde_json::from_str(&json).unwrap();
+        assert_eq!(a, back);
+    }
+}

--- a/core/crates/library/src/git.rs
+++ b/core/crates/library/src/git.rs
@@ -5,6 +5,7 @@ use std::time::{Duration, Instant};
 use tokio::sync::{mpsc, oneshot, Mutex};
 use tokio::task::JoinHandle;
 
+use crate::attribution::CommitAttribution;
 use crate::importer::GitFileHash;
 use crate::{GitHubAppTokenProvider, LibraryError};
 
@@ -87,6 +88,7 @@ pub enum BatchOpKind {
 pub struct BatchOp {
     pub commit_message: String,
     pub kind: BatchOpKind,
+    pub attribution: CommitAttribution,
 }
 
 struct QueuedOp {
@@ -398,10 +400,12 @@ impl GitEngine {
         path: String,
         content: Vec<u8>,
         commit_message: String,
+        attribution: CommitAttribution,
     ) -> Result<(), LibraryError> {
         self.enqueue(BatchOp {
             commit_message,
             kind: BatchOpKind::Write { path, content },
+            attribution,
         })
         .await
     }
@@ -412,10 +416,12 @@ impl GitEngine {
         &self,
         path: String,
         commit_message: String,
+        attribution: CommitAttribution,
     ) -> Result<(), LibraryError> {
         self.enqueue(BatchOp {
             commit_message,
             kind: BatchOpKind::Delete { path },
+            attribution,
         })
         .await
     }
@@ -429,10 +435,12 @@ impl GitEngine {
         path: String,
         update: BatchRmwFn,
         commit_message: String,
+        attribution: CommitAttribution,
     ) -> Result<(), LibraryError> {
         self.enqueue(BatchOp {
             commit_message,
             kind: BatchOpKind::Rmw { path, update },
+            attribution,
         })
         .await
     }
@@ -445,10 +453,12 @@ impl GitEngine {
         from: String,
         to: String,
         commit_message: String,
+        attribution: CommitAttribution,
     ) -> Result<(), LibraryError> {
         self.enqueue(BatchOp {
             commit_message,
             kind: BatchOpKind::Move { from, to },
+            attribution,
         })
         .await
     }
@@ -463,6 +473,7 @@ impl GitEngine {
         to_path: String,
         content: Vec<u8>,
         commit_message: String,
+        attribution: CommitAttribution,
     ) -> Result<(), LibraryError> {
         self.enqueue(BatchOp {
             commit_message,
@@ -471,6 +482,7 @@ impl GitEngine {
                 to_path,
                 content,
             },
+            attribution,
         })
         .await
     }
@@ -482,10 +494,12 @@ impl GitEngine {
         &self,
         dir_path: String,
         commit_message: String,
+        attribution: CommitAttribution,
     ) -> Result<(), LibraryError> {
         self.enqueue(BatchOp {
             commit_message,
             kind: BatchOpKind::DeleteDir { path: dir_path },
+            attribution,
         })
         .await
     }
@@ -498,6 +512,7 @@ impl GitEngine {
         &self,
         changes: Vec<(String, Option<Vec<u8>>)>,
         commit_message: String,
+        attribution: CommitAttribution,
     ) -> Result<(), LibraryError> {
         if changes.is_empty() {
             return Ok(());
@@ -505,6 +520,7 @@ impl GitEngine {
         self.enqueue(BatchOp {
             commit_message,
             kind: BatchOpKind::MultiFile { changes },
+            attribution,
         })
         .await
     }
@@ -779,14 +795,22 @@ impl GitEngine {
         let new_tree = repo
             .find_tree(new_tree_oid)
             .map_err(|e| LibraryError::Git(format!("find tree: {e}")))?;
-        let sig = git2::Signature::now("drua-library", "drua-library@local")
-            .map_err(|e| LibraryError::Git(format!("signature: {e}")))?;
+        let author =
+            git2::Signature::now(&op.attribution.author_name, &op.attribution.author_email)
+                .map_err(|e| LibraryError::Git(format!("author signature: {e}")))?;
+        let committer = git2::Signature::now(
+            &op.attribution.committer_name,
+            &op.attribution.committer_email,
+        )
+        .map_err(|e| LibraryError::Git(format!("committer signature: {e}")))?;
+        let mut message = op.commit_message.clone();
+        message.push_str(&op.attribution.render_message_suffix());
         let commit_oid = repo
             .commit(
                 Some("HEAD"),
-                &sig,
-                &sig,
-                &op.commit_message,
+                &author,
+                &committer,
+                &message,
                 &new_tree,
                 &[&parent_commit],
             )

--- a/core/crates/library/src/job/write.rs
+++ b/core/crates/library/src/job/write.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use job::{CurrentJob, Job, JobCompletion, JobInitializer, JobRunner, JobSpawner, JobType};
 use serde::{Deserialize, Serialize};
 
+use crate::attribution::CommitAttribution;
 use crate::git::GitEngine;
 
 pub(crate) const LIBRARY_WRITE_JOB: &str = "library.write";
@@ -48,6 +49,11 @@ pub enum WriteOp {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct LibraryWriteConfig {
     pub op: WriteOp,
+    /// Captured at enqueue time so the rendered author/committer/trailer
+    /// block reflects the originating request even after the persisted
+    /// job is replayed across a process restart.
+    #[serde(default)]
+    pub attribution: CommitAttribution,
 }
 
 pub(crate) struct LibraryWriteJobInitializer {
@@ -76,6 +82,7 @@ impl JobInitializer for LibraryWriteJobInitializer {
         Ok(Box::new(LibraryWriteRunner {
             git: Arc::clone(&self.git),
             op: config.op,
+            attribution: config.attribution,
         }))
     }
 }
@@ -83,6 +90,7 @@ impl JobInitializer for LibraryWriteJobInitializer {
 struct LibraryWriteRunner {
     git: Arc<GitEngine>,
     op: WriteOp,
+    attribution: CommitAttribution,
 }
 
 #[async_trait::async_trait]
@@ -92,6 +100,7 @@ impl JobRunner for LibraryWriteRunner {
         &self,
         _current_job: CurrentJob,
     ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        let attribution = self.attribution.clone();
         match &self.op {
             WriteOp::WriteFile {
                 path,
@@ -99,7 +108,7 @@ impl JobRunner for LibraryWriteRunner {
                 message,
             } => {
                 self.git
-                    .write_file(path.clone(), content.clone(), message.clone())
+                    .write_file(path.clone(), content.clone(), message.clone(), attribution)
                     .await?;
             }
             WriteOp::WriteFileWithRename {
@@ -114,23 +123,28 @@ impl JobRunner for LibraryWriteRunner {
                         new_path.clone(),
                         content.clone(),
                         message.clone(),
+                        attribution,
                     )
                     .await?;
             }
             WriteOp::DeleteFile { path, message } => {
-                self.git.delete_file(path.clone(), message.clone()).await?;
+                self.git
+                    .delete_file(path.clone(), message.clone(), attribution)
+                    .await?;
             }
             WriteOp::DeleteDir { path, message } => {
-                self.git.delete_dir(path.clone(), message.clone()).await?;
+                self.git
+                    .delete_dir(path.clone(), message.clone(), attribution)
+                    .await?;
             }
             WriteOp::Batch { changes, message } => {
                 self.git
-                    .commit_changes(changes.clone(), message.clone())
+                    .commit_changes(changes.clone(), message.clone(), attribution)
                     .await?;
             }
             WriteOp::Move { from, to, message } => {
                 self.git
-                    .move_file(from.clone(), to.clone(), message.clone())
+                    .move_file(from.clone(), to.clone(), message.clone(), attribution)
                     .await?;
             }
         }

--- a/core/crates/library/src/lib.rs
+++ b/core/crates/library/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod attribution;
 mod config;
 mod error;
 mod git;
@@ -14,6 +15,7 @@ use std::time::Duration;
 
 use tokio::sync::mpsc;
 
+pub use attribution::{CommitAttribution, CommitSubjectKind};
 pub use config::LibraryConfig;
 pub use error::LibraryError;
 pub use github_app::GitHubAppTokenProvider;
@@ -194,6 +196,10 @@ impl Library {
     /// this: projects the entity into a write op and registers the
     /// commit hook when at least one persisted event was a content
     /// event.
+    ///
+    /// Reads the [`CommitAttribution`] from the request's `EventContext`
+    /// (populated by `drua_core::audit::Audit::commit_attribution`);
+    /// falls back to the library default when nothing was captured.
     #[tracing::instrument(name = "library.sync_entity_in_op", skip_all)]
     pub async fn sync_entity_in_op<E, OP>(
         &self,
@@ -214,6 +220,7 @@ impl Library {
                 fields: Some(entity.searchable_fields()),
                 deletes: entity.extra_search_deletes(),
                 write_op: Some(entity.write_op()),
+                attribution: CommitAttribution::from_event_context(),
             },
         )
         .await
@@ -227,6 +234,7 @@ impl Library {
         &self,
         op: &mut impl es_entity::AtomicOperation,
         write_op: WriteOp,
+        attribution: CommitAttribution,
     ) -> Result<(), LibraryError> {
         self.enqueue_in_op(
             op,
@@ -234,6 +242,7 @@ impl Library {
                 fields: None,
                 deletes: Vec::new(),
                 write_op: Some(write_op),
+                attribution,
             },
         )
         .await
@@ -249,6 +258,7 @@ impl Library {
         fields: Option<SearchableFields>,
         deletes: Vec<(uuid::Uuid, DocType)>,
         write_op: Option<WriteOp>,
+        attribution: CommitAttribution,
     ) -> Result<(), LibraryError> {
         if fields.is_none() && deletes.is_empty() && write_op.is_none() {
             return Ok(());
@@ -259,6 +269,7 @@ impl Library {
                 fields,
                 deletes,
                 write_op,
+                attribution,
             },
         )
         .await
@@ -274,6 +285,7 @@ impl Library {
         scope_id: uuid::Uuid,
         dir_path: String,
         commit_message: String,
+        attribution: CommitAttribution,
     ) -> Result<(), LibraryError> {
         self.search.delete_for_scope_in_op(op, scope_id).await?;
         self.enqueue_write_in_op(
@@ -282,6 +294,7 @@ impl Library {
                 path: dir_path,
                 message: commit_message,
             },
+            attribution,
         )
         .await
     }

--- a/core/crates/library/src/space/mod.rs
+++ b/core/crates/library/src/space/mod.rs
@@ -8,6 +8,7 @@ pub use entity::{NewSpace, Space, SpaceEvent};
 pub use error::*;
 
 use self::repo::SpaceRepo;
+use crate::attribution::CommitAttribution;
 use crate::git::GitEngine;
 use crate::importer::{DocType, GitFileHash, LibraryImporter, UpsertError};
 use crate::SearchableFields;
@@ -38,9 +39,12 @@ impl Spaces {
         &self,
         slug: String,
         description: Option<String>,
+        attribution: CommitAttribution,
     ) -> Result<Space, SpaceError> {
         let mut op = self.repo.begin_op().await?;
-        let space = self.create_in_op(&mut op, slug, description).await?;
+        let space = self
+            .create_in_op(&mut op, slug, description, attribution)
+            .await?;
         op.commit().await?;
         Ok(space)
     }
@@ -51,6 +55,7 @@ impl Spaces {
         op: &mut es_entity::DbOp<'_>,
         slug: String,
         description: Option<String>,
+        attribution: CommitAttribution,
     ) -> Result<Space, SpaceError> {
         let mut builder = NewSpace::builder().slug(slug);
         if let Some(desc) = description {
@@ -64,6 +69,7 @@ impl Spaces {
                 format!("spaces/{}/.gitkeep", space.slug),
                 Vec::new(),
                 format!("space: init {}", space.slug),
+                attribution,
             )
             .await
             .map_err(|e| SpaceError::Git(e.to_string()))?;
@@ -78,6 +84,7 @@ impl Spaces {
         slug: &str,
         relative_path: &str,
         content: String,
+        attribution: CommitAttribution,
     ) -> Result<(), SpaceError> {
         let path = format!("spaces/{slug}/{relative_path}");
         self.git
@@ -85,6 +92,7 @@ impl Spaces {
                 path,
                 content.into_bytes(),
                 format!("space:{slug}: write {relative_path}"),
+                attribution,
             )
             .await
             .map_err(|e| SpaceError::Git(e.to_string()))
@@ -92,10 +100,19 @@ impl Spaces {
 
     /// Removes `spaces/{slug}/{relative_path}`. No-op if absent at HEAD.
     #[tracing::instrument(name = "library.spaces.delete_file", skip_all, fields(%slug, %relative_path))]
-    pub async fn delete_file(&self, slug: &str, relative_path: &str) -> Result<(), SpaceError> {
+    pub async fn delete_file(
+        &self,
+        slug: &str,
+        relative_path: &str,
+        attribution: CommitAttribution,
+    ) -> Result<(), SpaceError> {
         let path = format!("spaces/{slug}/{relative_path}");
         self.git
-            .delete_file(path, format!("space:{slug}: delete {relative_path}"))
+            .delete_file(
+                path,
+                format!("space:{slug}: delete {relative_path}"),
+                attribution,
+            )
             .await
             .map_err(|e| SpaceError::Git(e.to_string()))
     }
@@ -109,6 +126,7 @@ impl Spaces {
         relative_path: &str,
         old_str: String,
         new_str: String,
+        attribution: CommitAttribution,
     ) -> Result<(), SpaceError> {
         let path = format!("spaces/{slug}/{relative_path}");
         let path_for_err = path.clone();
@@ -139,7 +157,12 @@ impl Spaces {
             ))
         });
         self.git
-            .update_file(path, update, format!("space:{slug}: edit {relative_path}"))
+            .update_file(
+                path,
+                update,
+                format!("space:{slug}: edit {relative_path}"),
+                attribution,
+            )
             .await
             .map_err(|e| match e {
                 crate::LibraryError::Validation(msg) => SpaceError::Validation(msg),
@@ -156,6 +179,7 @@ impl Spaces {
         relative_path: &str,
         line_number: usize,
         text: String,
+        attribution: CommitAttribution,
     ) -> Result<(), SpaceError> {
         let path = format!("spaces/{slug}/{relative_path}");
         let path_for_err = path.clone();
@@ -186,6 +210,7 @@ impl Spaces {
                 path,
                 update,
                 format!("space:{slug}: insert {relative_path}"),
+                attribution,
             )
             .await
             .map_err(|e| match e {
@@ -302,7 +327,13 @@ impl Spaces {
     /// Renames `spaces/{slug}/{from}` → `spaces/{slug}/{to}`. Errors if
     /// `from` is missing or `to` already exists.
     #[tracing::instrument(name = "library.spaces.move_file", skip_all, fields(%slug, %from, %to))]
-    pub async fn move_file(&self, slug: &str, from: &str, to: &str) -> Result<(), SpaceError> {
+    pub async fn move_file(
+        &self,
+        slug: &str,
+        from: &str,
+        to: &str,
+        attribution: CommitAttribution,
+    ) -> Result<(), SpaceError> {
         let from_path = format!("spaces/{slug}/{from}");
         let to_path = format!("spaces/{slug}/{to}");
         self.git
@@ -310,6 +341,7 @@ impl Spaces {
                 from_path,
                 to_path,
                 format!("space:{slug}: move {from} -> {to}"),
+                attribution,
             )
             .await
             .map_err(|e| match e {

--- a/core/crates/library/src/synced.rs
+++ b/core/crates/library/src/synced.rs
@@ -1,6 +1,7 @@
 use es_entity::operation::hooks::{CommitHook, HookOperation, PreCommitRet};
 use job::{JobId, JobSpawner};
 
+use crate::attribution::CommitAttribution;
 use crate::importer::DocType;
 use crate::job::{LibraryEmbedConfig, LibraryWriteConfig, WriteOp};
 use crate::search::{SearchStore, SearchableFields};
@@ -40,6 +41,7 @@ pub(crate) struct HookEntry {
     pub fields: Option<SearchableFields>,
     pub deletes: Vec<(uuid::Uuid, DocType)>,
     pub write_op: Option<WriteOp>,
+    pub attribution: CommitAttribution,
 }
 
 /// Batches per-transaction library writes. On the per-transaction
@@ -108,6 +110,7 @@ impl CommitHook for LibrarySyncHook {
             if let Some(write_op) = &entry.write_op {
                 let config = LibraryWriteConfig {
                     op: write_op.clone(),
+                    attribution: entry.attribution.clone(),
                 };
                 if let Err(e) = self
                     .write_spawner

--- a/core/crates/library/tests/space_writes.rs
+++ b/core/crates/library/tests/space_writes.rs
@@ -4,7 +4,11 @@ use std::path::Path;
 use std::sync::Arc;
 
 use common::{library_data_dir, reset_library_db_state, TestRepo};
-use drua_library::{Library, LibraryConfig, SpaceError};
+use drua_library::{CommitAttribution, Library, LibraryConfig, SpaceError};
+
+fn attr() -> CommitAttribution {
+    CommitAttribution::library_default()
+}
 
 const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
 const FETCH_INTERVAL_MS: u64 = 100;
@@ -21,6 +25,24 @@ fn read_blob(repo_path: &Path, path: &str) -> Option<Vec<u8>> {
     let entry = tree.get_path(std::path::Path::new(path)).ok()?;
     let blob = repo.find_blob(entry.id()).ok()?;
     Some(blob.content().to_vec())
+}
+
+/// Borrow-free snapshot of a commit's author/committer + message.
+fn head_commit_meta(repo_path: &Path) -> (String, String, String, String, String) {
+    let repo = git2::Repository::open(repo_path).expect("open upstream");
+    let commit = repo
+        .head()
+        .and_then(|h| h.peel_to_commit())
+        .expect("peel head");
+    let author = commit.author();
+    let committer = commit.committer();
+    (
+        author.name().unwrap_or("").to_owned(),
+        author.email().unwrap_or("").to_owned(),
+        committer.name().unwrap_or("").to_owned(),
+        committer.email().unwrap_or("").to_owned(),
+        commit.message().unwrap_or("").to_owned(),
+    )
 }
 
 fn path_exists(repo_path: &Path, path: &str) -> bool {
@@ -67,12 +89,12 @@ async fn write_then_str_replace_happy_path() {
     let slug = "writers";
     library
         .spaces()
-        .create(slug.into(), None)
+        .create(slug.into(), None, attr())
         .await
         .expect("create space");
     library
         .spaces()
-        .write_file(slug, "doc.md", "alpha bravo charlie\n".into())
+        .write_file(slug, "doc.md", "alpha bravo charlie\n".into(), attr())
         .await
         .expect("write");
 
@@ -83,7 +105,7 @@ async fn write_then_str_replace_happy_path() {
 
     library
         .spaces()
-        .str_replace(slug, "doc.md", "bravo".into(), "BRAVO".into())
+        .str_replace(slug, "doc.md", "bravo".into(), "BRAVO".into(), attr())
         .await
         .expect("str_replace");
 
@@ -100,18 +122,18 @@ async fn str_replace_errors_when_old_str_absent_or_ambiguous() {
     let slug = "errors";
     library
         .spaces()
-        .create(slug.into(), None)
+        .create(slug.into(), None, attr())
         .await
         .expect("create space");
     library
         .spaces()
-        .write_file(slug, "doc.md", "alpha bravo bravo\n".into())
+        .write_file(slug, "doc.md", "alpha bravo bravo\n".into(), attr())
         .await
         .expect("write");
 
     let absent = library
         .spaces()
-        .str_replace(slug, "doc.md", "zulu".into(), "ZULU".into())
+        .str_replace(slug, "doc.md", "zulu".into(), "ZULU".into(), attr())
         .await;
     assert!(
         matches!(absent, Err(SpaceError::Validation(_))),
@@ -120,7 +142,7 @@ async fn str_replace_errors_when_old_str_absent_or_ambiguous() {
 
     let ambiguous = library
         .spaces()
-        .str_replace(slug, "doc.md", "bravo".into(), "BRAVO".into())
+        .str_replace(slug, "doc.md", "bravo".into(), "BRAVO".into(), attr())
         .await;
     assert!(
         matches!(ambiguous, Err(SpaceError::Validation(_))),
@@ -135,18 +157,18 @@ async fn move_then_delete() {
     let slug = "moves";
     library
         .spaces()
-        .create(slug.into(), None)
+        .create(slug.into(), None, attr())
         .await
         .expect("create space");
     library
         .spaces()
-        .write_file(slug, "old.md", "content\n".into())
+        .write_file(slug, "old.md", "content\n".into(), attr())
         .await
         .expect("write");
 
     library
         .spaces()
-        .move_file(slug, "old.md", "new.md")
+        .move_file(slug, "old.md", "new.md", attr())
         .await
         .expect("move");
     assert!(!path_exists(
@@ -158,12 +180,15 @@ async fn move_then_delete() {
         Some(&b"content\n"[..]),
     );
 
-    let dup = library.spaces().move_file(slug, "new.md", "new.md").await;
+    let dup = library
+        .spaces()
+        .move_file(slug, "new.md", "new.md", attr())
+        .await;
     assert!(matches!(dup, Err(SpaceError::Validation(_))), "{dup:?}");
 
     let missing = library
         .spaces()
-        .move_file(slug, "ghost.md", "elsewhere.md")
+        .move_file(slug, "ghost.md", "elsewhere.md", attr())
         .await;
     assert!(
         matches!(missing, Err(SpaceError::Validation(_))),
@@ -172,7 +197,7 @@ async fn move_then_delete() {
 
     library
         .spaces()
-        .delete_file(slug, "new.md")
+        .delete_file(slug, "new.md", attr())
         .await
         .expect("delete");
     assert!(!path_exists(
@@ -188,18 +213,18 @@ async fn insert_at_line_number() {
     let slug = "inserts";
     library
         .spaces()
-        .create(slug.into(), None)
+        .create(slug.into(), None, attr())
         .await
         .expect("create space");
     library
         .spaces()
-        .write_file(slug, "list.md", "one\ntwo\nthree\n".into())
+        .write_file(slug, "list.md", "one\ntwo\nthree\n".into(), attr())
         .await
         .expect("write");
 
     library
         .spaces()
-        .insert(slug, "list.md", 1, "one-and-a-half".into())
+        .insert(slug, "list.md", 1, "one-and-a-half".into(), attr())
         .await
         .expect("insert");
 
@@ -207,4 +232,73 @@ async fn insert_at_line_number() {
         read_blob(fixture.path(), &format!("spaces/{slug}/list.md")).as_deref(),
         Some(&b"one\none-and-a-half\ntwo\nthree\n"[..]),
     );
+}
+
+/// End-to-end: a rich `CommitAttribution` (agent-on-behalf-of-human)
+/// is rendered into the upstream commit's author, committer, and
+/// trailer block.
+#[tokio::test]
+#[ignore = "requires postgres + writes to tests/.library; run with --ignored"]
+async fn write_renders_rich_attribution_into_commit() {
+    let (fixture, library, _pool) = fresh_library("write_renders_rich_attribution").await;
+    let slug = "attribution";
+    library
+        .spaces()
+        .create(slug.into(), None, attr())
+        .await
+        .expect("create space");
+
+    let mut rich = CommitAttribution {
+        author_name: "Alice (via drua)".to_owned(),
+        author_email: "12345+alice@users.noreply.github.com".to_owned(),
+        committer_name: "drua-agent[bot]".to_owned(),
+        committer_email: "agent@agent.galoy.io".to_owned(),
+        kind: drua_library::CommitSubjectKind::AgentOnBehalfOfUser,
+        trailers: Vec::new(),
+        co_authored_by: Vec::new(),
+    };
+    rich.add_trailer("Drua-Subject-Type", "agent_on_behalf_of_user");
+    rich.add_trailer("Drua-Acting-User", "5f1c8b3a");
+    rich.add_trailer("Drua-Project", "a1b2c3d4");
+    rich.add_trailer("Drua-Agent", "019df3aa");
+    rich.add_trailer("Drua-Action", "space.write_file");
+    rich.add_co_authored_by("Alice", "12345+alice@users.noreply.github.com");
+
+    library
+        .spaces()
+        .write_file(slug, "doc.md", "hello\n".into(), rich)
+        .await
+        .expect("write doc.md");
+
+    let (a_name, a_email, c_name, c_email, message) = head_commit_meta(fixture.path());
+    assert_eq!(a_name, "Alice (via drua)");
+    assert_eq!(a_email, "12345+alice@users.noreply.github.com");
+    assert_eq!(c_name, "drua-agent[bot]");
+    assert_eq!(c_email, "agent@agent.galoy.io");
+
+    assert!(
+        message.starts_with(&format!("space:{slug}: write doc.md")),
+        "summary missing: {message:?}"
+    );
+    assert!(
+        message.contains("\nCo-Authored-By: Alice <12345+alice@users.noreply.github.com>\n"),
+        "co-authored-by missing: {message:?}"
+    );
+    assert!(
+        message.contains("\nDrua-Acting-User: 5f1c8b3a\n"),
+        "acting-user missing: {message:?}"
+    );
+    assert!(
+        message.contains("\nDrua-Subject-Type: agent_on_behalf_of_user"),
+        "subject-type missing: {message:?}"
+    );
+    assert!(
+        message.contains("\nDrua-Action: space.write_file"),
+        "action missing: {message:?}"
+    );
+    let acting = message.find("Drua-Acting-User").expect("acting present");
+    let agent = message.find("Drua-Agent").expect("agent present");
+    let project = message.find("Drua-Project").expect("project present");
+    let subject = message.find("Drua-Subject-Type").expect("subject present");
+    assert!(acting < agent && agent < project && project < subject);
 }

--- a/core/crates/library/tests/space_writes_batch.rs
+++ b/core/crates/library/tests/space_writes_batch.rs
@@ -4,7 +4,11 @@ use std::path::Path;
 use std::sync::Arc;
 
 use common::{library_data_dir, reset_library_db_state, TestRepo};
-use drua_library::{Library, LibraryConfig, SpaceError};
+use drua_library::{CommitAttribution, Library, LibraryConfig, SpaceError};
+
+fn attr() -> CommitAttribution {
+    CommitAttribution::library_default()
+}
 
 const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
 const FETCH_INTERVAL_MS: u64 = 100;
@@ -105,17 +109,17 @@ async fn concurrent_writes_batch_with_per_op_results() {
 
     library
         .spaces()
-        .create(slug.into(), None)
+        .create(slug.into(), None, attr())
         .await
         .expect("create space");
     library
         .spaces()
-        .write_file(slug, "a.md", "alpha bravo charlie\n".into())
+        .write_file(slug, "a.md", "alpha bravo charlie\n".into(), attr())
         .await
         .expect("seed a.md");
     library
         .spaces()
-        .write_file(slug, "c.md", "to be deleted\n".into())
+        .write_file(slug, "c.md", "to be deleted\n".into(), attr())
         .await
         .expect("seed c.md");
 
@@ -133,18 +137,18 @@ async fn concurrent_writes_batch_with_per_op_results() {
     // them into a single push. Order within the batch follows submission
     // order, so str_replace lands on a.md before insert.
     let (r1, r2, r3, r4, r5, r6) = tokio::join!(
-        async move { s1.write_file(slug, "d.md", "delta\n".into()).await },
+        async move { s1.write_file(slug, "d.md", "delta\n".into(), attr()).await },
         async move {
-            s2.str_replace(slug, "a.md", "bravo".into(), "BRAVO".into())
+            s2.str_replace(slug, "a.md", "bravo".into(), "BRAVO".into(), attr())
                 .await
         },
         async move {
-            s3.str_replace(slug, "missing.md", "x".into(), "y".into())
+            s3.str_replace(slug, "missing.md", "x".into(), "y".into(), attr())
                 .await
         },
-        async move { s4.delete_file(slug, "c.md").await },
-        async move { s5.move_file(slug, "ghost.md", "elsewhere.md").await },
-        async move { s6.insert(slug, "a.md", 1, "appended".into()).await },
+        async move { s4.delete_file(slug, "c.md", attr()).await },
+        async move { s5.move_file(slug, "ghost.md", "elsewhere.md", attr()).await },
+        async move { s6.insert(slug, "a.md", 1, "appended".into(), attr()).await },
     );
 
     r1.expect("write d.md");

--- a/core/crates/library/tests/sync.rs
+++ b/core/crates/library/tests/sync.rs
@@ -4,7 +4,7 @@ use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use common::{library_data_dir, reset_library_db_state, TestRepo};
-use drua_library::{Library, LibraryConfig};
+use drua_library::{CommitAttribution, Library, LibraryConfig};
 
 const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
 const FETCH_INTERVAL_MS: u64 = 100;
@@ -47,7 +47,11 @@ async fn space_file_imports_into_search_store() {
     let slug = format!("oncall-{}", uuid::Uuid::new_v4().simple());
     library
         .spaces()
-        .create(slug.clone(), Some("on-call rotation".into()))
+        .create(
+            slug.clone(),
+            Some("on-call rotation".into()),
+            CommitAttribution::library_default(),
+        )
         .await
         .expect("create space");
 

--- a/core/src/audit/mod.rs
+++ b/core/src/audit/mod.rs
@@ -1,8 +1,11 @@
 pub mod error;
 pub mod primitives;
 
+use drua_library::{CommitAttribution, CommitSubjectKind};
 use es_entity::context::EventContext;
 use tracing::instrument;
+
+use crate::user::Users;
 
 pub use crate::primitives::*;
 pub use error::*;
@@ -171,6 +174,91 @@ impl Audit {
     pub fn collect_context() -> Option<AuditContextData> {
         let ec = EventContext::current();
         ec.data().lookup(AUDIT_CONTEXT_KEY).ok().flatten()
+    }
+
+    /// Build the [`CommitAttribution`] for the current request and stash
+    /// it in the request's [`EventContext`] so library post-persist hooks
+    /// (Notes / Skills / Workflows) pick it up.
+    ///
+    /// JIT-resolves the human's GitHub identity for the
+    /// `Co-Authored-By:` line: when an `acting_user_id` or
+    /// `on_behalf_of_user_id` is present, looks the user up via `users`
+    /// once. Failures degrade to a userless attribution rather than
+    /// failing the write.
+    #[instrument(name = "audit.commit_attribution", skip_all)]
+    pub async fn commit_attribution(users: &Users) -> CommitAttribution {
+        let ctx = match Self::collect_context() {
+            Some(c) => c,
+            None => {
+                let attribution = CommitAttribution::library_default();
+                attribution.put_in_event_context();
+                return attribution;
+            }
+        };
+
+        let human_user_id = ctx.on_behalf_of_user_id.or(ctx.acting_user_id);
+        let human = match human_user_id {
+            Some(uid) => match users.find_by_id(uid).await {
+                Ok(u) => Some(u),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        user_id = %uid,
+                        "commit_attribution: user lookup failed; degrading to userless attribution"
+                    );
+                    None
+                }
+            },
+            None => None,
+        };
+
+        let kind = subject_kind(&ctx);
+        let (author_name, author_email, committer_name, committer_email) =
+            signatures_for(kind, human.as_ref());
+
+        let mut attribution = CommitAttribution {
+            author_name,
+            author_email,
+            committer_name,
+            committer_email,
+            kind,
+            trailers: Vec::new(),
+            co_authored_by: Vec::new(),
+        };
+
+        attribution.add_trailer("Drua-Subject-Type", kind.as_trailer_value());
+
+        if let Some(user) = human.as_ref() {
+            let (display, email) = github_co_author(user);
+            attribution.add_co_authored_by(display, email);
+            attribution.add_trailer("Drua-Acting-User", user.id.to_string());
+        }
+
+        for (audit_key, trailer_key) in [
+            ("project_id", "Drua-Project"),
+            ("workflow_id", "Drua-Workflow-Definition"),
+            ("workflow_run_id", "Drua-Workflow-Run"),
+            ("agent_id", "Drua-Agent"),
+            ("sandbox_id", "Drua-Sandbox"),
+            ("space_id", "Drua-Space"),
+        ] {
+            if let Some(value) = ctx.resource_ids.get(audit_key).and_then(|v| v.as_str()) {
+                attribution.add_trailer(trailer_key, value);
+            }
+        }
+
+        if let Some(agent_id) = ctx.acting_agent_id {
+            attribution.add_trailer("Drua-Acting-Agent", agent_id.to_string());
+        }
+        if let Some(action) = ctx.action.as_deref() {
+            attribution.add_trailer("Drua-Action", action);
+        }
+        if let Some(entrypoint) = ctx.entrypoint.as_deref() {
+            attribution.add_trailer("Drua-Entrypoint", entrypoint);
+        }
+
+        attribution.put_in_event_context();
+        attribution
     }
 
     /// Persist accumulated context as an audit entry. Fire-and-forget;
@@ -350,6 +438,94 @@ impl Audit {
         .await?;
         Ok(row)
     }
+}
+
+fn subject_kind(ctx: &AuditContextData) -> CommitSubjectKind {
+    if ctx.resource_ids.contains_key("workflow_run_id") {
+        return CommitSubjectKind::WorkflowAgent;
+    }
+    match (
+        ctx.acting_user_id,
+        ctx.acting_agent_id,
+        ctx.on_behalf_of_user_id,
+    ) {
+        (_, Some(_), Some(_)) => CommitSubjectKind::AgentOnBehalfOfUser,
+        (_, Some(_), None) => CommitSubjectKind::WorkflowAgent,
+        (Some(_), None, _) => CommitSubjectKind::User,
+        (None, None, Some(_)) => CommitSubjectKind::AgentOnBehalfOfUser,
+        (None, None, None) => CommitSubjectKind::System,
+    }
+}
+
+fn signatures_for(
+    kind: CommitSubjectKind,
+    human: Option<&crate::user::User>,
+) -> (String, String, String, String) {
+    use drua_library::attribution::{
+        ADMIN_BOT_EMAIL, ADMIN_BOT_NAME, AGENT_BOT_EMAIL, AGENT_BOT_NAME, LIBRARY_BOT_EMAIL,
+        LIBRARY_BOT_NAME, SYSTEM_BOT_EMAIL, SYSTEM_BOT_NAME, WORKFLOW_BOT_EMAIL, WORKFLOW_BOT_NAME,
+    };
+    match kind {
+        CommitSubjectKind::System => (
+            SYSTEM_BOT_NAME.to_owned(),
+            SYSTEM_BOT_EMAIL.to_owned(),
+            SYSTEM_BOT_NAME.to_owned(),
+            SYSTEM_BOT_EMAIL.to_owned(),
+        ),
+        CommitSubjectKind::Library => (
+            LIBRARY_BOT_NAME.to_owned(),
+            LIBRARY_BOT_EMAIL.to_owned(),
+            LIBRARY_BOT_NAME.to_owned(),
+            LIBRARY_BOT_EMAIL.to_owned(),
+        ),
+        CommitSubjectKind::User | CommitSubjectKind::ExportedAgent => {
+            let (display, email) = human
+                .map(github_co_author)
+                .unwrap_or_else(|| (ADMIN_BOT_NAME.to_owned(), ADMIN_BOT_EMAIL.to_owned()));
+            (
+                format!("{display} (via drua)"),
+                email,
+                ADMIN_BOT_NAME.to_owned(),
+                ADMIN_BOT_EMAIL.to_owned(),
+            )
+        }
+        CommitSubjectKind::AgentOnBehalfOfUser => {
+            let (display, email) = human
+                .map(github_co_author)
+                .unwrap_or_else(|| (AGENT_BOT_NAME.to_owned(), AGENT_BOT_EMAIL.to_owned()));
+            (
+                format!("{display} (via drua)"),
+                email,
+                AGENT_BOT_NAME.to_owned(),
+                AGENT_BOT_EMAIL.to_owned(),
+            )
+        }
+        CommitSubjectKind::WorkflowAgent => (
+            WORKFLOW_BOT_NAME.to_owned(),
+            WORKFLOW_BOT_EMAIL.to_owned(),
+            WORKFLOW_BOT_NAME.to_owned(),
+            WORKFLOW_BOT_EMAIL.to_owned(),
+        ),
+    }
+}
+
+/// Render a `(display_name, email)` pair for a `Co-Authored-By:` line.
+/// Email keys on the immutable GitHub user id (form
+/// `<id>+<username>@users.noreply.github.com`) so renames don't break
+/// avatar lookup.
+fn github_co_author(user: &crate::user::User) -> (String, String) {
+    let display = user
+        .name
+        .clone()
+        .or_else(|| user.github_username.clone())
+        .unwrap_or_else(|| format!("github:{}", user.github_id));
+    let username = user.github_username.as_deref().unwrap_or("anonymous");
+    let email = format!(
+        "{id}+{username}@users.noreply.github.com",
+        id = user.github_id,
+        username = username,
+    );
+    (display, email)
 }
 
 #[cfg(test)]

--- a/core/src/audit/mod.rs
+++ b/core/src/audit/mod.rs
@@ -1,11 +1,8 @@
 pub mod error;
 pub mod primitives;
 
-use drua_library::{CommitAttribution, CommitSubjectKind};
 use es_entity::context::EventContext;
 use tracing::instrument;
-
-use crate::user::Users;
 
 pub use crate::primitives::*;
 pub use error::*;
@@ -174,91 +171,6 @@ impl Audit {
     pub fn collect_context() -> Option<AuditContextData> {
         let ec = EventContext::current();
         ec.data().lookup(AUDIT_CONTEXT_KEY).ok().flatten()
-    }
-
-    /// Build the [`CommitAttribution`] for the current request and stash
-    /// it in the request's [`EventContext`] so library post-persist hooks
-    /// (Notes / Skills / Workflows) pick it up.
-    ///
-    /// JIT-resolves the human's GitHub identity for the
-    /// `Co-Authored-By:` line: when an `acting_user_id` or
-    /// `on_behalf_of_user_id` is present, looks the user up via `users`
-    /// once. Failures degrade to a userless attribution rather than
-    /// failing the write.
-    #[instrument(name = "audit.commit_attribution", skip_all)]
-    pub async fn commit_attribution(users: &Users) -> CommitAttribution {
-        let ctx = match Self::collect_context() {
-            Some(c) => c,
-            None => {
-                let attribution = CommitAttribution::library_default();
-                attribution.put_in_event_context();
-                return attribution;
-            }
-        };
-
-        let human_user_id = ctx.on_behalf_of_user_id.or(ctx.acting_user_id);
-        let human = match human_user_id {
-            Some(uid) => match users.find_by_id(uid).await {
-                Ok(u) => Some(u),
-                Err(e) => {
-                    tracing::warn!(
-                        error = %e,
-                        user_id = %uid,
-                        "commit_attribution: user lookup failed; degrading to userless attribution"
-                    );
-                    None
-                }
-            },
-            None => None,
-        };
-
-        let kind = subject_kind(&ctx);
-        let (author_name, author_email, committer_name, committer_email) =
-            signatures_for(kind, human.as_ref());
-
-        let mut attribution = CommitAttribution {
-            author_name,
-            author_email,
-            committer_name,
-            committer_email,
-            kind,
-            trailers: Vec::new(),
-            co_authored_by: Vec::new(),
-        };
-
-        attribution.add_trailer("Drua-Subject-Type", kind.as_trailer_value());
-
-        if let Some(user) = human.as_ref() {
-            let (display, email) = github_co_author(user);
-            attribution.add_co_authored_by(display, email);
-            attribution.add_trailer("Drua-Acting-User", user.id.to_string());
-        }
-
-        for (audit_key, trailer_key) in [
-            ("project_id", "Drua-Project"),
-            ("workflow_id", "Drua-Workflow-Definition"),
-            ("workflow_run_id", "Drua-Workflow-Run"),
-            ("agent_id", "Drua-Agent"),
-            ("sandbox_id", "Drua-Sandbox"),
-            ("space_id", "Drua-Space"),
-        ] {
-            if let Some(value) = ctx.resource_ids.get(audit_key).and_then(|v| v.as_str()) {
-                attribution.add_trailer(trailer_key, value);
-            }
-        }
-
-        if let Some(agent_id) = ctx.acting_agent_id {
-            attribution.add_trailer("Drua-Acting-Agent", agent_id.to_string());
-        }
-        if let Some(action) = ctx.action.as_deref() {
-            attribution.add_trailer("Drua-Action", action);
-        }
-        if let Some(entrypoint) = ctx.entrypoint.as_deref() {
-            attribution.add_trailer("Drua-Entrypoint", entrypoint);
-        }
-
-        attribution.put_in_event_context();
-        attribution
     }
 
     /// Persist accumulated context as an audit entry. Fire-and-forget;
@@ -438,94 +350,6 @@ impl Audit {
         .await?;
         Ok(row)
     }
-}
-
-fn subject_kind(ctx: &AuditContextData) -> CommitSubjectKind {
-    if ctx.resource_ids.contains_key("workflow_run_id") {
-        return CommitSubjectKind::WorkflowAgent;
-    }
-    match (
-        ctx.acting_user_id,
-        ctx.acting_agent_id,
-        ctx.on_behalf_of_user_id,
-    ) {
-        (_, Some(_), Some(_)) => CommitSubjectKind::AgentOnBehalfOfUser,
-        (_, Some(_), None) => CommitSubjectKind::WorkflowAgent,
-        (Some(_), None, _) => CommitSubjectKind::User,
-        (None, None, Some(_)) => CommitSubjectKind::AgentOnBehalfOfUser,
-        (None, None, None) => CommitSubjectKind::System,
-    }
-}
-
-fn signatures_for(
-    kind: CommitSubjectKind,
-    human: Option<&crate::user::User>,
-) -> (String, String, String, String) {
-    use drua_library::attribution::{
-        ADMIN_BOT_EMAIL, ADMIN_BOT_NAME, AGENT_BOT_EMAIL, AGENT_BOT_NAME, LIBRARY_BOT_EMAIL,
-        LIBRARY_BOT_NAME, SYSTEM_BOT_EMAIL, SYSTEM_BOT_NAME, WORKFLOW_BOT_EMAIL, WORKFLOW_BOT_NAME,
-    };
-    match kind {
-        CommitSubjectKind::System => (
-            SYSTEM_BOT_NAME.to_owned(),
-            SYSTEM_BOT_EMAIL.to_owned(),
-            SYSTEM_BOT_NAME.to_owned(),
-            SYSTEM_BOT_EMAIL.to_owned(),
-        ),
-        CommitSubjectKind::Library => (
-            LIBRARY_BOT_NAME.to_owned(),
-            LIBRARY_BOT_EMAIL.to_owned(),
-            LIBRARY_BOT_NAME.to_owned(),
-            LIBRARY_BOT_EMAIL.to_owned(),
-        ),
-        CommitSubjectKind::User | CommitSubjectKind::ExportedAgent => {
-            let (display, email) = human
-                .map(github_co_author)
-                .unwrap_or_else(|| (ADMIN_BOT_NAME.to_owned(), ADMIN_BOT_EMAIL.to_owned()));
-            (
-                format!("{display} (via drua)"),
-                email,
-                ADMIN_BOT_NAME.to_owned(),
-                ADMIN_BOT_EMAIL.to_owned(),
-            )
-        }
-        CommitSubjectKind::AgentOnBehalfOfUser => {
-            let (display, email) = human
-                .map(github_co_author)
-                .unwrap_or_else(|| (AGENT_BOT_NAME.to_owned(), AGENT_BOT_EMAIL.to_owned()));
-            (
-                format!("{display} (via drua)"),
-                email,
-                AGENT_BOT_NAME.to_owned(),
-                AGENT_BOT_EMAIL.to_owned(),
-            )
-        }
-        CommitSubjectKind::WorkflowAgent => (
-            WORKFLOW_BOT_NAME.to_owned(),
-            WORKFLOW_BOT_EMAIL.to_owned(),
-            WORKFLOW_BOT_NAME.to_owned(),
-            WORKFLOW_BOT_EMAIL.to_owned(),
-        ),
-    }
-}
-
-/// Render a `(display_name, email)` pair for a `Co-Authored-By:` line.
-/// Email keys on the immutable GitHub user id (form
-/// `<id>+<username>@users.noreply.github.com`) so renames don't break
-/// avatar lookup.
-fn github_co_author(user: &crate::user::User) -> (String, String) {
-    let display = user
-        .name
-        .clone()
-        .or_else(|| user.github_username.clone())
-        .unwrap_or_else(|| format!("github:{}", user.github_id));
-    let username = user.github_username.as_deref().unwrap_or("anonymous");
-    let email = format!(
-        "{id}+{username}@users.noreply.github.com",
-        id = user.github_id,
-        username = username,
-    );
-    (display, email)
 }
 
 #[cfg(test)]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -161,7 +161,11 @@ impl App {
         )
         .await
         .map_err(|e| AppError::Library(e.to_string()))?;
-        let spaces = Arc::new(AuthedSpaces::new(library.spaces().clone()));
+        let users = Arc::new(Users::new(pool));
+        let spaces = Arc::new(AuthedSpaces::new(
+            library.spaces().clone(),
+            Arc::clone(&users),
+        ));
         let search = Arc::new(AuthedSearch::new(library.search().clone()));
 
         // Bumped by Notes/Skills mutations (local) and PG NOTIFY (peers).
@@ -175,6 +179,7 @@ impl App {
             pool,
             Arc::clone(&sandboxes),
             library.clone(),
+            Arc::clone(&users),
             context_generation.clone(),
         ));
 
@@ -191,6 +196,7 @@ impl App {
         let notes = Arc::new(Notes::new(
             pool,
             library.clone(),
+            Arc::clone(&users),
             context_generation.clone(),
         ));
 
@@ -213,6 +219,7 @@ impl App {
             Arc::clone(&skills),
             Arc::clone(&agents),
             Arc::clone(&sandboxes),
+            Arc::clone(&users),
             &mut jobs,
         ));
 
@@ -226,6 +233,7 @@ impl App {
             Arc::clone(&workflows),
             library.clone(),
             (*spaces).clone(),
+            Arc::clone(&users),
             context_generation.clone(),
         ));
         // Late-binding: Agents needs Projects to render the dynamic
@@ -239,6 +247,7 @@ impl App {
         let space_fs = Arc::new(space_fs::SpaceFs::new(
             Arc::new(library.spaces().clone()),
             Arc::clone(&projects),
+            Arc::clone(&users),
         ));
         toolsets.register_top_level(TextEditor::new(
             Arc::clone(&sandboxes),
@@ -308,7 +317,7 @@ impl App {
         let jobs = Arc::new(jobs);
 
         Ok(Self {
-            users: Arc::new(Users::new(pool)),
+            users,
             mcp_creds: Arc::new(mcp_creds),
             agents: Arc::clone(&agents),
             audit,

--- a/core/src/library/mod.rs
+++ b/core/src/library/mod.rs
@@ -85,7 +85,7 @@ impl AuthedSpaces {
     ) -> Result<Space, LibraryError> {
         sub.can(AuthVerb::Create, AuthResource::Space(None))?;
         Audit::record_action_if_unset("library.spaces.create");
-        let attribution = Audit::commit_attribution(&self.users).await;
+        let attribution = self.users.commit_attribution().await;
         let space = self
             .inner
             .create(slug.into(), description, attribution)
@@ -111,7 +111,7 @@ impl AuthedSpaces {
     ) -> Result<Space, LibraryError> {
         sub.can(AuthVerb::Create, AuthResource::Space(None))?;
         Audit::record_action_if_unset("library.spaces.create");
-        let attribution = Audit::commit_attribution(&self.users).await;
+        let attribution = self.users.commit_attribution().await;
         let space = self
             .inner
             .create_in_op(op, slug.into(), description, attribution)

--- a/core/src/library/mod.rs
+++ b/core/src/library/mod.rs
@@ -7,9 +7,12 @@ pub use drua_library::{
     SpaceEvent, Spaces, WriteOp, SPACE_DOC_TYPE,
 };
 
+use std::sync::Arc;
+
 use crate::audit::Audit;
 use crate::auth::{AuthResource, AuthSubject, AuthVerb};
 use crate::primitives::SpaceId;
+use crate::user::Users;
 
 const DEFAULT_SKILL_SYNC_INTERVAL_SECS: u64 = 20;
 
@@ -63,11 +66,12 @@ impl LibraryConfig {
 #[derive(Clone)]
 pub struct AuthedSpaces {
     inner: drua_library::Spaces,
+    users: Arc<Users>,
 }
 
 impl AuthedSpaces {
-    pub fn new(inner: drua_library::Spaces) -> Self {
-        Self { inner }
+    pub fn new(inner: drua_library::Spaces, users: Arc<Users>) -> Self {
+        Self { inner, users }
     }
 
     /// Persists a new `Space`, scaffolds `spaces/<slug>/.gitkeep`
@@ -81,7 +85,11 @@ impl AuthedSpaces {
     ) -> Result<Space, LibraryError> {
         sub.can(AuthVerb::Create, AuthResource::Space(None))?;
         Audit::record_action_if_unset("library.spaces.create");
-        let space = self.inner.create(slug.into(), description).await?;
+        let attribution = Audit::commit_attribution(&self.users).await;
+        let space = self
+            .inner
+            .create(slug.into(), description, attribution)
+            .await?;
         Audit::record_space_id(space.id);
         tracing::info!(space.id = %space.id, space.slug = %space.slug, "space created");
         Ok(space)
@@ -103,9 +111,10 @@ impl AuthedSpaces {
     ) -> Result<Space, LibraryError> {
         sub.can(AuthVerb::Create, AuthResource::Space(None))?;
         Audit::record_action_if_unset("library.spaces.create");
+        let attribution = Audit::commit_attribution(&self.users).await;
         let space = self
             .inner
-            .create_in_op(op, slug.into(), description)
+            .create_in_op(op, slug.into(), description, attribution)
             .await?;
         Audit::record_space_id(space.id);
         tracing::info!(space.id = %space.id, space.slug = %space.slug, "space created in op");

--- a/core/src/note/mod.rs
+++ b/core/src/note/mod.rs
@@ -14,7 +14,6 @@ use repo::*;
 
 pub const NOTE_DOC_TYPE: drua_library::DocType = drua_library::DocType::new("note");
 
-use crate::audit::Audit;
 use crate::auth::AuthSubject;
 use crate::note::file::render_note_markdown;
 use crate::primitives::*;
@@ -103,7 +102,7 @@ impl Notes {
 
         // Populate EventContext so the Note's post_persist_hook (which
         // calls library.sync_entity_in_op) picks up rich attribution.
-        Audit::commit_attribution(&self.users).await;
+        self.users.commit_attribution().await;
         let note = self.repo.create_in_op(&mut op, new_note).await?;
         op.commit().await?;
         Ok(note)
@@ -149,7 +148,7 @@ impl Notes {
         let file_hash = drua_library::GitFileHash::new(rendered);
 
         if note.update(title, content, tags, file_hash).did_execute() {
-            Audit::commit_attribution(&self.users).await;
+            self.users.commit_attribution().await;
             self.repo.update_in_op(&mut op, &mut note).await?;
         }
         op.commit().await?;

--- a/core/src/note/mod.rs
+++ b/core/src/note/mod.rs
@@ -14,15 +14,19 @@ use repo::*;
 
 pub const NOTE_DOC_TYPE: drua_library::DocType = drua_library::DocType::new("note");
 
+use crate::audit::Audit;
 use crate::auth::AuthSubject;
 use crate::note::file::render_note_markdown;
 use crate::primitives::*;
+use crate::user::Users;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct Notes {
     repo: NoteRepo,
     library: drua_library::Library,
     pool: sqlx::PgPool,
+    users: Arc<Users>,
     context_generation: ContextGeneration,
 }
 
@@ -30,12 +34,14 @@ impl Notes {
     pub fn new(
         pool: &sqlx::PgPool,
         library: drua_library::Library,
+        users: Arc<Users>,
         context_generation: ContextGeneration,
     ) -> Self {
         Self {
             repo: NoteRepo::new(pool, library.clone()),
             library,
             pool: pool.clone(),
+            users,
             context_generation,
         }
     }
@@ -95,6 +101,9 @@ impl Notes {
             .build()
             .expect("NewNote builder should not fail");
 
+        // Populate EventContext so the Note's post_persist_hook (which
+        // calls library.sync_entity_in_op) picks up rich attribution.
+        Audit::commit_attribution(&self.users).await;
         let note = self.repo.create_in_op(&mut op, new_note).await?;
         op.commit().await?;
         Ok(note)
@@ -140,6 +149,7 @@ impl Notes {
         let file_hash = drua_library::GitFileHash::new(rendered);
 
         if note.update(title, content, tags, file_hash).did_execute() {
+            Audit::commit_attribution(&self.users).await;
             self.repo.update_in_op(&mut op, &mut note).await?;
         }
         op.commit().await?;

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -123,7 +123,7 @@ impl Projects {
                 )
             })
             .collect::<Vec<_>>();
-        let attribution = Audit::commit_attribution(&self.users).await;
+        let attribution = self.users.commit_attribution().await;
         self.library
             .enqueue_write_in_op(
                 &mut op,
@@ -261,7 +261,7 @@ impl Projects {
             tracing::warn!(error = %e, "failed to delete workflows during project delete");
         }
 
-        let attribution = Audit::commit_attribution(&self.users).await;
+        let attribution = self.users.commit_attribution().await;
         if let Err(e) = self
             .library
             .cleanup_for_scope_in_op(

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -23,6 +23,7 @@ use crate::primitives::*;
 use crate::project_secret::ProjectSecrets;
 use crate::sandbox::Sandboxes;
 use crate::skill::Skills;
+use crate::user::Users;
 use crate::workflow::Workflows;
 
 #[derive(Clone)]
@@ -37,6 +38,7 @@ pub struct Projects {
     workflows: Arc<Workflows>,
     library: drua_library::Library,
     spaces: AuthedSpaces,
+    users: Arc<Users>,
     context_generation: ContextGeneration,
 }
 
@@ -52,6 +54,7 @@ impl Projects {
         workflows: Arc<Workflows>,
         library: drua_library::Library,
         spaces: AuthedSpaces,
+        users: Arc<Users>,
         context_generation: ContextGeneration,
     ) -> Self {
         let repo = ProjectRepo::new(pool);
@@ -66,6 +69,7 @@ impl Projects {
             workflows,
             library,
             spaces,
+            users,
             context_generation,
         }
     }
@@ -119,6 +123,7 @@ impl Projects {
                 )
             })
             .collect::<Vec<_>>();
+        let attribution = Audit::commit_attribution(&self.users).await;
         self.library
             .enqueue_write_in_op(
                 &mut op,
@@ -126,6 +131,7 @@ impl Projects {
                     changes: scaffold,
                     message: format!("project: init {name}"),
                 },
+                attribution,
             )
             .await?;
 
@@ -255,6 +261,7 @@ impl Projects {
             tracing::warn!(error = %e, "failed to delete workflows during project delete");
         }
 
+        let attribution = Audit::commit_attribution(&self.users).await;
         if let Err(e) = self
             .library
             .cleanup_for_scope_in_op(
@@ -262,6 +269,7 @@ impl Projects {
                 uuid::Uuid::from(id),
                 format!("runtime/projects/{}", project.name),
                 format!("project: delete {}", project.name),
+                attribution,
             )
             .await
         {

--- a/core/src/skill/mod.rs
+++ b/core/src/skill/mod.rs
@@ -15,8 +15,10 @@ use drua_library::SearchHit;
 use es_entity::AtomicOperation;
 use tracing::instrument;
 
+use crate::audit::Audit;
 pub use crate::primitives::*;
 use crate::sandbox::Sandboxes;
+use crate::user::Users;
 pub use entity::*;
 pub use error::*;
 use repo::*;
@@ -34,6 +36,7 @@ pub struct Skills {
     /// (registered in App init); unused on the forward-only paths.
     #[allow(dead_code)]
     pool: Option<sqlx::PgPool>,
+    users: Option<Arc<Users>>,
     #[allow(dead_code)]
     context_generation: ContextGeneration,
 }
@@ -43,6 +46,7 @@ impl Skills {
         pool: &sqlx::PgPool,
         sandboxes: Arc<Sandboxes>,
         library: drua_library::Library,
+        users: Arc<Users>,
         context_generation: ContextGeneration,
     ) -> Self {
         let repo = SkillRepo::new(pool, library.clone());
@@ -51,7 +55,18 @@ impl Skills {
             sandboxes,
             library: Some(library),
             pool: Some(pool.clone()),
+            users: Some(users),
             context_generation,
+        }
+    }
+
+    /// Side-effect: populates `EventContext` with the rich
+    /// [`drua_library::CommitAttribution`] so post-persist library
+    /// sync hooks pick it up. No-op when `users` isn't wired (test
+    /// constructors via `new_without_library`).
+    async fn populate_attribution(&self) {
+        if let Some(users) = self.users.as_ref() {
+            let _ = Audit::commit_attribution(users).await;
         }
     }
 
@@ -351,6 +366,7 @@ impl Skills {
             .build()
             .map_err(|e| SkillError::BuildEntity(e.to_string()))?;
 
+        self.populate_attribution().await;
         let skill = self.repo.create(new).await?;
         Ok(skill)
     }
@@ -374,6 +390,7 @@ impl Skills {
             }));
         }
         if skill.update_content(name, description, body).did_execute() {
+            self.populate_attribution().await;
             self.repo.update(&mut skill).await?;
         }
         Ok(skill)
@@ -398,6 +415,7 @@ impl Skills {
             }));
         }
         let mut op = self.repo.begin_op().await?;
+        self.populate_attribution().await;
         self.repo.delete_in_op(&mut op, skill).await?;
         op.commit().await?;
         Ok(())
@@ -497,6 +515,7 @@ impl Skills {
             sandboxes,
             library: None,
             pool: None,
+            users: None,
             context_generation: ContextGeneration::new(),
         }
     }

--- a/core/src/skill/mod.rs
+++ b/core/src/skill/mod.rs
@@ -15,7 +15,6 @@ use drua_library::SearchHit;
 use es_entity::AtomicOperation;
 use tracing::instrument;
 
-use crate::audit::Audit;
 pub use crate::primitives::*;
 use crate::sandbox::Sandboxes;
 use crate::user::Users;
@@ -66,7 +65,7 @@ impl Skills {
     /// constructors via `new_without_library`).
     async fn populate_attribution(&self) {
         if let Some(users) = self.users.as_ref() {
-            let _ = Audit::commit_attribution(users).await;
+            let _ = users.commit_attribution().await;
         }
     }
 

--- a/core/src/space_fs.rs
+++ b/core/src/space_fs.rs
@@ -23,8 +23,10 @@ use tracing::instrument;
 
 use drua_library::{Space, SpaceError, Spaces};
 
+use crate::audit::Audit;
 use crate::auth::AuthSubject;
 use crate::project::{ProjectError, Projects};
+use crate::user::Users;
 
 /// Soft cap on `view_file` to keep tool responses bounded. Larger than
 /// the typical sandbox `text_editor view` ceiling; agents needing more
@@ -75,11 +77,16 @@ struct Resolved {
 pub struct SpaceFs {
     spaces: Arc<Spaces>,
     projects: Arc<Projects>,
+    users: Arc<Users>,
 }
 
 impl SpaceFs {
-    pub fn new(spaces: Arc<Spaces>, projects: Arc<Projects>) -> Self {
-        Self { spaces, projects }
+    pub fn new(spaces: Arc<Spaces>, projects: Arc<Projects>, users: Arc<Users>) -> Self {
+        Self {
+            spaces,
+            projects,
+            users,
+        }
     }
 
     /// Pure peek — does `path` start with the `space:` prefix and have
@@ -183,9 +190,15 @@ impl SpaceFs {
         let Some(resolved) = self.resolve(sub, path).await? else {
             return Ok(None);
         };
-        crate::audit::Audit::record_action_if_unset("space.write_file");
+        Audit::record_action_if_unset("space.write_file");
+        let attribution = Audit::commit_attribution(&self.users).await;
         self.spaces
-            .write_file(&resolved.space.slug, &resolved.rel_path, content)
+            .write_file(
+                &resolved.space.slug,
+                &resolved.rel_path,
+                content,
+                attribution,
+            )
             .await
             .map_err(|e| -> ProjectError { e.into() })?;
         Ok(Some(()))
@@ -208,9 +221,16 @@ impl SpaceFs {
         let Some(resolved) = self.resolve(sub, path).await? else {
             return Ok(None);
         };
-        crate::audit::Audit::record_action_if_unset("space.str_replace");
+        Audit::record_action_if_unset("space.str_replace");
+        let attribution = Audit::commit_attribution(&self.users).await;
         self.spaces
-            .str_replace(&resolved.space.slug, &resolved.rel_path, old_str, new_str)
+            .str_replace(
+                &resolved.space.slug,
+                &resolved.rel_path,
+                old_str,
+                new_str,
+                attribution,
+            )
             .await
             .map_err(|e| -> ProjectError { e.into() })?;
         Ok(Some(()))
@@ -229,9 +249,16 @@ impl SpaceFs {
         let Some(resolved) = self.resolve(sub, path).await? else {
             return Ok(None);
         };
-        crate::audit::Audit::record_action_if_unset("space.insert");
+        Audit::record_action_if_unset("space.insert");
+        let attribution = Audit::commit_attribution(&self.users).await;
         self.spaces
-            .insert(&resolved.space.slug, &resolved.rel_path, line_number, text)
+            .insert(
+                &resolved.space.slug,
+                &resolved.rel_path,
+                line_number,
+                text,
+                attribution,
+            )
             .await
             .map_err(|e| -> ProjectError { e.into() })?;
         Ok(Some(()))
@@ -248,9 +275,10 @@ impl SpaceFs {
         let Some(resolved) = self.resolve(sub, path).await? else {
             return Ok(None);
         };
-        crate::audit::Audit::record_action_if_unset("space.delete_file");
+        Audit::record_action_if_unset("space.delete_file");
+        let attribution = Audit::commit_attribution(&self.users).await;
         self.spaces
-            .delete_file(&resolved.space.slug, &resolved.rel_path)
+            .delete_file(&resolved.space.slug, &resolved.rel_path, attribution)
             .await
             .map_err(|e| -> ProjectError { e.into() })?;
         Ok(Some(()))
@@ -298,9 +326,15 @@ impl SpaceFs {
         }
         let to_rel = normalize_rel_path(to_ref.rel_path);
         Self::validate_rel_path(&to_rel)?;
-        crate::audit::Audit::record_action_if_unset("space.move_file");
+        Audit::record_action_if_unset("space.move_file");
+        let attribution = Audit::commit_attribution(&self.users).await;
         self.spaces
-            .move_file(&from_resolved.space.slug, &from_resolved.rel_path, &to_rel)
+            .move_file(
+                &from_resolved.space.slug,
+                &from_resolved.rel_path,
+                &to_rel,
+                attribution,
+            )
             .await
             .map_err(|e| -> ProjectError { e.into() })?;
         Ok(Some(()))

--- a/core/src/space_fs.rs
+++ b/core/src/space_fs.rs
@@ -191,7 +191,7 @@ impl SpaceFs {
             return Ok(None);
         };
         Audit::record_action_if_unset("space.write_file");
-        let attribution = Audit::commit_attribution(&self.users).await;
+        let attribution = self.users.commit_attribution().await;
         self.spaces
             .write_file(
                 &resolved.space.slug,
@@ -222,7 +222,7 @@ impl SpaceFs {
             return Ok(None);
         };
         Audit::record_action_if_unset("space.str_replace");
-        let attribution = Audit::commit_attribution(&self.users).await;
+        let attribution = self.users.commit_attribution().await;
         self.spaces
             .str_replace(
                 &resolved.space.slug,
@@ -250,7 +250,7 @@ impl SpaceFs {
             return Ok(None);
         };
         Audit::record_action_if_unset("space.insert");
-        let attribution = Audit::commit_attribution(&self.users).await;
+        let attribution = self.users.commit_attribution().await;
         self.spaces
             .insert(
                 &resolved.space.slug,
@@ -276,7 +276,7 @@ impl SpaceFs {
             return Ok(None);
         };
         Audit::record_action_if_unset("space.delete_file");
-        let attribution = Audit::commit_attribution(&self.users).await;
+        let attribution = self.users.commit_attribution().await;
         self.spaces
             .delete_file(&resolved.space.slug, &resolved.rel_path, attribution)
             .await
@@ -327,7 +327,7 @@ impl SpaceFs {
         let to_rel = normalize_rel_path(to_ref.rel_path);
         Self::validate_rel_path(&to_rel)?;
         Audit::record_action_if_unset("space.move_file");
-        let attribution = Audit::commit_attribution(&self.users).await;
+        let attribution = self.users.commit_attribution().await;
         self.spaces
             .move_file(
                 &from_resolved.space.slug,

--- a/core/src/user/mod.rs
+++ b/core/src/user/mod.rs
@@ -2,6 +2,7 @@ mod entity;
 pub mod error;
 pub(crate) mod repo;
 
+use drua_library::{CommitAttribution, CommitSubjectKind};
 use tracing::instrument;
 
 pub use entity::User;
@@ -9,6 +10,7 @@ use entity::*;
 pub use error::*;
 use repo::*;
 
+use crate::audit::{Audit, AuditContextData};
 use crate::primitives::*;
 
 #[derive(Clone)]
@@ -61,6 +63,179 @@ impl Users {
     ) -> Result<User, UserError> {
         Ok(self.repo.find_by_id(id.into()).await?)
     }
+
+    /// Build the [`CommitAttribution`] for the current request and stash
+    /// it in the request's `EventContext` so library post-persist hooks
+    /// (Notes / Skills / Workflows) pick it up.
+    ///
+    /// JIT-resolves the human's GitHub identity for the
+    /// `Co-Authored-By:` line: when an `acting_user_id` or
+    /// `on_behalf_of_user_id` is present, looks the user up once.
+    /// Failures degrade to a userless attribution rather than failing
+    /// the write.
+    #[instrument(name = "domain.user.commit_attribution", skip(self))]
+    pub async fn commit_attribution(&self) -> CommitAttribution {
+        let ctx = match Audit::collect_context() {
+            Some(c) => c,
+            None => {
+                let attribution = CommitAttribution::library_default();
+                attribution.put_in_event_context();
+                return attribution;
+            }
+        };
+
+        let human_user_id = ctx.on_behalf_of_user_id.or(ctx.acting_user_id);
+        let human = match human_user_id {
+            Some(uid) => match self.find_by_id(uid).await {
+                Ok(u) => Some(u),
+                Err(e) => {
+                    tracing::warn!(
+                        error = %e,
+                        user_id = %uid,
+                        "commit_attribution: user lookup failed; degrading to userless attribution"
+                    );
+                    None
+                }
+            },
+            None => None,
+        };
+
+        let kind = subject_kind(&ctx);
+        let (author_name, author_email, committer_name, committer_email) =
+            signatures_for(kind, human.as_ref());
+
+        let mut attribution = CommitAttribution {
+            author_name,
+            author_email,
+            committer_name,
+            committer_email,
+            kind,
+            trailers: Vec::new(),
+            co_authored_by: Vec::new(),
+        };
+
+        attribution.add_trailer("Drua-Subject-Type", kind.as_trailer_value());
+
+        if let Some(user) = human.as_ref() {
+            let (display, email) = github_co_author(user);
+            attribution.add_co_authored_by(display, email);
+            attribution.add_trailer("Drua-Acting-User", user.id.to_string());
+        }
+
+        for (audit_key, trailer_key) in [
+            ("project_id", "Drua-Project"),
+            ("workflow_id", "Drua-Workflow-Definition"),
+            ("workflow_run_id", "Drua-Workflow-Run"),
+            ("agent_id", "Drua-Agent"),
+            ("sandbox_id", "Drua-Sandbox"),
+            ("space_id", "Drua-Space"),
+        ] {
+            if let Some(value) = ctx.resource_ids.get(audit_key).and_then(|v| v.as_str()) {
+                attribution.add_trailer(trailer_key, value);
+            }
+        }
+
+        if let Some(agent_id) = ctx.acting_agent_id {
+            attribution.add_trailer("Drua-Acting-Agent", agent_id.to_string());
+        }
+        if let Some(action) = ctx.action.as_deref() {
+            attribution.add_trailer("Drua-Action", action);
+        }
+        if let Some(entrypoint) = ctx.entrypoint.as_deref() {
+            attribution.add_trailer("Drua-Entrypoint", entrypoint);
+        }
+
+        attribution.put_in_event_context();
+        attribution
+    }
+}
+
+fn subject_kind(ctx: &AuditContextData) -> CommitSubjectKind {
+    if ctx.resource_ids.contains_key("workflow_run_id") {
+        return CommitSubjectKind::WorkflowAgent;
+    }
+    match (
+        ctx.acting_user_id,
+        ctx.acting_agent_id,
+        ctx.on_behalf_of_user_id,
+    ) {
+        (_, Some(_), Some(_)) => CommitSubjectKind::AgentOnBehalfOfUser,
+        (_, Some(_), None) => CommitSubjectKind::WorkflowAgent,
+        (Some(_), None, _) => CommitSubjectKind::User,
+        (None, None, Some(_)) => CommitSubjectKind::AgentOnBehalfOfUser,
+        (None, None, None) => CommitSubjectKind::System,
+    }
+}
+
+fn signatures_for(
+    kind: CommitSubjectKind,
+    human: Option<&User>,
+) -> (String, String, String, String) {
+    use drua_library::attribution::{
+        ADMIN_BOT_EMAIL, ADMIN_BOT_NAME, AGENT_BOT_EMAIL, AGENT_BOT_NAME, LIBRARY_BOT_EMAIL,
+        LIBRARY_BOT_NAME, SYSTEM_BOT_EMAIL, SYSTEM_BOT_NAME, WORKFLOW_BOT_EMAIL, WORKFLOW_BOT_NAME,
+    };
+    match kind {
+        CommitSubjectKind::System => (
+            SYSTEM_BOT_NAME.to_owned(),
+            SYSTEM_BOT_EMAIL.to_owned(),
+            SYSTEM_BOT_NAME.to_owned(),
+            SYSTEM_BOT_EMAIL.to_owned(),
+        ),
+        CommitSubjectKind::Library => (
+            LIBRARY_BOT_NAME.to_owned(),
+            LIBRARY_BOT_EMAIL.to_owned(),
+            LIBRARY_BOT_NAME.to_owned(),
+            LIBRARY_BOT_EMAIL.to_owned(),
+        ),
+        CommitSubjectKind::User | CommitSubjectKind::ExportedAgent => {
+            let (display, email) = human
+                .map(github_co_author)
+                .unwrap_or_else(|| (ADMIN_BOT_NAME.to_owned(), ADMIN_BOT_EMAIL.to_owned()));
+            (
+                format!("{display} (via drua)"),
+                email,
+                ADMIN_BOT_NAME.to_owned(),
+                ADMIN_BOT_EMAIL.to_owned(),
+            )
+        }
+        CommitSubjectKind::AgentOnBehalfOfUser => {
+            let (display, email) = human
+                .map(github_co_author)
+                .unwrap_or_else(|| (AGENT_BOT_NAME.to_owned(), AGENT_BOT_EMAIL.to_owned()));
+            (
+                format!("{display} (via drua)"),
+                email,
+                AGENT_BOT_NAME.to_owned(),
+                AGENT_BOT_EMAIL.to_owned(),
+            )
+        }
+        CommitSubjectKind::WorkflowAgent => (
+            WORKFLOW_BOT_NAME.to_owned(),
+            WORKFLOW_BOT_EMAIL.to_owned(),
+            WORKFLOW_BOT_NAME.to_owned(),
+            WORKFLOW_BOT_EMAIL.to_owned(),
+        ),
+    }
+}
+
+/// Render a `(display_name, email)` pair for a `Co-Authored-By:` line.
+/// Email keys on the immutable GitHub user id (form
+/// `<id>+<username>@users.noreply.github.com`) so renames don't break
+/// avatar lookup.
+fn github_co_author(user: &User) -> (String, String) {
+    let display = user
+        .name
+        .clone()
+        .or_else(|| user.github_username.clone())
+        .unwrap_or_else(|| format!("github:{}", user.github_id));
+    let username = user.github_username.as_deref().unwrap_or("anonymous");
+    let email = format!(
+        "{id}+{username}@users.noreply.github.com",
+        id = user.github_id,
+        username = username,
+    );
+    (display, email)
 }
 
 fn build_new_user(

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -17,7 +17,6 @@ use rand::RngCore;
 use tracing::instrument;
 
 use crate::agent::Agents;
-use crate::audit::Audit;
 use crate::primitives::*;
 use crate::sandbox::Sandboxes;
 use crate::skill::Skills;
@@ -360,7 +359,7 @@ impl Workflows {
             .map_err(|e| WorkflowError::BuildEntity(e.to_string()))?;
 
         let mut op = self.repo.begin_op().await?;
-        Audit::commit_attribution(&self.users).await;
+        self.users.commit_attribution().await;
         let workflow = self.repo.create_in_op(&mut op, new).await?;
         self.register_cron_in_op(&mut op, &workflow).await?;
         op.commit().await?;
@@ -418,7 +417,7 @@ impl Workflows {
             .did_execute()
         {
             let mut op = self.repo.begin_op().await?;
-            Audit::commit_attribution(&self.users).await;
+            self.users.commit_attribution().await;
             self.repo.update_in_op(&mut op, &mut definition).await?;
             let is_cron = matches!(definition.trigger, WorkflowTrigger::Cron { .. });
             if !was_cron && is_cron {

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -17,9 +17,11 @@ use rand::RngCore;
 use tracing::instrument;
 
 use crate::agent::Agents;
+use crate::audit::Audit;
 use crate::primitives::*;
 use crate::sandbox::Sandboxes;
 use crate::skill::Skills;
+use crate::user::Users;
 
 pub const WORKFLOW_DOC_TYPE: drua_library::DocType = drua_library::DocType::new("workflow");
 
@@ -41,6 +43,7 @@ pub struct Workflows {
     repo: WorkflowDefinitionRepo,
     run_repo: WorkflowRunRepo,
     skills: Arc<Skills>,
+    users: Arc<Users>,
     execute_run_spawner: ::job::JobSpawner<ExecuteRunConfig>,
     cron_spawner: ::job::JobSpawner<TriggerCronConfig>,
     /// Cloned `Jobs` handle so `await_run_completion` can block on the
@@ -53,12 +56,14 @@ impl Workflows {
     /// `TriggerCron` job initializers with `jobs`. Cron schedules
     /// persist as job rows, so no startup-recovery is needed — the
     /// poller will pick them up on its first tick.
+    #[allow(clippy::too_many_arguments)]
     pub fn init(
         pool: &sqlx::PgPool,
         library: drua_library::Library,
         skills: Arc<Skills>,
         agents: Arc<Agents>,
         sandboxes: Arc<Sandboxes>,
+        users: Arc<Users>,
         jobs: &mut ::job::Jobs,
     ) -> Self {
         let execute_run_spawner = jobs.add_initializer(ExecuteRunJobInitializer::new(
@@ -77,6 +82,7 @@ impl Workflows {
             repo: WorkflowDefinitionRepo::new(pool, library),
             run_repo: WorkflowRunRepo::new(pool),
             skills,
+            users,
             execute_run_spawner,
             cron_spawner,
             jobs: jobs.clone(),
@@ -354,6 +360,7 @@ impl Workflows {
             .map_err(|e| WorkflowError::BuildEntity(e.to_string()))?;
 
         let mut op = self.repo.begin_op().await?;
+        Audit::commit_attribution(&self.users).await;
         let workflow = self.repo.create_in_op(&mut op, new).await?;
         self.register_cron_in_op(&mut op, &workflow).await?;
         op.commit().await?;
@@ -411,6 +418,7 @@ impl Workflows {
             .did_execute()
         {
             let mut op = self.repo.begin_op().await?;
+            Audit::commit_attribution(&self.users).await;
             self.repo.update_in_op(&mut op, &mut definition).await?;
             let is_cron = matches!(definition.trigger, WorkflowTrigger::Cron { .. });
             if !was_cron && is_cron {

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -164,10 +164,7 @@ mod tests {
 
     #[test]
     fn extract_secret_passes_raw_for_honeycomb() {
-        assert_eq!(
-            extract_secret("whsec_abc", Some("honeycomb")),
-            "whsec_abc"
-        );
+        assert_eq!(extract_secret("whsec_abc", Some("honeycomb")), "whsec_abc");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces the hardcoded `drua-library@local` author/committer on every library commit with a per-subject `CommitAttribution` value object. Implements the MVP from research report **019df42f**.

Every library/repo commit now carries:
- **Distinct author + committer signatures** — human author (`<name> (via drua)`) with a synthetic drua bot committer, or fully-bot for autonomous paths.
- **`Co-Authored-By:`** keyed on the immutable GitHub id (`<gh_id>+<username>@users.noreply.github.com`) so renames don't break avatar lookup.
- **Machine-parseable `Drua-*:` trailer block** — `Drua-Subject-Type`, `Drua-Acting-User`, `Drua-Acting-Agent`, `Drua-Project`, `Drua-Workflow-Run`, `Drua-Workflow-Definition`, `Drua-Agent`, `Drua-Sandbox`, `Drua-Space`, `Drua-Action`, `Drua-Entrypoint`.

JIT user lookup at the write call sites (no DB hits on read paths). Synthetic bot identities use the `agent.galoy.io` domain.

Research report: stored as memory `019df42f` — *"Commit Attribution for Drua Library/Repo Writes — Options & Recommendation"*.

## Call sites changed

Single underlying funnel (`core/crates/library/src/git.rs::commit_one`), but the change touches every public path that ends there:

- `drua_library::git::GitEngine::{write_file, delete_file, update_file, move_file, write_with_rename, delete_dir, commit_changes}` — each takes `attribution: CommitAttribution`.
- `drua_library::Library::{enqueue_write_in_op, enqueue_full_in_op, cleanup_for_scope_in_op}` — each takes `attribution: CommitAttribution`.
- `drua_library::Spaces::{create, create_in_op, write_file, delete_file, str_replace, insert, move_file}` — each takes `attribution: CommitAttribution`.
- `drua_library::WriteOp` is unchanged; the persisted job config (`LibraryWriteConfig`) gains an `attribution` field that survives the round trip.
- `LibrarySynced` post-persist hook reads attribution from `EventContext` (caller seeds it via `Audit::commit_attribution`).
- New `core/crates/library/src/attribution.rs`: `CommitAttribution`, `CommitSubjectKind`, bot-identity constants, renderer.
- New `Audit::commit_attribution(users: &Users) -> CommitAttribution` (`core/src/audit/mod.rs`) — JIT user resolution + EventContext side-effect.
- `Arc<Users>` plumbed into `SpaceFs`, `Projects`, `Notes`, `Skills`, `Workflows`, `AuthedSpaces` so each service method that mutates library content can call `Audit::commit_attribution(&self.users).await` before the write.

## Before / after example commit

**Before** (every commit, regardless of who triggered it):
```
author drua-library <drua-library@local> 1746480000 +0000
committer drua-library <drua-library@local> 1746480000 +0000

space:oncall: edit runbooks/postgres.md
```

**After** (agent acting on behalf of a human, via chat session):
```
author Alice (via drua) <12345+alice@users.noreply.github.com> 1746480000 +0000
committer drua-agent[bot] <agent@agent.galoy.io> 1746480000 +0000

space:oncall: edit runbooks/postgres.md

Co-Authored-By: Alice <12345+alice@users.noreply.github.com>
Drua-Acting-Agent: 019df3aa-...
Drua-Acting-User: 5f1c8b3a-...
Drua-Action: space.str_replace
Drua-Agent: 019df3aa-...
Drua-Entrypoint: api: POST /spaces/oncall/...
Drua-Project: a1b2c3d4-...
Drua-Subject-Type: agent_on_behalf_of_user
```

**After** (autonomous workflow run):
```
author drua-workflow[bot] <workflow@agent.galoy.io> 1746480000 +0000
committer drua-workflow[bot] <workflow@agent.galoy.io> 1746480000 +0000

space:oncall: write status/honeycomb-alert.md

Drua-Acting-Agent: 019df3aa-...
Drua-Action: space.write_file
Drua-Agent: 019df3aa-...
Drua-Project: a1b2c3d4-...
Drua-Subject-Type: workflow_agent
Drua-Workflow-Run: 019df3a1-...
```

## Out of scope (deferred follow-ups)

These are the long-term north-star items called out in §D.2 of report 019df42f. Trailers above are designed to compose with all of them — only the author/committer/signing slots change.

- **Switch to GitHub Contents API push path** (currently libgit2 push). Required for the green Verified badge from GitHub-side GPG.
- **User-to-server (UaS) tokens** so `AgentOnBehalfOfUser` paths produce commits natively attributed to the human's GitHub account.
- **Sigstore / `gitsign` keyless signing** with Rekor for cryptographic audit (server-identity or human-OIDC variants).
- **Sandbox-side shell `git commit` attribution.** Sandboxes spawn a long-lived `bash` (`images/sandbox/server/src/session.rs`) and the agent drives `git` as a subprocess. Different code path entirely; needs sandbox-image `~/.gitconfig` seeding + commit-msg hook + credential-forwarding work.
- **`ExportedAgent`** subject kind currently maps to `User`. Distinguishing bearer-token paths in audit context is a follow-up.
- **`Co-Authored-By: Claude`** on Claude-Code-authored drua-source commits is not preserved on library/repo commits (it doesn't apply — those commits aren't authored by Claude Code, they're written programmatically by drua's library subsystem on the agent's/user's behalf).

## Test plan

- [x] `cargo fmt && git add -A && nix flake check` — passes (fmt / clippy `--deny warnings` / nextest / graphql schema / default-config).
- [x] 9 unit tests in `core/crates/library/src/attribution.rs` covering: default fallback, system, render-suffix ordering, dedupe, agent-on-behalf trailer ordering, snake-case serde, round-trip serde.
- [x] New ignored integration test `write_renders_rich_attribution_into_commit` in `core/crates/library/tests/space_writes.rs` exercising `Spaces::write_file` end-to-end and asserting the upstream commit's author / committer / trailer block. Runs alongside the existing ignored Postgres-backed tests via `cargo test -- --ignored`.
- [ ] Smoke-test in dev: `nix run .#drua` and trigger a notes / spaces / skills mutation, inspect `git log` upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core library write/commit pipeline and many call sites, changing commit author/committer identities and message formatting; bugs could misattribute commits or break persisted write-job replay, but no direct auth/permissions logic changes.
> 
> **Overview**
> All git writes performed via `drua-library` now carry a serialized `CommitAttribution` (author, committer, subject kind, co-authors, and `Drua-*` trailers) instead of the previously hardcoded `drua-library@local` signature.
> 
> This threads attribution through the write stack: `GitEngine` ops, the persisted `LibraryWriteConfig` job payload, and `Spaces`/`Library` enqueue APIs; `commit_one` now builds signatures from attribution and appends a rendered trailer block to the commit message.
> 
> Core services (`Users`, `AuthedSpaces`, `SpaceFs`, `Projects`, `Notes`, `Skills`, `Workflows`) are updated to generate/populate attribution from audit context (with JIT user lookup for `Co-Authored-By`) so post-persist hooks and direct space writes produce correctly attributed upstream commits; tests are updated and expanded to assert end-to-end attribution rendering.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abd01caca2a79b48cc522145cb8aaa6cd9dde36d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->