### PR TITLE
fix(sandbox): cascade-delete sandboxes + PVCs on project delete

### DIFF
--- a/.sqlx/query-003cfb912f6fa9330bedc3b9002274c39651112bc7f75bbbbf6b323a89a1d429.json
+++ b/.sqlx/query-003cfb912f6fa9330bedc3b9002274c39651112bc7f75bbbbf6b323a89a1d429.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT created_at, id FROM sandboxes WHERE COALESCE(project_id = $1, $1 IS NULL) AND COALESCE(name = $2, $2 IS NULL) AND (COALESCE((created_at, id) < ($5, $4), $4 IS NULL)) ORDER BY created_at DESC, id DESC LIMIT $3) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $6 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE (COALESCE(id > $2, true)) AND deleted = FALSE ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,11 +31,8 @@
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Text",
         "Int8",
         "Uuid",
-        "Timestamptz",
         "Bool"
       ]
     },
@@ -47,5 +44,5 @@
       false
     ]
   },
-  "hash": "02c1d7233bbbbc137bf6c3f7870709147ea2ca974b9e7dd914c292a4e1a74430"
+  "hash": "003cfb912f6fa9330bedc3b9002274c39651112bc7f75bbbbf6b323a89a1d429"
 }

--- a/.sqlx/query-135bf248a90382a5c675bf0e2c83e8563f85848f52685e268acd102e928b13ac.json
+++ b/.sqlx/query-135bf248a90382a5c675bf0e2c83e8563f85848f52685e268acd102e928b13ac.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT created_at, id FROM sandboxes WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT project_id, created_at, id FROM sandboxes WHERE ((project_id = $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,6 +31,7 @@
     ],
     "parameters": {
       "Left": [
+        "Uuid",
         "Int8",
         "Uuid",
         "Timestamptz",
@@ -45,5 +46,5 @@
       false
     ]
   },
-  "hash": "45c814aad886420c46d935f45c121d0ec444d65c1e85d1b89890b000bb53d27c"
+  "hash": "135bf248a90382a5c675bf0e2c83e8563f85848f52685e268acd102e928b13ac"
 }

--- a/.sqlx/query-17eaa2f2396e671ec4e6c9c482eff01eebeb1edbf4b108c63efc963944c1496a.json
+++ b/.sqlx/query-17eaa2f2396e671ec4e6c9c482eff01eebeb1edbf4b108c63efc963944c1496a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT name, created_at, id FROM sandboxes WHERE ((name = $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE workflow_id IS NOT DISTINCT FROM $1 AND deleted = FALSE) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,10 +31,7 @@
     ],
     "parameters": {
       "Left": [
-        "Text",
-        "Int8",
         "Uuid",
-        "Timestamptz",
         "Bool"
       ]
     },
@@ -46,5 +43,5 @@
       false
     ]
   },
-  "hash": "2e7b7b00eee3b08291d7c1f41ee17a1d2b247ba5de6f43e7d78c9bc88560b649"
+  "hash": "17eaa2f2396e671ec4e6c9c482eff01eebeb1edbf4b108c63efc963944c1496a"
 }

--- a/.sqlx/query-2c0e3980725c5ae0e735db35c7f6da01f78fa2cc95ed2292e69dd6f92aae73bd.json
+++ b/.sqlx/query-2c0e3980725c5ae0e735db35c7f6da01f78fa2cc95ed2292e69dd6f92aae73bd.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT created_at, id FROM sandboxes WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT name, created_at, id FROM sandboxes WHERE ((name = $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,6 +31,7 @@
     ],
     "parameters": {
       "Left": [
+        "Text",
         "Int8",
         "Uuid",
         "Timestamptz",
@@ -45,5 +46,5 @@
       false
     ]
   },
-  "hash": "b71c2c941d0101ccd6a301b2bccd2e3a2105621f88fdc08e03b698c74eef289b"
+  "hash": "2c0e3980725c5ae0e735db35c7f6da01f78fa2cc95ed2292e69dd6f92aae73bd"
 }

--- a/.sqlx/query-3e333add6596d52b1c5880eef404de875711f795277a1246bf7fcb54dedc5e35.json
+++ b/.sqlx/query-3e333add6596d52b1c5880eef404de875711f795277a1246bf7fcb54dedc5e35.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE COALESCE(project_id = $1, $1 IS NULL) AND COALESCE(name = $2, $2 IS NULL) AND (COALESCE(id < $4, true)) ORDER BY id DESC LIMIT $3) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE COALESCE(project_id = $1, $1 IS NULL) AND COALESCE(name = $2, $2 IS NULL) AND (COALESCE(id > $4, true)) AND deleted = FALSE ORDER BY id ASC LIMIT $3) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -46,5 +46,5 @@
       false
     ]
   },
-  "hash": "ab51801ca09b72b3a57ef0a42dd88227bf4fb903f26fb9f653e54dc823115ebe"
+  "hash": "3e333add6596d52b1c5880eef404de875711f795277a1246bf7fcb54dedc5e35"
 }

--- a/.sqlx/query-46f480e0d44b10b9067f8b93de331165d4e73e48066ffe6f8e605fce530b11d1.json
+++ b/.sqlx/query-46f480e0d44b10b9067f8b93de331165d4e73e48066ffe6f8e605fce530b11d1.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT created_at, id FROM sandboxes WHERE COALESCE(project_id = $1, $1 IS NULL) AND COALESCE(name = $2, $2 IS NULL) AND (COALESCE((created_at, id) > ($5, $4), $4 IS NULL)) ORDER BY created_at ASC, id ASC LIMIT $3) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $6 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT name, created_at, id FROM sandboxes WHERE ((name = $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,7 +31,6 @@
     ],
     "parameters": {
       "Left": [
-        "Uuid",
         "Text",
         "Int8",
         "Uuid",
@@ -47,5 +46,5 @@
       false
     ]
   },
-  "hash": "53190ed59019fffaf30d015d738af9ab7321b5efe1ed9ed8343e5995d721726a"
+  "hash": "46f480e0d44b10b9067f8b93de331165d4e73e48066ffe6f8e605fce530b11d1"
 }

--- a/.sqlx/query-495ce90cb4b8d63e106dc8e345d061b9a25411bb7e252cc7939c41841a843321.json
+++ b/.sqlx/query-495ce90cb4b8d63e106dc8e345d061b9a25411bb7e252cc7939c41841a843321.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE id = $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "query": "WITH entities AS (SELECT created_at, id FROM sandboxes WHERE COALESCE(project_id = $1, $1 IS NULL) AND COALESCE(name = $2, $2 IS NULL) AND (COALESCE((created_at, id) > ($5, $4), $4 IS NULL)) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $3) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $6 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -32,6 +32,10 @@
     "parameters": {
       "Left": [
         "Uuid",
+        "Text",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
         "Bool"
       ]
     },
@@ -43,5 +47,5 @@
       false
     ]
   },
-  "hash": "ad660cbe7ccbb1171bc179ccd78e27a88806c8b7dcdc78106502efa9192fc9a3"
+  "hash": "495ce90cb4b8d63e106dc8e345d061b9a25411bb7e252cc7939c41841a843321"
 }

--- a/.sqlx/query-54d0efabba5063f72e3eb41ef401f3d1a5b936b5dacfd77e856d3ac065839c2d.json
+++ b/.sqlx/query-54d0efabba5063f72e3eb41ef401f3d1a5b936b5dacfd77e856d3ac065839c2d.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE name = $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE id = $1 AND deleted = FALSE) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,7 +31,7 @@
     ],
     "parameters": {
       "Left": [
-        "Text",
+        "Uuid",
         "Bool"
       ]
     },
@@ -43,5 +43,5 @@
       false
     ]
   },
-  "hash": "7b1229286803e675e8988db10256fa7e381dea1e7055a36b89b25c8cf5611426"
+  "hash": "54d0efabba5063f72e3eb41ef401f3d1a5b936b5dacfd77e856d3ac065839c2d"
 }

--- a/.sqlx/query-60fbbf91e6f6525665d74ed63e9948b02d9e3f3f1c68766cee53f1416f972f03.json
+++ b/.sqlx/query-60fbbf91e6f6525665d74ed63e9948b02d9e3f3f1c68766cee53f1416f972f03.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT project_id, created_at, id FROM sandboxes WHERE ((project_id = $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE COALESCE(project_id = $1, $1 IS NULL) AND COALESCE(name = $2, $2 IS NULL) AND (COALESCE(id < $4, true)) AND deleted = FALSE ORDER BY id DESC LIMIT $3) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -32,9 +32,9 @@
     "parameters": {
       "Left": [
         "Uuid",
+        "Text",
         "Int8",
         "Uuid",
-        "Timestamptz",
         "Bool"
       ]
     },
@@ -46,5 +46,5 @@
       false
     ]
   },
-  "hash": "7e8892e9cac7c33390b8b653a452857431bf43f432ce026b83a964d1e734772b"
+  "hash": "60fbbf91e6f6525665d74ed63e9948b02d9e3f3f1c68766cee53f1416f972f03"
 }

--- a/.sqlx/query-6543b3e529879730075cde5a4b54fbc8fcf1cca975177ed08c10b244587c2498.json
+++ b/.sqlx/query-6543b3e529879730075cde5a4b54fbc8fcf1cca975177ed08c10b244587c2498.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE (COALESCE(id > $2, true)) ORDER BY id ASC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE name = $1 AND deleted = FALSE) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,8 +31,7 @@
     ],
     "parameters": {
       "Left": [
-        "Int8",
-        "Uuid",
+        "Text",
         "Bool"
       ]
     },
@@ -44,5 +43,5 @@
       false
     ]
   },
-  "hash": "b1a1fe9ba096eecf9b8e0c550fe6ee5e228b2e7df025a9d6a0d478b907b01bb6"
+  "hash": "6543b3e529879730075cde5a4b54fbc8fcf1cca975177ed08c10b244587c2498"
 }

--- a/.sqlx/query-8450fb37bb568df65669928dc418c5531ce2dba3fa3aeee5f45a26df6f991cff.json
+++ b/.sqlx/query-8450fb37bb568df65669928dc418c5531ce2dba3fa3aeee5f45a26df6f991cff.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE workflow_id IS NOT DISTINCT FROM $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "query": "WITH entities AS (SELECT created_at, id FROM sandboxes WHERE (COALESCE((created_at, id) > ($3, $2), $2 IS NULL)) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,7 +31,9 @@
     ],
     "parameters": {
       "Left": [
+        "Int8",
         "Uuid",
+        "Timestamptz",
         "Bool"
       ]
     },
@@ -43,5 +45,5 @@
       false
     ]
   },
-  "hash": "43a70463279005278365f1da22d0834dfc536d0b82b51d392bd27d6792db7bf6"
+  "hash": "8450fb37bb568df65669928dc418c5531ce2dba3fa3aeee5f45a26df6f991cff"
 }

--- a/.sqlx/query-95e190ead7ee945e0408685b3551847c9f523efc2623025b75af7b7d6ac32ac6.json
+++ b/.sqlx/query-95e190ead7ee945e0408685b3551847c9f523efc2623025b75af7b7d6ac32ac6.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE project_id = $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id, e.sequence",
+  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE project_id = $1 AND deleted = FALSE) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $2 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -43,5 +43,5 @@
       false
     ]
   },
-  "hash": "a80aca9c4fbc078c3753ec49cb90dcd0cf34fe0703e8a45c067e1e2190005efe"
+  "hash": "95e190ead7ee945e0408685b3551847c9f523efc2623025b75af7b7d6ac32ac6"
 }

--- a/.sqlx/query-c3097017bfd6aa33719a90e0a4150c668ef94c5bbdb182a69a60c7670625aeb2.json
+++ b/.sqlx/query-c3097017bfd6aa33719a90e0a4150c668ef94c5bbdb182a69a60c7670625aeb2.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE (COALESCE(id < $2, true)) ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT project_id, created_at, id FROM sandboxes WHERE ((project_id = $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,8 +31,10 @@
     ],
     "parameters": {
       "Left": [
+        "Uuid",
         "Int8",
         "Uuid",
+        "Timestamptz",
         "Bool"
       ]
     },
@@ -44,5 +46,5 @@
       false
     ]
   },
-  "hash": "dd9c291afea23c6d0b44cc9d0d5396e38ce814caabd93d1c819612cf08f422a4"
+  "hash": "c3097017bfd6aa33719a90e0a4150c668ef94c5bbdb182a69a60c7670625aeb2"
 }

--- a/.sqlx/query-d9280725e32a2ead423a60000c51352a443c9307635d6c4f76e2d60208506713.json
+++ b/.sqlx/query-d9280725e32a2ead423a60000c51352a443c9307635d6c4f76e2d60208506713.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT project_id, created_at, id FROM sandboxes WHERE ((project_id = $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT created_at, id FROM sandboxes WHERE COALESCE(project_id = $1, $1 IS NULL) AND COALESCE(name = $2, $2 IS NULL) AND (COALESCE((created_at, id) < ($5, $4), $4 IS NULL)) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $3) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $6 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -32,6 +32,7 @@
     "parameters": {
       "Left": [
         "Uuid",
+        "Text",
         "Int8",
         "Uuid",
         "Timestamptz",
@@ -46,5 +47,5 @@
       false
     ]
   },
-  "hash": "a0e7f3e610617d24593aebc3c09d1c2ce6affd1453f9b23cda81e52c888300c9"
+  "hash": "d9280725e32a2ead423a60000c51352a443c9307635d6c4f76e2d60208506713"
 }

--- a/.sqlx/query-ea5a862daf800ebd62300b4b7dabb7b6cb98ec6b670bb1a3c94ac6d05b985bc3.json
+++ b/.sqlx/query-ea5a862daf800ebd62300b4b7dabb7b6cb98ec6b670bb1a3c94ac6d05b985bc3.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT name, created_at, id FROM sandboxes WHERE ((name = $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE (COALESCE(id < $2, true)) AND deleted = FALSE ORDER BY id DESC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $3 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,10 +31,8 @@
     ],
     "parameters": {
       "Left": [
-        "Text",
         "Int8",
         "Uuid",
-        "Timestamptz",
         "Bool"
       ]
     },
@@ -46,5 +44,5 @@
       false
     ]
   },
-  "hash": "605c843eb71ec0dd9b8a874025ae4fb1fa1b8a193379e9f8282fb0cc20ec3eaf"
+  "hash": "ea5a862daf800ebd62300b4b7dabb7b6cb98ec6b670bb1a3c94ac6d05b985bc3"
 }

--- a/.sqlx/query-fcb2ebcb31ff45a9ff6428c136fc628fc1018cc31fc47c64a5e6a0552c88c6b0.json
+++ b/.sqlx/query-fcb2ebcb31ff45a9ff6428c136fc628fc1018cc31fc47c64a5e6a0552c88c6b0.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE COALESCE(project_id = $1, $1 IS NULL) AND COALESCE(name = $2, $2 IS NULL) AND (COALESCE(id > $4, true)) ORDER BY id ASC LIMIT $3) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "query": "WITH entities AS (SELECT created_at, id FROM sandboxes WHERE (COALESCE((created_at, id) < ($3, $2), $2 IS NULL)) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $1) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $4 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
   "describe": {
     "columns": [
       {
@@ -31,10 +31,9 @@
     ],
     "parameters": {
       "Left": [
-        "Uuid",
-        "Text",
         "Int8",
         "Uuid",
+        "Timestamptz",
         "Bool"
       ]
     },
@@ -46,5 +45,5 @@
       false
     ]
   },
-  "hash": "873c9836b96208c26c79ee35a4207d2a2d1375a5fa808aaa5fa3060075059b04"
+  "hash": "fcb2ebcb31ff45a9ff6428c136fc628fc1018cc31fc47c64a5e6a0552c88c6b0"
 }

--- a/.sqlx/query-fd2932b40020a2d543aab5b88a3b2254c3af734dc918092e00836113e2070b35.json
+++ b/.sqlx/query-fd2932b40020a2d543aab5b88a3b2254c3af734dc918092e00836113e2070b35.json
@@ -1,0 +1,17 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE sandboxes SET project_id = $2, name = $3, workflow_id = $4, deleted = TRUE WHERE id = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Uuid",
+        "Varchar",
+        "Uuid"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "fd2932b40020a2d543aab5b88a3b2254c3af734dc918092e00836113e2070b35"
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,7 @@ use clap::{Parser, Subcommand};
 #[command(name = "drua", about = "Drua — AI agent projects")]
 struct Cli {
     #[command(subcommand)]
-        command: Command,
+    command: Command,
 }
 
 #[derive(Subcommand)]

--- a/core/migrations/20260506040000_sandboxes_soft_delete.sql
+++ b/core/migrations/20260506040000_sandboxes_soft_delete.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.sandboxes
+    ADD COLUMN deleted boolean DEFAULT false NOT NULL;

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -603,20 +603,29 @@ impl Agents {
         project_id: ProjectId,
     ) -> Result<Vec<Agent>, AgentError> {
         Audit::record_project_id(project_id);
-        let query = es_entity::PaginatedQueryArgs {
-            first: 100,
+        const PAGE_SIZE: usize = 100;
+        let mut all = Vec::new();
+        let mut query = es_entity::PaginatedQueryArgs {
+            first: PAGE_SIZE,
             after: None,
         };
-        let result = self
-            .repo
-            .list_for_project_id_by_created_at_in_op(
-                &mut *op,
-                project_id,
-                query,
-                es_entity::ListDirection::Descending,
-            )
-            .await?;
-        Ok(result.entities)
+        loop {
+            let mut result = self
+                .repo
+                .list_for_project_id_by_created_at_in_op(
+                    &mut *op,
+                    project_id,
+                    query,
+                    es_entity::ListDirection::Descending,
+                )
+                .await?;
+            all.append(&mut result.entities);
+            match result.into_next_query() {
+                Some(next) => query = next,
+                None => break,
+            }
+        }
+        Ok(all)
     }
 
     #[instrument(name = "domain.agent.delete", skip(self, sub))]
@@ -637,6 +646,7 @@ impl Agents {
         let mut op = self.repo.begin_op().await?;
         self.delete_in_op(&mut op, id).await?;
         op.commit().await?;
+        self.invalidate_agent_cache(id);
         Ok(())
     }
 

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -209,8 +209,21 @@ impl Projects {
         Audit::record_action_if_unset("project.delete");
         Audit::record_project_id(id);
         let mut op = self.repo.begin_op().await?;
+        // Snapshot agent ids before the cascade so we can wipe the
+        // in-memory `Agents::context_cache` post-commit. The cache is
+        // keyed by AgentId; once delete_in_op runs the entries are
+        // unreachable through the DB but still occupy heap.
+        let agent_ids: Vec<AgentId> = self
+            .agents
+            .list_for_project_in_op(&mut op, id)
+            .await
+            .map(|agents| agents.into_iter().map(|a| a.id).collect())
+            .unwrap_or_default();
         let project = self.delete_in_op(&mut op, sub, id).await?;
         op.commit().await?;
+        for agent_id in agent_ids {
+            self.agents.invalidate_agent_cache(agent_id);
+        }
         Ok(project)
     }
 
@@ -228,12 +241,6 @@ impl Projects {
             return Ok(project);
         }
 
-        // Tear down pods/processes via the admin client before touching DB
-        // state so in-flight sandbox work stops first.
-        if let Err(e) = self.sandboxes.suspend_for_project_in_op(op, id).await {
-            tracing::warn!(error = %e, "failed to suspend sandboxes during project delete");
-        }
-
         let agent_list = self.agents.list_for_project_in_op(op, id).await?;
         for agent in &agent_list {
             if let Err(e) = self.agents.delete_in_op(op, agent.id).await {
@@ -243,6 +250,20 @@ impl Projects {
                     "failed to delete agent during project delete"
                 );
             }
+        }
+
+        // Sandbox tear-down runs after agent delete so each agent's
+        // detach event lands while the sandbox row is still live;
+        // `cascade_delete_for_project_in_op` then deletes the pod,
+        // tears down PVCs (workspace + nix-store), and soft-deletes
+        // the row so we don't leave zombie sandboxes pointing at a
+        // tombstoned project.
+        if let Err(e) = self
+            .sandboxes
+            .cascade_delete_for_project_in_op(op, id)
+            .await
+        {
+            tracing::warn!(error = %e, "failed to cascade-delete sandboxes during project delete");
         }
 
         if let Err(e) = self.skills.delete_for_project_in_op(op, id).await {

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -721,39 +721,80 @@ impl Sandboxes {
         Ok(sandbox)
     }
 
-    /// Best-effort: per-sandbox failures are logged and skipped.
-    #[instrument(name = "domain.sandbox.suspend_for_project_in_op", skip(self, op))]
-    pub async fn suspend_for_project_in_op(
+    /// Project-cascade entry point: tears down every sandbox owned by
+    /// `project_id` end-to-end — pod / local process via the admin
+    /// client, persistent storage (PVCs / `.sandboxes/<name>/`) via
+    /// `delete_pvcs`, and the DB row via the repo's
+    /// `soft_without_queries` cascade. Per-sandbox admin failures are
+    /// logged and skipped so a transient k8s blip can't strand the
+    /// whole project delete; the row flip still lands so the entity
+    /// stops being addressable.
+    #[instrument(
+        name = "domain.sandbox.cascade_delete_for_project_in_op",
+        skip(self, op)
+    )]
+    pub async fn cascade_delete_for_project_in_op(
         &self,
         op: &mut DbOp<'_>,
         project_id: ProjectId,
     ) -> Result<(), SandboxError> {
-        let query = PaginatedQueryArgs {
-            first: 100,
-            after: None,
-        };
-        let result = self
-            .repo
-            .list_for_project_id_by_created_at_in_op(
-                &mut *op,
-                project_id,
-                query,
-                ListDirection::Descending,
-            )
-            .await?;
-        for sandbox in result.entities {
-            if sandbox.state == SandboxState::Suspended {
-                continue;
+        for sandbox in self.list_all_for_project_in_op(op, project_id).await? {
+            let resource_name = sandbox.resource_name();
+            if sandbox.state != SandboxState::Suspended {
+                if let Err(e) = self.admin.delete_sandbox(&resource_name).await {
+                    tracing::warn!(
+                        sandbox_id = %sandbox.id,
+                        sandbox = %resource_name,
+                        error = %e,
+                        "admin delete_sandbox failed during project cascade"
+                    );
+                }
             }
-            if let Err(e) = self.suspend_in_op(op, sandbox.id).await {
+            if let Err(e) = self.admin.delete_pvcs(&resource_name).await {
                 tracing::warn!(
                     sandbox_id = %sandbox.id,
+                    sandbox = %resource_name,
                     error = %e,
-                    "failed to suspend sandbox during project delete"
+                    "admin delete_pvcs failed during project cascade"
                 );
             }
         }
+        self.repo
+            .cascade_delete_for_project_in_op(op, project_id)
+            .await?;
         Ok(())
+    }
+
+    /// Drains every page of `list_for_project_id_by_created_at_in_op`
+    /// — used by the cascade variants that *must not* miss rows.
+    async fn list_all_for_project_in_op(
+        &self,
+        op: &mut DbOp<'_>,
+        project_id: ProjectId,
+    ) -> Result<Vec<Sandbox>, SandboxError> {
+        const PAGE_SIZE: usize = 100;
+        let mut all = Vec::new();
+        let mut query = PaginatedQueryArgs {
+            first: PAGE_SIZE,
+            after: None,
+        };
+        loop {
+            let mut result = self
+                .repo
+                .list_for_project_id_by_created_at_in_op(
+                    &mut *op,
+                    project_id,
+                    query,
+                    ListDirection::Descending,
+                )
+                .await?;
+            all.append(&mut result.entities);
+            match result.into_next_query() {
+                Some(next) => query = next,
+                None => break,
+            }
+        }
+        Ok(all)
     }
 
     #[instrument(name = "domain.sandbox.suspend", skip(self, sub))]

--- a/core/src/sandbox/repo.rs
+++ b/core/src/sandbox/repo.rs
@@ -13,7 +13,8 @@ use super::entity::*;
         project_id(ty = "ProjectId", list_for(by(created_at))),
         name(ty = "String", list_for(by(created_at))),
         workflow_id(ty = "Option<WorkflowDefinitionId>"),
-    )
+    ),
+    delete = "soft_without_queries"
 )]
 pub struct SandboxRepo {
     #[allow(dead_code)]
@@ -23,5 +24,22 @@ pub struct SandboxRepo {
 impl SandboxRepo {
     pub fn new(pool: &PgPool) -> Self {
         Self { pool: pool.clone() }
+    }
+
+    /// Bulk soft-delete every sandbox row belonging to `project_id`.
+    /// `soft_without_queries` makes a column update equivalent to
+    /// iterating each entity through `delete_in_op`; no events generated.
+    /// Pod / PVC teardown happens out-of-band via `AdminClient` before
+    /// callers invoke this — the row flip is the final tombstone.
+    pub async fn cascade_delete_for_project_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        project_id: ProjectId,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE sandboxes SET deleted = TRUE WHERE project_id = $1")
+            .bind(project_id)
+            .execute(op.as_executor())
+            .await?;
+        Ok(())
     }
 }

--- a/core/tests/sandbox_cascade.rs
+++ b/core/tests/sandbox_cascade.rs
@@ -1,0 +1,168 @@
+use std::sync::Arc;
+
+use drua_core::primitives::ProjectId;
+use drua_core::sandbox::{SandboxConfig, SandboxMode, SandboxSpecs, Sandboxes};
+
+const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
+
+async fn pool() -> sqlx::PgPool {
+    let url = std::env::var("DATABASE_URL").unwrap_or_else(|_| PG_CON.to_string());
+    sqlx::PgPool::connect(&url).await.expect("connect to pg")
+}
+
+async fn insert_project(pool: &sqlx::PgPool) -> ProjectId {
+    let id = ProjectId::new();
+    let name = format!("test-project-{}", uuid::Uuid::from(id));
+    sqlx::query("INSERT INTO projects (id, name, created_at) VALUES ($1, $2, NOW())")
+        .bind(id)
+        .bind(&name)
+        .execute(pool)
+        .await
+        .expect("insert project");
+    id
+}
+
+fn specs() -> SandboxSpecs {
+    SandboxSpecs {
+        cpu: "100m".into(),
+        memory: "128Mi".into(),
+        disk_size: "1Gi".into(),
+    }
+}
+
+async fn build_sandboxes(pool: &sqlx::PgPool) -> Arc<Sandboxes> {
+    Arc::new(
+        Sandboxes::init(pool, SandboxConfig::default(), None)
+            .await
+            .expect("init sandboxes"),
+    )
+}
+
+/// Bulk soft-delete + admin teardown both fire and cover every sandbox
+/// in the project — the audit's H2/H3 coverage gap that the old
+/// `suspend_for_project_in_op` capped at 100 rows.
+#[tokio::test]
+async fn cascade_delete_marks_every_project_sandbox_deleted() {
+    let pool = pool().await;
+    let sandboxes = build_sandboxes(&pool).await;
+    let project_id = insert_project(&pool).await;
+
+    let mut op = sandboxes.begin_op().await.expect("begin op");
+    let sb_a = sandboxes
+        .create_in_op(&mut op, project_id, "a", specs(), SandboxMode::Scratch)
+        .await
+        .expect("create a");
+    let sb_b = sandboxes
+        .create_in_op(&mut op, project_id, "b", specs(), SandboxMode::Scratch)
+        .await
+        .expect("create b");
+    op.commit().await.expect("commit creates");
+
+    let mut op = sandboxes.begin_op().await.expect("begin op");
+    sandboxes
+        .cascade_delete_for_project_in_op(&mut op, project_id)
+        .await
+        .expect("cascade");
+    op.commit().await.expect("commit cascade");
+
+    for id in [sb_a.id, sb_b.id] {
+        let row: (bool,) = sqlx::query_as("SELECT deleted FROM sandboxes WHERE id = $1")
+            .bind(id)
+            .fetch_one(&pool)
+            .await
+            .expect("fetch deleted flag");
+        assert!(row.0, "sandbox {id} should be soft-deleted");
+    }
+
+    // Soft-deleted rows must no longer surface in service-level reads.
+    assert!(
+        sandboxes
+            .maybe_find_by_id(sb_a.id)
+            .await
+            .expect("lookup")
+            .is_none(),
+        "soft-deleted sandbox should not be findable"
+    );
+}
+
+#[tokio::test]
+async fn cascade_delete_paginates_past_first_100() {
+    let pool = pool().await;
+    let sandboxes = build_sandboxes(&pool).await;
+    let project_id = insert_project(&pool).await;
+
+    let mut op = sandboxes.begin_op().await.expect("begin op");
+    let mut ids = Vec::with_capacity(105);
+    for i in 0..105 {
+        let sb = sandboxes
+            .create_in_op(
+                &mut op,
+                project_id,
+                format!("sb-{i:03}"),
+                specs(),
+                SandboxMode::Scratch,
+            )
+            .await
+            .expect("create");
+        ids.push(sb.id);
+    }
+    op.commit().await.expect("commit creates");
+
+    let mut op = sandboxes.begin_op().await.expect("begin op");
+    sandboxes
+        .cascade_delete_for_project_in_op(&mut op, project_id)
+        .await
+        .expect("cascade");
+    op.commit().await.expect("commit cascade");
+
+    let undeleted: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM sandboxes WHERE project_id = $1 AND deleted = FALSE",
+    )
+    .bind(project_id)
+    .fetch_one(&pool)
+    .await
+    .expect("count");
+    assert_eq!(
+        undeleted, 0,
+        "cascade should soft-delete every sandbox row, not just the first 100"
+    );
+}
+
+#[tokio::test]
+async fn cascade_delete_is_noop_for_other_projects() {
+    let pool = pool().await;
+    let sandboxes = build_sandboxes(&pool).await;
+    let project_a = insert_project(&pool).await;
+    let project_b = insert_project(&pool).await;
+
+    let mut op = sandboxes.begin_op().await.expect("begin op");
+    let sb_a = sandboxes
+        .create_in_op(&mut op, project_a, "a", specs(), SandboxMode::Scratch)
+        .await
+        .expect("create a");
+    let sb_b = sandboxes
+        .create_in_op(&mut op, project_b, "b", specs(), SandboxMode::Scratch)
+        .await
+        .expect("create b");
+    op.commit().await.expect("commit creates");
+
+    let mut op = sandboxes.begin_op().await.expect("begin op");
+    sandboxes
+        .cascade_delete_for_project_in_op(&mut op, project_a)
+        .await
+        .expect("cascade");
+    op.commit().await.expect("commit cascade");
+
+    let row_a: (bool,) = sqlx::query_as("SELECT deleted FROM sandboxes WHERE id = $1")
+        .bind(sb_a.id)
+        .fetch_one(&pool)
+        .await
+        .expect("fetch a");
+    let row_b: (bool,) = sqlx::query_as("SELECT deleted FROM sandboxes WHERE id = $1")
+        .bind(sb_b.id)
+        .fetch_one(&pool)
+        .await
+        .expect("fetch b");
+    assert!(row_a.0, "project A sandbox should be deleted");
+    assert!(!row_b.0, "project B sandbox should be untouched");
+}

--- a/lib/sandbox/src/admin_client/k8s/mod.rs
+++ b/lib/sandbox/src/admin_client/k8s/mod.rs
@@ -401,7 +401,8 @@ impl K8sAdminClient {
         Ok(current)
     }
 
-    /// PVC is retained for recreation.
+    /// PVC is retained for recreation. Use [`Self::delete_pvcs`] to tear
+    /// it down when the owning project is being deleted.
     #[instrument(name = "sandbox.admin.k8s.delete_sandbox", skip_all, fields(%name))]
     pub async fn delete_sandbox(&self, name: &str) -> Result<(), AdminError> {
         let sandboxes: Api<Sandbox> = Api::namespaced(self.client.clone(), &self.namespace);
@@ -417,6 +418,42 @@ impl K8sAdminClient {
                 _ => AdminError::Kube(e),
             })?;
         tracing::info!(sandbox = %name, "Sandbox deleted");
+        Ok(())
+    }
+
+    /// Delete every PVC labeled `sandbox-name=<name>` (workspace PVC plus
+    /// any controller-owned `volumeClaimTemplate` PVCs — both carry the
+    /// label, see `ensure_pvc` and `nix_store_claim_template`). Pod-bound
+    /// PVCs enter `Terminating` and finalize once the pod is gone — call
+    /// `delete_sandbox` first.
+    #[instrument(name = "sandbox.admin.k8s.delete_pvcs", skip_all, fields(%name))]
+    pub async fn delete_pvcs(&self, name: &str) -> Result<(), AdminError> {
+        let pvcs: Api<PersistentVolumeClaim> =
+            Api::namespaced(self.client.clone(), &self.namespace);
+        let lp = ListParams::default().labels(&format!("sandbox-name={name}"));
+        let list = pvcs.list(&lp).await?;
+        if list.items.is_empty() {
+            return Ok(());
+        }
+        for pvc in list.items {
+            let Some(pvc_name) = pvc.metadata.name.as_deref() else {
+                continue;
+            };
+            match pvcs.delete(pvc_name, &DeleteParams::default()).await {
+                Ok(_) => {
+                    tracing::info!(sandbox = %name, pvc = %pvc_name, "PVC deleted");
+                }
+                Err(kube::Error::Api(resp)) if resp.code == 404 => {}
+                Err(e) => {
+                    tracing::warn!(
+                        sandbox = %name,
+                        pvc = %pvc_name,
+                        error = %e,
+                        "PVC delete failed (continuing)"
+                    );
+                }
+            }
+        }
         Ok(())
     }
 
@@ -667,6 +704,10 @@ impl AdminClient for K8sAdminClient {
 
     async fn delete_sandbox(&self, name: &str) -> Result<(), AdminError> {
         K8sAdminClient::delete_sandbox(self, name).await
+    }
+
+    async fn delete_pvcs(&self, name: &str) -> Result<(), AdminError> {
+        K8sAdminClient::delete_pvcs(self, name).await
     }
 
     async fn get_sandbox(&self, name: &str) -> Result<SandboxView, AdminError> {

--- a/lib/sandbox/src/admin_client/local/mod.rs
+++ b/lib/sandbox/src/admin_client/local/mod.rs
@@ -142,6 +142,30 @@ impl LocalAdminClient {
         Ok(())
     }
 
+    /// Local equivalent of the k8s PVC tear-down: removes the per-sandbox
+    /// directory under `.sandboxes/<name>/` (workspace + secrets). Missing
+    /// dir is a no-op so callers can run delete_sandbox + delete_pvcs
+    /// even if the sandbox was never spawned.
+    #[instrument(name = "sandbox.admin.local.delete_pvcs", skip(self), fields(%name))]
+    pub async fn delete_pvcs(&self, name: &str) -> Result<(), AdminError> {
+        let sandbox_dir = self.sandboxes_root.join(name);
+        match tokio::fs::remove_dir_all(&sandbox_dir).await {
+            Ok(_) => {
+                tracing::info!(sandbox = %name, dir = %sandbox_dir.display(), "Local sandbox dir removed");
+            }
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => {
+                tracing::warn!(
+                    sandbox = %name,
+                    dir = %sandbox_dir.display(),
+                    error = %e,
+                    "Local sandbox dir remove failed (continuing)"
+                );
+            }
+        }
+        Ok(())
+    }
+
     pub async fn get_sandbox(&self, name: &str) -> Result<SandboxView, AdminError> {
         let sandboxes = self.sandboxes.lock().await;
         sandboxes
@@ -168,6 +192,10 @@ impl AdminClient for LocalAdminClient {
 
     async fn delete_sandbox(&self, name: &str) -> Result<(), AdminError> {
         LocalAdminClient::delete_sandbox(self, name).await
+    }
+
+    async fn delete_pvcs(&self, name: &str) -> Result<(), AdminError> {
+        LocalAdminClient::delete_pvcs(self, name).await
     }
 
     async fn get_sandbox(&self, name: &str) -> Result<SandboxView, AdminError> {

--- a/lib/sandbox/src/admin_client/trait.rs
+++ b/lib/sandbox/src/admin_client/trait.rs
@@ -17,6 +17,12 @@ pub trait AdminClient: Send + Sync {
 
     async fn delete_sandbox(&self, name: &str) -> Result<(), AdminError>;
 
+    /// Tear down any persistent storage (PVCs on k8s; nothing on local)
+    /// associated with `name`. Called after `delete_sandbox` during
+    /// project-cascade cleanup so we don't leak paid storage when the
+    /// owning project goes away. Idempotent: missing storage is a no-op.
+    async fn delete_pvcs(&self, name: &str) -> Result<(), AdminError>;
+
     async fn get_sandbox(&self, name: &str) -> Result<Sandbox, AdminError>;
 
     async fn list_sandboxes(&self) -> Result<Vec<Sandbox>, AdminError>;


### PR DESCRIPTION
## Summary

Closes the three High-severity gaps from the delete-paths audit (memory report `019dfc1b`):

- **PVC orphaning** — `K8sAdminClient::delete_sandbox` retained workspace + nix-store PVCs by design, leaving paid storage alive forever after every project delete.
- **Pagination cap of 100** — `Sandboxes::suspend_for_project_in_op` and `Agents::list_for_project_in_op` were hardcoded `first: 100`, silently leaking every row past that bound.
- **Zombie sandbox rows** — there was no `Sandboxes::cascade_delete_*`; rows lived on with `state=Suspended` and `project_id` pointing to a tombstoned project.

## What changed

### New `AdminClient::delete_pvcs(name)` method
- K8s impl deletes every PVC labelled `sandbox-name=<name>` (label is set on workspace PVC + nix-store `volumeClaimTemplate`, so one call covers both).
- Local impl wipes `.sandboxes/<name>/` (workspace + secrets) so dev mirrors prod cascade behaviour.
- Idempotent: missing storage is a no-op so callers can chain `delete_sandbox` + `delete_pvcs`.

### New `Sandboxes::cascade_delete_for_project_in_op`
- Drains every page of project sandboxes (no more 100-row cap).
- For each: `admin.delete_sandbox` (skipped if already Suspended) → `admin.delete_pvcs` → continue on warning.
- Repo-side `cascade_delete_for_project_in_op` flips the new `deleted` column in one bulk SQL update; `SandboxRepo` now uses `delete = "soft_without_queries"` (mirrors Skills / Agents / Notes).
- Migration `20260506040000_sandboxes_soft_delete.sql` adds `deleted boolean DEFAULT false NOT NULL`.

### `Project::delete_in_op` rewired
- Reorders to delete agents *first* so each agent's detach event lands while the sandbox row is still live.
- Replaces the `suspend_for_project_in_op` leg with `cascade_delete_for_project_in_op`.
- Removed dead `suspend_for_project_in_op` (had no remaining callers).

### `Agents::list_for_project_in_op` paginated
- Drains all pages via `into_next_query`. Used by the project cascade so >100-agent projects no longer leak agent rows + sessions.

### Agent cache invalidation (audit gap L1)
- `Agents::delete` now calls `invalidate_agent_cache(id)` post-commit.
- `Projects::delete` snapshots agent ids pre-cascade and invalidates each post-commit so the in-memory `HashMap<AgentId, CachedAgentContext>` doesn't accumulate entries keyed by tombstoned ids.

## Test plan

- [x] `cargo build --all-targets` (DB live)
- [x] `cargo clippy --all-targets -- --deny warnings`
- [x] `cargo fmt --check`
- [x] `cargo test -p drua-core` (all 80+ integration tests pass)
- [x] New `core/tests/sandbox_cascade.rs` — 3 tests:
  - `cascade_delete_marks_every_project_sandbox_deleted` — basic + soft-delete visibility
  - `cascade_delete_paginates_past_first_100` — proves 105 rows all get flagged (was 100 cap)
  - `cascade_delete_is_noop_for_other_projects` — project isolation
- [x] `cargo run --bin write_sdl` — GraphQL SDL byte-for-byte unchanged
- [ ] Verify on a staging cluster: delete a project with N sandboxes → confirm pods + workspace + nix-store PVCs are all gone; sandbox rows are `deleted=TRUE`.

## Out of scope (separate PRs)

The audit also flagged Medium gaps that are *not* in this PR:
- In-flight workflow run cancellation on parent delete
- Workflow cron job row proactive cancel
- `WorkflowsImporter::delete_in_op` reverse-sync
- Public `Spaces::delete` / `Workflows::delete` / `Sandboxes::delete` (policy decisions)

See report `019dfc1b` for the full list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the project deletion cascade and sandbox lifecycle/DB queries; mistakes could leave resources undeleted or hide sandboxes unexpectedly, though changes are localized and covered by new integration tests.
> 
> **Overview**
> Project deletion now **cascades sandbox teardown end-to-end**: each sandbox is deleted via `AdminClient::delete_sandbox`, its persistent storage is removed via new `AdminClient::delete_pvcs`, and the DB row is **soft-deleted** via a new `sandboxes.deleted` flag.
> 
> Pagination caps were removed for cascade paths by draining all pages when listing agents/sandboxes, and agent context cache entries are explicitly invalidated after agent/project deletes to avoid heap leaks. A new `sandbox_cascade` test suite validates soft-delete behavior, pagination beyond 100 rows, and project isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d2ce37e9d5086fd12cc1683946ea7c9c1f26ef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->