### PR TITLE
fix(sandbox): tolerate existing attic cache

### DIFF
--- a/charts/drua/templates/sandbox-attic-bootstrap.yaml
+++ b/charts/drua/templates/sandbox-attic-bootstrap.yaml
@@ -105,14 +105,24 @@ spec:
               sleep 2
             done
 
-            attic cache create --public \
+            if ! attic cache create --public \
               --priority "$ATTIC_PRIORITY" \
               --upstream-cache-key-name cache.nixos.org-1 \
-              "$ATTIC_CACHE" >/tmp/attic-cache-create.log 2>&1 || \
-            attic cache configure --public \
-              --priority "$ATTIC_PRIORITY" \
-              --upstream-cache-key-name cache.nixos.org-1 \
-              "$ATTIC_CACHE"
+              "$ATTIC_CACHE" >/tmp/attic-cache-create.log 2>&1; then
+              if ! attic cache info "$ATTIC_CACHE" >/tmp/attic-cache-info.log 2>&1; then
+                cat /tmp/attic-cache-create.log >&2 || true
+                cat /tmp/attic-cache-info.log >&2 || true
+                exit 1
+              fi
+
+              attic cache configure --public \
+                --priority "$ATTIC_PRIORITY" \
+                --upstream-cache-key-name cache.nixos.org-1 \
+                "$ATTIC_CACHE" >/tmp/attic-cache-configure.log 2>&1 || {
+                  echo "Attic cache $ATTIC_CACHE already exists; continuing with existing configuration." >&2
+                  cat /tmp/attic-cache-configure.log >&2 || true
+                }
+            fi
 
             cache_info="$(attic cache info "$ATTIC_CACHE" 2>&1)"
             public_key="$(printf "%s\\n" "$cache_info" | grep -o "$ATTIC_CACHE:[^[:space:]]*" | sed -n "1p")"


### PR DESCRIPTION
## What changed

Make the Attic bootstrap hook tolerate an already-existing cache. If `attic cache create` fails, the hook now verifies that the cache can be read, attempts to reconfigure it, and continues with the existing configuration if Attic rejects reconfiguration.

## Why

The production deploy failed after PR #270 because the `lana-bats` cache already existed from the manual bootstrap. On upgrade, the hook fell through from `attic cache create` to `attic cache configure`, and Attic returned an access error, causing Helm's post-upgrade hook to hit `BackoffLimitExceeded`.

## Validation

- `helm lint charts/drua --set global.security.allowInsecureImages=true -f /tmp/drua-prod-values-rendered.yaml`
- rendered the production chart and inspected the hook
- applied the patched bootstrap template manually in `galoy-agents-sandboxes`; the hook completed in 40s against the existing `lana-bats` cache and restored the Attic-first `NIX_CONFIG` ConfigMap
