### PR TITLE
feat(llm): caching cost reporting across providers (Anthropic, OpenAI, OpenRouter)

### DIFF
--- a/core/src/agent/session/compaction/prune.rs
+++ b/core/src/agent/session/compaction/prune.rs
@@ -342,6 +342,7 @@ mod tests {
                 cache_read: 0,
                 cache_write: 0,
                 total_tokens: 0,
+                reasoning: 0,
             },
             cost: Cost::default(),
         }

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -895,6 +895,7 @@ mod tests {
                 cache_read: 0,
                 cache_write: 0,
                 total_tokens: 0,
+                reasoning: 0,
             },
             cost: Cost::default(),
         }

--- a/core/src/agent/session/metadata.rs
+++ b/core/src/agent/session/metadata.rs
@@ -15,6 +15,10 @@ pub struct Usage {
     pub cache_read: u64,
     pub cache_write: u64,
     pub total_tokens: u64,
+    /// Subset of `output` spent on reasoning (OpenAI o-series, OpenRouter
+    /// `completion_tokens_details.reasoning_tokens`).
+    #[serde(default)]
+    pub reasoning: u64,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -24,6 +28,10 @@ pub struct Cost {
     pub cache_read: f64,
     pub cache_write: f64,
     pub total: f64,
+    /// OpenRouter BYOK only: the actual upstream provider cost (vs the
+    /// gateway-charged credits in `total`).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_inference_usd: Option<f64>,
 }
 
 impl From<llm::response::Usage> for AssistantResponseMetadata {
@@ -37,8 +45,64 @@ impl From<llm::response::Usage> for AssistantResponseMetadata {
                 cache_read: usage.cache_read_input_tokens as u64,
                 cache_write: usage.cache_creation_input_tokens as u64,
                 total_tokens: (usage.input_tokens + usage.output_tokens) as u64,
+                reasoning: usage.reasoning_output_tokens as u64,
             },
-            cost: Cost::default(),
+            cost: Cost {
+                total: usage.cost_usd.unwrap_or(0.0),
+                upstream_inference_usd: usage.upstream_inference_cost_usd,
+                ..Cost::default()
+            },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn metadata_from_llm_usage_carries_cost_and_reasoning() {
+        let llm_usage = llm::response::Usage {
+            input_tokens: 1000,
+            output_tokens: 500,
+            cache_read_input_tokens: 800,
+            cache_creation_input_tokens: 0,
+            reasoning_output_tokens: 120,
+            cost_usd: Some(0.0042),
+            upstream_inference_cost_usd: Some(0.0038),
+        };
+        let metadata = AssistantResponseMetadata::from(llm_usage);
+        assert_eq!(metadata.usage.input, 1000);
+        assert_eq!(metadata.usage.cache_read, 800);
+        assert_eq!(metadata.usage.reasoning, 120);
+        assert_eq!(metadata.cost.total, 0.0042);
+        assert_eq!(metadata.cost.upstream_inference_usd, Some(0.0038));
+    }
+
+    #[test]
+    fn legacy_metadata_without_new_fields_round_trips() {
+        // Persisted before this PR: no `reasoning` on usage, no
+        // `upstream_inference_usd` on cost. Must hydrate with defaults.
+        let json = r#"{
+            "api": "anthropic",
+            "model": "claude-sonnet-4",
+            "usage": {
+                "input": 100,
+                "output": 50,
+                "cache_read": 10,
+                "cache_write": 5,
+                "total_tokens": 150
+            },
+            "cost": {
+                "input": 0.0,
+                "output": 0.0,
+                "cache_read": 0.0,
+                "cache_write": 0.0,
+                "total": 0.0
+            }
+        }"#;
+        let m: AssistantResponseMetadata = serde_json::from_str(json).expect("legacy hydrates");
+        assert_eq!(m.usage.reasoning, 0);
+        assert!(m.cost.upstream_inference_usd.is_none());
     }
 }

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -174,6 +174,7 @@ impl Sessions {
                 cache_read: 0,
                 cache_write: 0,
                 total_tokens: 0,
+                reasoning: 0,
             },
             cost: Cost::default(),
         };

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -178,8 +178,7 @@ async fn send_message_round_trip_via_prompt_channel() {
             usage: Usage {
                 input_tokens: 5,
                 output_tokens: 3,
-                cache_read_input_tokens: 0,
-                cache_creation_input_tokens: 0,
+                ..Default::default()
             },
             stop_reason: None,
             model_used: None,
@@ -349,8 +348,7 @@ async fn send_message_dispatches_registered_tool_call() {
             usage: Usage {
                 input_tokens: 7,
                 output_tokens: 4,
-                cache_read_input_tokens: 0,
-                cache_creation_input_tokens: 0,
+                ..Default::default()
             },
             stop_reason: Some(StopReason::ToolUse),
             model_used: None,
@@ -372,8 +370,7 @@ async fn send_message_dispatches_registered_tool_call() {
             usage: Usage {
                 input_tokens: 9,
                 output_tokens: 2,
-                cache_read_input_tokens: 0,
-                cache_creation_input_tokens: 0,
+                ..Default::default()
             },
             stop_reason: None,
             model_used: None,

--- a/lib/anthropic-client/src/convert.rs
+++ b/lib/anthropic-client/src/convert.rs
@@ -215,6 +215,7 @@ pub(crate) fn accumulated_to_response(acc: AccumulatedResponse) -> PromptRespons
         output_tokens: acc.usage.output_tokens as u32,
         cache_read_input_tokens: acc.usage.cache_read_tokens as u32,
         cache_creation_input_tokens: acc.usage.cache_write_tokens as u32,
+        ..Default::default()
     };
 
     PromptResponse {
@@ -294,6 +295,9 @@ impl AnthropicDeltaConverter {
                     output_tokens: 0,
                     cache_read_input_tokens,
                     cache_creation_input_tokens,
+                    reasoning_output_tokens: 0,
+                    cost_usd: None,
+                    upstream_inference_cost_usd: None,
                 }]
             }
             AnthropicStreamEvent::ContentBlockStart {
@@ -356,6 +360,9 @@ impl AnthropicDeltaConverter {
                         output_tokens: u.output_tokens as u32,
                         cache_read_input_tokens: 0,
                         cache_creation_input_tokens: 0,
+                        reasoning_output_tokens: 0,
+                        cost_usd: None,
+                        upstream_inference_cost_usd: None,
                     });
                 }
                 let stop_reason = delta.stop_reason.map(|sr| match sr {

--- a/lib/llm/src/response.rs
+++ b/lib/llm/src/response.rs
@@ -25,6 +25,17 @@ pub struct Usage {
     pub cache_read_input_tokens: u32,
     #[serde(default)]
     pub cache_creation_input_tokens: u32,
+    /// Subset of `output_tokens` spent on reasoning (OpenAI o-series,
+    /// OpenRouter `completion_tokens_details.reasoning_tokens`).
+    #[serde(default)]
+    pub reasoning_output_tokens: u32,
+    /// Provider-reported USD cost for this call. Populated when the upstream
+    /// returns it (OpenRouter always; direct Anthropic/OpenAI never).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cost_usd: Option<f64>,
+    /// Upstream provider's actual inference cost (OpenRouter BYOK requests).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upstream_inference_cost_usd: Option<f64>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/lib/llm/src/router.rs
+++ b/lib/llm/src/router.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use crate::provider::LlmProvider;
 use crate::request::PromptError;
+use crate::response::Usage;
 use crate::{Prompt, StreamHandle};
 
 #[derive(Clone)]
@@ -31,6 +32,10 @@ pub struct AttemptRecord {
     pub model_id: String,
     pub provider_name: String,
     pub outcome: AttemptOutcome,
+    /// Populated only on `Succeeded`, and only after the consumer drains the
+    /// stream and back-fills via `WalkOutcome::record_winning_usage`.
+    /// Walker can't observe stream Usage itself — the receiver is handed off.
+    pub usage: Option<Usage>,
 }
 
 #[derive(Debug, Clone)]
@@ -45,6 +50,20 @@ pub struct WalkOutcome {
     pub stream: StreamHandle,
     pub model_used: String,
     pub attempts: Vec<AttemptRecord>,
+}
+
+impl WalkOutcome {
+    /// Back-fill the winning (last `Succeeded`) attempt's usage once the
+    /// caller has finished draining the stream.
+    pub fn record_winning_usage(attempts: &mut [AttemptRecord], usage: Usage) {
+        if let Some(a) = attempts
+            .iter_mut()
+            .rev()
+            .find(|a| matches!(a.outcome, AttemptOutcome::Succeeded))
+        {
+            a.usage = Some(usage);
+        }
+    }
 }
 
 /// First `Ok` from `send_prompt_streaming` wins. Mid-stream errors are
@@ -70,6 +89,7 @@ pub async fn walk(chain: &[ChainEntry], base: &Prompt) -> Result<WalkOutcome, Pr
                     model_id: entry.model_id.clone(),
                     provider_name: entry.provider.name().to_string(),
                     outcome: AttemptOutcome::Succeeded,
+                    usage: None,
                 });
                 tracing::info!(
                     model = %entry.model_id,
@@ -88,6 +108,7 @@ pub async fn walk(chain: &[ChainEntry], base: &Prompt) -> Result<WalkOutcome, Pr
                     model_id: entry.model_id.clone(),
                     provider_name: entry.provider.name().to_string(),
                     outcome: AttemptOutcome::Terminal(e.to_string()),
+                    usage: None,
                 });
                 tracing::error!(
                     model = %entry.model_id,
@@ -108,6 +129,7 @@ pub async fn walk(chain: &[ChainEntry], base: &Prompt) -> Result<WalkOutcome, Pr
                     model_id: entry.model_id.clone(),
                     provider_name: entry.provider.name().to_string(),
                     outcome: AttemptOutcome::Transient(e.to_string()),
+                    usage: None,
                 });
                 last_err = Some(e);
             }
@@ -237,5 +259,31 @@ mod tests {
         let chain: Vec<ChainEntry> = vec![];
         let err = walk(&chain, &Prompt::default()).await.unwrap_err();
         assert!(matches!(err, PromptError::Provider(_)));
+    }
+
+    #[tokio::test]
+    async fn record_winning_usage_attaches_to_succeeded_attempt() {
+        let bad = Arc::new(FailingProvider::new(
+            "bad",
+            PromptError::transient(TransientKind::ServerError, "503"),
+        ));
+        let good = Arc::new(OkProvider { name: "openai" });
+        let chain = vec![entry("primary", bad), entry("fallback", good)];
+        let mut outcome = walk(&chain, &Prompt::default()).await.unwrap();
+
+        let usage = Usage {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_input_tokens: 80,
+            cost_usd: Some(0.0042),
+            ..Default::default()
+        };
+        WalkOutcome::record_winning_usage(&mut outcome.attempts, usage);
+
+        assert!(outcome.attempts[0].usage.is_none(), "transient stays None");
+        let winning = outcome.attempts[1].usage.expect("succeeded got usage");
+        assert_eq!(winning.input_tokens, 100);
+        assert_eq!(winning.cache_read_input_tokens, 80);
+        assert_eq!(winning.cost_usd, Some(0.0042));
     }
 }

--- a/lib/llm/src/stream.rs
+++ b/lib/llm/src/stream.rs
@@ -34,6 +34,9 @@ pub enum StreamDelta {
         output_tokens: u32,
         cache_read_input_tokens: u32,
         cache_creation_input_tokens: u32,
+        reasoning_output_tokens: u32,
+        cost_usd: Option<f64>,
+        upstream_inference_cost_usd: Option<f64>,
     },
     Done {
         stop_reason: Option<StopReason>,
@@ -116,11 +119,22 @@ impl StreamAccumulator {
                 output_tokens,
                 cache_read_input_tokens,
                 cache_creation_input_tokens,
+                reasoning_output_tokens,
+                cost_usd,
+                upstream_inference_cost_usd,
             } => {
                 self.usage.input_tokens += *input_tokens;
                 self.usage.output_tokens += *output_tokens;
                 self.usage.cache_read_input_tokens += *cache_read_input_tokens;
                 self.usage.cache_creation_input_tokens += *cache_creation_input_tokens;
+                self.usage.reasoning_output_tokens += *reasoning_output_tokens;
+                if let Some(c) = cost_usd {
+                    self.usage.cost_usd = Some(self.usage.cost_usd.unwrap_or(0.0) + *c);
+                }
+                if let Some(c) = upstream_inference_cost_usd {
+                    self.usage.upstream_inference_cost_usd =
+                        Some(self.usage.upstream_inference_cost_usd.unwrap_or(0.0) + *c);
+                }
             }
             StreamDelta::Done { stop_reason } => {
                 self.stop_reason = *stop_reason;
@@ -195,6 +209,9 @@ mod tests {
             output_tokens: 0,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_output_tokens: 0,
+            cost_usd: None,
+            upstream_inference_cost_usd: None,
         });
         acc.process(&StreamDelta::TextDelta {
             text: "Hello".to_string(),
@@ -207,6 +224,9 @@ mod tests {
             output_tokens: 5,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_output_tokens: 0,
+            cost_usd: None,
+            upstream_inference_cost_usd: None,
         });
         acc.process(&StreamDelta::Done {
             stop_reason: Some(StopReason::EndTurn),
@@ -244,6 +264,9 @@ mod tests {
             output_tokens: 20,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_output_tokens: 0,
+            cost_usd: None,
+            upstream_inference_cost_usd: None,
         });
         acc.process(&StreamDelta::Done {
             stop_reason: Some(StopReason::ToolUse),
@@ -299,6 +322,9 @@ mod tests {
             output_tokens: 0,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_output_tokens: 0,
+            cost_usd: None,
+            upstream_inference_cost_usd: None,
         });
         // Thinking
         acc.process(&StreamDelta::ThinkingDelta {
@@ -322,6 +348,9 @@ mod tests {
             output_tokens: 30,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_output_tokens: 0,
+            cost_usd: None,
+            upstream_inference_cost_usd: None,
         });
         acc.process(&StreamDelta::Done {
             stop_reason: Some(StopReason::ToolUse),
@@ -419,6 +448,9 @@ mod tests {
             output_tokens: 0,
             cache_read_input_tokens: 80,
             cache_creation_input_tokens: 20,
+            reasoning_output_tokens: 0,
+            cost_usd: None,
+            upstream_inference_cost_usd: None,
         });
         acc.process(&StreamDelta::TextDelta {
             text: "hi".to_string(),
@@ -428,6 +460,9 @@ mod tests {
             output_tokens: 50,
             cache_read_input_tokens: 0,
             cache_creation_input_tokens: 0,
+            reasoning_output_tokens: 0,
+            cost_usd: None,
+            upstream_inference_cost_usd: None,
         });
         acc.process(&StreamDelta::Done {
             stop_reason: Some(StopReason::EndTurn),

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -203,6 +203,10 @@ struct PendingUsage {
     input_tokens: u32,
     output_tokens: u32,
     cache_read_input_tokens: u32,
+    cache_creation_input_tokens: u32,
+    reasoning_output_tokens: u32,
+    cost_usd: Option<f64>,
+    upstream_inference_cost_usd: Option<f64>,
 }
 
 impl DeltaSynthesizer {
@@ -228,15 +232,28 @@ impl DeltaSynthesizer {
         let mut deltas = Vec::new();
 
         if let Some(usage) = &chunk.usage {
-            let cached_tokens = usage
+            let (cache_read, cache_write) = usage
                 .prompt_tokens_details
                 .as_ref()
-                .map(|details| details.cached_tokens)
+                .map(|d| (d.cached_tokens, d.cache_write_tokens))
+                .unwrap_or((0, 0));
+            let reasoning = usage
+                .completion_tokens_details
+                .as_ref()
+                .map(|d| d.reasoning_tokens)
                 .unwrap_or(0);
+            let upstream = usage
+                .cost_details
+                .as_ref()
+                .and_then(|d| d.upstream_inference_cost);
             self.pending_usage = Some(PendingUsage {
                 input_tokens: usage.prompt_tokens,
                 output_tokens: usage.completion_tokens,
-                cache_read_input_tokens: cached_tokens,
+                cache_read_input_tokens: cache_read,
+                cache_creation_input_tokens: cache_write,
+                reasoning_output_tokens: reasoning,
+                cost_usd: usage.cost,
+                upstream_inference_cost_usd: upstream,
             });
         }
 
@@ -317,7 +334,10 @@ impl DeltaSynthesizer {
                 input_tokens: u.input_tokens,
                 output_tokens: u.output_tokens,
                 cache_read_input_tokens: u.cache_read_input_tokens,
-                cache_creation_input_tokens: 0,
+                cache_creation_input_tokens: u.cache_creation_input_tokens,
+                reasoning_output_tokens: u.reasoning_output_tokens,
+                cost_usd: u.cost_usd,
+                upstream_inference_cost_usd: u.upstream_inference_cost_usd,
             }],
             None => Vec::new(),
         }
@@ -495,6 +515,7 @@ mod tests {
                 output_tokens: 5,
                 cache_read_input_tokens: 0,
                 cache_creation_input_tokens: 0,
+                ..
             }
         )));
         assert!(deltas.iter().any(|d| matches!(
@@ -598,6 +619,86 @@ mod tests {
                 ..
             }
         )));
+    }
+
+    #[test]
+    fn synthesizer_extracts_openrouter_cost_and_cache_write() {
+        let mut synth = DeltaSynthesizer::new();
+
+        // OpenRouter routing an Anthropic-backed model: cache_write_tokens
+        // populated, plus top-level cost and reasoning tokens.
+        synth
+            .process_chunk(r#"{"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}"#)
+            .unwrap();
+        let deltas = synth
+            .process_chunk(
+                r#"{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1500,"completion_tokens":300,"prompt_tokens_details":{"cached_tokens":900,"cache_write_tokens":400},"completion_tokens_details":{"reasoning_tokens":120},"cost":0.00785,"cost_details":{"upstream_inference_cost":0.00712}}}"#,
+            )
+            .unwrap();
+
+        let usage = deltas
+            .iter()
+            .find_map(|d| match d {
+                StreamDelta::Usage {
+                    input_tokens,
+                    output_tokens,
+                    cache_read_input_tokens,
+                    cache_creation_input_tokens,
+                    reasoning_output_tokens,
+                    cost_usd,
+                    upstream_inference_cost_usd,
+                } => Some((
+                    *input_tokens,
+                    *output_tokens,
+                    *cache_read_input_tokens,
+                    *cache_creation_input_tokens,
+                    *reasoning_output_tokens,
+                    *cost_usd,
+                    *upstream_inference_cost_usd,
+                )),
+                _ => None,
+            })
+            .expect("usage delta");
+        assert_eq!(usage.0, 1500);
+        assert_eq!(usage.1, 300);
+        assert_eq!(usage.2, 900);
+        assert_eq!(usage.3, 400);
+        assert_eq!(usage.4, 120);
+        assert_eq!(usage.5, Some(0.00785));
+        assert_eq!(usage.6, Some(0.00712));
+    }
+
+    #[test]
+    fn synthesizer_direct_openai_leaves_cost_none() {
+        let mut synth = DeltaSynthesizer::new();
+        synth
+            .process_chunk(r#"{"choices":[{"delta":{"content":"hi"},"finish_reason":null}]}"#)
+            .unwrap();
+        let deltas = synth
+            .process_chunk(
+                r#"{"choices":[{"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":10,"completion_tokens":5,"prompt_tokens_details":{"cached_tokens":3}}}"#,
+            )
+            .unwrap();
+
+        let (cache_write, cost, upstream) = deltas
+            .iter()
+            .find_map(|d| match d {
+                StreamDelta::Usage {
+                    cache_creation_input_tokens,
+                    cost_usd,
+                    upstream_inference_cost_usd,
+                    ..
+                } => Some((
+                    *cache_creation_input_tokens,
+                    *cost_usd,
+                    *upstream_inference_cost_usd,
+                )),
+                _ => None,
+            })
+            .expect("usage delta");
+        assert_eq!(cache_write, 0, "direct OpenAI never has cache_write");
+        assert_eq!(cost, None, "direct OpenAI never has cost");
+        assert_eq!(upstream, None);
     }
 
     #[test]

--- a/lib/openai-client/src/lib.rs
+++ b/lib/openai-client/src/lib.rs
@@ -198,6 +198,10 @@ impl OpenAiClient {
             usage.input_tokens = tracing::field::Empty,
             usage.output_tokens = tracing::field::Empty,
             usage.cache_read_input_tokens = tracing::field::Empty,
+            usage.cache_creation_input_tokens = tracing::field::Empty,
+            usage.reasoning_output_tokens = tracing::field::Empty,
+            usage.cost_usd = tracing::field::Empty,
+            usage.upstream_inference_cost_usd = tracing::field::Empty,
             stream.delta_count = tracing::field::Empty,
         );
 
@@ -231,7 +235,7 @@ async fn drive_stream_with_retry(
     let mut current_resp = initial_resp;
     let mut empty_retries: u32 = 0;
     let mut delta_count: u64 = 0;
-    let mut usage_seen: Option<(u32, u32, u32)> = None;
+    let mut usage_seen: Option<UsageSnapshot> = None;
 
     loop {
         let byte_stream = current_resp.bytes_stream();
@@ -248,11 +252,21 @@ async fn drive_stream_with_retry(
                             input_tokens,
                             output_tokens,
                             cache_read_input_tokens,
-                            ..
+                            cache_creation_input_tokens,
+                            reasoning_output_tokens,
+                            cost_usd,
+                            upstream_inference_cost_usd,
                         } = &delta
                         {
-                            usage_seen =
-                                Some((*input_tokens, *output_tokens, *cache_read_input_tokens));
+                            usage_seen = Some(UsageSnapshot {
+                                input_tokens: *input_tokens,
+                                output_tokens: *output_tokens,
+                                cache_read_input_tokens: *cache_read_input_tokens,
+                                cache_creation_input_tokens: *cache_creation_input_tokens,
+                                reasoning_output_tokens: *reasoning_output_tokens,
+                                cost_usd: *cost_usd,
+                                upstream_inference_cost_usd: *upstream_inference_cost_usd,
+                            });
                         }
                         tx.try_send(Ok(delta))
                             .map_err(|e| SseError::Processing(e.to_string()))?;
@@ -305,11 +319,33 @@ async fn drive_stream_with_retry(
 
     span.record("empty_completion_retries", empty_retries);
     span.record("stream.delta_count", delta_count);
-    if let Some((input, output, cache_read)) = usage_seen {
-        span.record("usage.input_tokens", input);
-        span.record("usage.output_tokens", output);
-        span.record("usage.cache_read_input_tokens", cache_read);
+    if let Some(u) = usage_seen {
+        span.record("usage.input_tokens", u.input_tokens);
+        span.record("usage.output_tokens", u.output_tokens);
+        span.record("usage.cache_read_input_tokens", u.cache_read_input_tokens);
+        span.record(
+            "usage.cache_creation_input_tokens",
+            u.cache_creation_input_tokens,
+        );
+        span.record("usage.reasoning_output_tokens", u.reasoning_output_tokens);
+        if let Some(c) = u.cost_usd {
+            span.record("usage.cost_usd", c);
+        }
+        if let Some(c) = u.upstream_inference_cost_usd {
+            span.record("usage.upstream_inference_cost_usd", c);
+        }
     }
+}
+
+#[derive(Copy, Clone)]
+struct UsageSnapshot {
+    input_tokens: u32,
+    output_tokens: u32,
+    cache_read_input_tokens: u32,
+    cache_creation_input_tokens: u32,
+    reasoning_output_tokens: u32,
+    cost_usd: Option<f64>,
+    upstream_inference_cost_usd: Option<f64>,
 }
 
 /// Best-effort scrape of `error.metadata.retry_after_seconds` from an

--- a/lib/openai-client/src/responses.rs
+++ b/lib/openai-client/src/responses.rs
@@ -499,7 +499,11 @@ struct ToolCallState {
 struct PendingUsage {
     input_tokens: u32,
     output_tokens: u32,
-    cached_input_tokens: u32,
+    cache_read_input_tokens: u32,
+    cache_creation_input_tokens: u32,
+    reasoning_output_tokens: u32,
+    cost_usd: Option<f64>,
+    upstream_inference_cost_usd: Option<f64>,
 }
 
 impl ResponsesDeltaSynthesizer {
@@ -536,14 +540,30 @@ impl ResponsesDeltaSynthesizer {
             ResponsesResponseEvent::ResponseCompleted { response }
             | ResponsesResponseEvent::ResponseDone { response }
             | ResponsesResponseEvent::ResponseIncomplete { response } => {
-                self.pending_usage = response.usage.as_ref().map(|usage| PendingUsage {
-                    input_tokens: usage.input_tokens,
-                    output_tokens: usage.output_tokens,
-                    cached_input_tokens: usage
+                self.pending_usage = response.usage.as_ref().map(|usage| {
+                    let (cache_read, cache_write) = usage
                         .input_tokens_details
                         .as_ref()
-                        .map(|details| details.cached_tokens)
-                        .unwrap_or(0),
+                        .map(|d| (d.cached_tokens, d.cache_write_tokens))
+                        .unwrap_or((0, 0));
+                    let reasoning = usage
+                        .output_tokens_details
+                        .as_ref()
+                        .map(|d| d.reasoning_tokens)
+                        .unwrap_or(0);
+                    let upstream = usage
+                        .cost_details
+                        .as_ref()
+                        .and_then(|d| d.upstream_inference_cost);
+                    PendingUsage {
+                        input_tokens: usage.input_tokens,
+                        output_tokens: usage.output_tokens,
+                        cache_read_input_tokens: cache_read,
+                        cache_creation_input_tokens: cache_write,
+                        reasoning_output_tokens: reasoning,
+                        cost_usd: usage.cost,
+                        upstream_inference_cost_usd: upstream,
+                    }
                 });
                 self.pending_incomplete_reason = response.incomplete_reason();
                 Ok(Vec::new())
@@ -723,7 +743,11 @@ impl ResponsesDeltaSynthesizer {
         let Some(PendingUsage {
             input_tokens,
             output_tokens,
-            cached_input_tokens,
+            cache_read_input_tokens,
+            cache_creation_input_tokens,
+            reasoning_output_tokens,
+            cost_usd,
+            upstream_inference_cost_usd,
         }) = self.pending_usage
         else {
             return Err("OpenAI Responses stream ended without terminal response".to_string());
@@ -734,8 +758,11 @@ impl ResponsesDeltaSynthesizer {
             StreamDelta::Usage {
                 input_tokens,
                 output_tokens,
-                cache_read_input_tokens: cached_input_tokens,
-                cache_creation_input_tokens: 0,
+                cache_read_input_tokens,
+                cache_creation_input_tokens,
+                reasoning_output_tokens,
+                cost_usd,
+                upstream_inference_cost_usd,
             },
             StreamDelta::Done {
                 stop_reason: Some(self.stop_reason()),
@@ -889,12 +916,32 @@ struct ResponsesUsage {
     input_tokens_details: Option<ResponsesInputTokensDetails>,
     #[serde(default)]
     output_tokens: u32,
+    #[serde(default)]
+    output_tokens_details: Option<ResponsesOutputTokensDetails>,
+    #[serde(default)]
+    cost: Option<f64>,
+    #[serde(default)]
+    cost_details: Option<ResponsesCostDetails>,
 }
 
 #[derive(Debug, Deserialize)]
 struct ResponsesInputTokensDetails {
     #[serde(default)]
     cached_tokens: u32,
+    #[serde(default)]
+    cache_write_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponsesOutputTokensDetails {
+    #[serde(default)]
+    reasoning_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+struct ResponsesCostDetails {
+    #[serde(default)]
+    upstream_inference_cost: Option<f64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1090,6 +1137,7 @@ mod tests {
                 output_tokens: 1,
                 cache_read_input_tokens: 1,
                 cache_creation_input_tokens: 0,
+                ..
             }
         )));
         assert!(terminal.iter().any(|delta| matches!(

--- a/lib/openai-client/src/types.rs
+++ b/lib/openai-client/src/types.rs
@@ -130,10 +130,35 @@ pub(crate) struct OpenAiUsage {
     pub completion_tokens: u32,
     #[serde(default)]
     pub prompt_tokens_details: Option<OpenAiPromptTokensDetails>,
+    #[serde(default)]
+    pub completion_tokens_details: Option<OpenAiCompletionTokensDetails>,
+    /// OpenRouter populates this with USD credits charged. Direct OpenAI
+    /// never sets it; presence is the OpenRouter signal.
+    #[serde(default)]
+    pub cost: Option<f64>,
+    #[serde(default)]
+    pub cost_details: Option<OpenAiCostDetails>,
 }
 
 #[derive(Debug, Deserialize)]
 pub(crate) struct OpenAiPromptTokensDetails {
     #[serde(default)]
     pub cached_tokens: u32,
+    /// OpenRouter populates this for upstream models with explicit cache-write
+    /// pricing (Anthropic family). OpenAI direct never sets it.
+    #[serde(default)]
+    pub cache_write_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiCompletionTokensDetails {
+    #[serde(default)]
+    pub reasoning_tokens: u32,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct OpenAiCostDetails {
+    /// Actual upstream provider cost; OpenRouter BYOK only.
+    #[serde(default)]
+    pub upstream_inference_cost: Option<f64>,
 }


### PR DESCRIPTION
## Summary
Closes the cost-reporting gap called out in memories **019df96b / 019df980 / 019dfd57**. The runtime backbone landed in PR #278 — this PR makes per-attempt token-class and dollar cost flow end-to-end so the workflow-run inspection surface (PR #268) and future cost-per-progress analyses can read first-class numbers instead of eyeballing list-price math.

## What changed

### Unified `llm::response::Usage` (additive, all `#[serde(default)]`)
- `reasoning_output_tokens: u32` — subset of `output_tokens` for OpenAI o-series / OpenRouter `completion_tokens_details.reasoning_tokens`
- `cost_usd: Option<f64>` — provider-reported USD cost (populated when present; `None` for direct Anthropic/OpenAI which never return a cost field)
- `upstream_inference_cost_usd: Option<f64>` — OpenRouter BYOK only

`StreamDelta::Usage` carries the same fields; `StreamAccumulator` folds them additively (cost_usd accumulates if a provider splits across multiple usage events).

### Per-provider extraction
| Provider | cache_read | cache_write | reasoning | cost | upstream cost |
|---|---|---|---|---|---|
| Anthropic Messages | ✓ (existing) | ✓ (existing) | — | — | — |
| OpenAI Chat Completions | ✓ (existing) | **new** (`cache_write_tokens`) | **new** | **new** | **new** |
| OpenAI Responses API | ✓ (existing) | **new** | **new** | **new** | **new** |
| OpenRouter | rides through OpenAI client paths since OpenRouter is OpenAI-API-compatible. All four new fields fire whenever upstream populates them. |

### Chain walker (`lib/llm/router.rs`)
- `AttemptRecord` gains `usage: Option<Usage>` (None on Transient/Terminal — no response landed)
- `WalkOutcome::record_winning_usage(&mut attempts, usage)` lets the consumer back-fill the winning attempt once the stream drains. Walker doesn't observe Usage itself — the receiver is handed off

### Session metadata (`core/.../metadata.rs`)
- `Usage::reasoning: u64` and `Cost::upstream_inference_usd: Option<f64>` — both `#[serde(default)]`, so existing persisted `AssistantResponseReceived` events hydrate cleanly (round-trip test included)
- `From<llm::response::Usage> for AssistantResponseMetadata` now populates `Cost::total` from `usage.cost_usd` and `Cost::upstream_inference_usd` from the OpenRouter cost-details field

## Decisions confirmed with PM
1. **No pricing table this PR.** OpenRouter-routed traffic gets exact dollar cost from `usage.cost`; direct Anthropic/OpenAI cost stays defaulted to 0.0 until a follow-up adds a per-million table
2. **Schema additions are all additive optional `#[serde(default)]` fields** — no new event variants, no migration needed
3. `AttemptRecord.usage` is in-memory observability only; session log keeps the winning-attempt Usage as before

## Before / after example

Before (workflow run, OpenRouter routing `claude-sonnet-4`):
```json
"metadata": {
  "model": "claude-sonnet-4",
  "usage": { "input": 1500, "output": 300, "cache_read": 900, "cache_write": 0, "total_tokens": 1800 },
  "cost":  { "input": 0.0, "output": 0.0, "cache_read": 0.0, "cache_write": 0.0, "total": 0.0 }
}
```

After:
```json
"metadata": {
  "model": "claude-sonnet-4",
  "usage": { "input": 1500, "output": 300, "cache_read": 900, "cache_write": 400, "total_tokens": 1800, "reasoning": 120 },
  "cost":  { "input": 0.0, "output": 0.0, "cache_read": 0.0, "cache_write": 0.0, "total": 0.00785, "upstream_inference_usd": 0.00712 }
}
```

## Tests
- `synthesizer_extracts_openrouter_cost_and_cache_write` — OpenRouter-shape fixture asserts all 4 new fields land
- `synthesizer_direct_openai_leaves_cost_none` — direct OpenAI fixture asserts cost stays None / cache_write 0
- `record_winning_usage_attaches_to_succeeded_attempt` — chain walker integration: transient stays None, succeeded attempt gets back-filled
- `metadata_from_llm_usage_carries_cost_and_reasoning` + `legacy_metadata_without_new_fields_round_trips` — serde round-trip including the back-compat path
- All existing `usage` test sites updated to use `..Default::default()` (cleaner than enumerating the new fields)

`nix flake check` passes clean (clippy `--deny warnings`, fmt, nextest, schema-check, default-config-check).

## Deferred to follow-up
- **Pricing table** for direct Anthropic / OpenAI calls so `Cost.total` is non-zero outside OpenRouter routing. Likely a checked-in TOML auto-refreshed from OpenRouter's pricing API on startup
- **Workflow-run inspection MCP surface** (PR #268) — extend `workflow.run --include=steps` token field to break out cached vs fresh and surface `cost_usd`. The numbers are now in the persisted metadata, the surface just needs to read them
- **Dashboard / cost-per-progress automation** — feed `Cost.total` into the workflow-comparison analysis from memory 019dfd57

## Test plan
- [ ] CI green on draft PR
- [ ] Live OpenRouter call surfaces `cost_usd` in tracing span (will verify post-merge once a workflow run goes through main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new serialized usage/cost fields and threads them through streaming accumulation and provider adapters; mistakes could skew accounting/observability but core request/response flow is unchanged.
> 
> **Overview**
> **Extends LLM usage accounting end-to-end** by adding reasoning-token and provider-reported cost fields to `llm::response::Usage` and `StreamDelta::Usage`, and updating `StreamAccumulator` to aggregate them (including additive accumulation for multi-usage streams).
> 
> **Improves provider extraction** by teaching the OpenAI clients (Chat Completions + Responses, including OpenRouter-compatible shapes) to parse `cache_write_tokens`, `reasoning_tokens`, and cost details into the unified usage struct; Anthropic streaming now emits the expanded `Usage` delta shape with defaults.
> 
> **Persists richer session metadata** by adding `usage.reasoning` and `cost.upstream_inference_usd` to `AssistantResponseMetadata` (with `#[serde(default)]` back-compat) and mapping them from `llm::response::Usage` (including `cost.total` from `cost_usd`).
> 
> **Adds per-attempt observability** in the chain walker by extending `AttemptRecord` with optional `usage` and providing `WalkOutcome::record_winning_usage` to back-fill the successful attempt after stream drain; tests and fixtures are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a57f4a1e150ab199b4b71f70c489fb704e0fd40e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->