### PR TITLE
docs(library): include space_file in library_search tool description

### DIFF
--- a/core/src/toolset/searchable/library.rs
+++ b/core/src/toolset/searchable/library.rs
@@ -291,7 +291,7 @@ impl LibraryToolSet {
         let tools = vec![
             tool_entry(
                 "search",
-                "Cross-type, cross-project library search across skills and notes. \
+                "Cross-type, cross-project library search across skills, notes, and space files. \
                  Hybrid FTS + semantic similarity. Always global — results span every \
                  project the subject can read. Returns ranked snippets; pair with \
                  `get_files` to load full bodies. Workflows are git-synced but not \


### PR DESCRIPTION
## Summary

The MCP tool description for `library_search` claimed the index covers "skills and notes", but `space_file` is the third indexed type — and is returned in live results today (verified against the on-call space's `triage-log.md`, `open-items.md`, and a freshly-created `drua-dev` space's `research/ha-readiness.md`).

Agents reading the misleading description would incorrectly assume that arbitrary markdown files dropped in a space subtree (e.g. `research/foo.md`) are not searchable, and skip searching for them.

One-line fix: `"across skills and notes"` → `"across skills, notes, and space files"`.

## Test plan
- [x] `cargo fmt -p drua-core`
- [x] `cargo check -p drua-core` (clean)
- [ ] CI — let `nix flake check` run on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the `library` toolset's `search` tool description string with no functional or data-handling impact.
> 
> **Overview**
> Updates the `library` toolset `search` tool description to correctly state that global search covers **skills, notes, and `space_file`s** (in addition to the existing indexed types).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca599bfe563a39532b46a60d069af8b997651cdf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->