### PR TITLE
feat(agents): delete agent end-to-end (domain + GraphQL + admin/top-level toolsets)

### DIFF
--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -548,6 +548,27 @@ impl Agents {
         Ok(result.entities)
     }
 
+    #[instrument(name = "domain.agent.delete", skip(self, sub))]
+    pub async fn delete(
+        &self,
+        sub: &AuthSubject,
+        id: impl Into<AgentId> + std::fmt::Debug,
+    ) -> Result<(), AgentError> {
+        let id = id.into();
+        let agent = self.repo.find_by_id(id).await?;
+        sub.can(
+            AuthVerb::Delete,
+            AuthResource::Agent(agent.project_id, Some(agent.id)),
+        )?;
+        Audit::record_action_if_unset("agent.delete");
+        Audit::record_project_id(agent.project_id);
+        Audit::record_agent_id(id);
+        let mut op = self.repo.begin_op().await?;
+        self.delete_in_op(&mut op, id).await?;
+        op.commit().await?;
+        Ok(())
+    }
+
     #[instrument(name = "domain.agent.delete_in_op", skip(self, op))]
     pub async fn delete_in_op(
         &self,
@@ -558,6 +579,14 @@ impl Agents {
         let agent = self.repo.find_by_id_in_op(&mut *op, id).await?;
         Audit::record_project_id(agent.project_id);
         Audit::record_agent_id(id);
+        // Drop the sandbox-side attachment so its `attached_agents`
+        // list doesn't reference a deleted agent. Idempotent — no-op
+        // when nothing is attached.
+        if let Some(sandbox_id) = agent.attached_sandbox_id() {
+            self.sandboxes
+                .detach_from_agent_in_op(op, sandbox_id, id)
+                .await?;
+        }
         // Cascade soft-delete sessions before agent (mirrors project → agents).
         self.sessions.delete_for_agent_in_op(op, id).await?;
         self.repo.delete_in_op(op, agent).await?;

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -576,19 +576,27 @@ impl Agents {
         id: impl Into<AgentId> + std::fmt::Debug,
     ) -> Result<(), AgentError> {
         let id = id.into();
-        let agent = self.repo.find_by_id_in_op(&mut *op, id).await?;
+        let mut agent = self.repo.find_by_id_in_op(&mut *op, id).await?;
         Audit::record_project_id(agent.project_id);
         Audit::record_agent_id(id);
-        // Drop the sandbox-side attachment so its `attached_agents`
-        // list doesn't reference a deleted agent. Idempotent — no-op
-        // when nothing is attached.
-        if let Some(sandbox_id) = agent.attached_sandbox_id() {
-            self.sandboxes
+        // Mirror `detach_sandbox`: agent-side detach event + sandbox-side
+        // detach. The session detach notification is folded into the
+        // session delete below to avoid loading the session twice.
+        let session_detach = if let Some(sandbox_id) = agent.attached_sandbox_id() {
+            if agent.sandbox_detached(sandbox_id).did_execute() {
+                self.repo.update_in_op(&mut *op, &mut agent).await?;
+            }
+            let sandbox = self
+                .sandboxes
                 .detach_from_agent_in_op(op, sandbox_id, id)
                 .await?;
-        }
-        // Cascade soft-delete sessions before agent (mirrors project → agents).
-        self.sessions.delete_for_agent_in_op(op, id).await?;
+            Some((sandbox.name, session::message::SandboxOperation::Detach))
+        } else {
+            None
+        };
+        self.sessions
+            .delete_for_agent_in_op(op, id, session_detach)
+            .await?;
         self.repo.delete_in_op(op, agent).await?;
         Ok(())
     }

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -280,15 +280,23 @@ impl Sessions {
         session.exportable_thread(target)
     }
 
+    /// Used by the agent-delete cascade. The optional `detach` records
+    /// a sandbox-detach notification on the session (mirrors
+    /// [`Self::sandbox_notification_in_op`]) right before the soft
+    /// delete, so the chat history reflects the detach without an extra
+    /// load. `EsRepo::delete_in_op` cascades to nested `session_threads`.
     #[instrument(name = "domain.agent_session.delete_for_agent_in_op", skip(self, op))]
     pub async fn delete_for_agent_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,
         agent_id: AgentId,
+        detach: Option<(String, message::SandboxOperation)>,
     ) -> Result<(), AgentSessionError> {
-        self.repo
-            .cascade_delete_for_agent_in_op(op, agent_id)
-            .await?;
+        let mut session = self.repo.find_by_agent_id_in_op(op, agent_id).await?;
+        if let Some((sandbox_name, operation)) = detach {
+            session.add_sandbox_notification(sandbox_name, operation)?;
+        }
+        self.repo.delete_in_op(op, session).await?;
         Ok(())
     }
 }

--- a/core/src/agent/session/repo.rs
+++ b/core/src/agent/session/repo.rs
@@ -26,27 +26,6 @@ impl AgentSessionRepo {
             threads: SessionThreadRepo::new(pool),
         }
     }
-
-    /// Soft-delete = no-event column update, so bulk SQL is equivalent to
-    /// per-entity `delete_in_op`.
-    pub async fn cascade_delete_for_agent_in_op(
-        &self,
-        op: &mut es_entity::DbOp<'_>,
-        agent_id: AgentId,
-    ) -> Result<(), sqlx::Error> {
-        sqlx::query(
-            "UPDATE session_threads SET deleted = TRUE \
-             WHERE session_id IN (SELECT id FROM agent_sessions WHERE agent_id = $1)",
-        )
-        .bind(agent_id)
-        .execute(op.as_executor())
-        .await?;
-        sqlx::query("UPDATE agent_sessions SET deleted = TRUE WHERE agent_id = $1")
-            .bind(agent_id)
-            .execute(op.as_executor())
-            .await?;
-        Ok(())
-    }
 }
 
 #[derive(EsRepo, Clone)]

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -82,6 +82,7 @@ enum AgentCommand {
     List,
     AttachSandbox,
     DetachSandbox,
+    Delete,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -93,7 +94,7 @@ struct AgentParams {
     project_id: Option<ProjectId>,
     /// Display name for the new agent (required for `create`).
     name: Option<String>,
-    /// ID of the agent (required for `attach_sandbox` and `detach_sandbox`).
+    /// ID of the agent (required for `attach_sandbox`, `detach_sandbox`, and `delete`).
     #[schemars(with = "Option<uuid::Uuid>")]
     agent_id: Option<AgentId>,
     /// ID of the sandbox (required for `attach_sandbox` and `detach_sandbox`).
@@ -491,7 +492,9 @@ static TOOLS: &[ToolDef] = &[
         description: "Manage agents. Commands: `create` (requires `project_id`, `name`), \
                        `list` (requires `project_id`), \
                        `attach_sandbox` (requires `agent_id`, `sandbox_id`, optional `mode`), \
-                       `detach_sandbox` (requires `agent_id`, `sandbox_id`).",
+                       `detach_sandbox` (requires `agent_id`, `sandbox_id`), \
+                       `delete` (requires `agent_id`; soft-deletes the agent, cascades \
+                       to its session and detaches any attached sandbox).",
         schema: &AGENT_SCHEMA,
     },
     ToolDef {
@@ -747,6 +750,19 @@ impl AdminToolSet {
                     .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
                 Ok(CallToolResult::success(vec![Content::text(format_agent(
                     &agent,
+                ))]))
+            }
+
+            AgentCommand::Delete => {
+                let agent_id = params.agent_id.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("agent_id is required for delete".to_string())
+                })?;
+                self.agents
+                    .delete(subject, agent_id)
+                    .await
+                    .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Agent deleted (id {agent_id})."
                 ))]))
             }
         }

--- a/core/src/toolset/top_level/agent.rs
+++ b/core/src/toolset/top_level/agent.rs
@@ -40,6 +40,7 @@ enum ProjectAgentCommand {
     List,
     AttachSandbox,
     DetachSandbox,
+    Delete,
 }
 
 impl ProjectAgentCommand {
@@ -49,6 +50,7 @@ impl ProjectAgentCommand {
             Self::List => "agent.list",
             Self::AttachSandbox => "agent.attach_sandbox",
             Self::DetachSandbox => "agent.detach_sandbox",
+            Self::Delete => "agent.delete",
         }
     }
 }
@@ -91,7 +93,9 @@ impl TopLevelTool for ProjectAgent {
     fn description(&self) -> &str {
         "Manage agents. Commands: `create` (requires `name`), `list`, \
          `attach_sandbox` (requires `agent_id`, `sandbox_id`, optional `mode`), \
-         `detach_sandbox` (requires `agent_id`, `sandbox_id`)."
+         `detach_sandbox` (requires `agent_id`, `sandbox_id`), \
+         `delete` (requires `agent_id`; soft-deletes the agent, cascades \
+         to its session and detaches any attached sandbox)."
     }
 
     fn input_schema(&self) -> &serde_json::Value {
@@ -188,6 +192,20 @@ impl TopLevelTool for ProjectAgent {
                     .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
                 Ok(CallToolResult::success(vec![Content::text(format_agent(
                     &agent,
+                ))]))
+            }
+
+            ProjectAgentCommand::Delete => {
+                let agent_id = params.agent_id.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("agent_id is required for delete".to_string())
+                })?;
+
+                self.agents
+                    .delete(subject, agent_id)
+                    .await
+                    .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Agent deleted (id {agent_id})."
                 ))]))
             }
         }

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -18,6 +18,83 @@ async fn pool() -> sqlx::PgPool {
     sqlx::PgPool::connect(&url).await.expect("connect to pg")
 }
 
+/// Inserts a bare project row so foreign keys (agents.project_id, etc.)
+/// resolve in tests that don't go through `Projects::create`.
+async fn insert_project(pool: &sqlx::PgPool) -> ProjectId {
+    let id = ProjectId::new();
+    let name = format!("test-project-{}", uuid::Uuid::from(id));
+    sqlx::query("INSERT INTO projects (id, name, created_at) VALUES ($1, $2, NOW())")
+        .bind(id)
+        .bind(&name)
+        .execute(pool)
+        .await
+        .expect("insert project");
+    id
+}
+
+/// Builds a minimal `Agents` (+ shared `Sandboxes`) wired against a real
+/// pool. The prompt-request channel is dropped on the receiver side; tests
+/// that exercise `delete` / `list` don't dispatch prompts.
+async fn build_agents(pool: &sqlx::PgPool) -> (Agents, Arc<Sandboxes>) {
+    let (prompt_tx, _prompt_rx) = mpsc::channel::<PromptRequest>(64);
+
+    let model_name = "claude-haiku-4-5-20251001".to_string();
+    let mut builtin_roles = HashMap::new();
+    builtin_roles.insert(
+        AgentRole::ProjectLead,
+        RoleConfig {
+            model: model_name.clone(),
+            compaction: Default::default(),
+        },
+    );
+    builtin_roles.insert(
+        AgentRole::Agent,
+        RoleConfig {
+            model: model_name.clone(),
+            compaction: Default::default(),
+        },
+    );
+    let mut models = HashMap::new();
+    models.insert(
+        model_name.clone(),
+        ModelDefaults {
+            model: model_name,
+            max_tokens_per_response: 1024,
+            context_window_tokens: 200_000,
+        },
+    );
+    let config = AgentsConfig {
+        builtin_roles,
+        models,
+    };
+
+    let toolsets = Arc::new(
+        ToolSets::init(ToolSetsConfig::default())
+            .await
+            .expect("init toolsets"),
+    );
+    let sandboxes = Arc::new(
+        Sandboxes::init(pool, SandboxConfig::default(), None)
+            .await
+            .expect("init sandboxes"),
+    );
+    let skills = Arc::new(drua_core::skill::Skills::new_without_library(
+        pool,
+        Arc::clone(&sandboxes),
+    ));
+    let agents = Agents::new(
+        pool,
+        config,
+        toolsets,
+        prompt_tx,
+        Arc::clone(&sandboxes),
+        skills,
+        None,
+        ContextGeneration::new(),
+    );
+    (agents, sandboxes)
+}
+
 #[tokio::test]
 async fn send_message_round_trip_via_prompt_channel() {
     let pool = pool().await;
@@ -356,4 +433,102 @@ async fn send_message_dispatches_registered_tool_call() {
         }
         other => panic!("event[5] should be Done, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn delete_removes_agent_from_listing() {
+    let pool = pool().await;
+    let (agents, _sandboxes) = build_agents(&pool).await;
+    let project_id = insert_project(&pool).await;
+    let sub = AuthSubject::User(UserId::new());
+
+    let agent = agents
+        .create_project_lead(&sub, project_id, "lead", "test-project")
+        .await
+        .expect("create lead");
+
+    agents.delete(&sub, agent.id).await.expect("delete");
+
+    let listed = agents
+        .list_for_project(&sub, project_id)
+        .await
+        .expect("list");
+    assert!(
+        !listed.iter().any(|a| a.id == agent.id),
+        "deleted agent should not appear in listing"
+    );
+}
+
+#[tokio::test]
+async fn delete_is_idempotent_on_second_call() {
+    let pool = pool().await;
+    let (agents, _sandboxes) = build_agents(&pool).await;
+    let project_id = insert_project(&pool).await;
+    let sub = AuthSubject::User(UserId::new());
+
+    let agent = agents
+        .create_project_lead(&sub, project_id, "lead", "test-project")
+        .await
+        .expect("create lead");
+
+    agents.delete(&sub, agent.id).await.expect("first delete");
+    // Second delete on a soft-deleted entity surfaces as `Find` —
+    // expected and acceptable per project convention; the row is gone
+    // from listings either way.
+    let second = agents.delete(&sub, agent.id).await;
+    assert!(
+        second.is_err(),
+        "soft-deleted agent should not be findable for re-delete"
+    );
+}
+
+#[tokio::test]
+async fn delete_detaches_attached_sandbox() {
+    use drua_core::sandbox::{SandboxAgentMode, SandboxMode, SandboxSpecs};
+
+    let pool = pool().await;
+    let (agents, sandboxes) = build_agents(&pool).await;
+    let project_id = insert_project(&pool).await;
+    let sub = AuthSubject::User(UserId::new());
+
+    let _lead = agents
+        .create_project_lead(&sub, project_id, "lead", "test-project")
+        .await
+        .expect("create lead");
+
+    let sandbox = sandboxes
+        .create(
+            &sub,
+            project_id,
+            "sb",
+            SandboxSpecs {
+                cpu: "100m".to_string(),
+                memory: "128Mi".to_string(),
+                disk_size: "1Gi".to_string(),
+            },
+            SandboxMode::Scratch,
+        )
+        .await
+        .expect("create sandbox");
+
+    let agent = agents
+        .create_agent(
+            &sub,
+            project_id,
+            "worker",
+            Some((sandbox.id, SandboxAgentMode::Read)),
+        )
+        .await
+        .expect("create attached agent");
+
+    agents.delete(&sub, agent.id).await.expect("delete agent");
+
+    let after = sandboxes
+        .find_by_id(&sub, sandbox.id)
+        .await
+        .expect("find sandbox");
+    assert!(
+        after.attached_agents.iter().all(|(id, _)| *id != agent.id),
+        "sandbox.attached_agents should not reference the deleted agent"
+    );
 }

--- a/server/src/graphql/agent.rs
+++ b/server/src/graphql/agent.rs
@@ -133,3 +133,13 @@ pub struct AgentDetachSandboxInput {
 }
 
 mutation_payload! { AgentDetachSandboxPayload, agent: Agent }
+
+#[derive(InputObject)]
+pub struct AgentDeleteInput {
+    pub id: AgentId,
+}
+
+#[derive(async_graphql::SimpleObject)]
+pub struct AgentDeletePayload {
+    pub deleted_id: AgentId,
+}

--- a/server/src/graphql/mutation.rs
+++ b/server/src/graphql/mutation.rs
@@ -94,6 +94,18 @@ impl Mutation {
         Ok(AgentDetachSandboxPayload::from(Agent::from(agent)))
     }
 
+    async fn agent_delete(
+        &self,
+        ctx: &Context<'_>,
+        input: AgentDeleteInput,
+    ) -> async_graphql::Result<AgentDeletePayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        app.agents().delete(sub, input.id).await?;
+        Ok(AgentDeletePayload {
+            deleted_id: input.id,
+        })
+    }
+
     async fn sandbox_create(
         &self,
         ctx: &Context<'_>,

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -28,6 +28,14 @@ type AgentCreatePayload {
 	agent: Agent!
 }
 
+input AgentDeleteInput {
+	id: AgentId!
+}
+
+type AgentDeletePayload {
+	deletedId: AgentId!
+}
+
 input AgentDetachSandboxInput {
 	agentId: AgentId!
 	sandboxId: SandboxId!
@@ -214,6 +222,7 @@ type Me {
 type Mutation {
 	agentAttachSandbox(input: AgentAttachSandboxInput!): AgentAttachSandboxPayload!
 	agentCreate(input: AgentCreateInput!): AgentCreatePayload!
+	agentDelete(input: AgentDeleteInput!): AgentDeletePayload!
 	agentDetachSandbox(input: AgentDetachSandboxInput!): AgentDetachSandboxPayload!
 	mcpCredentialsCreate(input: McpCredentialsCreateInput!): McpCredentialsCreatePayload!
 	mcpCredentialsRevoke(input: McpCredentialsRevokeInput!): McpCredentialsRevokePayload!


### PR DESCRIPTION
## Summary

End-to-end `delete agent` use case across all four layers.

### Domain (`core/src/agent/mod.rs`)
- New `Agents::delete` (auth + own op + commit) — mirrors `Skills::delete` /
  `ProjectSecrets::delete`. Auth: `AuthVerb::Delete` on
  `AuthResource::Agent(project_id, Some(id))` (gated by `ProjectAdmin`).
- `Agents::delete_in_op` (already used by project cascade) extended to
  detach the agent from any attached sandbox so `Sandbox.attached_agents`
  never references a deleted agent.
- Soft-delete via the existing `AgentRepo` `delete = "soft_without_queries"`
  machinery — no new `AgentEvent::Deleted` (matches the Skills /
  ProjectSecrets peer pattern). Re-delete on a soft-deleted agent surfaces
  as `AgentError::Find` (es-entity convention); listings already filter it.

### GraphQL (`server/src/graphql/{agent,mutation,schema.graphql}.rs`)
- `agentDelete(input: AgentDeleteInput!): AgentDeletePayload!`
- `AgentDeleteInput { id }`, `AgentDeletePayload { deletedId }` —
  exact shape match for `projectSecretDelete`.
- SDL regenerated via `cargo run --bin write_sdl`.

### Admin searchable (`core/src/toolset/searchable/admin.rs`)
- `drua_admin_agent` gains `Delete` command (`agent_id` required).

### Top-level (`core/src/toolset/top_level/agent.rs`)
- Workspace-lead `agent` tool gains `Delete` command (`agent_id` required).

### Tests (`core/tests/agent.rs`)
- `delete_removes_agent_from_listing`
- `delete_is_idempotent_on_second_call`
- `delete_detaches_attached_sandbox`

Existing tests untouched. `nix flake check` passes (fmt + clippy + nextest
+ graphql-schema + default-config).

## Cascade & policy decisions

- **Soft delete** via es-entity `soft_without_queries`. Matches
  `Skills::delete`, `ProjectSecrets::delete`. No new event variant.
- **Cascade**: sessions (already), sandbox-attachment detach (new).
  Workflow-spawned agents already filter out of `list_for_project`; the
  workflow-run executor is the only thing that deletes them via project
  cascade today and that path is unaffected.
- **Auth**: `Delete` on `Agent(project, Some(id))` — same gate as the
  other write-ops (`update`, `attach_sandbox`, `detach_sandbox`).
- **Idempotency**: re-delete on a soft-deleted agent returns
  `AgentError::Find`. Project convention — same shape as Skills /
  ProjectSecrets re-delete.

## Discrepancy with recent direction

Commit `acca538` (~12h before this PR) explicitly **removed** `delete`
from `drua_admin_workflow`, `drua_admin_skill`, and the top-level
`workflow` tool, plus dropped `Workflows::delete` entirely. Per the task
spec ("admin searchable + top-level workspace-lead, mirroring how
delete-sandbox / delete-workflow / delete-skill are exposed") this PR
re-introduces the Delete arm on both admin and top-level for agents.

Easy revert if the broader policy is "no entity-level delete in toolsets,
top-level included" — drop the two `Delete` arms and keep the domain +
GraphQL layer.

## Test plan

- [ ] `nix flake check` passes (already verified locally)
- [ ] CI green
- [ ] Manual: GraphQL `agentDelete` round-trips on a project with an
      attached agent, sandbox's `attachedAgents` no longer lists it
- [ ] Manual: `drua_admin_agent { command: "delete", agent_id: ... }`
      succeeds and lists no longer show the agent
- [ ] Manual: top-level `agent { command: "delete", agent_id: ... }`
      from a project-lead session

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new delete path that mutates multiple related entities (agent, session, sandbox attachments) and is now exposed via GraphQL and toolsets, so bugs could leave inconsistent attachments or missing audit coverage. Uses soft-deletes and existing auth checks, reducing data-loss risk but still touching core lifecycle behavior.
> 
> **Overview**
> Adds end-to-end **agent deletion** support. The domain layer introduces `Agents::delete` (auth + audited transaction) and extends `delete_in_op` to **detach any attached sandbox** before soft-deleting the agent and cascading the session delete (recording a final sandbox-detach notification).
> 
> Exposes this capability via a new GraphQL mutation `agentDelete` and adds a `delete` command to both the admin searchable `agent` tool and the project-scoped top-level `agent` tool. Adds integration tests covering listing removal, expected behavior on re-delete, and sandbox detachment on delete.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0bea3bed2e76c2a35b10038da5766ef14ebff03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->