### PR TITLE
fix(sandbox): require attic cache

### DIFF
--- a/charts/drua/templates/_helpers.tpl
+++ b/charts/drua/templates/_helpers.tpl
@@ -79,6 +79,46 @@ Attic config secret. Defaults to <app>-attic-config unless overridden.
 {{/*
 Internal Attic binary cache URL for sandbox NIX_CONFIG.
 */}}
+{{- define "galoyAgents.attic.endpoint" -}}
+{{- printf "http://%s.%s.svc.cluster.local:%v" (include "galoyAgents.attic.fullname" .) (include "galoyAgents.sandboxNamespace" .) .Values.sandbox.attic.service.port -}}
+{{- end -}}
+
 {{- define "galoyAgents.attic.cacheUrl" -}}
-{{- printf "http://%s.%s.svc.cluster.local:%v/%s" (include "galoyAgents.attic.fullname" .) (include "galoyAgents.sandboxNamespace" .) .Values.sandbox.attic.service.port .Values.sandbox.attic.cacheName -}}
+{{- printf "%s/%s" (include "galoyAgents.attic.endpoint" .) .Values.sandbox.attic.cacheName -}}
+{{- end -}}
+
+{{/*
+Sandbox NIX_CONFIG ConfigMap name. The Attic bootstrap job updates this
+ConfigMap with Attic's generated public signing key.
+*/}}
+{{- define "galoyAgents.sandbox.nixConfigMapName" -}}
+{{- printf "%s-sandbox-nix-config" (include "galoyAgents.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Sandbox NIX_CONFIG contents. Before the bootstrap job discovers Attic's generated
+public key, this safely falls back to the configured remote substituters.
+*/}}
+{{- define "galoyAgents.sandbox.nixSubstituterUrls" -}}
+{{- range $i, $substituter := .Values.sandbox.nixSubstituters -}}
+{{- if $i }} {{ end -}}{{ $substituter.url -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "galoyAgents.sandbox.nixPublicKeys" -}}
+{{- range $i, $substituter := .Values.sandbox.nixSubstituters -}}
+{{- if $i }} {{ end -}}{{ $substituter.publicKey -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "galoyAgents.sandbox.nixConfig" -}}
+substituters = {{- if and .Values.sandbox.attic.enabled .Values.sandbox.attic.publicKey }} {{ include "galoyAgents.attic.cacheUrl" . }}{{- end }}{{- with (include "galoyAgents.sandbox.nixSubstituterUrls" .) }} {{ . }}{{- end }} https://cache.nixos.org/
+trusted-public-keys = {{- if and .Values.sandbox.attic.enabled .Values.sandbox.attic.publicKey }} {{ .Values.sandbox.attic.publicKey }}{{- end }}{{- with (include "galoyAgents.sandbox.nixPublicKeys" .) }} {{ . }}{{- end }} cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+{{- end -}}
+
+{{/*
+Attic bootstrap service account name.
+*/}}
+{{- define "galoyAgents.attic.bootstrapServiceAccountName" -}}
+{{- printf "%s-bootstrap" (include "galoyAgents.attic.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/drua/templates/sandbox-attic-bootstrap.yaml
+++ b/charts/drua/templates/sandbox-attic-bootstrap.yaml
@@ -1,0 +1,171 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.attic.enabled .Values.sandbox.attic.bootstrap.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "galoyAgents.attic.bootstrapServiceAccountName" . }}
+  namespace: {{ include "galoyAgents.sandboxNamespace" . }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    app.kubernetes.io/component: sandbox-attic-bootstrap
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ include "galoyAgents.attic.bootstrapServiceAccountName" . }}
+  namespace: {{ include "galoyAgents.sandboxNamespace" . }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    app.kubernetes.io/component: sandbox-attic-bootstrap
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+rules:
+- apiGroups: [""]
+  resources: ["configmaps"]
+  resourceNames:
+  - {{ include "galoyAgents.sandbox.nixConfigMapName" . }}
+  verbs: ["get", "patch", "update"]
+- apiGroups: [""]
+  resources: ["configmaps"]
+  verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ include "galoyAgents.attic.bootstrapServiceAccountName" . }}
+  namespace: {{ include "galoyAgents.sandboxNamespace" . }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    app.kubernetes.io/component: sandbox-attic-bootstrap
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "galoyAgents.attic.bootstrapServiceAccountName" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "galoyAgents.attic.bootstrapServiceAccountName" . }}
+  namespace: {{ include "galoyAgents.sandboxNamespace" . }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "galoyAgents.attic.fullname" . }}-bootstrap
+  namespace: {{ include "galoyAgents.sandboxNamespace" . }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    app.kubernetes.io/component: sandbox-attic-bootstrap
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-weight": "10"
+spec:
+  backoffLimit: 2
+  template:
+    metadata:
+      labels:
+        app: {{ template "galoyAgents.fullname" . }}
+        app.kubernetes.io/component: sandbox-attic-bootstrap
+        release: "{{ .Release.Name }}"
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ include "galoyAgents.attic.bootstrapServiceAccountName" . }}
+      containers:
+      - name: bootstrap
+        image: {{ .Values.sandbox.attic.bootstrap.image.repository }}:{{ .Values.sandbox.attic.bootstrap.image.tag }}
+        imagePullPolicy: {{ .Values.sandbox.attic.bootstrap.image.pullPolicy }}
+        command:
+        - /bin/sh
+        - -ec
+        - |
+          export NIX_CONFIG="experimental-features = nix-command flakes"
+          nix shell nixpkgs#attic-client nixpkgs#attic-server nixpkgs#gnugrep nixpkgs#gnused nixpkgs#kubectl -c /bin/sh -ec '
+            set -eu
+
+            token="$(atticadm --config /etc/attic/server.toml make-token \
+              --sub sandbox-attic-bootstrap \
+              --validity "$ATTIC_TOKEN_VALIDITY" \
+              --create-cache "*" \
+              --configure-cache "*" \
+              --pull "*" \
+              --push "*")"
+
+            for i in $(seq 1 120); do
+              if attic login local "$ATTIC_ENDPOINT" "$token" --set-default >/tmp/attic-login.log 2>&1; then
+                break
+              fi
+              if [ "$i" = 120 ]; then
+                cat /tmp/attic-login.log >&2 || true
+                exit 1
+              fi
+              sleep 2
+            done
+
+            attic cache create --public \
+              --priority "$ATTIC_PRIORITY" \
+              --upstream-cache-key-name cache.nixos.org-1 \
+              "$ATTIC_CACHE" >/tmp/attic-cache-create.log 2>&1 || \
+            attic cache configure --public \
+              --priority "$ATTIC_PRIORITY" \
+              --upstream-cache-key-name cache.nixos.org-1 \
+              "$ATTIC_CACHE"
+
+            cache_info="$(attic cache info "$ATTIC_CACHE" 2>&1)"
+            public_key="$(printf "%s\\n" "$cache_info" | grep -o "$ATTIC_CACHE:[^[:space:]]*" | sed -n "1p")"
+            if [ -z "$public_key" ]; then
+              printf "%s\\n" "$cache_info" >&2
+              echo "failed to read Attic public key for cache $ATTIC_CACHE" >&2
+              exit 1
+            fi
+
+            {
+              printf "substituters = %s/%s" "$ATTIC_ENDPOINT" "$ATTIC_CACHE"
+              if [ -n "$NIX_SUBSTITUTERS" ]; then
+                printf " %s" "$NIX_SUBSTITUTERS"
+              fi
+              printf " https://cache.nixos.org/\\n"
+              printf "trusted-public-keys = %s" "$public_key"
+              if [ -n "$NIX_PUBLIC_KEYS" ]; then
+                printf " %s" "$NIX_PUBLIC_KEYS"
+              fi
+              printf " cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=\\n"
+            } > /tmp/NIX_CONFIG
+
+            kubectl -n "$SANDBOX_NAMESPACE" create configmap "$NIX_CONFIG_MAP" \
+              --from-file=NIX_CONFIG=/tmp/NIX_CONFIG \
+              --dry-run=client \
+              -o yaml | kubectl apply -f -
+          '
+        env:
+        - name: ATTIC_ENDPOINT
+          value: {{ include "galoyAgents.attic.endpoint" . | quote }}
+        - name: ATTIC_CACHE
+          value: {{ .Values.sandbox.attic.cacheName | quote }}
+        - name: ATTIC_PRIORITY
+          value: {{ .Values.sandbox.attic.bootstrap.priority | quote }}
+        - name: ATTIC_TOKEN_VALIDITY
+          value: {{ .Values.sandbox.attic.bootstrap.tokenValidity | quote }}
+        - name: SANDBOX_NAMESPACE
+          value: {{ include "galoyAgents.sandboxNamespace" . | quote }}
+        - name: NIX_CONFIG_MAP
+          value: {{ include "galoyAgents.sandbox.nixConfigMapName" . | quote }}
+        - name: NIX_SUBSTITUTERS
+          value: {{ include "galoyAgents.sandbox.nixSubstituterUrls" . | quote }}
+        - name: NIX_PUBLIC_KEYS
+          value: {{ include "galoyAgents.sandbox.nixPublicKeys" . | quote }}
+        resources:
+          {{- toYaml .Values.sandbox.attic.bootstrap.resources | nindent 10 }}
+        volumeMounts:
+        - name: config
+          mountPath: /etc/attic/server.toml
+          subPath: server.toml
+          readOnly: true
+      volumes:
+      - name: config
+        secret:
+          secretName: {{ include "galoyAgents.attic.configSecretName" . }}
+{{- end }}

--- a/charts/drua/templates/sandbox-attic-config-secret.yaml
+++ b/charts/drua/templates/sandbox-attic-config-secret.yaml
@@ -1,8 +1,15 @@
 {{- if and .Values.sandbox.enabled .Values.sandbox.attic.enabled .Values.sandbox.attic.configSecret.create }}
+{{- $secretName := include "galoyAgents.attic.configSecretName" . -}}
+{{- $existing := lookup "v1" "Secret" (include "galoyAgents.sandboxNamespace" .) $secretName -}}
+{{- $existingServerToml := "" -}}
+{{- if and $existing $existing.data (index $existing.data "server.toml") -}}
+{{- $existingServerToml = index $existing.data "server.toml" | b64dec -}}
+{{- end -}}
+{{- $preserveExistingServerToml := and $existingServerToml (contains "token-hs256-secret-base64" $existingServerToml) (not .Values.sandbox.attic.configSecret.jwtSecret) -}}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "galoyAgents.attic.configSecretName" . }}
+  name: {{ $secretName }}
   namespace: {{ include "galoyAgents.sandboxNamespace" . }}
   labels:
     app: {{ template "galoyAgents.fullname" . }}
@@ -12,12 +19,15 @@ metadata:
 type: Opaque
 stringData:
   server.toml: |-
+    {{- if $preserveExistingServerToml }}
+    {{- $existingServerToml | nindent 4 }}
+    {{- else }}
     listen = "[::]:{{ .Values.sandbox.attic.service.port }}"
     allowed-hosts = []
     api-endpoint = "http://{{ include "galoyAgents.attic.fullname" . }}.{{ include "galoyAgents.sandboxNamespace" . }}.svc.cluster.local:{{ .Values.sandbox.attic.service.port }}/"
 
     [database]
-    url = "sqlite:///data/server.db"
+    url = "sqlite:///data/server.db?mode=rwc"
 
     [storage]
     type = "local"
@@ -29,8 +39,7 @@ stringData:
     avg-size = 65536
     max-size = 262144
 
-    [jwt]
-
     [jwt.signing]
-    secret = {{ required "sandbox.attic.configSecret.jwtSecret is required when sandbox.attic.enabled and sandbox.attic.configSecret.create are true" .Values.sandbox.attic.configSecret.jwtSecret | quote }}
+    token-hs256-secret-base64 = {{ default (randAlphaNum 64) .Values.sandbox.attic.configSecret.jwtSecret | b64enc | quote }}
+    {{- end }}
 {{- end }}

--- a/charts/drua/templates/sandbox-network-policy.yaml
+++ b/charts/drua/templates/sandbox-network-policy.yaml
@@ -69,7 +69,7 @@ spec:
           kubernetes.io/metadata.name: {{ .Values.sandbox.otelCollectorNamespace }}
   {{- end }}
   # 4. Sandbox-local Attic binary cache.
-  {{- if and .Values.sandbox.attic.enabled .Values.sandbox.attic.publicKey }}
+  {{- if .Values.sandbox.attic.enabled }}
   - ports:
     - protocol: TCP
       port: {{ .Values.sandbox.attic.service.port }}

--- a/charts/drua/templates/sandbox-nix-config.yaml
+++ b/charts/drua/templates/sandbox-nix-config.yaml
@@ -1,0 +1,15 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.attic.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "galoyAgents.sandbox.nixConfigMapName" . }}
+  namespace: {{ include "galoyAgents.sandboxNamespace" . }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    app.kubernetes.io/component: sandbox-nix-config
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+data:
+  NIX_CONFIG: |-
+{{ include "galoyAgents.sandbox.nixConfig" . | indent 4 }}
+{{- end }}

--- a/charts/drua/templates/sandbox-template.yaml
+++ b/charts/drua/templates/sandbox-template.yaml
@@ -57,11 +57,16 @@ spec:
         - name: MCP_GATEWAY_URL
           value: {{ .Values.sandbox.mcpGatewayUrl | quote }}
         {{- end }}
-        {{- if or .Values.sandbox.nixSubstituters (and .Values.sandbox.attic.enabled .Values.sandbox.attic.publicKey) }}
+        {{- if .Values.sandbox.attic.enabled }}
+        - name: NIX_CONFIG
+          valueFrom:
+            configMapKeyRef:
+              name: {{ include "galoyAgents.sandbox.nixConfigMapName" . }}
+              key: NIX_CONFIG
+        {{- else if .Values.sandbox.nixSubstituters }}
         - name: NIX_CONFIG
           value: |-
-            substituters = {{- if and .Values.sandbox.attic.enabled .Values.sandbox.attic.publicKey }} {{ include "galoyAgents.attic.cacheUrl" . }}{{- end }}{{ range .Values.sandbox.nixSubstituters }} {{ .url }}{{ end }} https://cache.nixos.org/
-            trusted-public-keys = {{- if and .Values.sandbox.attic.enabled .Values.sandbox.attic.publicKey }} {{ .Values.sandbox.attic.publicKey }}{{- end }}{{ range .Values.sandbox.nixSubstituters }} {{ .publicKey }}{{ end }} cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+{{ include "galoyAgents.sandbox.nixConfig" . | indent 12 }}
         {{- end }}
         volumeMounts:
         - name: mcp-token

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -305,13 +305,11 @@ sandbox:
   - url: https://galoy-agents.cachix.org
     publicKey: galoy-agents.cachix.org-1:wGb5wYMLJ3yPYoOvf2O5vt9gEZEJ7hHsqDCNPMELGPY=
   attic:
-    enabled: false
-    ## Cache name created in Attic, e.g. by:
-    ##   attic cache create --public --priority 20 lana-bats
+    enabled: true
+    ## Cache name created and configured by the bootstrap job.
     cacheName: lana-bats
-    ## Public signing key printed by `attic cache info <cacheName>`.
-    ## When set with `enabled: true`, sandboxes put the Attic cache before
-    ## the other nix substituters and the NetworkPolicy allows egress to it.
+    ## Optional pre-seeded public signing key. Normally left empty because the
+    ## bootstrap job discovers the generated key and updates sandbox NIX_CONFIG.
     publicKey: ""
     image:
       repository: ghcr.io/zhaofengli/attic
@@ -326,7 +324,23 @@ sandbox:
       ## managed secret with a `server.toml` key.
       name: ""
       ## Required only when `create: true` and `enabled: true`.
+      ## If empty, Helm generates and then preserves a secret in the cluster.
       jwtSecret: ""
+    bootstrap:
+      enabled: true
+      image:
+        repository: nixos/nix
+        tag: latest
+        pullPolicy: IfNotPresent
+      ## Attic cache priority. cache.nixos.org uses priority 40, so 20 wins.
+      priority: 20
+      tokenValidity: 10y
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 2Gi
     persistence:
       size: 80Gi
       ## Falls back to `persistence.storageClassName` when empty.

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -152,6 +152,14 @@ sandbox:
   nixSubstituters:
   - url: https://galoy-agents.cachix.org
     publicKey: galoy-agents.cachix.org-1:wGb5wYMLJ3yPYoOvf2O5vt9gEZEJ7hHsqDCNPMELGPY=
+  attic:
+    enabled: true
+    cacheName: lana-bats
+    persistence:
+      size: 80Gi
+      storageClassName: standard-rwo
+    bootstrap:
+      enabled: true
   otelCollectorNamespace: galoy-agents-otel
   mcpGatewayUrl: "http://galoy-agents.galoy-agents.svc.cluster.local:5254/mcp"
 


### PR DESCRIPTION
## What changed

- Make the in-cluster Attic cache part of normal sandbox deployments by default.
- Add production values for the sandbox-local `lana-bats` Attic cache and 80Gi cache PVC.
- Add an Attic bootstrap Job that creates/configures the cache, reads the generated public key, and patches the sandbox `NIX_CONFIG` ConfigMap.
- Point new sandbox pods at that ConfigMap so Attic is first in `substituters`, followed by Galoy Cachix and `cache.nixos.org`.

## Why

The previous sandbox PR deployed the per-sandbox `/nix` PVC, but Attic was still optional and production did not enable it. After merge, the live Helm release had no Attic Deployment/Service/PVC/Job, so sandboxes only saw Galoy Cachix and `cache.nixos.org`.

## Validation

- `helm lint charts/drua --set global.security.allowInsecureImages=true`
- `helm lint charts/drua --set global.security.allowInsecureImages=true --set sandbox.enabled=true --set sandbox.namespace=drua-sandbox`
- rendered production Terraform-template values with placeholder digests and ran Helm lint/template
- `abkube apply --dry-run=client -f -` against the full rendered manifest
- staging smoke test in a fresh disposable namespace and fresh Attic PVC:
  - Attic Deployment became available
  - bootstrap Job completed in 67s
  - resulting `NIX_CONFIG` had Attic first, then Galoy Cachix, then `cache.nixos.org`

Note: this ensures Attic is present and used by newly-created sandbox pods. A brand-new empty Attic PVC still needs to be warmed before it gives the fast Lana e2e path.
