### PR TITLE
fix(sandbox): reset_repo subshell + honest ok contract

### DIFF
--- a/images/sandbox/server/src/main.rs
+++ b/images/sandbox/server/src/main.rs
@@ -57,7 +57,12 @@ struct AttachRequest {
 
 #[derive(Debug, Serialize)]
 struct ResetRepoResponse {
-    /// True iff every reset step exited 0. Best-effort callers can ignore this.
+    /// `true` when the workspace is in the expected post-reset state:
+    /// either every reset step succeeded (script printed
+    /// `__reset_done__`) or the cwd had no `.git` so reset was a no-op
+    /// (script printed `__reset_skipped_no_git__`). `false` means at
+    /// least one reset step failed and the workspace state is
+    /// unspecified — caller should treat as a soft warning.
     ok: bool,
     /// Concatenated stdout/stderr of the reset script, for observability.
     output: String,
@@ -659,31 +664,45 @@ async fn attach(
 
 /// Resets the cloned repo at the bash session's cwd to a clean baseline:
 /// `git fetch origin main && git checkout main && git reset --hard origin/main
-/// && git clean -fd`, then drops any leftover `bot/*` branches. Best-effort:
-/// individual steps may fail (e.g. `fetch` if the token is stale) and the
-/// remaining steps still run. Runs through the existing bash session so the
-/// commands inherit the UID-drop and the agent's git config.
+/// && git clean -fd`, then drops any leftover `bot/*` branches.
 ///
-/// No-op (returns `ok=true`) when the cwd does not contain a `.git` dir —
-/// e.g. scratch-mode sandboxes.
+/// Runs through the existing bash session so the commands inherit the
+/// UID-drop and the agent's git config. The script body runs in a
+/// **subshell** with `set -e` so a failing step (e.g. `git fetch` on a
+/// stale token) aborts the chain without printing the success marker —
+/// AND without `exit` killing the persistent shell.
+///
+/// Markers (mutually exclusive — at most one prints to stdout):
+/// - `__reset_done__` — every reset step succeeded.
+/// - `__reset_skipped_no_git__` — cwd has no `.git`; nothing to reset
+///   (e.g. scratch-mode sandboxes).
+/// - neither — at least one reset step failed; workspace state is
+///   unspecified.
+///
+/// `ok = output.contains(__reset_done__) || output.contains(__reset_skipped_no_git__)`.
 #[instrument(name = "sandbox.server.reset_repo", skip_all)]
 async fn reset_repo(State(session): State<SharedSession>) -> Json<ResetRepoResponse> {
     let cwd = session.current_cwd().await;
+    // Subshell `( ... )` confines `exit` so the no-`.git` short-circuit
+    // and any `set -e` abort don't terminate the persistent bash
+    // session. Outer `|| true` keeps the session's last exit code 0
+    // (the script itself is success-via-marker, not via exit code).
     let script = format!(
-        r#"set +e; cd {cwd} 2>/dev/null || exit 0; \
-[ -d .git ] || exit 0; \
+        r#"( set -e; cd {cwd}; [ -d .git ] || {{ echo __reset_skipped_no_git__; exit 0; }}; \
 git fetch origin main; \
 git checkout main 2>/dev/null || git checkout -B main origin/main; \
 git reset --hard origin/main; \
 git clean -fd; \
-for b in $(git branch --list 'bot/*' | sed 's/^[* ]*//'); do git branch -D "$b" 2>/dev/null || true; done; \
-echo __reset_done__"#
+for b in $(git branch --list 'bot/*' | sed 's/^[* ]*//'); do git branch -D "$b" || true; done; \
+echo __reset_done__ ) || true"#
     );
 
     const RESET_TIMEOUT_MS: u64 = 60_000;
     match session.execute(&script, RESET_TIMEOUT_MS).await {
         Ok(r) => Json(ResetRepoResponse {
-            ok: !r.shell_died && r.output.contains("__reset_done__"),
+            ok: !r.shell_died
+                && (r.output.contains("__reset_done__")
+                    || r.output.contains("__reset_skipped_no_git__")),
             output: r.output,
         }),
         Err(e) => Json(ResetRepoResponse {
@@ -2352,19 +2371,60 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reset_repo_is_noop_when_cwd_has_no_git_dir() {
+    async fn reset_repo_skipped_when_cwd_has_no_git_dir() {
         let workspace = fresh_test_dir("sandbox-reset-nogit");
         let session: SharedSession = Arc::new(BashSession::new());
         session.set_cwd(workspace).await;
 
         let resp = reset_repo(State(session)).await;
-        // Best-effort: no .git → script exits 0 immediately. The marker
-        // never echoes (we exit before it), so `ok` is false but the
-        // call succeeds without error.
+        // No `.git` → subshell prints `__reset_skipped_no_git__` and
+        // exits 0. `ok` reports the workspace is in the expected
+        // baseline state (a no-op skip is a fine outcome).
         assert!(
-            !resp.0.ok || resp.0.output.is_empty() || !resp.0.output.contains("__reset_done__"),
-            "no-git case should not falsely claim success: {:?}",
+            resp.0.ok,
+            "no-git skip case should be ok=true: {:?}",
             resp.0
+        );
+        assert!(
+            resp.0.output.contains("__reset_skipped_no_git__"),
+            "expected skip marker in output: {:?}",
+            resp.0.output
+        );
+        assert!(
+            !resp.0.output.contains("__reset_done__"),
+            "must not falsely emit reset_done marker: {:?}",
+            resp.0.output
+        );
+    }
+
+    /// Regression test for the "exit 0 kills the persistent shell" bug
+    /// (Bugbot finding on PR #286): the reset script's early-return
+    /// must run in a subshell so the persistent `BashSession` survives
+    /// and a follow-up `execute` doesn't have to respawn.
+    #[tokio::test]
+    async fn reset_repo_does_not_kill_persistent_shell() {
+        let workspace = fresh_test_dir("sandbox-reset-shell-survives");
+        let session: SharedSession = Arc::new(BashSession::new());
+        session.set_cwd(workspace).await;
+
+        let _ = reset_repo(State(session.clone())).await;
+
+        // If the subshell isolation is broken, this command will
+        // either fail with `shell_died` or come back from a brand-new
+        // respawned shell. Either way it's a regression.
+        let post = session
+            .execute("echo persistent_shell_alive", 5_000)
+            .await
+            .expect("post-reset execute must succeed");
+        assert!(
+            !post.shell_died,
+            "shell must survive reset; output={:?}",
+            post.output
+        );
+        assert!(
+            post.output.contains("persistent_shell_alive"),
+            "follow-up command must run on the same shell; output={:?}",
+            post.output
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes two bugs raised by [Cursor Bugbot on PR #286](https://github.com/GaloyMoney/drua/pull/286) (already merged) in the sandbox-server's `reset_repo` handler.

### Bug 1 — `exit 0` killed the persistent bash session (Medium)

The reset script used `cd {cwd} || exit 0` and `[ -d .git ] || exit 0` as early-returns. Since the script ran directly in the persistent bash session (not a subshell), `exit 0` terminated the entire shell process → `shell_died: true` → `ok: false`. This contradicted the doc claim of "returns `ok=true`" for the no-`.git` case, and forced an unnecessary respawn on the next `execute` call.

**Fix**: wrap the script body in `( ... ) || true` so `exit` and `set -e` aborts can only ever terminate the subshell.

### Bug 2 — `ok` semantics didn't match implementation (Low)

`ResetRepoResponse.ok` was documented as "True iff every reset step exited 0", but the implementation only checked `!shell_died && output.contains("__reset_done__")`. With `set +e`, `git fetch` could fail (e.g. stale token, network blip) and the unconditional final `echo __reset_done__` would still print → `ok: true` → caller logged INFO `"reset: repo reset to clean baseline"` while the workspace actually held stale content.

**Fix**: use `set -e` inside the subshell so any failing step aborts the chain *before* the success marker prints. Distinguish two success modes via mutually-exclusive markers:
- `__reset_done__` — every step succeeded.
- `__reset_skipped_no_git__` — cwd has no `.git` (e.g. scratch sandbox).

`ok = true` iff one of these markers prints; neither = at least one step failed → `ok = false`, caller logs WARN.

The `||`-chained checkout fallback and `|| true` on the per-branch delete loop preserve the intentional best-effort semantics for those two specific steps; `set -e` only aborts on unhandled non-zero exits.

## Wire format

**No change**. Same `{ ok: bool, output: String }` shape — just honest semantics behind it. Old clients are unaffected.

## Tests

- Strengthened `reset_repo_skipped_when_cwd_has_no_git_dir`: now asserts `ok == true` AND `output` contains `__reset_skipped_no_git__` AND **does not** contain `__reset_done__` (the previous test accepted the buggy behaviour).
- New regression test `reset_repo_does_not_kill_persistent_shell`: runs reset on a no-`.git` cwd, then asserts a follow-up `session.execute("echo persistent_shell_alive", ...)` succeeds with `shell_died == false` on the same session. This is the direct regression test for Bug 1.

`nix flake check` clean (fmt + clippy + nextest + graphql + default-config).

## Test plan

- [ ] CI green (especially bats, where these tests run).
- [ ] After deploy: trigger a workflow run on a sandbox where the cwd is a real cloned repo. Verify INFO log `reset: repo reset to clean baseline` and the agent's first `git status` shows a clean tree.
- [ ] Force a `git fetch` failure (e.g. revoke the token mid-run) and verify the caller logs WARN `"reset: repo reset partially failed (continuing)"` with the `__reset_done__` marker absent from the output.
- [ ] Verify a workflow attached to a (hypothetical) misconfigured `Repo`-mode sandbox with no `.git` produces `ok=true` with the skip marker — operators see the workspace is in baseline state, but the marker indicates the actual condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the sandbox `reset_repo` execution/exit behavior and success detection, which can affect how persistent sessions and repo state resets behave during workflow runs.
> 
> **Overview**
> Fixes `reset_repo` to run its git-cleanup script inside a subshell with `set -e`, preventing early `exit` from killing the long-lived `BashSession` and avoiding false-positive resets when intermediate git steps fail.
> 
> Clarifies and tightens the `ResetRepoResponse.ok` contract by introducing a distinct `__reset_skipped_no_git__` marker for non-repo workspaces and treating success as *marker-based* (`__reset_done__` or skip marker), plus adds/updates tests to assert the skip marker and verify the persistent shell survives a reset call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8649c9296c5629dbda963cad2f4af6053a98e6e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->