### PR TITLE
chore: trigger drua CI with Rust comment

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -21,6 +21,7 @@ use auth::sa_token::SaTokenValidator;
 use auth::session_store::PgSessionStore;
 use domain::code_assistant::CodeAssistant;
 
+// Dummy CI trigger: 2026-05-05.
 /// Parsed once at boot from `config.server.tunnel.deployments`.
 pub type TunnelPublicKeys = Arc<HashMap<String, ed25519_dalek::VerifyingKey>>;
 


### PR DESCRIPTION
Dummy one-line Rust comment change to trigger CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a comment-only change with no functional or behavioral impact.
> 
> **Overview**
> Adds a single no-op comment (`// Dummy CI trigger: 2026-05-05.`) in `server/src/lib.rs` to force a CI run; no runtime logic or interfaces are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 273271fcd1a750f07345861d5980bb8c4888a899. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->