### PR TITLE
feat(spaces): LS space: + BadRequest taxonomy + post-delete LS noise fix

### DIFF
--- a/core/crates/library/src/space/error.rs
+++ b/core/crates/library/src/space/error.rs
@@ -24,10 +24,7 @@ pub enum SpaceError {
     Validation(String),
     #[error("SpaceError - NotFound: space {slug:?} does not exist")]
     NotFound { slug: String },
-    /// Malformed space URI — distinct from `Unauthorized` (real auth
-    /// denial) and `NotFound` (well-formed but unknown slug). The model
-    /// should fix the path argument, not switch tools or assume access
-    /// is missing.
+    /// Malformed space URI — distinguishes "fix the path" from auth denial (`Unauthorized`) or unknown slug (`NotFound`).
     #[error("SpaceError - BadRequest: {reason}")]
     BadRequest { reason: String },
     #[error("SpaceError - NotMounted: space {slug:?} is not mounted in project {project_id:?}")]

--- a/core/crates/library/src/space/error.rs
+++ b/core/crates/library/src/space/error.rs
@@ -24,6 +24,12 @@ pub enum SpaceError {
     Validation(String),
     #[error("SpaceError - NotFound: space {slug:?} does not exist")]
     NotFound { slug: String },
+    /// Malformed space URI — distinct from `Unauthorized` (real auth
+    /// denial) and `NotFound` (well-formed but unknown slug). The model
+    /// should fix the path argument, not switch tools or assume access
+    /// is missing.
+    #[error("SpaceError - BadRequest: {reason}")]
+    BadRequest { reason: String },
     #[error("SpaceError - NotMounted: space {slug:?} is not mounted in project {project_id:?}")]
     NotMounted {
         slug: String,

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -469,11 +469,7 @@ impl Projects {
         Ok(self.spaces.find_by_ids(&project.mounted_spaces).await?)
     }
 
-    /// Spaces this subject can address: admins see every space in the
-    /// library; project-bound subjects see only spaces mounted in
-    /// their carrying project. Mirrors the auth shape of
-    /// `space_for_subject` but with no slug — used by the bare
-    /// `LS space:` discovery surface.
+    /// Spaces the subject can address: admins see all; project subjects see their `mounted_spaces`.
     #[instrument(name = "domain.project.list_visible_spaces", skip(self, sub))]
     pub async fn list_visible_spaces(&self, sub: &AuthSubject) -> Result<Vec<Space>, ProjectError> {
         if sub.is_admin() {
@@ -482,6 +478,9 @@ impl Projects {
         let project_id = sub
             .project_id()
             .ok_or(crate::auth::error::AuthorizationError::AuthenticationRequired)?;
+        sub.can(AuthVerb::Read, AuthResource::Project(Some(project_id)))?;
+        Audit::record_action_if_unset("project.list_visible_spaces");
+        Audit::record_project_id(project_id);
         let project = self.repo.find_by_id(project_id).await?;
         if project.mounted_spaces.is_empty() {
             return Ok(Vec::new());

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -469,6 +469,26 @@ impl Projects {
         Ok(self.spaces.find_by_ids(&project.mounted_spaces).await?)
     }
 
+    /// Spaces this subject can address: admins see every space in the
+    /// library; project-bound subjects see only spaces mounted in
+    /// their carrying project. Mirrors the auth shape of
+    /// `space_for_subject` but with no slug — used by the bare
+    /// `LS space:` discovery surface.
+    #[instrument(name = "domain.project.list_visible_spaces", skip(self, sub))]
+    pub async fn list_visible_spaces(&self, sub: &AuthSubject) -> Result<Vec<Space>, ProjectError> {
+        if sub.is_admin() {
+            return Ok(self.spaces.list_all(sub).await?);
+        }
+        let project_id = sub
+            .project_id()
+            .ok_or(crate::auth::error::AuthorizationError::AuthenticationRequired)?;
+        let project = self.repo.find_by_id(project_id).await?;
+        if project.mounted_spaces.is_empty() {
+            return Ok(Vec::new());
+        }
+        Ok(self.spaces.find_by_ids(&project.mounted_spaces).await?)
+    }
+
     /// Central authorization primitive for sandboxless space access.
     /// Resolves `slug` via `Library` and returns the `Space`. For
     /// project-bound subjects (`Agent` / `AgentOnBehalfOfUser`),

--- a/core/src/space_fs.rs
+++ b/core/src/space_fs.rs
@@ -65,11 +65,7 @@ fn parse_space_path(path: &str) -> Option<SpaceRef<'_>> {
     })
 }
 
-/// True iff `path` is a "bare" space URI naming no slug — `space:`,
-/// `space:/`, `space://`, etc. These are routed to the
-/// `list_mounted_spaces` codepath instead of per-space resolution so
-/// the agent can discover what's mounted without needing the
-/// `<spaces>` system-prompt block.
+/// True for slugless space URIs (`space:`, `space:/`, etc.); routed to `list_mounted_spaces` for runtime discovery.
 fn is_bare_space_path(path: &str) -> bool {
     let Some(rest) = path.strip_prefix("space:") else {
         return false;
@@ -111,13 +107,8 @@ impl SpaceFs {
         !slug.is_empty()
     }
 
-    /// Parses `path`, runs the auth gate, normalises and validates
-    /// the rel-path, and bundles the resolved `(Space, rel_path)`.
-    /// `Ok(None)` means `path` isn't a space path (caller falls
-    /// through to the sandbox). A `space:`-prefixed path that doesn't
-    /// parse — e.g. empty slug — is `BadRequest`, not silent
-    /// fall-through, so a malformed input doesn't masquerade as
-    /// "not authorized" downstream.
+    /// `Ok(None)` for non-`space:` paths (caller falls through to sandbox).
+    /// `space:`-prefixed paths that don't parse return `BadRequest`, so malformed input never masquerades as an auth denial.
     async fn resolve(
         &self,
         sub: &AuthSubject,
@@ -202,13 +193,8 @@ impl SpaceFs {
         Ok(Some(FileView::File(apply_view_range(&content, view_range))))
     }
 
-    /// List a directory under a `space:` path. Bare `space:` (no slug)
-    /// returns the slugs of mounted spaces — see `list_mounted_spaces`.
-    /// Paths that resolve to no entries return an empty listing rather
-    /// than an Io error: an "implicit" subdirectory naturally vanishes
-    /// when its last backing file is removed, and that's a clean
-    /// outcome, not a tool failure (it shouldn't pollute audit error
-    /// counts).
+    /// Bare `space:` returns mounted-space slugs (see `list_mounted_spaces`).
+    /// Paths resolving to no entries return an empty listing (not an Io error) so post-delete LS doesn't pollute audit error counts.
     #[instrument(name = "library.space_fs.view_dir", skip(self, sub))]
     pub async fn view_dir(
         &self,

--- a/core/src/space_fs.rs
+++ b/core/src/space_fs.rs
@@ -65,6 +65,18 @@ fn parse_space_path(path: &str) -> Option<SpaceRef<'_>> {
     })
 }
 
+/// True iff `path` is a "bare" space URI naming no slug — `space:`,
+/// `space:/`, `space://`, etc. These are routed to the
+/// `list_mounted_spaces` codepath instead of per-space resolution so
+/// the agent can discover what's mounted without needing the
+/// `<spaces>` system-prompt block.
+fn is_bare_space_path(path: &str) -> bool {
+    let Some(rest) = path.strip_prefix("space:") else {
+        return false;
+    };
+    rest.trim_matches('/').is_empty()
+}
+
 /// Auth-gated, resolved view of a `space:<slug>/<rel>` path.
 struct Resolved {
     space: Space,
@@ -101,19 +113,50 @@ impl SpaceFs {
 
     /// Parses `path`, runs the auth gate, normalises and validates
     /// the rel-path, and bundles the resolved `(Space, rel_path)`.
-    /// `Ok(None)` means `path` isn't a space path.
+    /// `Ok(None)` means `path` isn't a space path (caller falls
+    /// through to the sandbox). A `space:`-prefixed path that doesn't
+    /// parse — e.g. empty slug — is `BadRequest`, not silent
+    /// fall-through, so a malformed input doesn't masquerade as
+    /// "not authorized" downstream.
     async fn resolve(
         &self,
         sub: &AuthSubject,
         path: &str,
     ) -> Result<Option<Resolved>, ProjectError> {
         let Some(sref) = parse_space_path(path) else {
+            if path.starts_with("space:") {
+                return Err(SpaceError::BadRequest {
+                    reason: format!(
+                        "'{path}' is not a valid space URI; expected 'space:<slug>' or 'space:<slug>/<rel>'"
+                    ),
+                }
+                .into());
+            }
             return Ok(None);
         };
         let space = self.projects.space_for_subject(sub, sref.slug).await?;
         let rel_path = normalize_rel_path(sref.rel_path);
         Self::validate_rel_path(&rel_path)?;
         Ok(Some(Resolved { space, rel_path }))
+    }
+
+    /// Slugs of every space the subject can address — admins see all
+    /// spaces in the library; project subjects see their project's
+    /// `mounted_spaces`. Returned as `space:<slug>/` directory entries
+    /// so the LS surface formats them like any other listing.
+    #[instrument(name = "library.space_fs.list_mounted_spaces", skip(self, sub))]
+    pub async fn list_mounted_spaces(
+        &self,
+        sub: &AuthSubject,
+    ) -> Result<Vec<String>, ProjectError> {
+        Audit::record_action_if_unset("space.list_mounted");
+        let spaces = self.projects.list_visible_spaces(sub).await?;
+        let mut entries: Vec<String> = spaces
+            .into_iter()
+            .map(|s| format!("space:{}/", s.slug))
+            .collect();
+        entries.sort();
+        Ok(entries)
     }
 
     /// View a file (or list a directory) under a `space:` path. Reads
@@ -159,13 +202,22 @@ impl SpaceFs {
         Ok(Some(FileView::File(apply_view_range(&content, view_range))))
     }
 
-    /// List a directory under a `space:` path.
+    /// List a directory under a `space:` path. Bare `space:` (no slug)
+    /// returns the slugs of mounted spaces — see `list_mounted_spaces`.
+    /// Paths that resolve to no entries return an empty listing rather
+    /// than an Io error: an "implicit" subdirectory naturally vanishes
+    /// when its last backing file is removed, and that's a clean
+    /// outcome, not a tool failure (it shouldn't pollute audit error
+    /// counts).
     #[instrument(name = "library.space_fs.view_dir", skip(self, sub))]
     pub async fn view_dir(
         &self,
         sub: &AuthSubject,
         path: &str,
     ) -> Result<Option<Vec<String>>, ProjectError> {
+        if is_bare_space_path(path) {
+            return Ok(Some(self.list_mounted_spaces(sub).await?));
+        }
         let Some(resolved) = self.resolve(sub, path).await? else {
             return Ok(None);
         };
@@ -174,7 +226,7 @@ impl SpaceFs {
             .list_dir(&resolved.space.slug, &resolved.rel_path)
             .await
             .map_err(|e| -> ProjectError { e.into() })?
-            .ok_or_else(|| io_err(format!("no such directory: {}", resolved.rel_path)))?;
+            .unwrap_or_default();
         Ok(Some(format_dir(entries)))
     }
 
@@ -638,6 +690,47 @@ mod tests {
     fn parse_rejects_empty_slug() {
         assert!(parse_space_path("space:").is_none());
         assert!(parse_space_path("space:/foo").is_none());
+    }
+
+    #[test]
+    fn bare_space_path_matches_only_slugless_uri() {
+        assert!(is_bare_space_path("space:"));
+        assert!(is_bare_space_path("space:/"));
+        assert!(is_bare_space_path("space://"));
+        assert!(!is_bare_space_path("space:demo"));
+        assert!(!is_bare_space_path("space:demo/"));
+        assert!(!is_bare_space_path("space:/foo"));
+        assert!(!is_bare_space_path(""));
+        assert!(!is_bare_space_path("/etc/passwd"));
+    }
+
+    #[test]
+    fn bad_request_error_stringifies_distinctly() {
+        let err = SpaceError::BadRequest {
+            reason: "'space:/foo' is not a valid space URI; expected 'space:<slug>' or 'space:<slug>/<rel>'".into(),
+        };
+        let s = err.to_string();
+        assert!(
+            s.contains("BadRequest"),
+            "expected error to surface BadRequest token, got: {s}"
+        );
+        assert!(!s.contains("Unauthorized"), "got: {s}");
+        assert!(!s.contains("NotFound"), "got: {s}");
+    }
+
+    #[test]
+    fn not_found_and_bad_request_are_distinct_strings() {
+        let nf = SpaceError::NotFound {
+            slug: "ghost".into(),
+        }
+        .to_string();
+        let br = SpaceError::BadRequest {
+            reason: "empty slug".into(),
+        }
+        .to_string();
+        assert_ne!(nf, br);
+        assert!(nf.contains("NotFound"));
+        assert!(br.contains("BadRequest"));
     }
 
     #[test]

--- a/core/src/toolset/top_level/ls.rs
+++ b/core/src/toolset/top_level/ls.rs
@@ -53,8 +53,10 @@ impl TopLevelTool for Ls {
     }
 
     fn description(&self) -> &str {
-        "List directory contents. Accepts either an in-sandbox path or a \
-         `space:<slug>/...` path that reads from the project's mounted spaces."
+        "List directory contents. Accepts either an in-sandbox path, a \
+         `space:<slug>/...` path that reads from the project's mounted spaces, \
+         or the bare prefix `space:` (no slug) to enumerate the spaces this \
+         agent can address."
     }
 
     fn input_schema(&self) -> &serde_json::Value {


### PR DESCRIPTION
Three independent follow-ups surfaced by memory **019dfdb7** (test-agent
inspection of agent_session `019dfd9c-39aa-7450-8a99-12413216c1e2`).

## Follow-ups

### #1 — `LS space:` enumerates mounted spaces

The agent's natural first guess for "what spaces can I see" — `LS {path:"space:"}`
— used to fall through to the sandbox and surface `Unauthorized`. It now returns
the slugs of mounted spaces (admins see the full library, project subjects see
their `mounted_spaces`), formatted as `space:<slug>/` directory entries.

Files:
- `core/src/space_fs.rs` — new `is_bare_space_path` helper, new
  `SpaceFs::list_mounted_spaces`, `view_dir` short-circuits on bare path
- `core/src/project/mod.rs` — new `Projects::list_visible_spaces` (admin →
  `list_all`; project → `mounted_spaces`)
- `core/src/toolset/top_level/ls.rs` — description updated so the model
  discovers the surface

Audit action recorded as `space.list_mounted` (no schema change).

### #2 — Error taxonomy: BadRequest / NotFound / Unauthorized

Three failure modes used to collapse to `Unauthorized`, telling the model "switch
tools" when the actual fix is "fix the path". Now distinct:

| Path                       | Before                | After                                          |
|----------------------------|-----------------------|------------------------------------------------|
| `space:/foo` (empty slug)  | `Unauthorized`        | `SpaceError - BadRequest: '...' is not a valid space URI; ...` |
| `space:nonexistent`        | `NotFound` (already)  | unchanged                                      |
| `space:real-but-unmounted` | `NotMounted`          | unchanged                                      |
| `space:` (slugless)        | `Unauthorized`        | succeeds (FU#1)                                |

Files:
- `core/crates/library/src/space/error.rs` — new `BadRequest { reason }` variant
- `core/src/space_fs.rs::resolve` — emits `BadRequest` for `space:`-prefixed
  paths that don't parse, instead of silent `Ok(None)` fall-through

### #3 — Post-delete LS no longer counts as audit error

`view_dir` on a path that resolves to no entries returned
`Io: no such directory: <path>`. After deleting the last file in an "implicit"
subdirectory and listing it to verify, the resulting Io error showed up in
`audit_entries WHERE error_message IS NOT NULL` — polluting the
high-signal `errors_only` slice that future inspectors rely on.

Files:
- `core/src/space_fs.rs::view_dir` — `.ok_or_else(io_err(...))` →
  `.unwrap_or_default()` (memo's preferred fix A: backend behavior, not
  audit-side filtering)

`view_file` is unchanged — a missing path there really is a Read error.

## Verification

Per memory 019dfdb7's reproduction sequences:

- **#1**: `LS {path:"space:"}` now returns mounted-space entries in one call;
  no `<spaces>` block needed.
- **#2**: `LS {path:"space:/foo"}` produces a `BadRequest` string distinct from
  `LS {path:"space:nonexistent"}` (`NotFound`) and from a mounted-space access
  denial (`NotMounted` / `Unauthorized`). Asserted in
  `space_fs::tests::{bad_request_error_stringifies_distinctly, not_found_and_bad_request_are_distinct_strings}`.
- **#3**: create→delete→LS of the only file in a synthetic subdir produces zero
  rows in `audit_entries WHERE error_message IS NOT NULL`.

Tests added in `core/src/space_fs.rs` cover `is_bare_space_path` classification
and the error-string surface for the new variant. `nix flake check` clean.

## Deferred

- Memo's "alternative fix (cleaner)" for FU#1 — a dedicated `spaces_list` MCP
  tool — not pursued here. The `LS space:` overload is the smaller, agent-natural
  fix the memo recommends.
- The unrelated `bash` tool-def issue from the source inspection report is
  intentionally out of scope per the memo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes `LS`/`SpaceFs` behavior and error taxonomy around space-path parsing and authorization, which could affect agent access paths and audit/error reporting. Risk is moderate because it adds a new listing surface and alters how missing directories and malformed URIs are handled.
> 
> **Overview**
> Enables `LS {path:"space:"}` to enumerate the spaces a subject can address, returning entries formatted as `space:<slug>/` (admins see all spaces; project subjects see their project’s mounted spaces).
> 
> Improves space-URI error taxonomy by adding `SpaceError::BadRequest` and returning it for malformed `space:`-prefixed inputs instead of falling through and appearing as an auth/sandbox issue.
> 
> Reduces post-delete noise by making `SpaceFs::view_dir` return an empty listing when a resolved space directory has no entries, rather than raising an `Io` error, and updates the `LS` tool description accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 370b494f336ca3d2efd219caef016ac6b22e7b69. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->