### PR TITLE
feat(library): dev-tier scoped search + slug-in-results

### DIFF
--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -300,6 +300,7 @@ impl App {
             Arc::clone(&projects),
             Arc::clone(&spaces),
             Arc::clone(&space_fs),
+            Arc::clone(&search),
             Arc::clone(&workflows),
             Arc::clone(&skills),
             Arc::clone(&notes),

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -290,7 +290,10 @@ impl App {
 
         // Read-only library lookup lives behind progressive disclosure;
         // notes/skill tools cover project-scoped writes.
-        toolsets.register_searchable(LibraryToolSet::new(Arc::clone(&search)));
+        toolsets.register_searchable(LibraryToolSet::new(
+            Arc::clone(&search),
+            Arc::clone(&spaces),
+        ));
 
         // Behind progressive disclosure to keep top-level list_tools small.
         toolsets.register_searchable(AdminToolSet::new(

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -11,12 +11,12 @@ use rmcp::model::{CallToolResult, Content, JsonObject};
 use sandbox::instance_client::ExecuteRequest;
 use serde::Deserialize;
 
-use drua_library::{Space, SpaceError};
+use drua_library::{Space, SpaceError, SPACE_DOC_TYPE};
 
 use crate::agent::{Agent, AgentRole, Agents};
 use crate::audit::{Audit, AuditEntry, AuditLogQuery};
 use crate::auth::{AuthResource, AuthSubject, AuthVerb};
-use crate::library::AuthedSpaces;
+use crate::library::{AuthedSearch, AuthedSpaces};
 use crate::note::{Note, Notes};
 use crate::primitives::{
     AgentId, NoteId, ProjectId, SandboxId, SkillId, UserId, WorkflowDefinitionId,
@@ -31,6 +31,7 @@ use crate::workflow::{
 
 use super::super::error::ToolSetsError;
 use super::super::inspect::{dispatch_edit, dispatch_view, parse_view_range, EditOp, ReadOp};
+use super::super::top_level::SpacesTool;
 use super::super::traits::{SearchableToolSet, ToolSetEntry};
 
 fn parse_params<T: serde::de::DeserializeOwned>(
@@ -230,13 +231,18 @@ enum SpacesCommand {
     /// (write|str_replace|insert|delete|move); `op_args` shape
     /// depends on it.
     Edit,
+    /// Hybrid FTS + semantic search inside a single space. Admin
+    /// variant of the agent-tier `spaces.search` — does not require
+    /// the space to be mounted on any project.
+    Search,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
 struct SpacesParams {
     command: SpacesCommand,
-    /// Slug for `create`, `get`, `mount`, `unmount`, `view`, `edit`.
-    /// Must match `[a-z0-9-]+` with no leading / trailing / double hyphens.
+    /// Slug for `create`, `get`, `mount`, `unmount`, `view`, `edit`,
+    /// `search`. Must match `[a-z0-9-]+` with no leading / trailing /
+    /// double hyphens.
     slug: Option<String>,
     /// Optional human-readable summary, used by `create`.
     description: Option<String>,
@@ -252,6 +258,18 @@ struct SpacesParams {
     /// Per-op arguments. See command docs for shape.
     #[serde(default)]
     op_args: Option<JsonObject>,
+
+    /// Required for `search`. Keywords or natural language.
+    query: Option<String>,
+    /// `search`: optional path-prefix scope. Each entry restricts hits
+    /// to files whose path equals it or lives under it as a subtree.
+    /// Trailing slash optional. Empty / omitted = whole space. Reject
+    /// leading `/`, `..` segments, and glob metacharacters.
+    #[serde(default)]
+    paths: Option<Vec<String>>,
+    /// `search`: max number of hits (default 10).
+    #[serde(default)]
+    limit: Option<usize>,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -620,7 +638,12 @@ static TOOLS: &[ToolDef] = &[
                        (read|ls|grep|glob), `tool_args`), \
                        `write` (requires `slug`, `path`, `content`), \
                        `delete` (requires `slug`, `path`), \
-                       `move` (requires `slug`, `from`, `to`).",
+                       `move` (requires `slug`, `from`, `to`), \
+                       `search` (hybrid FTS + semantic search inside a single \
+                       space; requires `slug`, `query`; optional `paths` \
+                       (subtree prefixes; reject leading `/`, `..`, globs); \
+                       optional `limit` (default 10). Admin variant — does not \
+                       require the space to be mounted on any project).",
         schema: &SPACES_SCHEMA,
     },
 ];
@@ -633,6 +656,7 @@ pub struct AdminToolSet {
     projects: Arc<Projects>,
     spaces: Arc<AuthedSpaces>,
     space_fs: Arc<SpaceFs>,
+    search: Arc<AuthedSearch>,
     workflows: Arc<Workflows>,
     skills: Arc<Skills>,
     notes: Arc<Notes>,
@@ -647,6 +671,7 @@ impl AdminToolSet {
         projects: Arc<Projects>,
         spaces: Arc<AuthedSpaces>,
         space_fs: Arc<SpaceFs>,
+        search: Arc<AuthedSearch>,
         workflows: Arc<Workflows>,
         skills: Arc<Skills>,
         notes: Arc<Notes>,
@@ -672,6 +697,7 @@ impl AdminToolSet {
             projects,
             spaces,
             space_fs,
+            search,
             workflows,
             skills,
             notes,
@@ -1050,6 +1076,40 @@ impl AdminToolSet {
                 let op_args = params.op_args.unwrap_or_default();
                 Audit::record_action("spaces.edit");
                 dispatch_edit(&self.space_fs, subject, &slug, op, op_args).await
+            }
+
+            SpacesCommand::Search => {
+                let slug = params.slug.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("slug is required for search".to_string())
+                })?;
+                let query = params.query.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("query is required for search".to_string())
+                })?;
+                Audit::record_action("spaces.search");
+                subject
+                    .can(AuthVerb::Read, AuthResource::Space(None))
+                    .map_err(|e| ToolSetsError::Library(e.into()))?;
+                let space =
+                    self.spaces.find_by_slug(&slug).await?.ok_or_else(|| {
+                        ToolSetsError::Library(SpaceError::NotFound { slug }.into())
+                    })?;
+                let path_prefixes =
+                    SpacesTool::normalize_path_prefixes(params.paths.unwrap_or_default())?;
+                let limit = params.limit.unwrap_or(10);
+                let hits = self
+                    .search
+                    .search(
+                        subject,
+                        &[uuid::Uuid::from(space.id)],
+                        &query,
+                        &[SPACE_DOC_TYPE],
+                        &path_prefixes,
+                        limit,
+                    )
+                    .await?;
+                Ok(CallToolResult::success(vec![Content::text(
+                    format_space_search(&space, &hits),
+                )]))
             }
         }
     }
@@ -1953,6 +2013,29 @@ fn format_space(s: &Space, created: bool) -> String {
     )
 }
 
+fn format_space_search(space: &Space, hits: &[drua_library::SearchHit]) -> String {
+    if hits.is_empty() {
+        return format!("No matches in space '{}' for query.", space.slug);
+    }
+    let entries: Vec<String> = hits
+        .iter()
+        .map(|hit| {
+            let preview: String = hit.fields.content.chars().take(200).collect();
+            let path = hit.fields.path.clone().unwrap_or_default();
+            format!(
+                "path: {path}\ntitle: {}\nscore: {:.3}\npreview: {preview}",
+                hit.fields.name, hit.score,
+            )
+        })
+        .collect();
+    format!(
+        "Found {} hit(s) in space '{}':\n\n{}",
+        hits.len(),
+        space.slug,
+        entries.join("\n---\n"),
+    )
+}
+
 fn format_spaces(spaces: &[Space]) -> String {
     if spaces.is_empty() {
         return "No spaces found.".to_string();
@@ -2079,6 +2162,40 @@ mod tests {
         assert!(s.contains("\"unmount\""));
         assert!(s.contains("\"view\""));
         assert!(s.contains("\"edit\""));
+        assert!(s.contains("\"search\""));
+    }
+
+    #[test]
+    fn spaces_search_parses_minimal() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "search",
+            "slug": "oncall",
+            "query": "ha readiness",
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, SpacesCommand::Search));
+        assert_eq!(p.slug.as_deref(), Some("oncall"));
+        assert_eq!(p.query.as_deref(), Some("ha readiness"));
+        assert!(p.paths.is_none());
+        assert!(p.limit.is_none());
+    }
+
+    #[test]
+    fn spaces_search_parses_full_args() {
+        let p: SpacesParams = parse_params(args(serde_json::json!({
+            "command": "search",
+            "slug": "oncall",
+            "query": "tunnel registry",
+            "paths": ["research/", "decisions/"],
+            "limit": 25,
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, SpacesCommand::Search));
+        assert_eq!(
+            p.paths.as_deref(),
+            Some(&["research/".to_string(), "decisions/".to_string()][..])
+        );
+        assert_eq!(p.limit, Some(25));
     }
 
     #[test]

--- a/core/src/toolset/searchable/library.rs
+++ b/core/src/toolset/searchable/library.rs
@@ -6,11 +6,12 @@ use serde::Deserialize;
 
 use crate::audit::Audit;
 use crate::auth::AuthSubject;
-use crate::library::AuthedSearch;
+use crate::library::{AuthedSearch, AuthedSpaces};
 use crate::note::NOTE_DOC_TYPE;
 use crate::skill::SKILL_DOC_TYPE;
 
 use super::super::error::ToolSetsError;
+use super::super::top_level::SpacesTool;
 use super::super::traits::{SearchableToolSet, ToolSetEntry};
 
 /// Tool-shaped global search hit. Translated from `drua_library::SearchHit`
@@ -164,6 +165,22 @@ struct SearchParams {
     /// searchable types. Workflows are git-synced but not indexed.
     #[serde(default)]
     types: Option<Vec<LibraryFileType>>,
+    /// Restrict to these space slugs. Each slug resolves to a
+    /// `space_id` via the spaces resolver; unknown slugs return
+    /// `InvalidArgument`. Omit / empty = no slug filter (all spaces
+    /// the subject can read). Project-scoped skills/notes are
+    /// excluded when this filter is set unless they live inside one
+    /// of the listed spaces.
+    #[serde(default)]
+    slugs: Option<Vec<String>>,
+    /// Path-prefix scope for `space_file` hits. Each entry restricts
+    /// hits to files whose path equals it or lives under it as a
+    /// subtree. Trailing slash optional. Empty / omitted = no path
+    /// filter. Reject leading `/`, `..` segments, and glob
+    /// metacharacters. Only narrows `space_file` hits — ignored for
+    /// skill / note rows.
+    #[serde(default)]
+    paths: Option<Vec<String>>,
     /// Maximum number of results (default 50, capped at 200).
     #[serde(default = "default_search_limit")]
     limit: usize,
@@ -305,22 +322,27 @@ fn tool_entry(
 
 pub struct LibraryToolSet {
     search: Arc<AuthedSearch>,
+    spaces: Arc<AuthedSpaces>,
     tools: Vec<ToolSetEntry>,
 }
 
 impl LibraryToolSet {
-    pub fn new(search: Arc<AuthedSearch>) -> Self {
+    pub fn new(search: Arc<AuthedSearch>, spaces: Arc<AuthedSpaces>) -> Self {
         let tools = vec![
             tool_entry(
                 "search",
                 "Cross-type, cross-project library search across skills, notes, \
-                 and space files. Hybrid FTS + semantic similarity. Always \
-                 global — results span every project the subject can read. \
-                 Returns ranked snippets; `space_file` hits also carry \
-                 `space_slug` and `relative_path` so callers can route to \
-                 the file without a second lookup. Pair with `get_files` to \
-                 load full bodies. Workflows are git-synced but not \
-                 search-indexed.",
+                 and space files. Hybrid FTS + semantic similarity. Default \
+                 is global — results span every project the subject can read. \
+                 Optional `slugs` (list of space slugs) narrows to those \
+                 spaces; unknown slugs return InvalidArgument. Optional \
+                 `paths` (list of subtree prefixes; reject leading `/`, \
+                 `..`, globs) narrows `space_file` hits — ignored for \
+                 skill / note rows. Returns ranked snippets; `space_file` \
+                 hits also carry `space_slug` and `relative_path` so callers \
+                 can route to the file without a second lookup. Pair with \
+                 `get_files` to load full bodies. Workflows are git-synced \
+                 but not search-indexed.",
                 (*SEARCH_INPUT_SCHEMA).clone(),
                 (*SEARCH_OUTPUT_SCHEMA).clone(),
             ),
@@ -335,7 +357,36 @@ impl LibraryToolSet {
                 (*GET_FILES_OUTPUT_SCHEMA).clone(),
             ),
         ];
-        Self { search, tools }
+        Self {
+            search,
+            spaces,
+            tools,
+        }
+    }
+
+    async fn resolve_slugs(
+        &self,
+        slugs: Option<Vec<String>>,
+    ) -> Result<Vec<uuid::Uuid>, ToolSetsError> {
+        let Some(slugs) = slugs else {
+            return Ok(Vec::new());
+        };
+        let mut ids = Vec::with_capacity(slugs.len());
+        for slug in slugs {
+            let trimmed = slug.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            match self.spaces.find_by_slug(trimmed).await? {
+                Some(space) => ids.push(uuid::Uuid::from(space.id)),
+                None => {
+                    return Err(ToolSetsError::InvalidArgument(format!(
+                        "unknown space slug: {trimmed:?}"
+                    )))
+                }
+            }
+        }
+        Ok(ids)
     }
 
     async fn search(
@@ -357,9 +408,19 @@ impl LibraryToolSet {
             vec![SKILL_DOC_TYPE, NOTE_DOC_TYPE, SPACE_DOC_TYPE]
         };
 
+        let scope_ids = self.resolve_slugs(params.slugs).await?;
+        let path_prefixes = SpacesTool::normalize_path_prefixes(params.paths.unwrap_or_default())?;
+
         let raw = self
             .search
-            .search(subject, &[], &params.query, &doc_types, &[], limit)
+            .search(
+                subject,
+                &scope_ids,
+                &params.query,
+                &doc_types,
+                &path_prefixes,
+                limit,
+            )
             .await?;
 
         let hits: Vec<LibrarySearchHit> = raw
@@ -567,7 +628,41 @@ mod tests {
         let params: SearchParams = serde_json::from_value(json).unwrap();
         assert_eq!(params.query, "auth flow");
         assert!(params.types.is_none());
+        assert!(params.slugs.is_none());
+        assert!(params.paths.is_none());
         assert_eq!(params.limit, DEFAULT_SEARCH_LIMIT);
+    }
+
+    #[test]
+    fn parse_search_with_slugs_and_paths() {
+        let json = serde_json::json!({
+            "query": "decision",
+            "slugs": ["drua-dev", "on-call"],
+            "paths": ["decisions/", "research/"],
+        });
+        let params: SearchParams = serde_json::from_value(json).unwrap();
+        assert_eq!(
+            params.slugs.as_deref(),
+            Some(&["drua-dev".to_string(), "on-call".to_string()][..])
+        );
+        assert_eq!(
+            params.paths.as_deref(),
+            Some(&["decisions/".to_string(), "research/".to_string()][..])
+        );
+    }
+
+    #[test]
+    fn search_paths_validation_rejects_glob() {
+        let res = SpacesTool::normalize_path_prefixes(vec!["decisions/*.md".into()]);
+        assert!(matches!(res, Err(ToolSetsError::InvalidArgument(_))));
+    }
+
+    #[test]
+    fn search_input_schema_advertises_slugs_and_paths() {
+        let schema = &*SEARCH_INPUT_SCHEMA;
+        let s = schema.to_string();
+        assert!(s.contains("slugs"));
+        assert!(s.contains("paths"));
     }
 
     #[test]

--- a/core/src/toolset/searchable/library.rs
+++ b/core/src/toolset/searchable/library.rs
@@ -22,6 +22,11 @@ struct GlobalSearchHit {
     title: String,
     content: String,
     score: f64,
+    /// Set only when the hit is a `space_file` row — mirrors
+    /// `fields_to_file`'s slug attribution rule.
+    space_slug: Option<String>,
+    /// Set only when the hit is a `space_file` row.
+    relative_path: Option<String>,
 }
 
 /// Tool-shaped fetched library file. Translated from
@@ -39,12 +44,20 @@ struct LibraryFile {
 }
 
 fn hit_to_global(hit: SearchHit) -> GlobalSearchHit {
+    let is_space = hit.fields.doc_type == SPACE_DOC_TYPE;
+    let (space_slug, relative_path) = if is_space {
+        (hit.fields.scope_slug, hit.fields.path)
+    } else {
+        (None, None)
+    };
     GlobalSearchHit {
         doc_id: hit.fields.doc_id,
         doc_type: hit.fields.doc_type,
         title: hit.fields.name,
         content: hit.fields.content,
         score: hit.score,
+        space_slug,
+        relative_path,
     }
 }
 
@@ -186,6 +199,13 @@ struct LibrarySearchHit {
     snippet: String,
     score: f64,
     tags: Vec<String>,
+    /// Populated only for `space_file` hits. The space's slug.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    space_slug: Option<String>,
+    /// Populated only for `space_file` hits. The file's path inside
+    /// `spaces/<space_slug>/`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    relative_path: Option<String>,
 }
 
 impl From<GlobalSearchHit> for LibrarySearchHit {
@@ -197,6 +217,8 @@ impl From<GlobalSearchHit> for LibrarySearchHit {
             snippet: make_snippet(&hit.content, SNIPPET_CHARS),
             score: hit.score,
             tags: Vec::new(),
+            space_slug: hit.space_slug,
+            relative_path: hit.relative_path,
         }
     }
 }
@@ -291,10 +313,13 @@ impl LibraryToolSet {
         let tools = vec![
             tool_entry(
                 "search",
-                "Cross-type, cross-project library search across skills and notes. \
-                 Hybrid FTS + semantic similarity. Always global — results span every \
-                 project the subject can read. Returns ranked snippets; pair with \
-                 `get_files` to load full bodies. Workflows are git-synced but not \
+                "Cross-type, cross-project library search across skills, notes, \
+                 and space files. Hybrid FTS + semantic similarity. Always \
+                 global — results span every project the subject can read. \
+                 Returns ranked snippets; `space_file` hits also carry \
+                 `space_slug` and `relative_path` so callers can route to \
+                 the file without a second lookup. Pair with `get_files` to \
+                 load full bodies. Workflows are git-synced but not \
                  search-indexed.",
                 (*SEARCH_INPUT_SCHEMA).clone(),
                 (*SEARCH_OUTPUT_SCHEMA).clone(),
@@ -350,13 +375,16 @@ impl LibraryToolSet {
             let body = hits
                 .iter()
                 .map(|h| {
-                    format!(
-                        "[{}] {} (score {:.3})\n  {}",
-                        h.type_str(),
-                        h.title,
-                        h.score,
-                        h.snippet,
-                    )
+                    let header = match (&h.space_slug, &h.relative_path) {
+                        (Some(slug), Some(path)) => format!(
+                            "[{}] [{slug}] {path} — {} (score {:.3})",
+                            h.type_str(),
+                            h.title,
+                            h.score,
+                        ),
+                        _ => format!("[{}] {} (score {:.3})", h.type_str(), h.title, h.score,),
+                    };
+                    format!("{header}\n  {}", h.snippet)
                 })
                 .collect::<Vec<_>>()
                 .join("\n---\n");
@@ -699,5 +727,75 @@ mod tests {
     fn workflow_doc_type_collapses_to_note() {
         let lft: LibraryFileType = DocType::new("workflow").into();
         assert!(matches!(lft, LibraryFileType::Note));
+    }
+
+    fn make_hit(doc_type: DocType, scope_slug: Option<&str>, path: Option<&str>) -> SearchHit {
+        SearchHit {
+            score: 0.5,
+            fields: SearchableFields {
+                doc_id: uuid::Uuid::new_v4(),
+                doc_type,
+                scope_id: scope_slug.map(|_| uuid::Uuid::new_v4()),
+                scope_slug: scope_slug.map(str::to_string),
+                name: "title".into(),
+                path: path.map(str::to_string),
+                content: "body".into(),
+            },
+        }
+    }
+
+    #[test]
+    fn space_hit_carries_slug_and_path() {
+        let hit = make_hit(
+            SPACE_DOC_TYPE,
+            Some("drua-dev"),
+            Some("research/ha-readiness.md"),
+        );
+        let global = hit_to_global(hit);
+        assert_eq!(global.space_slug.as_deref(), Some("drua-dev"));
+        assert_eq!(
+            global.relative_path.as_deref(),
+            Some("research/ha-readiness.md")
+        );
+        let out = LibrarySearchHit::from(global);
+        assert_eq!(out.space_slug.as_deref(), Some("drua-dev"));
+        assert_eq!(
+            out.relative_path.as_deref(),
+            Some("research/ha-readiness.md")
+        );
+        let v = serde_json::to_value(&out).unwrap();
+        assert_eq!(v["space_slug"].as_str(), Some("drua-dev"));
+        assert_eq!(
+            v["relative_path"].as_str(),
+            Some("research/ha-readiness.md")
+        );
+    }
+
+    #[test]
+    fn skill_hit_omits_slug_and_path() {
+        let hit = make_hit(SKILL_DOC_TYPE, Some("project-name"), Some("skill.md"));
+        let global = hit_to_global(hit);
+        assert!(global.space_slug.is_none());
+        assert!(global.relative_path.is_none());
+        let out = LibrarySearchHit::from(global);
+        let v = serde_json::to_value(&out).unwrap();
+        assert!(!v.as_object().unwrap().contains_key("space_slug"));
+        assert!(!v.as_object().unwrap().contains_key("relative_path"));
+    }
+
+    #[test]
+    fn note_hit_omits_slug_and_path() {
+        let hit = make_hit(NOTE_DOC_TYPE, Some("project-name"), Some("note.md"));
+        let global = hit_to_global(hit);
+        assert!(global.space_slug.is_none());
+        assert!(global.relative_path.is_none());
+    }
+
+    #[test]
+    fn search_output_schema_advertises_slug_and_path() {
+        let schema = &*SEARCH_OUTPUT_SCHEMA;
+        let s = schema.to_string();
+        assert!(s.contains("space_slug"));
+        assert!(s.contains("relative_path"));
     }
 }

--- a/core/src/toolset/top_level/spaces.rs
+++ b/core/src/toolset/top_level/spaces.rs
@@ -20,43 +20,6 @@ fn default_search_limit() -> usize {
     10
 }
 
-/// Validate and normalise a caller-supplied list of path prefixes for
-/// `spaces.search`. Empty strings are silently dropped; trailing
-/// slashes are stripped (so `"triggers"` and `"triggers/"` are
-/// equivalent). Leading `/`, `..` segments, and glob metacharacters
-/// (`*`, `?`, `[`) are rejected — globs are explicitly out of scope
-/// in v1.
-fn normalize_path_prefixes(paths: Vec<String>) -> Result<Vec<String>, ToolSetsError> {
-    let mut out = Vec::with_capacity(paths.len());
-    for raw in paths {
-        let trimmed = raw.trim();
-        if trimmed.is_empty() {
-            continue;
-        }
-        if trimmed.starts_with('/') {
-            return Err(ToolSetsError::InvalidArgument(format!(
-                "spaces.search paths entry must not start with '/': {raw:?}"
-            )));
-        }
-        if trimmed.split('/').any(|seg| seg == "..") {
-            return Err(ToolSetsError::InvalidArgument(format!(
-                "spaces.search paths entry must not contain '..': {raw:?}"
-            )));
-        }
-        if trimmed.contains(['*', '?', '[']) {
-            return Err(ToolSetsError::InvalidArgument(format!(
-                "spaces.search does not support glob patterns in paths: {raw:?}"
-            )));
-        }
-        let normalized = trimmed.trim_end_matches('/');
-        if normalized.is_empty() {
-            continue;
-        }
-        out.push(normalized.to_string());
-    }
-    Ok(out)
-}
-
 #[derive(Deserialize)]
 #[serde(tag = "command", rename_all = "snake_case")]
 enum SpacesParams {
@@ -238,6 +201,45 @@ impl SpacesTool {
             space_fs,
             search,
         }
+    }
+
+    /// Validate and normalise caller-supplied path prefixes for any
+    /// space-scoped search (`spaces.search`, `drua_admin_spaces`
+    /// `search`, `library_search.paths`). Empty entries are dropped;
+    /// trailing slashes stripped. Leading `/`, `..` segments, and
+    /// glob metacharacters (`*`, `?`, `[`) are rejected — globs are
+    /// out of scope.
+    pub(crate) fn normalize_path_prefixes(
+        paths: Vec<String>,
+    ) -> Result<Vec<String>, ToolSetsError> {
+        let mut out = Vec::with_capacity(paths.len());
+        for raw in paths {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if trimmed.starts_with('/') {
+                return Err(ToolSetsError::InvalidArgument(format!(
+                    "path prefix entry must not start with '/': {raw:?}"
+                )));
+            }
+            if trimmed.split('/').any(|seg| seg == "..") {
+                return Err(ToolSetsError::InvalidArgument(format!(
+                    "path prefix entry must not contain '..': {raw:?}"
+                )));
+            }
+            if trimmed.contains(['*', '?', '[']) {
+                return Err(ToolSetsError::InvalidArgument(format!(
+                    "path prefix does not support glob patterns: {raw:?}"
+                )));
+            }
+            let normalized = trimmed.trim_end_matches('/');
+            if normalized.is_empty() {
+                continue;
+            }
+            out.push(normalized.to_string());
+        }
+        Ok(out)
     }
 }
 
@@ -422,7 +424,7 @@ impl TopLevelTool for SpacesTool {
                 limit,
             } => {
                 let space = self.projects.space_for_subject(subject, &slug).await?;
-                let path_prefixes = normalize_path_prefixes(paths)?;
+                let path_prefixes = Self::normalize_path_prefixes(paths)?;
                 let hits = self
                     .search
                     .search(
@@ -577,61 +579,65 @@ mod tests {
 
     #[test]
     fn normalize_paths_empty() {
-        assert!(normalize_path_prefixes(Vec::new()).unwrap().is_empty());
+        assert!(SpacesTool::normalize_path_prefixes(Vec::new())
+            .unwrap()
+            .is_empty());
     }
 
     #[test]
     fn normalize_paths_drops_trailing_slash() {
-        let got = normalize_path_prefixes(vec!["triggers/".into()]).unwrap();
+        let got = SpacesTool::normalize_path_prefixes(vec!["triggers/".into()]).unwrap();
         assert_eq!(got, vec!["triggers".to_string()]);
     }
 
     #[test]
     fn normalize_paths_no_trailing_slash_kept() {
-        let got = normalize_path_prefixes(vec!["triggers".into()]).unwrap();
+        let got = SpacesTool::normalize_path_prefixes(vec!["triggers".into()]).unwrap();
         assert_eq!(got, vec!["triggers".to_string()]);
     }
 
     #[test]
     fn normalize_paths_multiple_prefixes() {
-        let got = normalize_path_prefixes(vec!["triggers/".into(), "runbooks".into()]).unwrap();
+        let got = SpacesTool::normalize_path_prefixes(vec!["triggers/".into(), "runbooks".into()])
+            .unwrap();
         assert_eq!(got, vec!["triggers".to_string(), "runbooks".to_string()]);
     }
 
     #[test]
     fn normalize_paths_keeps_exact_file_path() {
-        let got = normalize_path_prefixes(vec!["triggers/account-locked.md".into()]).unwrap();
+        let got =
+            SpacesTool::normalize_path_prefixes(vec!["triggers/account-locked.md".into()]).unwrap();
         assert_eq!(got, vec!["triggers/account-locked.md".to_string()]);
     }
 
     #[test]
     fn normalize_paths_silently_drops_empty_strings() {
-        let got = normalize_path_prefixes(vec!["".into(), "  ".into()]).unwrap();
+        let got = SpacesTool::normalize_path_prefixes(vec!["".into(), "  ".into()]).unwrap();
         assert!(got.is_empty());
     }
 
     #[test]
     fn normalize_paths_bare_slash_rejected_as_leading() {
-        let err = normalize_path_prefixes(vec!["/".into()]).unwrap_err();
+        let err = SpacesTool::normalize_path_prefixes(vec!["/".into()]).unwrap_err();
         assert!(matches!(err, ToolSetsError::InvalidArgument(_)));
     }
 
     #[test]
     fn normalize_paths_rejects_leading_slash() {
-        let err = normalize_path_prefixes(vec!["/triggers".into()]).unwrap_err();
+        let err = SpacesTool::normalize_path_prefixes(vec!["/triggers".into()]).unwrap_err();
         assert!(matches!(err, ToolSetsError::InvalidArgument(_)));
     }
 
     #[test]
     fn normalize_paths_rejects_dotdot_segment() {
-        let err = normalize_path_prefixes(vec!["triggers/../etc".into()]).unwrap_err();
+        let err = SpacesTool::normalize_path_prefixes(vec!["triggers/../etc".into()]).unwrap_err();
         assert!(matches!(err, ToolSetsError::InvalidArgument(_)));
     }
 
     #[test]
     fn normalize_paths_rejects_glob_metacharacters() {
         for raw in ["triggers/*.md", "trig?ers", "trig[ab]"] {
-            let err = normalize_path_prefixes(vec![raw.into()]).unwrap_err();
+            let err = SpacesTool::normalize_path_prefixes(vec![raw.into()]).unwrap_err();
             assert!(
                 matches!(err, ToolSetsError::InvalidArgument(_)),
                 "expected InvalidArgument for {raw:?}",


### PR DESCRIPTION
Implements memory **019e0156** — _Dev-tier scoped search + slug-in-results_ — in 4 commits on a single PR.

## Why

Devs using claude-code (or any local harness) talking to drua via the MCP gateway only see the admin tier (`drua_admin_*` + `library_search` + `library_get_files`). Until now:

1. The admin spaces tool had no `search` command — no scoped indexed search inside a single space.
2. `library_search` hits dropped `scope_slug` and `path` at the toolset boundary, so callers couldn't tell which space a hit belonged to.
3. `library_search` had no way to scope to a subset of spaces or a path prefix — only "all spaces" or "fall back to single-space agent-tier search".

After this PR a dev can:

```
# Discover across all spaces, see where each hit lives
library_search { query: "ha readiness" }
  → hits[].space_slug = "drua-dev", relative_path = "research/ha-readiness.md"

# Cross-space scoped query
library_search { query: "decision",
                 slugs: ["drua-dev", "on-call"],
                 paths: ["decisions/"] }

# Single-space scoped indexed search (admin tier)
drua_admin_spaces { command: "search",
                    slug: "drua-dev",
                    query: "tunnel registry",
                    paths: ["research/"] }
```

## Commits

1. **`refactor(toolset): hoist normalize_path_prefixes onto SpacesTool`** — promote the path-prefix validator from a module-private fn to a `pub(crate)` associated fn on `SpacesTool` so admin spaces.search and library_search.paths can share it.
2. **`feat(admin): add search command to drua_admin_spaces`** (PR-1 in the memo) — surfaces the agent-tier `spaces.search` semantics on the admin tier; does not require the space to be mounted on a project.
3. **`feat(library): surface space_slug + relative_path on search hits`** (PR-2) — restore the slug + path metadata that was being discarded at the toolset boundary. `space_file` hits only; skill / note hits are unaffected.
4. **`feat(library): add slugs + paths filters to library_search`** (PR-3) — cross-space scoped query. Unknown slug → `InvalidArgument`. Path filter silently no-ops on skill / note hits, by design.

## Design clarifications (from PM)

- `normalize_path_prefixes` lives on `SpacesTool::` (not duplicated into each callsite, not on a domain type)
- PR-3 `paths` + non-`space_file` `types` collision: silent allow (matches agent-tier semantics)
- "MCP gateway discovery improvements" PR was intentionally dropped — `search_tools` / `describe_tool` auto-update from the schema changes

## Test plan

- [x] `nix flake check` passes clean (clippy `-D warnings`, fmt, nextest, sdl-rust, default-config)
- [x] New unit tests for admin `spaces.search` parsing (minimal + full args + schema enum)
- [x] New unit tests for slug + relative_path on space_file hits, omission for skill/note
- [x] New unit tests for `slugs` / `paths` parsing + path-validation reuse
- [x] All 67 `searchable` toolset tests green

Memory: 019e0156

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands admin/library search surfaces and changes `library_search` output shape, which could impact clients relying on prior schemas and introduces new scoping/validation paths tied to auth checks.
> 
> **Overview**
> Adds **space-scoped indexed search** to the admin toolset via `drua_admin_spaces` `command=search`, allowing hybrid FTS+semantic search within any space (without requiring project mounts) with optional path-prefix filtering.
> 
> Enhances `library_search` to (a) return `space_slug` + `relative_path` for `space_file` hits, and (b) accept new `slugs` and `paths` filters to scope global search to specific spaces/subtrees; unknown slugs now error.
> 
> Refactors shared path-prefix validation into `SpacesTool::normalize_path_prefixes` and wires `AuthedSearch`/`AuthedSpaces` dependencies through `LibraryToolSet::new` and `AdminToolSet::new`, with accompanying schema/parse unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0c23643bdacf2f4e6f534c1842c472ffd97ad55. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->