### PR TITLE
feat(admin): update_model_chain on agent + project MCP tools

### DIFF
--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -83,6 +83,9 @@ enum AgentCommand {
     AttachSandbox,
     DetachSandbox,
     Delete,
+    /// Set / replace / clear the per-agent chain. Rejects workflow
+    /// agents — their chain comes from the workflow definition.
+    UpdateModelChain,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -94,7 +97,8 @@ struct AgentParams {
     project_id: Option<ProjectId>,
     /// Display name for the new agent (required for `create`).
     name: Option<String>,
-    /// ID of the agent (required for `attach_sandbox`, `detach_sandbox`, and `delete`).
+    /// ID of the agent (required for `attach_sandbox`, `detach_sandbox`,
+    /// `delete`, and `update_model_chain`).
     #[schemars(with = "Option<uuid::Uuid>")]
     agent_id: Option<AgentId>,
     /// ID of the sandbox (required for `attach_sandbox` and `detach_sandbox`).
@@ -102,6 +106,10 @@ struct AgentParams {
     sandbox_id: Option<SandboxId>,
     /// Attach mode — 'read' or 'use'. Defaults to 'read'. Only for `attach_sandbox`.
     mode: Option<SandboxAgentMode>,
+    #[serde(default)]
+    model_chain: Option<llm::ModelChain>,
+    #[serde(default)]
+    clear_model_chain: bool,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -201,6 +209,10 @@ enum ProjectCommand {
     /// Create a new project (also seeds a ProjectLead agent named 'lead').
     Create,
     List,
+    /// Set / replace / clear the project-level chain.
+    /// `clear_model_chain: true` clears; otherwise `model_chain` sets.
+    /// Inherited by every non-workflow agent in the project.
+    UpdateModelChain,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -208,6 +220,13 @@ struct ProjectParams {
     command: ProjectCommand,
     name: Option<String>,
     description: Option<String>,
+    /// Project ID (required for `update_model_chain`).
+    #[schemars(with = "Option<uuid::Uuid>")]
+    project_id: Option<ProjectId>,
+    #[serde(default)]
+    model_chain: Option<llm::ModelChain>,
+    #[serde(default)]
+    clear_model_chain: bool,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -509,7 +528,9 @@ static TOOLS: &[ToolDef] = &[
                        `attach_sandbox` (requires `agent_id`, `sandbox_id`, optional `mode`), \
                        `detach_sandbox` (requires `agent_id`, `sandbox_id`), \
                        `delete` (requires `agent_id`; soft-deletes the agent, cascades \
-                       to its session and detaches any attached sandbox).",
+                       to its session and detaches any attached sandbox), \
+                       `update_model_chain` (requires `agent_id`; set `model_chain` to \
+                       override or `clear_model_chain: true` to clear; rejects workflow agents).",
         schema: &AGENT_SCHEMA,
     },
     ToolDef {
@@ -529,7 +550,10 @@ static TOOLS: &[ToolDef] = &[
     ToolDef {
         name: "project",
         description: "Manage projects. Commands: `create` (requires `name`, optional \
-                       `description`; also seeds a ProjectLead agent), `list`.",
+                       `description`; also seeds a ProjectLead agent), `list`, \
+                       `update_model_chain` (requires `project_id`; set `model_chain` \
+                       to pin a chain inherited by every non-workflow agent in the \
+                       project, or `clear_model_chain: true` to clear).",
         schema: &PROJECT_SCHEMA,
     },
     ToolDef {
@@ -800,6 +824,33 @@ impl AdminToolSet {
                     "Agent deleted (id {agent_id})."
                 ))]))
             }
+
+            AgentCommand::UpdateModelChain => {
+                let agent_id = params.agent_id.ok_or_else(|| {
+                    ToolSetsError::MissingArgument(
+                        "agent_id is required for update_model_chain".to_string(),
+                    )
+                })?;
+                let chain = if params.clear_model_chain {
+                    None
+                } else {
+                    params.model_chain
+                };
+                let agent = self
+                    .agents
+                    .update_model_chain(subject, agent_id, chain)
+                    .await
+                    .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Agent {} model_chain_override = {}",
+                    agent.id,
+                    agent
+                        .model_chain_override
+                        .as_ref()
+                        .map(|c| serde_yaml::to_string(c).unwrap_or_default())
+                        .unwrap_or_else(|| "<none>".to_string())
+                ))]))
+            }
         }
     }
 
@@ -924,6 +975,32 @@ impl AdminToolSet {
                 Ok(CallToolResult::success(vec![Content::text(
                     format_projects(&all),
                 )]))
+            }
+
+            ProjectCommand::UpdateModelChain => {
+                let project_id = params.project_id.ok_or_else(|| {
+                    ToolSetsError::MissingArgument(
+                        "project_id is required for update_model_chain".to_string(),
+                    )
+                })?;
+                let chain = if params.clear_model_chain {
+                    None
+                } else {
+                    params.model_chain
+                };
+                let project = self
+                    .projects
+                    .update_model_chain(subject, project_id, chain)
+                    .await?;
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Project {} model_chain_override = {}",
+                    project.id,
+                    project
+                        .model_chain_override
+                        .as_ref()
+                        .map(|c| serde_yaml::to_string(c).unwrap_or_default())
+                        .unwrap_or_else(|| "<none>".to_string())
+                ))]))
             }
         }
     }


### PR DESCRIPTION
## Summary

Adds the missing admin MCP path for setting / clearing the per-agent and per-project chain overrides — closes the parity gap with the GraphQL mutations and web UI shipped in #278.

- `drua_admin_agent` gains `update_model_chain` (params: `agent_id`, `model_chain` or `clear_model_chain: true`); rejects workflow agents via the existing `AgentError::WorkflowAgentChainImmutable` guard.
- `drua_admin_project` gains `update_model_chain` (params: `project_id`, `model_chain` or `clear_model_chain: true`); chain inherited by every non-workflow agent in the project unless that agent has its own override.

Mirrors the `clear_description` / `clear_model_chain` toggle pattern already in use on the workflow update surface so absence-vs-explicit-`None` is unambiguous.

## Why

The bulk migration "update all existing prod projects to use chain X" can't run from the admin MCP gateway today — the `project` and `agent` admin tools only expose `create` / `list` / sandbox attach/detach / `delete`. After this lands, an operator can issue `drua_admin_project { command: update_model_chain, project_id, model_chain }` per project and we can pin the live chain into each project entity (which is also what the new web UI on the project settings page does).

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo clippy --workspace --all-targets` — clean
- [ ] CI green
- [ ] After deploy: bulk-pin the 3 prod projects (run-drua, on-call, run-lana) to the live `agents.default_chain`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new admin MCP commands that modify persisted `model_chain_override` for agents and projects; mistakes in usage could change runtime model selection across a project, though access is admin-gated and underlying domain guards (e.g., workflow-agent immutability) remain in place.
> 
> **Overview**
> Adds `update_model_chain` support to the admin MCP `agent` and `project` tools, allowing operators to **set/replace or clear** `model_chain_override` via either `model_chain` or `clear_model_chain: true`.
> 
> Updates the tool schemas/help text and wires the new commands through `AdminToolSet` to `Agents::update_model_chain` (rejecting workflow agents) and `Projects::update_model_chain`, returning the resulting override value in the call output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9c6afd2460c36ec738cefadab340286b7fdc78f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->