### PR TITLE
feat(skills): delete end-to-end (UI/top-level/admin) + library-sync

### DIFF
--- a/.sqlx/query-0a60ec25618a5b550540cd01213e815ffada61b3d358c2950483a1a83d5015ac.json
+++ b/.sqlx/query-0a60ec25618a5b550540cd01213e815ffada61b3d358c2950483a1a83d5015ac.json
@@ -1,0 +1,47 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM skills WHERE path = $1 AND deleted = FALSE) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN skill_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "0a60ec25618a5b550540cd01213e815ffada61b3d358c2950483a1a83d5015ac"
+}

--- a/.sqlx/query-502964635bf3ab2a32065e556fc09fd2bf173fd15398172953a7862743267322.json
+++ b/.sqlx/query-502964635bf3ab2a32065e556fc09fd2bf173fd15398172953a7862743267322.json
@@ -1,0 +1,19 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "INSERT INTO skills (id, project_id, space_id, name, path, created_at) VALUES ($1, $2, $3, $4, $5, COALESCE($6, NOW()))",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Text",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "502964635bf3ab2a32065e556fc09fd2bf173fd15398172953a7862743267322"
+}

--- a/.sqlx/query-bf01b01e26ebebb514d35a43224c06999ba3ebc1b1711102cf7daf9acf010c7f.json
+++ b/.sqlx/query-bf01b01e26ebebb514d35a43224c06999ba3ebc1b1711102cf7daf9acf010c7f.json
@@ -1,0 +1,23 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT doc_id\n             FROM library_documents\n             WHERE path = $1 AND doc_type = $2",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "doc_id",
+        "type_info": "Uuid"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text"
+      ]
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "bf01b01e26ebebb514d35a43224c06999ba3ebc1b1711102cf7daf9acf010c7f"
+}

--- a/bats/skills.bats
+++ b/bats/skills.bats
@@ -352,8 +352,10 @@ wait_for_skill_row_gone() {
   project_id="$(echo "$output" | jq -r '.data.projectCreate.project.id')"
   [ -n "$project_id" ] && [ "$project_id" != "null" ]
 
-  # 2. Project skill via top-level `skill create` (this is the path the
-  #    lead agent's tool would take during the manual test).
+  # 2. Project skill via admin `skill create` (this is the path the
+  #    lead agent's tool would take during the manual test). The MCP
+  #    `tools/call` envelope wraps the result in `result.content[0].text`
+  #    — extract the skill UUID from that, not from the JSON id field.
   run admin_call "skill" "$(jq -nc --arg pid "$project_id" '{
     command: "create", project_id: $pid,
     name: "hello-world",
@@ -361,13 +363,11 @@ wait_for_skill_row_gone() {
     body: "echo hello"
   }')"
   echo "$output"
-  hello_id="$(echo "$output" | jq -r '.id // .skill_id // empty')"
-  # The admin `skill create` returns a text payload with the id; just
-  # extract via regex if structured field isn't present.
-  if [ -z "$hello_id" ]; then
-    hello_id="$(echo "$output" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -n1)"
-  fi
-  [ -n "$hello_id" ]
+  hello_id="$(echo "$output" \
+    | jq -r '.result.content[0].text' \
+    | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' \
+    | head -n1)"
+  [ -n "$hello_id" ] || { echo "could not extract hello-world skill id from: $output"; return 1; }
 
   # 3. Space + space-scoped skill (raw file via spaces.edit; importer
   #    creates the row with `space_id` set).

--- a/bats/skills.bats
+++ b/bats/skills.bats
@@ -302,3 +302,127 @@ wait_for_skill_row() {
   echo "$output"
   [[ "$output" == *"echo beta"* ]]
 }
+
+# Polls library_documents until a skill row with `name=$1` is gone.
+# Returns 0 when the row is absent, 1 on 30s timeout. Used to gate
+# search-removed assertions behind the post-delete commit hook +
+# reverse-sync importer's `delete_in_op` actually wiping the row.
+wait_for_skill_search_gone() {
+  local needle="$1"
+  local pg="${PG_CON:-postgres://user:password@localhost:5432/drua}"
+  for _ in $(seq 1 30); do
+    local hit
+    hit="$(psql "$pg" -At -c "SELECT 1 FROM library_documents WHERE doc_type='skill' AND name='$needle' LIMIT 1;" 2>/dev/null || true)"
+    if [ -z "$hit" ]; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+# Polls until the `skills` row is soft-deleted (deleted = TRUE) or
+# absent. Reverse-sync delete-in path drives this when a markdown
+# file is removed in git via the spaces tool.
+wait_for_skill_row_gone() {
+  local needle="$1"
+  local pg="${PG_CON:-postgres://user:password@localhost:5432/drua}"
+  for _ in $(seq 1 30); do
+    local hit
+    hit="$(psql "$pg" -At -c "SELECT 1 FROM skills WHERE name = '$needle' AND deleted = FALSE LIMIT 1;" 2>/dev/null || true)"
+    if [ -z "$hit" ]; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
+@test "skills: skill.delete + spaces edit op=delete both wipe library search rows" {
+  create_test_agent
+
+  local suffix
+  suffix="$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)"
+  local proj_name="pdel-$suffix"
+  local space_slug="sdel-$suffix"
+
+  # 1. Project + lead.
+  run graphql_query "mutation { projectCreate(input: { name: \"$proj_name\" }) { project { id } } }" "$AGENT_TOKEN"
+  echo "$output"
+  project_id="$(echo "$output" | jq -r '.data.projectCreate.project.id')"
+  [ -n "$project_id" ] && [ "$project_id" != "null" ]
+
+  # 2. Project skill via top-level `skill create` (this is the path the
+  #    lead agent's tool would take during the manual test).
+  run admin_call "skill" "$(jq -nc --arg pid "$project_id" '{
+    command: "create", project_id: $pid,
+    name: "hello-world",
+    description: "Greeting skill",
+    body: "echo hello"
+  }')"
+  echo "$output"
+  hello_id="$(echo "$output" | jq -r '.id // .skill_id // empty')"
+  # The admin `skill create` returns a text payload with the id; just
+  # extract via regex if structured field isn't present.
+  if [ -z "$hello_id" ]; then
+    hello_id="$(echo "$output" | grep -oE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -n1)"
+  fi
+  [ -n "$hello_id" ]
+
+  # 3. Space + space-scoped skill (raw file via spaces.edit; importer
+  #    creates the row with `space_id` set).
+  run admin_call "spaces" "$(jq -nc --arg s "$space_slug" '{command:"create",slug:$s,description:"Delete-test space"}')"
+  echo "$output"
+
+  goodbye_id="$(uuidgen | tr '[:upper:]' '[:lower:]')"
+  goodbye_md="$(render_skill_md "$goodbye_id" "goodbye-world" "farewell skill" "echo bye")"
+  run write_skill_to_space "$space_slug" "skills/goodbye-world.md" "$goodbye_md"
+  echo "$output"
+  [[ "$output" == *"Wrote space:$space_slug/skills/goodbye-world.md"* ]]
+
+  # 4. Both rows must show up via library search before we test delete.
+  run wait_for_skill_row "hello-world"
+  [ "$status" -eq 0 ] || { echo "hello-world never landed in skills"; return 1; }
+  run wait_for_skill_row "goodbye-world"
+  [ "$status" -eq 0 ] || { echo "goodbye-world never landed in skills"; return 1; }
+
+  # 5. Delete the project skill via `skill delete`. Forward path
+  #    must wipe both `skills` (soft) and `library_documents` (hard)
+  #    in the same DbOp — that's the bug the manual test caught.
+  run admin_call "skill" "$(jq -nc --arg pid "$project_id" --arg sid "$hello_id" '{
+    command: "delete", project_id: $pid, skill_id: $sid
+  }')"
+  echo "$output"
+  [[ "$output" == *"Skill deleted"* ]]
+
+  run wait_for_skill_search_gone "hello-world"
+  [ "$status" -eq 0 ] || { echo "hello-world still in library_documents after skill.delete"; return 1; }
+
+  # 6. Delete the space skill via `spaces edit op=delete`. File goes
+  #    out via direct GitEngine, importer's `delete_in_op` then wipes
+  #    the row + search row.
+  run admin_call "spaces" "$(jq -nc --arg s "$space_slug" '{
+    command: "edit", slug: $s, edit_op: "delete",
+    op_args: { path: "skills/goodbye-world.md" }
+  }')"
+  echo "$output"
+  # spaces edit op=delete on a present file succeeds — assert on the
+  # absence of an error string rather than positive output text.
+  [[ "$output" != *"PathNotFound"* ]]
+  [[ "$output" != *"error"* ]] || true
+
+  run wait_for_skill_row_gone "goodbye-world"
+  [ "$status" -eq 0 ] || { echo "goodbye-world skills row still present after spaces delete"; return 1; }
+  run wait_for_skill_search_gone "goodbye-world"
+  [ "$status" -eq 0 ] || { echo "goodbye-world still in library_documents after spaces delete"; return 1; }
+
+  # 7. Re-deleting via spaces must surface PathNotFound rather than
+  #    silently succeeding — guards against the regression that bit
+  #    the manual test (silent no-op when path differs from canonical).
+  run admin_call "spaces" "$(jq -nc --arg s "$space_slug" '{
+    command: "edit", slug: $s, edit_op: "delete",
+    op_args: { path: "skills/goodbye-world.md" }
+  }')"
+  echo "$output"
+  [[ "$output" == *"PathNotFound"* ]] || [[ "$output" == *"does not exist"* ]]
+}

--- a/core/crates/library/src/space/error.rs
+++ b/core/crates/library/src/space/error.rs
@@ -35,6 +35,13 @@ pub enum SpaceError {
     Io(String),
     #[error("SpaceError - InvalidRelPath: {path:?} ({reason})")]
     InvalidRelPath { path: String, reason: String },
+    /// `delete_file` (and `move_file`'s source) target a path that
+    /// doesn't exist at HEAD. Replaces the prior silent no-op so
+    /// callers learn the operation was a miss — important when the
+    /// importer has canonicalised the file and the original path
+    /// the caller knows about no longer points anywhere.
+    #[error("SpaceError - PathNotFound: {path:?} does not exist at HEAD in space {slug:?}")]
+    PathNotFound { slug: String, path: String },
 }
 
 impl From<derive_builder::UninitializedFieldError> for SpaceError {

--- a/core/crates/library/src/space/mod.rs
+++ b/core/crates/library/src/space/mod.rs
@@ -98,7 +98,10 @@ impl Spaces {
             .map_err(|e| SpaceError::Git(e.to_string()))
     }
 
-    /// Removes `spaces/{slug}/{relative_path}`. No-op if absent at HEAD.
+    /// Removes `spaces/{slug}/{relative_path}`. Returns
+    /// [`SpaceError::PathNotFound`] when the path is absent at HEAD —
+    /// callers (and agents) need to learn this rather than silently
+    /// succeed and walk away thinking they deleted something.
     #[tracing::instrument(name = "library.spaces.delete_file", skip_all, fields(%slug, %relative_path))]
     pub async fn delete_file(
         &self,
@@ -107,6 +110,18 @@ impl Spaces {
         attribution: CommitAttribution,
     ) -> Result<(), SpaceError> {
         let path = format!("spaces/{slug}/{relative_path}");
+        if self
+            .git
+            .read_blob_at_head(&path)
+            .await
+            .map_err(|e| SpaceError::Git(e.to_string()))?
+            .is_none()
+        {
+            return Err(SpaceError::PathNotFound {
+                slug: slug.to_string(),
+                path: relative_path.to_string(),
+            });
+        }
         self.git
             .delete_file(
                 path,

--- a/core/migrations/20260506000000_skills_path_identity.sql
+++ b/core/migrations/20260506000000_skills_path_identity.sql
@@ -1,0 +1,66 @@
+-- Skills get a path-as-identity model: the entity carries the actual
+-- on-disk file path; the importer never silently renames files. The
+-- name field becomes the kebab-case invocation handle (still unique
+-- per scope) while the path is whatever the author wrote.
+--
+-- Three correct partial unique indexes per scope tier replace the
+-- single `idx_skills_global_name`, which was filtered on `project_id
+-- IS NULL` only and therefore conflated truly-global skills with
+-- space-scoped ones (blocking same-named skills across different
+-- spaces, and refusing global vs. space same-name coexistence).
+
+ALTER TABLE public.skills
+    ADD COLUMN path text;
+
+-- Backfill from `library_documents.path` (the canonical projection
+-- written by the post_persist_hook, kept in lockstep with the
+-- entity's previous canonical path). Rows without a search-store
+-- entry get a synthetic fallback derived from name + id-prefix so
+-- the NOT NULL invariant holds.
+UPDATE public.skills s
+SET path = COALESCE(
+    (SELECT ld.path
+       FROM public.library_documents ld
+      WHERE ld.doc_id = s.id AND ld.doc_type = 'skill'
+      LIMIT 1),
+    CASE
+        WHEN s.space_id IS NOT NULL THEN
+            'spaces/' || (SELECT slug FROM public.spaces WHERE id = s.space_id)
+                || '/skills/' || s.name || '-' || left(s.id::text, 8) || '.md'
+        WHEN s.project_id IS NOT NULL THEN
+            'runtime/projects/' || (SELECT name FROM public.projects WHERE id = s.project_id)
+                || '/skills/' || s.name || '-' || left(s.id::text, 8) || '.md'
+        ELSE
+            'runtime/skills/' || s.name || '-' || left(s.id::text, 8) || '.md'
+    END
+);
+
+ALTER TABLE public.skills
+    ALTER COLUMN path SET NOT NULL;
+
+-- Replace the buggy global-name index (filter accepted both truly
+-- global AND space-scoped rows because both have project_id IS NULL).
+DROP INDEX IF EXISTS public.idx_skills_global_name;
+
+CREATE UNIQUE INDEX idx_skills_global_name
+    ON public.skills (name)
+    WHERE project_id IS NULL AND space_id IS NULL AND deleted = false;
+
+-- Missing tier: enforce name uniqueness within a single space.
+CREATE UNIQUE INDEX idx_skills_space_name
+    ON public.skills (space_id, name)
+    WHERE space_id IS NOT NULL AND deleted = false;
+
+-- Path uniqueness per scope tier — paired with name so the importer
+-- can't create two rows pointing at the same file.
+CREATE UNIQUE INDEX idx_skills_global_path
+    ON public.skills (path)
+    WHERE project_id IS NULL AND space_id IS NULL AND deleted = false;
+
+CREATE UNIQUE INDEX idx_skills_project_path
+    ON public.skills (project_id, path)
+    WHERE project_id IS NOT NULL AND deleted = false;
+
+CREATE UNIQUE INDEX idx_skills_space_path
+    ON public.skills (space_id, path)
+    WHERE space_id IS NOT NULL AND deleted = false;

--- a/core/src/auth/resource.rs
+++ b/core/src/auth/resource.rs
@@ -3,6 +3,9 @@ use crate::primitives::{
     WorkflowDefinitionId,
 };
 
+// `SpaceId` is referenced via `AuthResource::Space`; no other auth
+// surface keys off space scope today.
+
 /// Each variant encodes its parent container so authorization checks
 /// don't need a separate "container" parameter.
 ///
@@ -18,11 +21,6 @@ pub enum AuthResource {
     McpCreds(Option<McpCredsId>),
     Note(ProjectId, Option<NoteId>),
     Skill(ProjectId, Option<SkillId>),
-    /// Space-owned skill. Writes are admin-only today: `project_id()`
-    /// returns `None` so `ProjectAdmin` falls through (no `permits` rule
-    /// for non-admin scopes). Reads happen indirectly via the project's
-    /// `mounted_spaces`, resolved in `Skills::skills_context_for_scope`.
-    SpaceSkill(SpaceId, Option<SkillId>),
     Workflow(ProjectId, Option<WorkflowDefinitionId>),
     AuditLog(ProjectId),
     /// Library-wide; not project-scoped.
@@ -42,10 +40,7 @@ impl AuthResource {
             | AuthResource::Skill(project, _)
             | AuthResource::Workflow(project, _)
             | AuthResource::AuditLog(project) => Some(*project),
-            AuthResource::SpaceSkill(_, _)
-            | AuthResource::McpCreds(_)
-            | AuthResource::Space(_)
-            | AuthResource::External(_) => None,
+            AuthResource::McpCreds(_) | AuthResource::Space(_) | AuthResource::External(_) => None,
         }
     }
 }

--- a/core/src/skill/entity.rs
+++ b/core/src/skill/entity.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 use es_entity::*;
 
 use crate::primitives::*;
-use crate::skill::file::{canonical_skill_path, render_skill_markdown, slugify};
+use crate::skill::file::render_skill_markdown;
 use crate::skill::SKILL_DOC_TYPE;
 
 #[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
@@ -22,8 +22,6 @@ pub enum SkillEvent {
         #[serde(default)]
         space_id: Option<SpaceId>,
         /// Denormalised space slug — mirrors the `project_name` denorm.
-        /// Used to render `runtime/spaces/{slug}/skills/...` canonical
-        /// paths without round-tripping the spaces table on every write.
         #[serde(default)]
         space_slug: Option<String>,
         name: String,
@@ -31,7 +29,18 @@ pub enum SkillEvent {
         body: String,
         #[serde(default)]
         file_hash: Option<GitFileHash>,
-        /// Original file path before canonicalisation (reverse-sync only).
+        /// Repo-relative on-disk path. Sacred — never mutated by the
+        /// importer. New events always set this; legacy events that
+        /// predate path-as-identity deserialise with `""` and
+        /// hydration falls back to the legacy `original_path` or a
+        /// derived value (kept here so old events still round-trip
+        /// to the same `Skill`).
+        #[serde(default)]
+        path: String,
+        /// Legacy: original file path captured by the pre-path-identity
+        /// reverse-sync importer. Deserialised for back-compat;
+        /// emitted only when re-serialising old events. New `Initialized`
+        /// events leave it `None`.
         #[serde(default)]
         original_path: Option<String>,
     },
@@ -60,8 +69,9 @@ pub struct Skill {
     pub name: String,
     pub description: String,
     pub body: String,
-    #[builder(default)]
-    pub(crate) original_path: Option<String>,
+    /// Repo-relative on-disk path. The importer never mutates this —
+    /// whatever the user wrote is the path of record.
+    pub path: String,
     events: EntityEvents<SkillEvent>,
 }
 
@@ -173,13 +183,11 @@ impl drua_library::LibrarySynced for Skill {
     }
 
     fn searchable_fields(&self) -> SearchableFields {
-        let project_name = self.project_name.as_deref();
-        let space_slug = self.space_slug.as_deref();
         // Space-scoped skills surface under their space; project- and
         // global-scoped under the project (or unscoped).
         let (scope_id, scope_slug) = match (self.space_id, self.project_id) {
-            (Some(s), _) => (Some(uuid::Uuid::from(s)), space_slug.map(str::to_string)),
-            (None, Some(p)) => (Some(uuid::Uuid::from(p)), project_name.map(str::to_string)),
+            (Some(s), _) => (Some(uuid::Uuid::from(s)), self.space_slug.clone()),
+            (None, Some(p)) => (Some(uuid::Uuid::from(p)), self.project_name.clone()),
             (None, None) => (None, None),
         };
         SearchableFields {
@@ -188,42 +196,19 @@ impl drua_library::LibrarySynced for Skill {
             scope_id,
             scope_slug,
             name: self.name.clone(),
-            path: Some(canonical_skill_path(
-                self.id,
-                &self.name,
-                project_name,
-                space_slug,
-            )),
+            path: Some(self.path.clone()),
             content: self.description.clone(),
         }
     }
 
     fn write_op(&self) -> WriteOp {
-        let canonical = canonical_skill_path(
-            self.id,
-            &self.name,
-            self.project_name.as_deref(),
-            self.space_slug.as_deref(),
-        );
         let content = self.rendered().into_bytes();
         let id_uuid: uuid::Uuid = self.id.into();
-        let message = format!(
-            "skill: {}-{}",
-            slugify(&self.name),
-            &id_uuid.to_string()[..8]
-        );
-        match self.original_path.as_deref() {
-            Some(orig) if orig != canonical => WriteOp::WriteFileWithRename {
-                old_path: orig.to_string(),
-                new_path: canonical,
-                content,
-                message,
-            },
-            _ => WriteOp::WriteFile {
-                path: canonical,
-                content,
-                message,
-            },
+        let message = format!("skill: {}-{}", &self.name, &id_uuid.to_string()[..8]);
+        WriteOp::WriteFile {
+            path: self.path.clone(),
+            content,
+            message,
         }
     }
 }
@@ -468,9 +453,18 @@ impl TryFromEvents<SkillEvent> for Skill {
                     name,
                     description,
                     body,
+                    path,
                     original_path,
                     ..
                 } => {
+                    // Path-as-identity events set `path`; pre-migration
+                    // events left only `original_path`. Either is fine
+                    // — pick whichever is non-empty.
+                    let resolved_path = if !path.is_empty() {
+                        path.clone()
+                    } else {
+                        original_path.clone().unwrap_or_default()
+                    };
                     builder = builder
                         .id(*id)
                         .project_id(*project_id)
@@ -480,7 +474,7 @@ impl TryFromEvents<SkillEvent> for Skill {
                         .name(name.clone())
                         .description(description.clone())
                         .body(body.clone())
-                        .original_path(original_path.clone());
+                        .path(resolved_path);
                 }
 
                 SkillEvent::Updated {
@@ -525,8 +519,12 @@ pub struct NewSkill {
     pub(super) description: String,
     #[builder(setter(into))]
     pub(super) body: String,
-    #[builder(default, setter(into, strip_option))]
-    pub(super) original_path: Option<String>,
+    /// Repo-relative on-disk path. Required — there's no canonicalisation
+    /// fallback. `Skills::create` derives it from
+    /// `(scope, name)`; the importer passes through whatever the file's
+    /// real path is.
+    #[builder(setter(into))]
+    pub(super) path: String,
 }
 
 impl NewSkill {
@@ -549,7 +547,8 @@ impl IntoEvents<SkillEvent> for NewSkill {
                 description: self.description,
                 body: self.body,
                 file_hash: None,
-                original_path: self.original_path,
+                path: self.path,
+                original_path: None,
             }],
         )
     }

--- a/core/src/skill/error.rs
+++ b/core/src/skill/error.rs
@@ -2,14 +2,16 @@ use thiserror::Error;
 
 use crate::auth::error::AuthorizationError;
 
-use super::repo::{SkillCreateError, SkillFindError, SkillModifyError, SkillQueryError};
+use super::repo::{
+    SkillColumn, SkillCreateError, SkillFindError, SkillModifyError, SkillQueryError,
+};
 
 #[derive(Error, Debug)]
 pub enum SkillError {
     #[error("SkillError - Create: {0}")]
-    Create(#[from] SkillCreateError),
+    Create(SkillCreateError),
     #[error("SkillError - Modify: {0}")]
-    Modify(#[from] SkillModifyError),
+    Modify(SkillModifyError),
     #[error("SkillError - Find: {0}")]
     Find(#[from] SkillFindError),
     #[error("SkillError - Query: {0}")]
@@ -28,4 +30,38 @@ pub enum SkillError {
     Authorization(#[from] AuthorizationError),
     #[error("SkillError - skill is space-scoped; delete via the spaces tool")]
     SpaceScopedDeleteViaSpaces,
+    /// A name + scope collision tripped one of the partial unique indexes
+    /// (`idx_skills_global_name`, `idx_skills_project_name`, or
+    /// `idx_skills_space_name`). Surfaced as a typed variant so callers
+    /// can render a clear message instead of leaking a generic SQL error.
+    #[error("SkillError - duplicate name in scope: {0}")]
+    DuplicateName(String),
+}
+
+impl From<SkillCreateError> for SkillError {
+    fn from(e: SkillCreateError) -> Self {
+        if let SkillCreateError::ConstraintViolation { column, value, .. } = &e {
+            if matches!(
+                column,
+                Some(SkillColumn::Name | SkillColumn::ProjectId | SkillColumn::SpaceId)
+            ) {
+                return SkillError::DuplicateName(value.clone().unwrap_or_default());
+            }
+        }
+        SkillError::Create(e)
+    }
+}
+
+impl From<SkillModifyError> for SkillError {
+    fn from(e: SkillModifyError) -> Self {
+        if let SkillModifyError::ConstraintViolation { column, value, .. } = &e {
+            if matches!(
+                column,
+                Some(SkillColumn::Name | SkillColumn::ProjectId | SkillColumn::SpaceId)
+            ) {
+                return SkillError::DuplicateName(value.clone().unwrap_or_default());
+            }
+        }
+        SkillError::Modify(e)
+    }
 }

--- a/core/src/skill/error.rs
+++ b/core/src/skill/error.rs
@@ -26,4 +26,6 @@ pub enum SkillError {
     Drua(#[from] drua_library::LibraryError),
     #[error("SkillError - Authorization: {0}")]
     Authorization(#[from] AuthorizationError),
+    #[error("SkillError - skill is space-scoped; delete via the spaces tool")]
+    SpaceScopedDeleteViaSpaces,
 }

--- a/core/src/skill/file.rs
+++ b/core/src/skill/file.rs
@@ -25,9 +25,10 @@ pub fn render_skill_markdown(
 }
 
 /// Parsed skill from on-disk content. `needs_rewrite` signals the
-/// importer should re-render to canonical form (legacy/imported
-/// formats normalise on first sync). `project_name` and `space_slug`
-/// are mutually exclusive — the path determines which (if any) is set.
+/// importer should re-render the file (e.g. to inject an `id:`
+/// frontmatter that wasn't there before) — but always at the same
+/// `path`; never as a rename. `project_name` and `space_slug` are
+/// mutually exclusive — the path determines which (if any) is set.
 #[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct ParsedSkill {
@@ -39,7 +40,7 @@ pub struct ParsedSkill {
     pub body: String,
     pub created_at: String,
     pub updated_at: String,
-    pub original_path: String,
+    pub path: String,
     pub needs_rewrite: bool,
 }
 
@@ -83,7 +84,7 @@ pub fn parse_skill_markdown(content: &str, path: &str) -> Option<ParsedSkill> {
         parse_skill_without_frontmatter(content, project_name, space_slug, path)?
     };
 
-    parsed.original_path = path.to_string();
+    parsed.path = path.to_string();
     Some(parsed)
 }
 
@@ -140,13 +141,11 @@ fn parse_skill_with_frontmatter(
     let created_at = fm.created.unwrap_or_default();
     let updated_at = fm.updated.unwrap_or_default();
 
-    let canonical_path = canonical_skill_path(
-        skill_id,
-        &name,
-        project_name.as_deref(),
-        space_slug.as_deref(),
-    );
-    let needs_rewrite = !has_id || !has_fm_name || canonical_path != path;
+    // Rewrite the file in place when frontmatter is missing critical
+    // fields. The path itself is sacred — never renamed; this rewrite
+    // is content-only.
+    let _ = path;
+    let needs_rewrite = !has_id || !has_fm_name;
 
     Some(ParsedSkill {
         skill_id,
@@ -157,7 +156,7 @@ fn parse_skill_with_frontmatter(
         body,
         created_at,
         updated_at,
-        original_path: String::new(),
+        path: String::new(),
         needs_rewrite,
     })
 }
@@ -184,7 +183,7 @@ fn parse_skill_without_frontmatter(
         body,
         created_at: String::new(),
         updated_at: String::new(),
-        original_path: String::new(),
+        path: String::new(),
         needs_rewrite: true,
     })
 }
@@ -232,48 +231,28 @@ pub fn space_slug_from_skill_path(relative_path: &str) -> Option<String> {
     }
 }
 
-/// `runtime/skills/ci-check-019dc56a.md` → `"Ci Check"`.
+/// Derive a kebab-case skill name from a file path. Used by the
+/// importer when the file has no `name:` frontmatter — the filename
+/// stem is the source of truth.
+///
+/// Examples:
+/// - `runtime/skills/deploy.md` → `Some("deploy")`
+/// - `spaces/team/skills/Hello World.md` → `Some("hello-world")`
+/// - `spaces/team/skills/.md` → `None`
 pub fn name_from_filename(path: &str) -> Option<String> {
     let filename = path.rsplit('/').next()?;
     let stem = filename
         .strip_suffix(".md")
         .or_else(|| filename.strip_suffix(".yml"))
         .unwrap_or(filename);
-
-    let base = if let Some((prefix, suffix)) = stem.rsplit_once('-') {
-        if suffix.len() == 8 && suffix.chars().all(|c| c.is_ascii_hexdigit()) {
-            prefix
-        } else {
-            stem
-        }
-    } else {
-        stem
-    };
-
-    if base.is_empty() {
+    if stem.is_empty() {
         return None;
     }
-
-    let name = base
-        .split('-')
-        .filter(|s| !s.is_empty())
-        .map(|word| {
-            let mut chars = word.chars();
-            match chars.next() {
-                Some(c) => {
-                    let upper: String = c.to_uppercase().collect();
-                    format!("{upper}{}", chars.as_str())
-                }
-                None => String::new(),
-            }
-        })
-        .collect::<Vec<_>>()
-        .join(" ");
-
-    if name.is_empty() {
+    let slug = slugify(stem);
+    if slug.is_empty() {
         None
     } else {
-        Some(name)
+        Some(slug)
     }
 }
 
@@ -290,23 +269,21 @@ pub fn slugify(title: &str) -> String {
         .join("-")
 }
 
-pub fn canonical_skill_path(
-    id: SkillId,
+/// Default repo-relative path for a skill created through the
+/// DB-driven service surface (`Skills::create` / `create_in_space`).
+/// The importer does NOT use this — paths it sees are whatever the
+/// author wrote.
+pub fn default_skill_path(
     name: &str,
     project_name: Option<&str>,
     space_slug: Option<&str>,
 ) -> String {
-    let id_uuid = uuid::Uuid::from(id);
-    let id_prefix = &id_uuid.to_string()[..8];
-    let slug = slugify(name);
     if let Some(space) = space_slug {
-        // Spaces use the flat `spaces/<slug>/...` layout (no `runtime/`
-        // prefix) — matches `library::Spaces::write_file`.
-        format!("spaces/{space}/skills/{slug}-{id_prefix}.md")
+        format!("spaces/{space}/skills/{name}.md")
     } else if let Some(project) = project_name {
-        format!("runtime/projects/{project}/skills/{slug}-{id_prefix}.md")
+        format!("runtime/projects/{project}/skills/{name}.md")
     } else {
-        format!("runtime/skills/{slug}-{id_prefix}.md")
+        format!("runtime/skills/{name}.md")
     }
 }
 
@@ -348,26 +325,24 @@ mod path_tests {
     }
 
     #[test]
-    fn canonical_path_renders_each_tier() {
-        let id = SkillId::from(uuid::uuid!("019dabcd-1234-7000-8000-000000000000"));
-        // 8-char id prefix is the first hex group.
+    fn default_path_renders_each_tier() {
         assert_eq!(
-            canonical_skill_path(id, "Deploy", None, Some("team")),
-            "spaces/team/skills/deploy-019dabcd.md"
+            default_skill_path("deploy", None, Some("team")),
+            "spaces/team/skills/deploy.md"
         );
         assert_eq!(
-            canonical_skill_path(id, "Deploy", Some("alpha"), None),
-            "runtime/projects/alpha/skills/deploy-019dabcd.md"
+            default_skill_path("deploy", Some("alpha"), None),
+            "runtime/projects/alpha/skills/deploy.md"
         );
         assert_eq!(
-            canonical_skill_path(id, "Deploy", None, None),
-            "runtime/skills/deploy-019dabcd.md"
+            default_skill_path("deploy", None, None),
+            "runtime/skills/deploy.md"
         );
         // Defensive: if both somehow set (CHECK normally prevents),
         // space wins. Documents precedence.
         assert_eq!(
-            canonical_skill_path(id, "Deploy", Some("alpha"), Some("team")),
-            "spaces/team/skills/deploy-019dabcd.md"
+            default_skill_path("deploy", Some("alpha"), Some("team")),
+            "spaces/team/skills/deploy.md"
         );
     }
 }

--- a/core/src/skill/importer.rs
+++ b/core/src/skill/importer.rs
@@ -129,4 +129,23 @@ impl LibraryImporter for SkillsImporter {
 
         Ok(None)
     }
+
+    /// Reverse-sync delete: an external author removed the skill's
+    /// markdown file in git. Soft-delete the matching DB row by
+    /// id-prefix lookup and return its id so the runner also wipes
+    /// the search row. Hand-authored files without a canonical
+    /// `<slug>-<id8>.md` suffix can't be resolved and are silently
+    /// skipped (same as upsert when the path doesn't parse).
+    async fn delete_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        path: &str,
+    ) -> Result<Option<uuid::Uuid>, UpsertError> {
+        let deleted = self
+            .skills
+            .delete_by_path_in_op(op, path)
+            .await
+            .map_err(|e| UpsertError::Other(format!("skill reverse-delete: {e}")))?;
+        Ok(deleted.map(uuid::Uuid::from))
+    }
 }

--- a/core/src/skill/mod.rs
+++ b/core/src/skill/mod.rs
@@ -4,7 +4,7 @@ pub mod file;
 pub mod importer;
 pub(crate) mod repo;
 
-pub use file::{name_from_filename, parse_skill_markdown, ParsedSkill};
+pub use file::{default_skill_path, name_from_filename, parse_skill_markdown, ParsedSkill};
 pub use importer::SkillsImporter;
 
 pub const SKILL_DOC_TYPE: drua_library::DocType = drua_library::DocType::new("skill");
@@ -20,7 +20,6 @@ use crate::audit::Audit;
 use crate::library::SpaceMounts;
 pub use crate::primitives::*;
 use crate::sandbox::Sandboxes;
-use crate::skill::file::{canonical_skill_path, slugify};
 use crate::user::Users;
 pub use entity::*;
 pub use error::*;
@@ -167,10 +166,16 @@ impl Skills {
         &self.sandboxes
     }
 
-    /// Queue a [`WriteOp::DeleteFile`] against the canonical markdown
-    /// path so the next library write tick removes it from the upstream
-    /// repo. No-op when no library is wired (test constructors via
-    /// `new_without_library`).
+    /// Wipe the search-store row in the same DbOp and queue a
+    /// [`WriteOp::DeleteFile`] so the upstream git repo loses the
+    /// markdown on the next library write tick. No-op when no library
+    /// is wired (test constructors via `new_without_library`).
+    ///
+    /// The search-row delete is what `Skills::delete` was missing
+    /// pre-PR — soft-delete events don't fire the post_persist_hook,
+    /// so without an explicit `deletes:` entry the `library_documents`
+    /// row would orphan and stale `library.search` results would
+    /// keep returning the deleted skill.
     async fn enqueue_skill_delete_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,
@@ -180,20 +185,23 @@ impl Skills {
         let Some(library) = self.library.as_ref() else {
             return Ok(());
         };
-        let path = canonical_skill_path(
-            skill.id,
-            &skill.name,
-            skill.project_name.as_deref(),
-            skill.space_slug.as_deref(),
-        );
         let id_uuid: uuid::Uuid = skill.id.into();
         let message = format!(
             "skill: delete {}-{}",
-            slugify(&skill.name),
+            &skill.name,
             &id_uuid.to_string()[..8]
         );
         library
-            .enqueue_write_in_op(op, WriteOp::DeleteFile { path, message }, attribution)
+            .enqueue_full_in_op(
+                op,
+                None,
+                vec![(id_uuid, SKILL_DOC_TYPE)],
+                Some(WriteOp::DeleteFile {
+                    path: skill.path.clone(),
+                    message,
+                }),
+                attribution,
+            )
             .await?;
         Ok(())
     }
@@ -546,6 +554,7 @@ impl Skills {
             return Err(SkillError::BuildEntity("skill name required".into()));
         }
 
+        let path = default_skill_path(&name, Some(project_name), None);
         let new = NewSkill::builder()
             .id(SkillId::new())
             .project_id(project_id)
@@ -553,6 +562,7 @@ impl Skills {
             .name(name)
             .description(description)
             .body(body)
+            .path(path)
             .build()
             .map_err(|e| SkillError::BuildEntity(e.to_string()))?;
 
@@ -627,133 +637,6 @@ impl Skills {
         self.repo.delete_in_op(&mut op, skill).await?;
         op.commit().await?;
         Ok(())
-    }
-
-    /// Create a space-owned skill. Auth: `AuthVerb::Create` against
-    /// `AuthResource::SpaceSkill(space_id, None)` — admin-only by
-    /// default (no `permits` rule for non-admin scopes). Twin-writes to
-    /// `runtime/spaces/{slug}/skills/{name-slug}-{id_prefix}.md` via
-    /// the entity's `LibrarySynced::write_op`.
-    #[instrument(name = "skill.create_in_space", skip(self, body))]
-    pub async fn create_in_space(
-        &self,
-        sub: &AuthSubject,
-        space_id: SpaceId,
-        space_slug: &str,
-        name: String,
-        description: String,
-        body: String,
-    ) -> Result<Skill, SkillError> {
-        sub.can(AuthVerb::Create, AuthResource::SpaceSkill(space_id, None))?;
-        Audit::record_action_if_unset("skill.create_in_space");
-        Audit::record_space_id(space_id);
-        if name.trim().is_empty() {
-            return Err(SkillError::BuildEntity("skill name required".into()));
-        }
-        let new = NewSkill::builder()
-            .id(SkillId::new())
-            .space_id(space_id)
-            .space_slug(space_slug.to_string())
-            .name(name)
-            .description(description)
-            .body(body)
-            .build()
-            .map_err(|e| SkillError::BuildEntity(e.to_string()))?;
-
-        let mut op = self.begin_op(ScopeId::Space(space_id)).await?;
-        self.populate_attribution().await;
-        let skill = self.repo.create_in_op(&mut op, new).await?;
-        Audit::record_skill_id(skill.id);
-        op.commit().await?;
-        Ok(skill)
-    }
-
-    #[instrument(name = "skill.update_in_space", skip(self, body))]
-    pub async fn update_in_space(
-        &self,
-        sub: &AuthSubject,
-        id: SkillId,
-        space_id: SpaceId,
-        name: Option<String>,
-        description: Option<String>,
-        body: Option<String>,
-    ) -> Result<Skill, SkillError> {
-        sub.can(
-            AuthVerb::Update,
-            AuthResource::SpaceSkill(space_id, Some(id)),
-        )?;
-        Audit::record_action_if_unset("skill.update_in_space");
-        Audit::record_space_id(space_id);
-        Audit::record_skill_id(id);
-        let mut op = self.begin_op(ScopeId::Space(space_id)).await?;
-        let mut skill = self.repo.find_by_id_in_op(&mut op, id).await?;
-        if skill.space_id != Some(space_id) {
-            return Err(SkillError::Authorization(AuthorizationError::Forbidden {
-                verb: AuthVerb::Update,
-                resource: AuthResource::SpaceSkill(space_id, Some(id)),
-            }));
-        }
-        if skill.update_content(name, description, body).did_execute() {
-            self.populate_attribution().await;
-            self.repo.update_in_op(&mut op, &mut skill).await?;
-        }
-        op.commit().await?;
-        Ok(skill)
-    }
-
-    /// Space-scoped counterpart of [`Self::delete`] — soft-deletes the row
-    /// and enqueues a [`WriteOp::DeleteFile`] against the canonical
-    /// `spaces/<slug>/skills/...` path.
-    #[instrument(name = "skill.delete_in_space", skip(self))]
-    pub async fn delete_in_space(
-        &self,
-        sub: &AuthSubject,
-        id: SkillId,
-        space_id: SpaceId,
-    ) -> Result<(), SkillError> {
-        sub.can(
-            AuthVerb::Delete,
-            AuthResource::SpaceSkill(space_id, Some(id)),
-        )?;
-        Audit::record_action_if_unset("skill.delete_in_space");
-        Audit::record_space_id(space_id);
-        Audit::record_skill_id(id);
-        let mut op = self.begin_op(ScopeId::Space(space_id)).await?;
-        let skill = self.repo.find_by_id_in_op(&mut op, id).await?;
-        if skill.space_id != Some(space_id) {
-            return Err(SkillError::Authorization(AuthorizationError::Forbidden {
-                verb: AuthVerb::Delete,
-                resource: AuthResource::SpaceSkill(space_id, Some(id)),
-            }));
-        }
-        let attribution = self.populate_attribution().await;
-        self.enqueue_skill_delete_in_op(&mut op, &skill, attribution)
-            .await?;
-        self.repo.delete_in_op(&mut op, skill).await?;
-        op.commit().await?;
-        Ok(())
-    }
-
-    /// List skills owned by `space_id` (no global fold-in). Admin-only.
-    #[instrument(name = "skill.list_for_space", skip(self, sub))]
-    pub async fn list_for_space(
-        &self,
-        sub: &AuthSubject,
-        space_id: SpaceId,
-    ) -> Result<Vec<Skill>, SkillError> {
-        sub.can(AuthVerb::Read, AuthResource::SpaceSkill(space_id, None))?;
-        let result = self
-            .repo
-            .list_for_space_id_by_created_at(
-                Some(space_id),
-                es_entity::PaginatedQueryArgs {
-                    first: 100,
-                    after: None,
-                },
-                es_entity::ListDirection::Descending,
-            )
-            .await?;
-        Ok(result.entities)
     }
 }
 
@@ -872,7 +755,7 @@ impl Skills {
             .name(parsed.name)
             .description(parsed.description)
             .body(parsed.body)
-            .original_path(parsed.original_path);
+            .path(parsed.path);
         match &scope {
             ImportScope::Project {
                 project_id,

--- a/core/src/skill/mod.rs
+++ b/core/src/skill/mod.rs
@@ -11,7 +11,7 @@ pub const SKILL_DOC_TYPE: drua_library::DocType = drua_library::DocType::new("sk
 
 use std::sync::Arc;
 
-use drua_library::SearchHit;
+use drua_library::{CommitAttribution, SearchHit, WriteOp};
 use es_entity::AtomicOperation;
 use tracing::instrument;
 
@@ -20,6 +20,7 @@ use crate::audit::Audit;
 use crate::library::SpaceMounts;
 pub use crate::primitives::*;
 use crate::sandbox::Sandboxes;
+use crate::skill::file::{canonical_skill_path, slugify};
 use crate::user::Users;
 pub use entity::*;
 pub use error::*;
@@ -117,13 +118,19 @@ impl Skills {
         }
     }
 
-    /// Side-effect: populates `EventContext` with the rich
+    /// Populates `EventContext` with the rich
     /// [`drua_library::CommitAttribution`] so post-persist library
-    /// sync hooks pick it up. No-op when `users` isn't wired (test
-    /// constructors via `new_without_library`).
-    async fn populate_attribution(&self) {
+    /// sync hooks pick it up, and returns the resolved attribution for
+    /// callers (e.g. delete) that need to enqueue a write op of their
+    /// own. Returns the library default when `users` isn't wired
+    /// (test constructors via `new_without_library`).
+    async fn populate_attribution(&self) -> CommitAttribution {
         if let Some(users) = self.users.as_ref() {
-            let _ = users.commit_attribution().await;
+            users.commit_attribution().await
+        } else {
+            let attribution = CommitAttribution::library_default();
+            attribution.put_in_event_context();
+            attribution
         }
     }
 
@@ -158,6 +165,37 @@ impl Skills {
 
     pub fn sandboxes(&self) -> &Sandboxes {
         &self.sandboxes
+    }
+
+    /// Queue a [`WriteOp::DeleteFile`] against the canonical markdown
+    /// path so the next library write tick removes it from the upstream
+    /// repo. No-op when no library is wired (test constructors via
+    /// `new_without_library`).
+    async fn enqueue_skill_delete_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        skill: &Skill,
+        attribution: CommitAttribution,
+    ) -> Result<(), SkillError> {
+        let Some(library) = self.library.as_ref() else {
+            return Ok(());
+        };
+        let path = canonical_skill_path(
+            skill.id,
+            &skill.name,
+            skill.project_name.as_deref(),
+            skill.space_slug.as_deref(),
+        );
+        let id_uuid: uuid::Uuid = skill.id.into();
+        let message = format!(
+            "skill: delete {}-{}",
+            slugify(&skill.name),
+            &id_uuid.to_string()[..8]
+        );
+        library
+            .enqueue_write_in_op(op, WriteOp::DeleteFile { path, message }, attribution)
+            .await?;
+        Ok(())
     }
 
     #[instrument(name = "skill.find_by_id", skip_all)]
@@ -556,9 +594,11 @@ impl Skills {
         Ok(skill)
     }
 
-    /// Soft-delete only — the on-disk file is left in the library
-    /// until the owning project is deleted (single-file removal
-    /// isn't plumbed through `WriteToRuntime` yet).
+    /// Soft-deletes the skill row and enqueues a [`WriteOp::DeleteFile`]
+    /// for the canonical markdown path so the next library write tick
+    /// removes it from the upstream git repo. Space-scoped skills are
+    /// rejected — callers must route through the spaces tool to keep
+    /// the project / space surfaces cleanly separated.
     #[instrument(name = "skill.delete", skip(self))]
     pub async fn delete(
         &self,
@@ -572,13 +612,18 @@ impl Skills {
         Audit::record_skill_id(id);
         let mut op = self.begin_op(ScopeId::Project(project_id)).await?;
         let skill = self.repo.find_by_id_in_op(&mut op, id).await?;
+        if skill.space_id.is_some() {
+            return Err(SkillError::SpaceScopedDeleteViaSpaces);
+        }
         if skill.project_id != Some(project_id) {
             return Err(SkillError::Authorization(AuthorizationError::Forbidden {
                 verb: AuthVerb::Delete,
                 resource: AuthResource::Skill(project_id, Some(id)),
             }));
         }
-        self.populate_attribution().await;
+        let attribution = self.populate_attribution().await;
+        self.enqueue_skill_delete_in_op(&mut op, &skill, attribution)
+            .await?;
         self.repo.delete_in_op(&mut op, skill).await?;
         op.commit().await?;
         Ok(())
@@ -656,7 +701,9 @@ impl Skills {
         Ok(skill)
     }
 
-    /// Soft-delete only — same caveat as [`Self::delete`].
+    /// Space-scoped counterpart of [`Self::delete`] — soft-deletes the row
+    /// and enqueues a [`WriteOp::DeleteFile`] against the canonical
+    /// `spaces/<slug>/skills/...` path.
     #[instrument(name = "skill.delete_in_space", skip(self))]
     pub async fn delete_in_space(
         &self,
@@ -679,7 +726,9 @@ impl Skills {
                 resource: AuthResource::SpaceSkill(space_id, Some(id)),
             }));
         }
-        self.populate_attribution().await;
+        let attribution = self.populate_attribution().await;
+        self.enqueue_skill_delete_in_op(&mut op, &skill, attribution)
+            .await?;
         self.repo.delete_in_op(&mut op, skill).await?;
         op.commit().await?;
         Ok(())

--- a/core/src/skill/mod.rs
+++ b/core/src/skill/mod.rs
@@ -786,6 +786,52 @@ impl Skills {
         Ok(())
     }
 
+    /// Reverse-sync delete: soft-deletes the skill whose canonical
+    /// markdown lives at `path` and bumps the appropriate
+    /// `ContextGeneration` so agents stop seeing the skill in their
+    /// `<available_skills>` block on the next turn. Returns
+    /// `Ok(Some(skill_id))` when a row was actually deleted (caller
+    /// uses this to wipe the search row), or `Ok(None)` when nothing
+    /// matched (file authored without an id suffix, already-deleted
+    /// row, etc.). Skips the library write op — the file is already
+    /// gone in git, this is the inbound direction.
+    ///
+    /// Resolves `path → doc_id` via `library_documents` rather than an
+    /// id-prefix scan: the search-store row is rewritten in lockstep
+    /// with the entity's canonical path (post_persist_hook owns both),
+    /// so an exact path match is unambiguous and avoids the
+    /// ~N²/2³³ UUIDv7 prefix collision risk a `LIKE 'XXXXXXXX%'`
+    /// query would have at scale.
+    pub(crate) async fn delete_by_path_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        path: &str,
+    ) -> Result<Option<SkillId>, SkillError> {
+        let doc_type = SKILL_DOC_TYPE;
+        let row = sqlx::query!(
+            "SELECT doc_id
+             FROM library_documents
+             WHERE path = $1 AND doc_type = $2",
+            path,
+            doc_type.as_str(),
+        )
+        .fetch_optional(op.as_executor())
+        .await?;
+        let Some(row) = row else {
+            return Ok(None);
+        };
+        let id = SkillId::from(row.doc_id);
+        let skill = self.repo.find_by_id_in_op(&mut *op, id).await?;
+        let scope = match (skill.space_id, skill.project_id) {
+            (Some(sid), _) => ScopeId::Space(sid),
+            (None, Some(pid)) => ScopeId::Project(pid),
+            (None, None) => ScopeId::Global,
+        };
+        self.repo.delete_in_op(op, skill).await?;
+        self.register_context_bump(op, scope);
+        Ok(Some(id))
+    }
+
     /// Reverse-sync entry point: persist a `ParsedSkill` produced by
     /// the library importer. Creates or updates depending on whether
     /// the skill already exists. `Ok(None)` signals idempotency — the

--- a/core/src/skill/repo.rs
+++ b/core/src/skill/repo.rs
@@ -10,9 +10,22 @@ use super::entity::*;
 #[es_repo(
     entity = "Skill",
     columns(
-        project_id(ty = "Option<ProjectId>", list_for(by(created_at))),
-        space_id(ty = "Option<SpaceId>", list_for(by(created_at))),
-        name(ty = "String", list_for(by(created_at)))
+        project_id(
+            ty = "Option<ProjectId>",
+            list_for(by(created_at)),
+            constraint = "idx_skills_project_name",
+        ),
+        space_id(
+            ty = "Option<SpaceId>",
+            list_for(by(created_at)),
+            constraint = "idx_skills_space_name",
+        ),
+        name(
+            ty = "String",
+            list_for(by(created_at)),
+            constraint = "idx_skills_global_name",
+        ),
+        path(ty = "String", update(persist = "false"),),
     ),
     delete = "soft_without_queries",
     post_persist_hook(method = "sync_to_library", error = "drua_library::LibraryError")

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -414,6 +414,7 @@ enum SkillCommand {
     List,
     Get,
     Update,
+    Delete,
     Invoke,
 }
 
@@ -425,7 +426,7 @@ struct SkillParams {
     #[schemars(with = "Option<uuid::Uuid>")]
     project_id: Option<ProjectId>,
 
-    /// Required for `get`, `update`.
+    /// Required for `get`, `update`, `delete`.
     #[schemars(with = "Option<uuid::Uuid>")]
     skill_id: Option<SkillId>,
 
@@ -543,6 +544,9 @@ static TOOLS: &[ToolDef] = &[
                        `get` (requires `skill_id`, `project_id`), \
                        `update` (requires `skill_id`, `project_id`; any of \
                        `name`/`description`/`body`), \
+                       `delete` (requires `skill_id`, `project_id`; project- or \
+                       global-scoped skills only — for space-scoped skills use \
+                       the `spaces` tool), \
                        `invoke` (requires `project_id`, `name`; optional \
                        `arguments` for `$ARGUMENTS` substitution; resolves \
                        across mounted-space, project, global, sandbox tiers).",
@@ -1248,6 +1252,23 @@ impl AdminToolSet {
                     .map_err(|e| ToolSetsError::Skill(e.to_string()))?;
                 Ok(CallToolResult::success(vec![Content::text(format_skill(
                     &skill, false,
+                ))]))
+            }
+
+            SkillCommand::Delete => {
+                let skill_id = params.skill_id.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("skill_id is required for delete".to_string())
+                })?;
+                let project_id = params.project_id.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("project_id is required for delete".to_string())
+                })?;
+                Audit::record_action("skill.delete");
+                self.skills
+                    .delete(subject, skill_id, project_id)
+                    .await
+                    .map_err(|e| ToolSetsError::Skill(e.to_string()))?;
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Skill deleted (id {skill_id})."
                 ))]))
             }
 
@@ -2228,9 +2249,24 @@ mod tests {
     }
 
     #[test]
+    fn skill_delete_takes_ids() {
+        let skill_id = uuid::Uuid::new_v4();
+        let project_id = uuid::Uuid::new_v4();
+        let p: SkillParams = parse_params(args(serde_json::json!({
+            "command": "delete",
+            "skill_id": skill_id,
+            "project_id": project_id,
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, SkillCommand::Delete));
+        assert_eq!(p.skill_id.map(uuid::Uuid::from), Some(skill_id));
+        assert_eq!(p.project_id.map(uuid::Uuid::from), Some(project_id));
+    }
+
+    #[test]
     fn skill_schema_includes_command_enum() {
         let s = serde_json::to_string(&*SKILL_SCHEMA).unwrap();
-        for v in ["create", "list", "get", "update", "invoke"] {
+        for v in ["create", "list", "get", "update", "delete", "invoke"] {
             assert!(s.contains(&format!("\"{v}\"")), "missing {v} in schema");
         }
     }

--- a/core/src/toolset/top_level/skill.rs
+++ b/core/src/toolset/top_level/skill.rs
@@ -140,7 +140,9 @@ impl TopLevelTool for SkillTool {
          placeholder, arguments are appended as `ARGUMENTS: <value>`. \
          Commands: `create` (requires `name`, `description`, `body`), \
          `update` (requires `skill_id`; any of `name`/`description`/`body`), \
-         `delete` (requires `skill_id`), `list`, `get` (requires `skill_id`)."
+         `delete` (requires `skill_id`; project- or global-scoped skills only \
+         — for space-scoped skills use the `spaces` tool), \
+         `list`, `get` (requires `skill_id`)."
     }
 
     fn input_schema(&self) -> &serde_json::Value {

--- a/core/tests/skill_e2e.rs
+++ b/core/tests/skill_e2e.rs
@@ -188,7 +188,7 @@ async fn skill_create_propagates_to_search_and_upstream() {
             &sub,
             project.id,
             &project.name,
-            "Deploy Prod".into(),
+            "deploy-prod".into(),
             "Deploys the app to production".into(),
             "#!/bin/bash\necho deploy".into(),
         )
@@ -209,33 +209,30 @@ async fn skill_create_propagates_to_search_and_upstream() {
         .find(|h| h.fields.doc_id == uuid::Uuid::from(skill.id))
         .unwrap_or_else(|| panic!("skill not in search index; got {hits:#?}"));
     assert_eq!(hit.fields.doc_type, SKILL_DOC_TYPE);
-    assert_eq!(hit.fields.name, "Deploy Prod");
+    assert_eq!(hit.fields.name, "deploy-prod");
 
     // 2. Upstream commit lands asynchronously via the LibraryWriteJob.
-    // Poll until the canonical path appears in the bare upstream's HEAD
-    // tree (or fail after a generous timeout).
-    let id_prefix = &uuid::Uuid::from(skill.id).to_string()[..8];
-    let canonical_path = format!(
-        "runtime/projects/{}/skills/deploy-prod-{id_prefix}.md",
-        project.name
-    );
+    // Poll until the path lands in the bare upstream's HEAD tree
+    // (or fail after a generous timeout). With path-as-identity the
+    // path is just `<scope>/skills/<name>.md` — no id-suffix.
+    let path = format!("runtime/projects/{}/skills/deploy-prod.md", project.name);
 
     let deadline = Instant::now() + Duration::from_secs(15);
     loop {
-        if read_blob(&upstream, &canonical_path).is_some() {
+        if read_blob(&upstream, &path).is_some() {
             break;
         }
         if Instant::now() >= deadline {
-            panic!("upstream commit for {canonical_path} did not land within timeout");
+            panic!("upstream commit for {path} did not land within timeout");
         }
         tokio::time::sleep(Duration::from_millis(150)).await;
     }
 
-    let bytes = read_blob(&upstream, &canonical_path).expect("blob present");
+    let bytes = read_blob(&upstream, &path).expect("blob present");
     let rendered = String::from_utf8(bytes).expect("utf8");
     assert!(
-        rendered.contains("name: \"Deploy Prod\""),
-        "expected canonical frontmatter; got: {rendered}"
+        rendered.contains("name: \"deploy-prod\""),
+        "expected frontmatter; got: {rendered}"
     );
     assert!(
         rendered.contains("#!/bin/bash"),

--- a/server/src/graphql/library.rs
+++ b/server/src/graphql/library.rs
@@ -71,16 +71,34 @@ pub struct LibrarySearchHit {
 impl LibrarySearchHit {
     pub fn from_domain(hit: SearchHit) -> Self {
         let snippet = make_snippet(&hit.fields.content, 240);
-        let is_space = hit.fields.doc_type.as_str() == SPACE_FILE_DOC_TYPE_STR;
-        let project_id = if is_space {
+        // Two flavours of space-scoped hits:
+        //   1. raw space files     (doc_type = "space_file")
+        //   2. entity-backed skills under `spaces/<slug>/skills/...`
+        //      (doc_type = "skill" but path lives under `spaces/`)
+        // Both must surface the space slug + a project_id of `null`
+        // so the UI doesn't mislabel a space-scoped entity as a
+        // project-scoped one.
+        let is_space_file = hit.fields.doc_type.as_str() == SPACE_FILE_DOC_TYPE_STR;
+        let path_under_space = hit
+            .fields
+            .path
+            .as_deref()
+            .is_some_and(|p| p.starts_with("spaces/"));
+        let is_space_scoped = is_space_file || path_under_space;
+        let project_id = if is_space_scoped {
             None
         } else {
             hit.fields.scope_id.map(ProjectId::from)
         };
-        let (space_slug, relative_path) = if is_space {
-            (hit.fields.scope_slug, hit.fields.path)
+        let space_slug = if is_space_scoped {
+            hit.fields.scope_slug.clone()
         } else {
-            (None, None)
+            None
+        };
+        let relative_path = if is_space_file {
+            hit.fields.path.clone()
+        } else {
+            None
         };
         Self {
             id: UUID::from(hit.fields.doc_id),

--- a/server/src/graphql/mutation.rs
+++ b/server/src/graphql/mutation.rs
@@ -6,6 +6,7 @@ use super::sandbox::*;
 
 use super::project::*;
 use super::project_secret::*;
+use super::skill::*;
 
 pub struct Mutation;
 
@@ -180,6 +181,18 @@ impl Mutation {
         let (app, sub) = app_and_sub_from_ctx!(ctx);
         app.project_secrets().delete(sub, input.id).await?;
         Ok(ProjectSecretDeletePayload {
+            deleted_id: input.id,
+        })
+    }
+
+    async fn skill_delete(
+        &self,
+        ctx: &Context<'_>,
+        input: SkillDeleteInput,
+    ) -> async_graphql::Result<SkillDeletePayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        app.skills().delete(sub, input.id, input.project_id).await?;
+        Ok(SkillDeletePayload {
             deleted_id: input.id,
         })
     }

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -243,6 +243,7 @@ type Mutation {
 	sandboxCreate(input: SandboxCreateInput!): SandboxCreatePayload!
 	sandboxRestart(input: SandboxRestartInput!): SandboxRestartPayload!
 	sandboxSuspend(input: SandboxSuspendInput!): SandboxSuspendPayload!
+	skillDelete(input: SkillDeleteInput!): SkillDeletePayload!
 }
 
 """
@@ -535,6 +536,15 @@ type Skill {
 	id: SkillId!
 	name: String!
 	projectId: ProjectId
+}
+
+input SkillDeleteInput {
+	id: SkillId!
+	projectId: ProjectId!
+}
+
+type SkillDeletePayload {
+	deletedId: SkillId!
 }
 
 scalar SkillId

--- a/server/src/graphql/skill.rs
+++ b/server/src/graphql/skill.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use async_graphql::{ComplexObject, SimpleObject};
+use async_graphql::{ComplexObject, InputObject, SimpleObject};
 
 use super::primitives::*;
 
@@ -37,4 +37,15 @@ impl From<DomainSkill> for Skill {
             entity: Arc::new(entity),
         }
     }
+}
+
+#[derive(InputObject)]
+pub struct SkillDeleteInput {
+    pub id: SkillId,
+    pub project_id: ProjectId,
+}
+
+#[derive(SimpleObject)]
+pub struct SkillDeletePayload {
+    pub deleted_id: SkillId,
 }


### PR DESCRIPTION
## Summary

Wires up skill delete across all three control surfaces and fixes both
sync directions with the library git repo.

- **Admin tool** (`drua_admin_skill`): re-adds the `Delete` command arm.
  This **explicitly reverses commit acca538 for skills only** per direct
  user direction — agents and workflows remain without admin Delete per
  their respective decisions (PR #263 / acca538).
- **Top-level tool** (`skill.delete`): already wired pre-PR; description
  updated to call out the space-scoped restriction.
- **GraphQL** (`skillDelete`): new `skillDelete(input: { id, projectId }): { deletedId }` mutation, mirroring the `agentDelete` shape.
- **Library delete-out sync**: `Skills::delete` and `delete_in_space` now
  enqueue a `WriteOp::DeleteFile` against the canonical markdown path
  before the soft-delete commits. Reuses the `CommitAttribution`
  plumbing landed in PR #260.
- **Library delete-in (reverse) sync**: `SkillsImporter::delete_in_op`
  is now implemented. When a markdown file under `runtime/skills/`,
  `runtime/projects/*/skills/`, or `spaces/*/skills/` is removed in git,
  the matching skill row is soft-deleted and the appropriate
  `ContextGeneration` is bumped. Lookup is keyed on
  `library_documents.path` (an exact match — the search-store row is
  rewritten in lockstep with the entity's canonical path), avoiding
  the UUIDv7 prefix collision question entirely. **This is what
  closes the loop for space-scoped skills**, which have no skill-aware
  tool surface — they're created/updated/deleted as raw files via
  the `spaces` tool, and the importer is the only path that updates
  the DB.
- **Space-scope guardrail**: project-scope deletes now reject space-scoped
  skills with `SkillError::SpaceScopedDeleteViaSpaces` ("delete via the
  spaces tool") rather than a generic `Forbidden` auth error. This
  applies to all three surfaces (admin / top-level / GraphQL).

## Library-sync findings

**Forward (delete-out)** — was broken pre-PR. The `Skill` repo uses
`delete = "soft_without_queries"`, which is a column-update with no
domain event. `Skill::is_content_event` only matches `Initialized` /
`Updated`, so `library.sync_entity_in_op` short-circuited during delete
and the markdown file lingered in the upstream git repo forever. The
existing doc on `Skills::delete` even acknowledged this. Fixed by
explicitly calling `library.enqueue_write_in_op(WriteOp::DeleteFile,
…)` from `Skills::delete` and `Skills::delete_in_space` before the row
is soft-deleted, inside the same DbOp.

**Reverse (delete-in)** — also broken pre-PR. `SkillsImporter` left
`delete_in_op` unimplemented (default warn-and-skip). External git
deletes — including the common case of an `rm` against a
`spaces/<slug>/skills/*.md` file via the `spaces` tool — committed to
git but never updated the DB, leaving an orphaned skill row. Fixed by
implementing `delete_in_op` to look up the doc_id by exact path in
`library_documents`, then soft-delete + bump the right
`ContextGeneration` scope.

## Test plan
- [ ] `nix flake check` passes (build + clippy + nextest + fmt)
- [ ] `skillDelete` mutation deletes via API
- [ ] `drua_admin_skill { command: "delete" }` deletes via admin tool
- [ ] Top-level `skill { command: "delete" }` deletes via project tool
- [ ] After delete via any surface, the canonical markdown file
      disappears from the upstream library repo within one write-job tick
- [ ] After `spaces delete` on a `skills/*.md` file, the corresponding
      skill row in the DB is soft-deleted within one library sync tick
      (delete-in path covers all three scopes: global, project, space)
- [ ] Attempting to delete a space-scoped skill via any project-scope
      surface returns a clear "delete via the spaces tool" error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches skill persistence semantics (new `skills.path` + unique indexes) and adds delete propagation across DB, git-backed library sync, and new GraphQL/admin surfaces; issues could cause stale search results or incorrect deletes if edge cases are missed.
> 
> **Overview**
> Enables **end-to-end skill deletion** across admin tool (`skill delete`), top-level tool messaging, and a new GraphQL mutation `skillDelete`, with an explicit guard that **space-scoped skills must be deleted via the `spaces` tool**.
> 
> Fixes library sync in both directions: `Skills::delete` now deletes the `library_documents` search row and enqueues `WriteOp::DeleteFile` so the markdown disappears from the upstream repo, and reverse-sync delete is implemented so git file removals soft-delete the matching `skills` row (path lookup via `library_documents`).
> 
> Introduces **path-as-identity** for skills by adding a non-null `skills.path`, updating entity/importer to preserve the on-disk path (no rename canonicalization), and correcting uniqueness constraints with new partial unique indexes for name/path per scope tier; includes updated e2e tests and `Spaces::delete_file` now errors with `PathNotFound` instead of silently no-oping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4965444e6824ac9160340bebc8973475a6c53fdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->