### PR TITLE
fix(library): wake importer fetcher immediately on local commits

### DIFF
--- a/bats/notes.bats
+++ b/bats/notes.bats
@@ -134,7 +134,7 @@ render_note_md() {
 wait_for_note_row() {
   local needle="$1"
   local pg="${PG_CON:-postgres://user:password@localhost:5432/drua}"
-  for _ in $(seq 1 30); do
+  for _ in $(seq 1 60); do
     local hit
     hit="$(psql "$pg" -At -c "SELECT 1 FROM note_events WHERE event_type = 'initialized' AND event->>'title' = '$needle' LIMIT 1;" 2>/dev/null || true)"
     if [ -n "$hit" ]; then
@@ -151,7 +151,7 @@ wait_for_note_row() {
 wait_for_note_row_gone() {
   local needle="$1"
   local pg="${PG_CON:-postgres://user:password@localhost:5432/drua}"
-  for _ in $(seq 1 30); do
+  for _ in $(seq 1 60); do
     local hit
     hit="$(psql "$pg" -At -c "SELECT 1 FROM notes n JOIN note_events ne ON ne.id = n.id WHERE ne.event_type='initialized' AND ne.event->>'title' = '$needle' AND n.deleted = FALSE LIMIT 1;" 2>/dev/null || true)"
     if [ -z "$hit" ]; then
@@ -166,7 +166,7 @@ wait_for_note_row_gone() {
 wait_for_note_search_gone() {
   local needle="$1"
   local pg="${PG_CON:-postgres://user:password@localhost:5432/drua}"
-  for _ in $(seq 1 30); do
+  for _ in $(seq 1 60); do
     local hit
     hit="$(psql "$pg" -At -c "SELECT 1 FROM library_documents WHERE doc_type='note' AND name='$needle' LIMIT 1;" 2>/dev/null || true)"
     if [ -z "$hit" ]; then

--- a/bats/skills.bats
+++ b/bats/skills.bats
@@ -177,7 +177,7 @@ agent_skills_block() {
 wait_for_skill_row() {
   local needle="$1"
   local pg="${PG_CON:-postgres://user:password@localhost:5432/drua}"
-  for _ in $(seq 1 30); do
+  for _ in $(seq 1 60); do
     local hit
     hit="$(psql "$pg" -At -c "SELECT name FROM skills WHERE name = '$needle' AND deleted = FALSE LIMIT 1;" 2>/dev/null || true)"
     if [ -n "$hit" ]; then
@@ -306,13 +306,10 @@ wait_for_skill_row() {
 }
 
 # Polls library_documents until a skill row with `name=$1` is gone.
-# Returns 0 when the row is absent, 1 on 30s timeout. Used to gate
-# search-removed assertions behind the post-delete commit hook +
-# reverse-sync importer's `delete_in_op` actually wiping the row.
 wait_for_skill_search_gone() {
   local needle="$1"
   local pg="${PG_CON:-postgres://user:password@localhost:5432/drua}"
-  for _ in $(seq 1 30); do
+  for _ in $(seq 1 60); do
     local hit
     hit="$(psql "$pg" -At -c "SELECT 1 FROM library_documents WHERE doc_type='skill' AND name='$needle' LIMIT 1;" 2>/dev/null || true)"
     if [ -z "$hit" ]; then
@@ -329,7 +326,7 @@ wait_for_skill_search_gone() {
 wait_for_skill_row_gone() {
   local needle="$1"
   local pg="${PG_CON:-postgres://user:password@localhost:5432/drua}"
-  for _ in $(seq 1 30); do
+  for _ in $(seq 1 60); do
     local hit
     hit="$(psql "$pg" -At -c "SELECT 1 FROM skills WHERE name = '$needle' AND deleted = FALSE LIMIT 1;" 2>/dev/null || true)"
     if [ -z "$hit" ]; then

--- a/core/crates/library/src/git.rs
+++ b/core/crates/library/src/git.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use tokio::sync::{mpsc, oneshot, Mutex};
+use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 use tokio::task::JoinHandle;
 
 use crate::attribution::CommitAttribution;
@@ -120,6 +120,7 @@ pub struct GitEngine {
     /// in-flight commits before `push_main` lands.
     repo_mutex: Arc<Mutex<()>>,
     write_tx: mpsc::Sender<QueuedOp>,
+    local_commit_notify: Arc<Notify>,
     github_app: Option<Arc<GitHubAppTokenProvider>>,
     _writer: OwnedTaskHandle,
 }
@@ -129,6 +130,10 @@ impl GitEngine {
     /// SpaceFs reads land.
     pub fn repo_path(&self) -> &Path {
         &self.repo_path
+    }
+
+    pub fn local_commit_notify(&self) -> Arc<Notify> {
+        Arc::clone(&self.local_commit_notify)
     }
 
     #[tracing::instrument(name = "library.git.init", skip_all)]
@@ -152,10 +157,12 @@ impl GitEngine {
 
         let repo_mutex = Arc::new(Mutex::new(()));
         let (write_tx, write_rx) = mpsc::channel(QUEUE_CAPACITY);
+        let local_commit_notify = Arc::new(Notify::new());
         let writer = tokio::spawn(Self::run_writer(
             repo_path.clone(),
             github_app.clone(),
             Arc::clone(&repo_mutex),
+            Arc::clone(&local_commit_notify),
             write_rx,
         ));
 
@@ -163,6 +170,7 @@ impl GitEngine {
             repo_path,
             repo_mutex,
             write_tx,
+            local_commit_notify,
             github_app,
             _writer: OwnedTaskHandle::new(writer),
         })
@@ -545,6 +553,7 @@ impl GitEngine {
         repo_path: PathBuf,
         github_app: Option<Arc<GitHubAppTokenProvider>>,
         repo_mutex: Arc<Mutex<()>>,
+        local_commit_notify: Arc<Notify>,
         mut rx: mpsc::Receiver<QueuedOp>,
     ) {
         while let Some(first) = rx.recv().await {
@@ -562,7 +571,11 @@ impl GitEngine {
                     Err(_) => break,    // window elapsed
                 }
             }
-            Self::process_batch(&repo_path, github_app.as_ref(), &repo_mutex, batch).await;
+            let any_ok = Self::process_batch(&repo_path, github_app.as_ref(), &repo_mutex, batch)
+                .await;
+            if any_ok {
+                local_commit_notify.notify_waiters();
+            }
         }
     }
 
@@ -572,7 +585,7 @@ impl GitEngine {
         github_app: Option<&Arc<GitHubAppTokenProvider>>,
         repo_mutex: &Mutex<()>,
         batch: Vec<QueuedOp>,
-    ) {
+    ) -> bool {
         let _guard = repo_mutex.lock().await;
         let token = Self::fresh_token(github_app).await;
         let path = repo_path.to_path_buf();
@@ -591,9 +604,11 @@ impl GitEngine {
                 .collect()
         });
 
+        let any_ok = results.iter().any(|r| r.is_ok());
         for (resp, res) in responders.into_iter().zip(results) {
             let _ = resp.send(res);
         }
+        any_ok
     }
 
     /// Apply N ops as N commits, then push once. On non-FF push, fetch

--- a/core/crates/library/src/lib.rs
+++ b/core/crates/library/src/lib.rs
@@ -79,6 +79,7 @@ impl Library {
             Arc::clone(&git),
             tick_tx,
             Duration::from_millis(config.fetch_interval_ms),
+            git.local_commit_notify(),
         );
 
         let importers: ImporterRegistry =
@@ -132,13 +133,17 @@ impl Library {
         git: Arc<GitEngine>,
         tick_tx: mpsc::Sender<CommitTick>,
         interval: Duration,
+        local_commit_notify: Arc<tokio::sync::Notify>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(interval);
             ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             let mut last_head: Option<String> = None;
             loop {
-                ticker.tick().await;
+                tokio::select! {
+                    _ = ticker.tick() => {}
+                    _ = local_commit_notify.notified() => {}
+                }
                 match git.fetch_and_head().await {
                     Ok(Some(head)) => {
                         if last_head.as_deref() == Some(head.as_str()) {


### PR DESCRIPTION
## Summary

The reverse-sync importer's visibility latency for *local* writes (notes / skills / workflows pushed via the in-process `GitEngine` writer) was bounded below by `skill_sync_interval_secs` + one `fetch_origin` round-trip + repo-mutex contention with the writer itself. Under CI load this stretched past the bats `wait_for_*` 30 s poll budget — see the flaky failure on `galoy-agents-bin/test-bats` [build 558](https://ci.galoy.io/teams/galoy-agents/pipelines/galoy-agents-bin/jobs/test-bats/builds/558) (`notes: note.delete + spaces edit op=delete both wipe library search rows`).

## The fix

A `tokio::sync::Notify` pulsed by `GitEngine::run_writer` after every successful commit batch. `Library::spawn_fetcher` races its time-driven tick against the notify with `tokio::select!`, so a local commit shrinks the visibility latency from "next interval boundary + fetch RPC" to "milliseconds".

External commits (peers pushing to upstream) still rely on the interval-driven `fetch_and_head` — only the local fast path is new.

## Backstop

Bumped the bats helper poll budgets in `bats/notes.bats` and `bats/skills.bats` from 30×1s → 60×1s for `wait_for_note_row{,_gone}`, `wait_for_note_search_gone`, `wait_for_skill_row{,_gone}`, and `wait_for_skill_search_gone`. The notify path should keep these well under 1 s in practice; the bigger window protects against residual non-tick-driven races (importer queue backpressure, search index commit, downstream `note_events` insert).

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test -p drua-library --lib` — 20/20 pass
- [x] `cargo clippy --workspace --all-targets` — clean
- [ ] CI green on this PR
- [ ] Run `nix run .#bats` locally / on `galoy-agents-bin` and confirm the previously-flaky `notes` test passes consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes async coordination between the git writer and the fetcher loop; incorrect notifications or missed wakeups could affect importer timeliness or add extra fetch load, but scope is contained to library sync timing.
> 
> **Overview**
> Reduces reverse-sync latency for *local* library writes by adding a `tokio::sync::Notify` to `GitEngine` that is signaled after any successful write batch, and updating the fetcher loop to wake on either its interval tick or that notification (via `tokio::select!`).
> 
> Increases Bats E2E test polling budgets for notes/skills DB/search row assertions from 30s to 60s to mitigate CI flakiness around importer/search propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf8b4a11f5e2e2719e601915d2cd498ee053890f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->