### PR TITLE
feat(server): delete-agent button on agent detail page

### DIFF
--- a/server/templates/project_agent_detail.html
+++ b/server/templates/project_agent_detail.html
@@ -200,4 +200,21 @@
 {% endif %}
 {% endmatch %}
 {% endif %}
+
+{% if !agent.is_lead %}
+<hr>
+<h3>Danger zone</h3>
+<p><small>Soft-deletes the agent. Its chat history is retained but the agent
+no longer appears in listings. Any attached sandbox is detached (the sandbox
+itself is kept).</small></p>
+<button
+  data-gql-mutation="mutation($input: AgentDeleteInput!) { agentDelete(input: $input) { deletedId } }"
+  data-gql-input='{"id":"{{ agent.id }}"}'
+  data-gql-confirm="Delete agent '{{ agent.name }}'? This cannot be undone."
+  data-gql-redirect="/projects/{{ project.id }}"
+  class="outline secondary"
+>
+  Delete Agent
+</button>
+{% endif %}
 {% endblock %}


### PR DESCRIPTION
## Summary

PR #263 (`feat(agents): delete agent end-to-end`) shipped the
`agentDelete` GraphQL mutation but no UI surface existed for it. This
adds a **Danger Zone** section to the agent detail page that:

- Calls `agentDelete(input: { id })` via the existing
  `data-gql-mutation` button helper in `base.html`
- Prompts the user for confirmation (\"Delete agent '<name>'? This
  cannot be undone.\")
- Redirects back to the project hub on success
- Is hidden for project leads — their lifecycle is tied to the project,
  and `Agents::delete` won't gracefully replace them anyway

Mirrors the existing `Detach Sandbox` button on the same page and the
`Delete` row buttons in `project_secrets_list.html`.

## Test plan

- [ ] CI green
- [ ] Manual: log into the project hub, open an agent's detail page,
      click \"Delete Agent\", confirm — agent disappears from the
      sidebar and you land on the project page
- [ ] Manual: open a project lead's detail page — no delete button
      visible
- [ ] Manual: delete an agent that's attached to a sandbox — sandbox
      stays, agent gone, sandbox detail no longer lists it

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Exposes a destructive `agentDelete` action in the UI; while it uses an existing GraphQL mutation and client-side confirm/redirect, mistakes could lead to accidental deletions or incorrect visibility (e.g., showing for lead agents).
> 
> **Overview**
> Adds a **Danger zone** section to `project_agent_detail.html` that lets users soft-delete a non-lead agent from its detail page.
> 
> The new button triggers the existing `agentDelete` GraphQL mutation via the `data-gql-mutation` helper, prompts for confirmation, and redirects back to the project page on success; it is hidden when `agent.is_lead` is true.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52d0076d2d0aa521b6a8aab2f60fc70c472ae50d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->