### PR TITLE
fix(admin): require explicit set-or-clear for update_model_chain (PR #283 follow-up)

### DIFF
--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -75,6 +75,26 @@ fn deserialize_liberal_i64<'de, D: serde::Deserializer<'de>>(
     }
 }
 
+/// Caller must be explicit: provide `model_chain` to set, or
+/// `clear_model_chain: true` to clear. Omitting both used to silently
+/// unpin production overrides — now rejected.
+fn resolve_model_chain_update(
+    model_chain: Option<llm::ModelChain>,
+    clear: bool,
+) -> Result<Option<llm::ModelChain>, ToolSetsError> {
+    match (model_chain, clear) {
+        (Some(_), true) => Err(ToolSetsError::InvalidArgument(
+            "update_model_chain: provide either `model_chain` or `clear_model_chain: true`, not both"
+                .to_string(),
+        )),
+        (None, false) => Err(ToolSetsError::InvalidArgument(
+            "update_model_chain: must provide `model_chain` to set or `clear_model_chain: true` to clear"
+                .to_string(),
+        )),
+        (chain, _) => Ok(chain),
+    }
+}
+
 #[derive(Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 enum AgentCommand {
@@ -847,11 +867,8 @@ impl AdminToolSet {
                         "agent_id is required for update_model_chain".to_string(),
                     )
                 })?;
-                let chain = if params.clear_model_chain {
-                    None
-                } else {
-                    params.model_chain
-                };
+                let chain =
+                    resolve_model_chain_update(params.model_chain, params.clear_model_chain)?;
                 let agent = self
                     .agents
                     .update_model_chain(subject, agent_id, chain)
@@ -999,11 +1016,8 @@ impl AdminToolSet {
                         "project_id is required for update_model_chain".to_string(),
                     )
                 })?;
-                let chain = if params.clear_model_chain {
-                    None
-                } else {
-                    params.model_chain
-                };
+                let chain =
+                    resolve_model_chain_update(params.model_chain, params.clear_model_chain)?;
                 let project = self
                     .projects
                     .update_model_chain(subject, project_id, chain)
@@ -2588,5 +2602,31 @@ mod tests {
         for v in ["create", "list", "get", "update", "pin", "unpin", "delete"] {
             assert!(s.contains(&format!("\"{v}\"")), "missing {v} in schema");
         }
+    }
+
+    #[test]
+    fn resolve_model_chain_update_set() {
+        let chain = llm::ModelChain::from("claude-sonnet-4-5");
+        let resolved = resolve_model_chain_update(Some(chain.clone()), false).expect("ok");
+        assert_eq!(resolved, Some(chain));
+    }
+
+    #[test]
+    fn resolve_model_chain_update_clear() {
+        let resolved = resolve_model_chain_update(None, true).expect("ok");
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn resolve_model_chain_update_rejects_neither() {
+        let err = resolve_model_chain_update(None, false).expect_err("must reject");
+        assert!(matches!(err, ToolSetsError::InvalidArgument(_)));
+    }
+
+    #[test]
+    fn resolve_model_chain_update_rejects_both() {
+        let chain = llm::ModelChain::from("claude-sonnet-4-5");
+        let err = resolve_model_chain_update(Some(chain), true).expect_err("must reject");
+        assert!(matches!(err, ToolSetsError::InvalidArgument(_)));
     }
 }


### PR DESCRIPTION
## Summary

Follow-up to merged PR #283 — addresses review comment [discussion_r3194784757](https://github.com/GaloyMoney/drua/pull/283#discussion_r3194784757).

> ### Missing update payload validation
>
> The `update_model_chain` command for agents and projects implicitly clears an existing model chain override when the `model_chain` parameter is omitted. This happens even without `clear_model_chain: true`, potentially unpinning production chains unintentionally.

## Fix

Centralizes payload validation in a new `resolve_model_chain_update` helper used by both `AgentCommand::UpdateModelChain` and `ProjectCommand::UpdateModelChain`:

- `model_chain: Some(_), clear_model_chain: false` → set
- `model_chain: None,    clear_model_chain: true`  → clear
- `model_chain: None,    clear_model_chain: false` → `InvalidArgument` (was: silent clear — the bug)
- `model_chain: Some(_), clear_model_chain: true`  → `InvalidArgument` (ambiguous)

Operators must now be explicit. The advertised tool contract already documented this shape (`set model_chain to override OR clear_model_chain: true to clear`), so the change just enforces it.

## Test plan

- [x] 4 new unit tests on the helper (set / clear / rejects-neither / rejects-both)
- [x] All existing `admin::tests` still pass (44 total)
- [x] `cargo fmt && nix flake check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized validation change to admin-only `update_model_chain` that prevents accidental clearing but may break callers relying on the previous implicit-clear behavior.
> 
> **Overview**
> Prevents `agent` and `project` `update_model_chain` admin commands from *silently clearing* an existing override when `model_chain` is omitted.
> 
> Centralizes validation in `resolve_model_chain_update`, requiring callers to explicitly **set** via `model_chain` or **clear** via `clear_model_chain: true` (and rejecting ambiguous/neither cases), with new unit tests covering all four combinations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5938620d04ee09d8530fde76b0997e3236b7c15a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->