### PR TITLE
feat(workflow): borrow + auto-suspend sandboxes already attached to other agents

### DIFF
--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -764,6 +764,7 @@ impl Agents {
         op: &mut es_entity::DbOp<'_>,
         sandbox_id: SandboxId,
     ) -> Result<Vec<AgentId>, AgentError> {
+        Audit::record_action_if_unset("agent.detach_non_workflow_agents_from_sandbox");
         Audit::record_sandbox_id(sandbox_id);
 
         let sandbox = self.sandboxes.find_by_id_in_op(op, sandbox_id).await?;

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -743,60 +743,76 @@ impl Agents {
         Ok(agent)
     }
 
-    /// Pre-step helper for the workflow runtime. For every agent currently
-    /// attached to `sandbox_id` whose `workflow_run_id` is `None` (i.e. a
-    /// user-owned agent), runs the full per-agent detach choreography in
-    /// the caller's op: agent-side detach event, sandbox-side detach,
-    /// session detach notification, and skills-block refresh. Workflow-
-    /// spawned attachments are left in place — the subsequent attach will
-    /// surface `WriteSlotTaken` and the run will fail rather than steal
-    /// between concurrent workflow runs.
+    /// Pre-step helper for the workflow runtime. Detaches a single
+    /// conflicting non-workflow Writer when the workflow agent is about
+    /// to attach in `Write` mode; no-op otherwise.
     ///
-    /// Returns the detached agent ids so the caller can drop their
-    /// `cached_dynamic_blocks` entries after committing.
+    /// Conflict policy:
+    /// - `workflow_mode == Read`: never detach (Read is unbounded; we
+    ///   coexist with whatever's there).
+    /// - `workflow_mode == Write` and a non-workflow agent currently
+    ///   holds Write: run the full detach choreography (agent event,
+    ///   sandbox detach, session notification, skills refresh).
+    /// - `workflow_mode == Write` and the current Writer is itself a
+    ///   workflow agent (`workflow_run_id.is_some()`): no-op; the
+    ///   subsequent attach will surface `WriteSlotTaken` and the run
+    ///   will fail rather than steal between concurrent workflow runs.
+    /// - `workflow_mode == Write` and only Readers (or nothing) are
+    ///   attached: no-op; Read+Write is allowed at the entity layer.
+    ///
+    /// Returns the detached agent id (single-element vec or empty) so
+    /// the caller can drop its `cached_dynamic_blocks` entry after
+    /// committing.
     #[instrument(
-        name = "domain.agent.detach_non_workflow_agents_from_sandbox_in_op",
+        name = "domain.agent.detach_conflicting_writer_in_op",
         skip(self, op),
-        fields(%sandbox_id)
+        fields(%sandbox_id, ?workflow_mode)
     )]
-    pub async fn detach_non_workflow_agents_from_sandbox_in_op(
+    pub async fn detach_conflicting_writer_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,
         sandbox_id: SandboxId,
+        workflow_mode: SandboxAgentMode,
     ) -> Result<Vec<AgentId>, AgentError> {
-        Audit::record_action_if_unset("agent.detach_non_workflow_agents_from_sandbox");
+        if workflow_mode != SandboxAgentMode::Write {
+            return Ok(Vec::new());
+        }
+        Audit::record_action_if_unset("agent.detach_conflicting_writer");
         Audit::record_sandbox_id(sandbox_id);
 
         let sandbox = self.sandboxes.find_by_id_in_op(op, sandbox_id).await?;
-        let candidates: Vec<AgentId> = sandbox.attached_agents.iter().map(|(id, _)| *id).collect();
+        let writer_id = sandbox
+            .attached_agents
+            .iter()
+            .find(|(_, m)| *m == SandboxAgentMode::Write)
+            .map(|(id, _)| *id);
+        let Some(agent_id) = writer_id else {
+            return Ok(Vec::new());
+        };
 
-        let mut detached = Vec::new();
-        for agent_id in candidates {
-            let mut agent = self.repo.find_by_id_in_op(&mut *op, agent_id).await?;
-            if agent.workflow_run_id.is_some() {
-                continue;
-            }
-            let project_id = agent.project_id;
-            if agent.sandbox_detached(sandbox_id).did_execute() {
-                self.repo.update_in_op(&mut *op, &mut agent).await?;
-            }
-            let sandbox = self
-                .sandboxes
-                .detach_from_agent_in_op(op, sandbox_id, agent_id)
-                .await?;
-            self.sessions
-                .sandbox_notification_in_op(
-                    op,
-                    agent_id,
-                    sandbox.name,
-                    session::message::SandboxOperation::Detach,
-                )
-                .await?;
-            self.refresh_skills_block_in_op(op, agent_id, project_id, None)
-                .await;
-            detached.push(agent_id);
+        let mut agent = self.repo.find_by_id_in_op(&mut *op, agent_id).await?;
+        if agent.workflow_run_id.is_some() {
+            return Ok(Vec::new());
         }
-        Ok(detached)
+        let project_id = agent.project_id;
+        if agent.sandbox_detached(sandbox_id).did_execute() {
+            self.repo.update_in_op(&mut *op, &mut agent).await?;
+        }
+        let sandbox = self
+            .sandboxes
+            .detach_from_agent_in_op(op, sandbox_id, agent_id)
+            .await?;
+        self.sessions
+            .sandbox_notification_in_op(
+                op,
+                agent_id,
+                sandbox.name,
+                session::message::SandboxOperation::Detach,
+            )
+            .await?;
+        self.refresh_skills_block_in_op(op, agent_id, project_id, None)
+            .await;
+        Ok(vec![agent_id])
     }
 
     /// Recomputes the `Skills` system block for `agent_id` scoped to

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -743,6 +743,61 @@ impl Agents {
         Ok(agent)
     }
 
+    /// Pre-step helper for the workflow runtime. For every agent currently
+    /// attached to `sandbox_id` whose `workflow_run_id` is `None` (i.e. a
+    /// user-owned agent), runs the full per-agent detach choreography in
+    /// the caller's op: agent-side detach event, sandbox-side detach,
+    /// session detach notification, and skills-block refresh. Workflow-
+    /// spawned attachments are left in place — the subsequent attach will
+    /// surface `WriteSlotTaken` and the run will fail rather than steal
+    /// between concurrent workflow runs.
+    ///
+    /// Returns the detached agent ids so the caller can drop their
+    /// `cached_dynamic_blocks` entries after committing.
+    #[instrument(
+        name = "domain.agent.detach_non_workflow_agents_from_sandbox_in_op",
+        skip(self, op),
+        fields(%sandbox_id)
+    )]
+    pub async fn detach_non_workflow_agents_from_sandbox_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        sandbox_id: SandboxId,
+    ) -> Result<Vec<AgentId>, AgentError> {
+        Audit::record_sandbox_id(sandbox_id);
+
+        let sandbox = self.sandboxes.find_by_id_in_op(op, sandbox_id).await?;
+        let candidates: Vec<AgentId> = sandbox.attached_agents.iter().map(|(id, _)| *id).collect();
+
+        let mut detached = Vec::new();
+        for agent_id in candidates {
+            let mut agent = self.repo.find_by_id_in_op(&mut *op, agent_id).await?;
+            if agent.workflow_run_id.is_some() {
+                continue;
+            }
+            let project_id = agent.project_id;
+            if agent.sandbox_detached(sandbox_id).did_execute() {
+                self.repo.update_in_op(&mut *op, &mut agent).await?;
+            }
+            let sandbox = self
+                .sandboxes
+                .detach_from_agent_in_op(op, sandbox_id, agent_id)
+                .await?;
+            self.sessions
+                .sandbox_notification_in_op(
+                    op,
+                    agent_id,
+                    sandbox.name,
+                    session::message::SandboxOperation::Detach,
+                )
+                .await?;
+            self.refresh_skills_block_in_op(op, agent_id, project_id, None)
+                .await;
+            detached.push(agent_id);
+        }
+        Ok(detached)
+    }
+
     /// Recomputes the `Skills` system block for `agent_id` scoped to
     /// `sandbox_id` and pushes it. Idempotent: when the block content matches
     /// the latest persisted skills block no event is emitted. Errors from the
@@ -799,7 +854,7 @@ impl Agents {
     /// `cached_dynamic_blocks` call rebuilds. Used when `agent_id`'s scope
     /// changes (e.g. sandbox attach/detach) without bumping the global
     /// `ContextGeneration`.
-    fn invalidate_agent_cache(&self, agent_id: AgentId) {
+    pub(crate) fn invalidate_agent_cache(&self, agent_id: AgentId) {
         if let Ok(mut cache) = self.context_cache.write() {
             cache.remove(&agent_id);
         }

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -370,6 +370,18 @@ impl Sandboxes {
         Ok(self.repo.begin_op().await?)
     }
 
+    /// In-op lookup for sister services that already hold an open
+    /// `DbOp`. Auth-free; callers must have authorised the enclosing
+    /// operation themselves.
+    #[instrument(name = "domain.sandbox.find_by_id_in_op", skip(self, op))]
+    pub(crate) async fn find_by_id_in_op(
+        &self,
+        op: &mut DbOp<'_>,
+        id: SandboxId,
+    ) -> Result<Sandbox, SandboxError> {
+        Ok(self.repo.find_by_id_in_op(op, id).await?)
+    }
+
     /// `(project_id, name)` is unique at the DB level, so workflow-
     /// scoped sandboxes embed the workflow short-id in their stored
     /// name. The user's decl name stays the canonical reference inside

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -78,11 +78,11 @@ impl Executor {
         // fails the run terminates as Failed without running any step.
         // The synthetic `<pre-flight>` step keeps the diagnostic visible
         // in `runs` listings.
-        let sandbox_ids = match self
+        let (sandbox_ids, preexisting_ids) = match self
             .ensure_sandboxes_ready(project_id, workflow_id, &sandbox_decls)
             .await
         {
-            Ok(map) => map,
+            Ok(pair) => pair,
             Err(err) => {
                 let step_name = "<pre-flight>".to_string();
                 if run.step_started(step_name.clone()).did_execute() {
@@ -94,13 +94,19 @@ impl Executor {
                 if run.run_completed(WorkflowRunState::Failed).did_execute() {
                     self.runs.update(&mut run).await?;
                 }
-                self.suspend_workflow_sandboxes(project_id, workflow_id)
+                self.suspend_workflow_sandboxes(project_id, workflow_id, &HashSet::new())
                     .await;
                 return Ok(());
             }
         };
 
         let mut any_failed = run.any_step_failed();
+        // Preexisting sandboxes the workflow successfully attached to.
+        // Drives the post-flight suspend decision: a Preexisting sandbox
+        // is suspended at end-of-run only if (a) we attached at least
+        // once during the run AND (b) no other agent (workflow or user)
+        // is still attached at post-flight time.
+        let mut borrowed_preexisting: HashSet<SandboxId> = HashSet::new();
 
         for step in &steps {
             let step_name = step.name().to_string();
@@ -121,6 +127,8 @@ impl Executor {
                     step,
                     &trigger_context,
                     &sandbox_ids,
+                    &preexisting_ids,
+                    &mut borrowed_preexisting,
                 )
                 .await;
 
@@ -149,9 +157,10 @@ impl Executor {
             self.runs.update(&mut run).await?;
         }
 
-        // Post-flight: suspend every workflow-scoped sandbox. Always
-        // runs (even when a step failed). Best-effort.
-        self.suspend_workflow_sandboxes(project_id, workflow_id)
+        // Post-flight: always runs (even when a step failed).
+        // Best-effort. Workflow-scoped sandboxes always suspend; borrowed
+        // preexisting sandboxes only suspend if uncontested.
+        self.suspend_workflow_sandboxes(project_id, workflow_id, &borrowed_preexisting)
             .await;
 
         Ok(())
@@ -159,14 +168,16 @@ impl Executor {
 
     /// For each declared sandbox: find or create scoped to the workflow,
     /// restart if Suspended, then wait until Ready. Returns a name → id
-    /// map the step loop uses to resolve `sandbox: Some(name)` references.
+    /// map plus the set of Preexisting sandbox ids (used by post-flight
+    /// to apply the borrowed-and-uncontested suspend rule).
     async fn ensure_sandboxes_ready(
         &self,
         project_id: ProjectId,
         workflow_id: WorkflowDefinitionId,
         decls: &[WorkflowSandboxDecl],
-    ) -> Result<HashMap<String, SandboxId>, WorkflowError> {
+    ) -> Result<(HashMap<String, SandboxId>, HashSet<SandboxId>), WorkflowError> {
         let mut ids: HashMap<String, SandboxId> = HashMap::with_capacity(decls.len());
+        let mut preexisting_ids: HashSet<SandboxId> = HashSet::new();
         for decl in decls {
             let (decl_name, sandbox) = match decl {
                 // Reference an already-existing sandbox in the
@@ -253,15 +264,19 @@ impl Executor {
                     name: decl_name.clone(),
                     state: e.to_string(),
                 })?;
+            if matches!(decl, WorkflowSandboxDecl::Preexisting { .. }) {
+                preexisting_ids.insert(sandbox.id);
+            }
             ids.insert(decl_name.clone(), sandbox.id);
         }
-        Ok(ids)
+        Ok((ids, preexisting_ids))
     }
 
     async fn suspend_workflow_sandboxes(
         &self,
         project_id: ProjectId,
         workflow_id: WorkflowDefinitionId,
+        borrowed_preexisting: &HashSet<SandboxId>,
     ) {
         let definition = match self.definitions.find_by_id(workflow_id).await {
             Ok(d) => d,
@@ -278,27 +293,52 @@ impl Executor {
             }
         };
         for decl in &definition.sandboxes {
-            // Suspend both decl variants: borrowed preexisting sandboxes
-            // share the workflow-scoped lifecycle (user re-attaches
-            // manually).
-            let lookup = match decl {
-                WorkflowSandboxDecl::Provisioned { name, .. } => self
-                    .sandboxes
-                    .find_for_workflow(project_id, workflow_id, name)
-                    .await
-                    .map(|opt| (name, opt)),
-                WorkflowSandboxDecl::Preexisting { name } => self
-                    .sandboxes
-                    .find_by_name_in_project_unchecked(project_id, name)
-                    .await
-                    .map(|sb| (name, Some(sb))),
-            };
-            let (name, sandbox) = match lookup {
-                Ok((name, Some(sb))) => (name, sb),
-                Ok((_, None)) => continue,
-                Err(e) => {
-                    tracing::warn!(error = %e, "post-flight: lookup failed");
-                    continue;
+            let (name, sandbox) = match decl {
+                // Workflow-private; always suspend.
+                WorkflowSandboxDecl::Provisioned { name, .. } => {
+                    match self
+                        .sandboxes
+                        .find_for_workflow(project_id, workflow_id, name)
+                        .await
+                    {
+                        Ok(Some(sb)) => (name, sb),
+                        Ok(None) => continue,
+                        Err(e) => {
+                            tracing::warn!(error = %e, sandbox = %name, "post-flight: lookup failed");
+                            continue;
+                        }
+                    }
+                }
+                // Borrowed-and-uncontested: suspend iff (a) the workflow
+                // attached to this sandbox at least once during the run
+                // AND (b) no other agent (workflow or user) is currently
+                // attached. Whichever run is the last one out flips it
+                // to Suspended.
+                WorkflowSandboxDecl::Preexisting { name } => {
+                    let sb = match self
+                        .sandboxes
+                        .find_by_name_in_project_unchecked(project_id, name)
+                        .await
+                    {
+                        Ok(sb) => sb,
+                        Err(e) => {
+                            tracing::warn!(error = %e, sandbox = %name, "post-flight: lookup failed");
+                            continue;
+                        }
+                    };
+                    if !borrowed_preexisting.contains(&sb.id) {
+                        continue;
+                    }
+                    if !sb.attached_agents.is_empty() {
+                        tracing::info!(
+                            sandbox_id = %sb.id,
+                            sandbox = %name,
+                            still_attached = sb.attached_agents.len(),
+                            "post-flight: deferring suspend; other agents still attached",
+                        );
+                        continue;
+                    }
+                    (name, sb)
                 }
             };
             if sandbox.state == SandboxState::Suspended {
@@ -318,6 +358,7 @@ impl Executor {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn execute_step(
         &self,
         project_id: ProjectId,
@@ -326,6 +367,8 @@ impl Executor {
         step: &WorkflowStepDef,
         trigger_context: &serde_json::Value,
         sandbox_ids: &HashMap<String, SandboxId>,
+        preexisting_ids: &HashSet<SandboxId>,
+        borrowed_preexisting: &mut HashSet<SandboxId>,
     ) -> Result<serde_json::Value, WorkflowError> {
         match step {
             WorkflowStepDef::AgentStep {
@@ -370,14 +413,13 @@ impl Executor {
                     .await
                     .map_err(|e| WorkflowError::Agent(e.to_string()))?;
 
-                // Detach in the SAME op as create+attach so the sandbox
-                // is never observed double-attached or detached-but-not-
-                // yet-reattached. Skip-workflow-agents policy lives on
-                // the helper.
+                // Conflict-only steal: detach a non-workflow Writer iff
+                // we want Write. Same op as create+attach so the sandbox
+                // is never observed double-attached.
                 let detached_agents = match attach_sandbox {
-                    Some((sandbox_id, _)) => self
+                    Some((sandbox_id, mode)) => self
                         .agents
-                        .detach_non_workflow_agents_from_sandbox_in_op(&mut op, sandbox_id)
+                        .detach_conflicting_writer_in_op(&mut op, sandbox_id, mode)
                         .await
                         .map_err(|e| WorkflowError::Agent(e.to_string()))?,
                     None => Vec::new(),
@@ -398,6 +440,12 @@ impl Executor {
                 op.commit()
                     .await
                     .map_err(|e| WorkflowError::Agent(e.to_string()))?;
+
+                if let Some((sandbox_id, _)) = attach_sandbox {
+                    if preexisting_ids.contains(&sandbox_id) {
+                        borrowed_preexisting.insert(sandbox_id);
+                    }
+                }
 
                 for prior in detached_agents {
                     self.agents.invalidate_agent_cache(prior);

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -6,7 +6,7 @@ use crate::agent::{Agent, Agents};
 use crate::primitives::{
     AgentId, ChatOutputEvent, ProjectId, SandboxId, WorkflowDefinitionId, WorkflowRunId,
 };
-use crate::sandbox::{SandboxAgentMode, SandboxSpecs, SandboxState, Sandboxes};
+use crate::sandbox::{Sandbox, SandboxAgentMode, SandboxSpecs, SandboxState, Sandboxes};
 use crate::skill::Skills;
 
 use super::definition::{WorkflowSandboxDecl, WorkflowStepDef};
@@ -180,8 +180,12 @@ impl Executor {
         let mut preexisting_ids: HashSet<SandboxId> = HashSet::new();
         for decl in decls {
             let (decl_name, sandbox) = match decl {
-                // Reference an already-existing sandbox in the
-                // project by its (unique) name; attach only.
+                // Reference an already-existing sandbox in the project
+                // by its (unique) name. Auto-restart if Suspended or
+                // Errored — borrowed sandboxes share the workflow-scoped
+                // wake-up lifecycle: the user might have suspended it
+                // explicitly or via a prior workflow's post-flight, and
+                // the next trigger should bring it back to Ready.
                 WorkflowSandboxDecl::Preexisting { name } => {
                     let sb = self
                         .sandboxes
@@ -192,6 +196,7 @@ impl Executor {
                                 "preexisting sandbox '{name}': {e}"
                             ))
                         })?;
+                    let sb = self.restart_if_dormant(sb, name).await?;
                     (name, sb)
                 }
                 // Workflow-scoped sandbox: find / create / restart.
@@ -232,26 +237,7 @@ impl Executor {
                             self.sandboxes.spawn_sandbox_creation(sb.id);
                             sb
                         }
-                        Some(sb)
-                            if matches!(
-                                sb.state,
-                                SandboxState::Suspended | SandboxState::Errored
-                            ) =>
-                        {
-                            if sb.state == SandboxState::Errored {
-                                tracing::warn!(
-                                    sandbox_id = %sb.id,
-                                    sandbox_name = %name,
-                                    last_error = ?sb.last_error,
-                                    "pre-flight: restarting sandbox in Errored state",
-                                );
-                            }
-                            self.sandboxes
-                                .restart_for_workflow(sb.id)
-                                .await
-                                .map_err(|e| WorkflowError::Sandbox(e.to_string()))?
-                        }
-                        Some(sb) => sb,
+                        Some(sb) => self.restart_if_dormant(sb, name).await?,
                     };
                     (name, sandbox)
                 }
@@ -270,6 +256,34 @@ impl Executor {
             ids.insert(decl_name.clone(), sandbox.id);
         }
         Ok((ids, preexisting_ids))
+    }
+
+    /// Wakes a Suspended or Errored sandbox so the workflow can attach.
+    /// Errored is logged at warn so the prior failure stays visible in
+    /// observability.
+    async fn restart_if_dormant(
+        &self,
+        sandbox: Sandbox,
+        decl_name: &str,
+    ) -> Result<Sandbox, WorkflowError> {
+        if !matches!(
+            sandbox.state,
+            SandboxState::Suspended | SandboxState::Errored
+        ) {
+            return Ok(sandbox);
+        }
+        if sandbox.state == SandboxState::Errored {
+            tracing::warn!(
+                sandbox_id = %sandbox.id,
+                sandbox_name = %decl_name,
+                last_error = ?sandbox.last_error,
+                "pre-flight: restarting sandbox in Errored state",
+            );
+        }
+        self.sandboxes
+            .restart_for_workflow(sandbox.id)
+            .await
+            .map_err(|e| WorkflowError::Sandbox(e.to_string()))
     }
 
     async fn suspend_workflow_sandboxes(

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -278,19 +278,29 @@ impl Executor {
             }
         };
         for decl in &definition.sandboxes {
-            // Preexisting sandboxes are user-managed; never suspend them.
-            let WorkflowSandboxDecl::Provisioned { name, .. } = decl else {
-                continue;
+            // Both decl variants are suspended at end-of-run: workflow-
+            // scoped sandboxes resume on the next trigger; preexisting
+            // ones the workflow borrowed (and may have detached from a
+            // user agent) get the same lifecycle as workflow-scoped
+            // sandboxes — the user re-attaches manually if they need
+            // them again.
+            let lookup = match decl {
+                WorkflowSandboxDecl::Provisioned { name, .. } => self
+                    .sandboxes
+                    .find_for_workflow(project_id, workflow_id, name)
+                    .await
+                    .map(|opt| (name, opt)),
+                WorkflowSandboxDecl::Preexisting { name } => self
+                    .sandboxes
+                    .find_by_name_in_project_unchecked(project_id, name)
+                    .await
+                    .map(|sb| (name, Some(sb))),
             };
-            let sandbox = match self
-                .sandboxes
-                .find_for_workflow(project_id, workflow_id, name)
-                .await
-            {
-                Ok(Some(sb)) => sb,
-                Ok(None) => continue,
+            let (name, sandbox) = match lookup {
+                Ok((name, Some(sb))) => (name, sb),
+                Ok((_, None)) => continue,
                 Err(e) => {
-                    tracing::warn!(error = %e, sandbox = %name, "post-flight: lookup failed");
+                    tracing::warn!(error = %e, "post-flight: lookup failed");
                     continue;
                 }
             };
@@ -298,7 +308,12 @@ impl Executor {
                 continue;
             }
             if let Err(e) = self.sandboxes.suspend_in_op(&mut op, sandbox.id).await {
-                tracing::warn!(error = %e, sandbox_id = %sandbox.id, "post-flight: suspend failed");
+                tracing::warn!(
+                    error = %e,
+                    sandbox_id = %sandbox.id,
+                    sandbox = %name,
+                    "post-flight: suspend failed",
+                );
             }
         }
         if let Err(e) = op.commit().await {
@@ -357,6 +372,25 @@ impl Executor {
                     .begin_op()
                     .await
                     .map_err(|e| WorkflowError::Agent(e.to_string()))?;
+
+                // Borrow semantics: any non-workflow agent currently
+                // attached to the target sandbox must be detached in the
+                // same op as the workflow agent's create+attach so the
+                // sandbox is never simultaneously attached to two
+                // writers and never observed detached-from-old-but-not-
+                // yet-attached-to-new. Existing workflow attachments are
+                // left intact — the subsequent attach surfaces
+                // `WriteSlotTaken` and the run fails rather than steal
+                // between concurrent workflow runs.
+                let detached_agents = match attach_sandbox {
+                    Some((sandbox_id, _)) => self
+                        .agents
+                        .detach_non_workflow_agents_from_sandbox_in_op(&mut op, sandbox_id)
+                        .await
+                        .map_err(|e| WorkflowError::Agent(e.to_string()))?,
+                    None => Vec::new(),
+                };
+
                 let agent = self
                     .agents
                     .create_for_workflow_run_in_op(
@@ -372,6 +406,10 @@ impl Executor {
                 op.commit()
                     .await
                     .map_err(|e| WorkflowError::Agent(e.to_string()))?;
+
+                for prior in detached_agents {
+                    self.agents.invalidate_agent_cache(prior);
+                }
 
                 let result = self
                     .stream_agent_response(&agent, prompt, name, *timeout_seconds)

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -278,12 +278,9 @@ impl Executor {
             }
         };
         for decl in &definition.sandboxes {
-            // Both decl variants are suspended at end-of-run: workflow-
-            // scoped sandboxes resume on the next trigger; preexisting
-            // ones the workflow borrowed (and may have detached from a
-            // user agent) get the same lifecycle as workflow-scoped
-            // sandboxes — the user re-attaches manually if they need
-            // them again.
+            // Suspend both decl variants: borrowed preexisting sandboxes
+            // share the workflow-scoped lifecycle (user re-attaches
+            // manually).
             let lookup = match decl {
                 WorkflowSandboxDecl::Provisioned { name, .. } => self
                     .sandboxes
@@ -373,15 +370,10 @@ impl Executor {
                     .await
                     .map_err(|e| WorkflowError::Agent(e.to_string()))?;
 
-                // Borrow semantics: any non-workflow agent currently
-                // attached to the target sandbox must be detached in the
-                // same op as the workflow agent's create+attach so the
-                // sandbox is never simultaneously attached to two
-                // writers and never observed detached-from-old-but-not-
-                // yet-attached-to-new. Existing workflow attachments are
-                // left intact — the subsequent attach surfaces
-                // `WriteSlotTaken` and the run fails rather than steal
-                // between concurrent workflow runs.
+                // Detach in the SAME op as create+attach so the sandbox
+                // is never observed double-attached or detached-but-not-
+                // yet-reattached. Skip-workflow-agents policy lives on
+                // the helper.
                 let detached_agents = match attach_sandbox {
                     Some((sandbox_id, _)) => self
                         .agents

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -536,25 +536,30 @@ async fn delete_detaches_attached_sandbox() {
     );
 }
 
-#[tokio::test]
-async fn detach_non_workflow_agents_releases_user_owned_attachment() {
-    use drua_core::sandbox::{SandboxAgentMode, SandboxMode, SandboxSpecs};
-
-    let pool = pool().await;
-    let (agents, sandboxes) = build_agents(&pool).await;
-    let project_id = insert_project(&pool).await;
+/// Test fixture: build agents + project + a sandbox in the given test name,
+/// without seeding any attached agents. Returns (agents, sandboxes, sandbox_id).
+async fn fixture_for_detach_test(
+    pool: &sqlx::PgPool,
+    sandbox_name: &str,
+) -> (
+    drua_core::agent::Agents,
+    std::sync::Arc<drua_core::sandbox::Sandboxes>,
+    drua_core::primitives::SandboxId,
+    drua_core::primitives::ProjectId,
+) {
+    use drua_core::sandbox::{SandboxMode, SandboxSpecs};
+    let (agents, sandboxes) = build_agents(pool).await;
+    let project_id = insert_project(pool).await;
     let sub = AuthSubject::User(UserId::new());
-
     let _lead = agents
         .create_project_lead(&sub, project_id, "lead", "test-project")
         .await
         .expect("create lead");
-
     let sandbox = sandboxes
         .create(
             &sub,
             project_id,
-            "sb-borrow",
+            sandbox_name,
             SandboxSpecs {
                 cpu: "100m".to_string(),
                 memory: "128Mi".to_string(),
@@ -564,82 +569,19 @@ async fn detach_non_workflow_agents_releases_user_owned_attachment() {
         )
         .await
         .expect("create sandbox");
-
-    let user_agent = agents
-        .create_agent(
-            &sub,
-            project_id,
-            "user-worker",
-            Some((sandbox.id, SandboxAgentMode::Write)),
-        )
-        .await
-        .expect("create user-owned agent");
-
-    let mut op = agents.begin_op().await.expect("begin op");
-    let detached = agents
-        .detach_non_workflow_agents_from_sandbox_in_op(&mut op, sandbox.id)
-        .await
-        .expect("detach helper");
-    op.commit().await.expect("commit");
-
-    assert_eq!(
-        detached,
-        vec![user_agent.id],
-        "helper should report the user-owned agent it detached",
-    );
-
-    let after_sandbox = sandboxes
-        .find_by_id(&sub, sandbox.id)
-        .await
-        .expect("find sandbox");
-    assert!(
-        after_sandbox.attached_agents.is_empty(),
-        "sandbox.attached_agents should be empty after detach: {:?}",
-        after_sandbox.attached_agents,
-    );
-
-    let after_agent = agents
-        .find_by_id(&sub, user_agent.id)
-        .await
-        .expect("find user agent");
-    assert!(
-        after_agent.attached_sandbox_id().is_none(),
-        "user agent's attached_sandbox_id should be None after detach",
-    );
+    (agents, sandboxes, sandbox.id, project_id)
 }
 
-#[tokio::test]
-async fn detach_non_workflow_agents_skips_workflow_owned_attachment() {
+/// Seeds an FK-valid `workflow_definitions` + `workflow_runs` row pair so
+/// `create_for_workflow_run_in_op` can attach a workflow-stamped agent.
+async fn seed_workflow_run(
+    pool: &sqlx::PgPool,
+    project_id: drua_core::primitives::ProjectId,
+) -> (
+    drua_core::primitives::WorkflowDefinitionId,
+    drua_core::primitives::WorkflowRunId,
+) {
     use drua_core::primitives::{WorkflowDefinitionId, WorkflowRunId};
-    use drua_core::sandbox::{SandboxAgentMode, SandboxMode, SandboxSpecs};
-
-    let pool = pool().await;
-    let (agents, sandboxes) = build_agents(&pool).await;
-    let project_id = insert_project(&pool).await;
-    let sub = AuthSubject::User(UserId::new());
-
-    let _lead = agents
-        .create_project_lead(&sub, project_id, "lead", "test-project")
-        .await
-        .expect("create lead");
-
-    let sandbox = sandboxes
-        .create(
-            &sub,
-            project_id,
-            "sb-shared",
-            SandboxSpecs {
-                cpu: "100m".to_string(),
-                memory: "128Mi".to_string(),
-                disk_size: "1Gi".to_string(),
-            },
-            SandboxMode::Scratch,
-        )
-        .await
-        .expect("create sandbox");
-
-    // A workflow-stamped agent already attached: simulates a concurrent
-    // workflow run holding the sandbox. The helper must leave it alone.
     let workflow_id = WorkflowDefinitionId::new();
     let run_id = WorkflowRunId::new();
     sqlx::query(
@@ -649,7 +591,7 @@ async fn detach_non_workflow_agents_skips_workflow_owned_attachment() {
     .bind(workflow_id)
     .bind(project_id)
     .bind(format!("test-wf-{}", uuid::Uuid::from(workflow_id)))
-    .execute(&pool)
+    .execute(pool)
     .await
     .expect("insert workflow_definition");
     sqlx::query(
@@ -659,9 +601,130 @@ async fn detach_non_workflow_agents_skips_workflow_owned_attachment() {
     .bind(run_id)
     .bind(project_id)
     .bind(workflow_id)
-    .execute(&pool)
+    .execute(pool)
     .await
     .expect("insert workflow_run");
+    (workflow_id, run_id)
+}
+
+#[tokio::test]
+async fn detach_conflicting_writer_steals_user_writer_when_wants_write() {
+    use drua_core::sandbox::SandboxAgentMode;
+
+    let pool = pool().await;
+    let (agents, sandboxes, sandbox_id, project_id) =
+        fixture_for_detach_test(&pool, "sb-borrow-w").await;
+    let sub = AuthSubject::User(UserId::new());
+
+    let user_agent = agents
+        .create_agent(
+            &sub,
+            project_id,
+            "user-writer",
+            Some((sandbox_id, SandboxAgentMode::Write)),
+        )
+        .await
+        .expect("create user agent");
+
+    let mut op = agents.begin_op().await.expect("begin op");
+    let detached = agents
+        .detach_conflicting_writer_in_op(&mut op, sandbox_id, SandboxAgentMode::Write)
+        .await
+        .expect("detach helper");
+    op.commit().await.expect("commit");
+
+    assert_eq!(detached, vec![user_agent.id]);
+
+    let after_sandbox = sandboxes.find_by_id(&sub, sandbox_id).await.expect("find");
+    assert!(after_sandbox.attached_agents.is_empty());
+    let after_agent = agents.find_by_id(&sub, user_agent.id).await.expect("find");
+    assert!(after_agent.attached_sandbox_id().is_none());
+}
+
+#[tokio::test]
+async fn detach_conflicting_writer_does_not_steal_user_reader_when_wants_write() {
+    use drua_core::sandbox::SandboxAgentMode;
+
+    let pool = pool().await;
+    let (agents, sandboxes, sandbox_id, project_id) =
+        fixture_for_detach_test(&pool, "sb-coexist-r").await;
+    let sub = AuthSubject::User(UserId::new());
+
+    let user_agent = agents
+        .create_agent(
+            &sub,
+            project_id,
+            "user-reader",
+            Some((sandbox_id, SandboxAgentMode::Read)),
+        )
+        .await
+        .expect("create user agent");
+
+    let mut op = agents.begin_op().await.expect("begin op");
+    let detached = agents
+        .detach_conflicting_writer_in_op(&mut op, sandbox_id, SandboxAgentMode::Write)
+        .await
+        .expect("detach helper");
+    op.commit().await.expect("commit");
+
+    assert!(
+        detached.is_empty(),
+        "helper must not steal a Reader when wanting Write: got {detached:?}",
+    );
+    let after = sandboxes.find_by_id(&sub, sandbox_id).await.expect("find");
+    assert!(after
+        .attached_agents
+        .iter()
+        .any(|(id, _)| *id == user_agent.id));
+}
+
+#[tokio::test]
+async fn detach_conflicting_writer_is_noop_when_wants_read() {
+    use drua_core::sandbox::SandboxAgentMode;
+
+    let pool = pool().await;
+    let (agents, sandboxes, sandbox_id, project_id) =
+        fixture_for_detach_test(&pool, "sb-read-want").await;
+    let sub = AuthSubject::User(UserId::new());
+
+    let user_agent = agents
+        .create_agent(
+            &sub,
+            project_id,
+            "user-writer",
+            Some((sandbox_id, SandboxAgentMode::Write)),
+        )
+        .await
+        .expect("create user agent");
+
+    let mut op = agents.begin_op().await.expect("begin op");
+    let detached = agents
+        .detach_conflicting_writer_in_op(&mut op, sandbox_id, SandboxAgentMode::Read)
+        .await
+        .expect("detach helper");
+    op.commit().await.expect("commit");
+
+    assert!(
+        detached.is_empty(),
+        "helper must not detach anything when wanting Read: got {detached:?}",
+    );
+    let after = sandboxes.find_by_id(&sub, sandbox_id).await.expect("find");
+    assert!(after
+        .attached_agents
+        .iter()
+        .any(|(id, _)| *id == user_agent.id));
+}
+
+#[tokio::test]
+async fn detach_conflicting_writer_skips_workflow_owned_writer() {
+    use drua_core::sandbox::SandboxAgentMode;
+
+    let pool = pool().await;
+    let (agents, sandboxes, sandbox_id, project_id) =
+        fixture_for_detach_test(&pool, "sb-wf-writer").await;
+    let sub = AuthSubject::User(UserId::new());
+
+    let (workflow_id, run_id) = seed_workflow_run(&pool, project_id).await;
     let mut op = agents.begin_op().await.expect("begin op");
     let workflow_agent = agents
         .create_for_workflow_run_in_op(
@@ -669,84 +732,53 @@ async fn detach_non_workflow_agents_skips_workflow_owned_attachment() {
             project_id,
             workflow_id,
             run_id,
-            "wf-agent",
-            Some((sandbox.id, SandboxAgentMode::Read)),
+            "wf-writer",
+            Some((sandbox_id, SandboxAgentMode::Write)),
         )
         .await
         .expect("create workflow agent");
-    op.commit().await.expect("commit workflow agent create");
+    op.commit().await.expect("commit");
 
     let mut op = agents.begin_op().await.expect("begin op");
     let detached = agents
-        .detach_non_workflow_agents_from_sandbox_in_op(&mut op, sandbox.id)
+        .detach_conflicting_writer_in_op(&mut op, sandbox_id, SandboxAgentMode::Write)
         .await
         .expect("detach helper");
     op.commit().await.expect("commit");
 
     assert!(
         detached.is_empty(),
-        "helper must not detach workflow-owned attachments, got {detached:?}",
+        "helper must not detach a workflow-owned Writer: got {detached:?}",
     );
-
-    let after_sandbox = sandboxes
-        .find_by_id(&sub, sandbox.id)
-        .await
-        .expect("find sandbox");
-    assert!(
-        after_sandbox
-            .attached_agents
-            .iter()
-            .any(|(id, _)| *id == workflow_agent.id),
-        "workflow agent should still be attached: {:?}",
-        after_sandbox.attached_agents,
-    );
+    let after = sandboxes.find_by_id(&sub, sandbox_id).await.expect("find");
+    assert!(after
+        .attached_agents
+        .iter()
+        .any(|(id, _)| *id == workflow_agent.id));
 }
 
 #[tokio::test]
-async fn detach_non_workflow_agents_is_noop_when_unattached() {
-    use drua_core::sandbox::{SandboxMode, SandboxSpecs};
+async fn detach_conflicting_writer_is_noop_when_unattached() {
+    use drua_core::sandbox::SandboxAgentMode;
 
     let pool = pool().await;
-    let (agents, sandboxes) = build_agents(&pool).await;
-    let project_id = insert_project(&pool).await;
-    let sub = AuthSubject::User(UserId::new());
-
-    let _lead = agents
-        .create_project_lead(&sub, project_id, "lead", "test-project")
-        .await
-        .expect("create lead");
-
-    let sandbox = sandboxes
-        .create(
-            &sub,
-            project_id,
-            "sb-empty",
-            SandboxSpecs {
-                cpu: "100m".to_string(),
-                memory: "128Mi".to_string(),
-                disk_size: "1Gi".to_string(),
-            },
-            SandboxMode::Scratch,
-        )
-        .await
-        .expect("create sandbox");
+    let (agents, _sandboxes, sandbox_id, _project_id) =
+        fixture_for_detach_test(&pool, "sb-empty").await;
 
     let mut op = agents.begin_op().await.expect("begin op");
     let detached = agents
-        .detach_non_workflow_agents_from_sandbox_in_op(&mut op, sandbox.id)
+        .detach_conflicting_writer_in_op(&mut op, sandbox_id, SandboxAgentMode::Write)
         .await
         .expect("detach helper");
     op.commit().await.expect("commit");
-
     assert!(detached.is_empty());
 
-    // Re-running on an already-empty sandbox stays a no-op.
+    // Idempotent re-run.
     let mut op = agents.begin_op().await.expect("begin op");
     let detached = agents
-        .detach_non_workflow_agents_from_sandbox_in_op(&mut op, sandbox.id)
+        .detach_conflicting_writer_in_op(&mut op, sandbox_id, SandboxAgentMode::Write)
         .await
         .expect("idempotent re-run");
     op.commit().await.expect("commit");
-
     assert!(detached.is_empty());
 }

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -535,3 +535,198 @@ async fn delete_detaches_attached_sandbox() {
         "sandbox.attached_agents should not reference the deleted agent"
     );
 }
+
+#[tokio::test]
+async fn detach_non_workflow_agents_releases_user_owned_attachment() {
+    use drua_core::sandbox::{SandboxAgentMode, SandboxMode, SandboxSpecs};
+
+    let pool = pool().await;
+    let (agents, sandboxes) = build_agents(&pool).await;
+    let project_id = insert_project(&pool).await;
+    let sub = AuthSubject::User(UserId::new());
+
+    let _lead = agents
+        .create_project_lead(&sub, project_id, "lead", "test-project")
+        .await
+        .expect("create lead");
+
+    let sandbox = sandboxes
+        .create(
+            &sub,
+            project_id,
+            "sb-borrow",
+            SandboxSpecs {
+                cpu: "100m".to_string(),
+                memory: "128Mi".to_string(),
+                disk_size: "1Gi".to_string(),
+            },
+            SandboxMode::Scratch,
+        )
+        .await
+        .expect("create sandbox");
+
+    let user_agent = agents
+        .create_agent(
+            &sub,
+            project_id,
+            "user-worker",
+            Some((sandbox.id, SandboxAgentMode::Write)),
+        )
+        .await
+        .expect("create user-owned agent");
+
+    let mut op = agents.begin_op().await.expect("begin op");
+    let detached = agents
+        .detach_non_workflow_agents_from_sandbox_in_op(&mut op, sandbox.id)
+        .await
+        .expect("detach helper");
+    op.commit().await.expect("commit");
+
+    assert_eq!(
+        detached,
+        vec![user_agent.id],
+        "helper should report the user-owned agent it detached",
+    );
+
+    let after_sandbox = sandboxes
+        .find_by_id(&sub, sandbox.id)
+        .await
+        .expect("find sandbox");
+    assert!(
+        after_sandbox.attached_agents.is_empty(),
+        "sandbox.attached_agents should be empty after detach: {:?}",
+        after_sandbox.attached_agents,
+    );
+
+    let after_agent = agents
+        .find_by_id(&sub, user_agent.id)
+        .await
+        .expect("find user agent");
+    assert!(
+        after_agent.attached_sandbox_id().is_none(),
+        "user agent's attached_sandbox_id should be None after detach",
+    );
+}
+
+#[tokio::test]
+async fn detach_non_workflow_agents_skips_workflow_owned_attachment() {
+    use drua_core::primitives::{WorkflowDefinitionId, WorkflowRunId};
+    use drua_core::sandbox::{SandboxAgentMode, SandboxMode, SandboxSpecs};
+
+    let pool = pool().await;
+    let (agents, sandboxes) = build_agents(&pool).await;
+    let project_id = insert_project(&pool).await;
+    let sub = AuthSubject::User(UserId::new());
+
+    let _lead = agents
+        .create_project_lead(&sub, project_id, "lead", "test-project")
+        .await
+        .expect("create lead");
+
+    let sandbox = sandboxes
+        .create(
+            &sub,
+            project_id,
+            "sb-shared",
+            SandboxSpecs {
+                cpu: "100m".to_string(),
+                memory: "128Mi".to_string(),
+                disk_size: "1Gi".to_string(),
+            },
+            SandboxMode::Scratch,
+        )
+        .await
+        .expect("create sandbox");
+
+    // A workflow-stamped agent already attached: simulates a concurrent
+    // workflow run holding the sandbox. The helper must leave it alone.
+    let workflow_id = WorkflowDefinitionId::new();
+    let run_id = WorkflowRunId::new();
+    let mut op = agents.begin_op().await.expect("begin op");
+    let workflow_agent = agents
+        .create_for_workflow_run_in_op(
+            &mut op,
+            project_id,
+            workflow_id,
+            run_id,
+            "wf-agent",
+            Some((sandbox.id, SandboxAgentMode::Read)),
+        )
+        .await
+        .expect("create workflow agent");
+    op.commit().await.expect("commit workflow agent create");
+
+    let mut op = agents.begin_op().await.expect("begin op");
+    let detached = agents
+        .detach_non_workflow_agents_from_sandbox_in_op(&mut op, sandbox.id)
+        .await
+        .expect("detach helper");
+    op.commit().await.expect("commit");
+
+    assert!(
+        detached.is_empty(),
+        "helper must not detach workflow-owned attachments, got {detached:?}",
+    );
+
+    let after_sandbox = sandboxes
+        .find_by_id(&sub, sandbox.id)
+        .await
+        .expect("find sandbox");
+    assert!(
+        after_sandbox
+            .attached_agents
+            .iter()
+            .any(|(id, _)| *id == workflow_agent.id),
+        "workflow agent should still be attached: {:?}",
+        after_sandbox.attached_agents,
+    );
+}
+
+#[tokio::test]
+async fn detach_non_workflow_agents_is_noop_when_unattached() {
+    use drua_core::sandbox::{SandboxMode, SandboxSpecs};
+
+    let pool = pool().await;
+    let (agents, sandboxes) = build_agents(&pool).await;
+    let project_id = insert_project(&pool).await;
+    let sub = AuthSubject::User(UserId::new());
+
+    let _lead = agents
+        .create_project_lead(&sub, project_id, "lead", "test-project")
+        .await
+        .expect("create lead");
+
+    let sandbox = sandboxes
+        .create(
+            &sub,
+            project_id,
+            "sb-empty",
+            SandboxSpecs {
+                cpu: "100m".to_string(),
+                memory: "128Mi".to_string(),
+                disk_size: "1Gi".to_string(),
+            },
+            SandboxMode::Scratch,
+        )
+        .await
+        .expect("create sandbox");
+
+    let mut op = agents.begin_op().await.expect("begin op");
+    let detached = agents
+        .detach_non_workflow_agents_from_sandbox_in_op(&mut op, sandbox.id)
+        .await
+        .expect("detach helper");
+    op.commit().await.expect("commit");
+
+    assert!(detached.is_empty());
+
+    // Re-running on an already-empty sandbox stays a no-op.
+    let mut op = agents.begin_op().await.expect("begin op");
+    let detached = agents
+        .detach_non_workflow_agents_from_sandbox_in_op(&mut op, sandbox.id)
+        .await
+        .expect("idempotent re-run");
+    op.commit().await.expect("commit");
+
+    assert!(detached.is_empty());
+}

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -642,6 +642,26 @@ async fn detach_non_workflow_agents_skips_workflow_owned_attachment() {
     // workflow run holding the sandbox. The helper must leave it alone.
     let workflow_id = WorkflowDefinitionId::new();
     let run_id = WorkflowRunId::new();
+    sqlx::query(
+        "INSERT INTO workflow_definitions (id, project_id, name, created_at) \
+         VALUES ($1, $2, $3, NOW())",
+    )
+    .bind(workflow_id)
+    .bind(project_id)
+    .bind(format!("test-wf-{}", uuid::Uuid::from(workflow_id)))
+    .execute(&pool)
+    .await
+    .expect("insert workflow_definition");
+    sqlx::query(
+        "INSERT INTO workflow_runs (id, project_id, definition_id, created_at) \
+         VALUES ($1, $2, $3, NOW())",
+    )
+    .bind(run_id)
+    .bind(project_id)
+    .bind(workflow_id)
+    .execute(&pool)
+    .await
+    .expect("insert workflow_run");
     let mut op = agents.begin_op().await.expect("begin op");
     let workflow_agent = agents
         .create_for_workflow_run_in_op(

--- a/matrix
+++ b/matrix
@@ -1,8 +1,0 @@
-attached-to-other-workflow | attached-to-non-workflow | wants          | outcome | suspends after
-          none             |       none               |  read / write  |  run  |    yes
-          read             |       none               |  read          |  run  |    no (yes if other workflow complete)
-          read             |       none               |  write         |  run  |    no (yes if other workflow complete)
-          write            |       none               |  write         |  error  |    no
-          none             |       read               |  read / write  |  run | no
-          none             |       write               |  read         |  run | no
-          none             |       write               |  write        |  run (steal) | yes

--- a/matrix
+++ b/matrix
@@ -1,0 +1,8 @@
+attached-to-other-workflow | attached-to-non-workflow | wants          | outcome | suspends after
+          none             |       none               |  read / write  |  run  |    yes
+          read             |       none               |  read          |  run  |    no (yes if other workflow complete)
+          read             |       none               |  write         |  run  |    no (yes if other workflow complete)
+          write            |       none               |  write         |  error  |    no
+          none             |       read               |  read / write  |  run | no
+          none             |       write               |  read         |  run | no
+          none             |       write               |  write        |  run (steal) | yes


### PR DESCRIPTION
## Summary

Borrow + auto-suspend semantics for workflow runs that target a `Preexisting` sandbox already attached to another agent. Steals only on actual conflict; suspends only when the run was the last one with the sandbox.

## Behaviour matrix

| concurrent workflow | non-workflow | workflow wants | outcome | suspends at end? |
|---|---|---|---|---|
| none | none | Read / Write | run | **yes** |
| Read | none | Read | run | no (yes if peer workflow done by post-flight) |
| Read | none | Write | run | no (yes if peer workflow done by post-flight) |
| Write | none | Write | error (`WriteSlotTaken`) | no — we never attached |
| none | Read | Read / Write | run | no — user reader still attached |
| none | Write | Read | run | no — user writer still attached (Read+Write OK) |
| none | Write | Write | **run + steal user writer** | **yes** |

## Mechanism

**Steal rule** (`Agents::detach_conflicting_writer_in_op`):
- workflow wants Read → never detach
- workflow wants Write + non-workflow holds Write → detach (this is the only conflict)
- workflow wants Write + non-workflow holds Read only → don't detach (Read+Write coexists)
- workflow wants Write + workflow agent holds Write → don't detach; let `WriteSlotTaken` propagate (never steal between concurrent workflow runs)

**Suspend rule** (`suspend_workflow_sandboxes`):
- `Provisioned` (workflow-scoped, private by name) → always suspend at end-of-run
- `Preexisting`:
  - we never attached during the run → don't suspend
  - we attached + `attached_agents` still non-empty at post-flight → don't suspend (defer; whichever run is last out flips it Suspended)
  - we attached + nobody else attached at post-flight → suspend

**Pre-flight wake-up**: both `Provisioned` AND `Preexisting` sandboxes that are Suspended or Errored at run trigger get auto-restarted to Ready (extracted into `restart_if_dormant` helper). A Preexisting sandbox the user explicitly suspended (or that a prior workflow's post-flight suspended) wakes up for the new run, then re-suspends at end if uncontested.

The detach + create + attach happen in a single op so the sandbox is never observed double-attached or transiently detached. After commit, the prior owner's `cached_dynamic_blocks` is invalidated. Audit attribution flows through `Audit::record_workflow_*` task-locals already set at run start.

## Decisions

1. **Don't preemptively kick out users.** The previous version detached every non-workflow agent regardless of mode; this version only detaches the single non-workflow Writer when there's an actual mode conflict. Readers stay.
2. **Don't steal between workflow runs.** Concurrent workflow runs targeting the same sandbox still surface `WriteSlotTaken` rather than steal from each other.
3. **Suspend only when uncontested.** A borrowed `Preexisting` sandbox stays alive until the last workflow run with the sandbox attached completes. Whichever run is the last one out flips it to Suspended (idempotent).
4. **Skills-block invalidation on the prior owner.** The helper bundles {agent.sandbox_detached event + sandbox detach + session Detach notification + `refresh_skills_block_in_op`} so the prior owner's `<available_skills>` rebuilds without the now-detached sandbox's exports.
5. **Pre-flight wake-up parity.** Provisioned and Preexisting now share the restart-if-dormant logic; the previous asymmetry (only Provisioned auto-woke) meant a Suspended Preexisting silently failed pre-flight after a 180s timeout.

## Test coverage

`core/tests/agent.rs` — 5 helper tests:
- `detach_conflicting_writer_steals_user_writer_when_wants_write`
- `detach_conflicting_writer_does_not_steal_user_reader_when_wants_write`
- `detach_conflicting_writer_is_noop_when_wants_read`
- `detach_conflicting_writer_skips_workflow_owned_writer`
- `detach_conflicting_writer_is_noop_when_unattached`

## Out of scope (flag for follow-up)

- Restoring the prior user's attachment after the workflow finishes.
- Reflecting `suspend_in_op`'s pod-deletion in entity-level `attached_agents` cleanup so a forced suspend doesn't leave dangling agent-side attachments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow sandbox attach/detach behavior by allowing workflow runs to detach an existing non-workflow writer and to suspend preexisting sandboxes under certain conditions, which could affect concurrent agent workflows and sandbox lifecycle edge cases.
> 
> **Overview**
> Workflow runs can now *borrow* `Preexisting` sandboxes with smarter conflict handling: before creating/attaching a workflow agent in `Write` mode, the executor calls new `Agents::detach_conflicting_writer_in_op` to detach **only** a non-workflow writer (never readers, and never writers owned by other workflow runs).
> 
> Post-flight sandbox cleanup is updated: workflow-scoped (`Provisioned`) sandboxes still always suspend, but `Preexisting` sandboxes are suspended only if the run actually attached to them and they are *uncontested* (no agents still attached) at end-of-run; pre-flight also restarts `Preexisting` sandboxes that are `Suspended`/`Errored` via `restart_if_dormant`.
> 
> Adds `Sandboxes::find_by_id_in_op` to support the in-op detach flow, exposes `Agents::invalidate_agent_cache` for workflow-driven cache invalidation, and adds focused tests covering the new writer-detach helper behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c613838905e847dacf6da23570c152ba74b549f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->