### PR TITLE
fix(library): drop id-postfix from workflow library paths

### DIFF
--- a/core/src/workflow/entity.rs
+++ b/core/src/workflow/entity.rs
@@ -263,13 +263,13 @@ impl drua_library::LibrarySynced for WorkflowDefinition {
             scope_id: Some(self.project_id.into()),
             scope_slug: project_name.map(str::to_string),
             name: self.name.clone(),
-            path: Some(canonical_workflow_path(self.id, &self.name, project_name)),
+            path: Some(canonical_workflow_path(&self.name, project_name)),
             content: self.description.clone().unwrap_or_default(),
         }
     }
 
     fn write_op(&self) -> WriteOp {
-        let canonical = canonical_workflow_path(self.id, &self.name, self.project_name.as_deref());
+        let canonical = canonical_workflow_path(&self.name, self.project_name.as_deref());
         let content = self.rendered().into_bytes();
         let id_uuid: uuid::Uuid = self.id.into();
         let message = format!(

--- a/core/src/workflow/yaml.rs
+++ b/core/src/workflow/yaml.rs
@@ -371,7 +371,7 @@ pub fn parse_workflow_yaml(content: &str, path: &str) -> Option<ParsedWorkflow> 
         &yaml.updated,
     );
 
-    let canonical_path = canonical_workflow_path(workflow_id, &name, project_name.as_deref());
+    let canonical_path = canonical_workflow_path(&name, project_name.as_deref());
     let needs_rewrite = !has_id || canonical_path != path;
 
     Some(ParsedWorkflow {
@@ -391,17 +391,11 @@ pub fn parse_workflow_yaml(content: &str, path: &str) -> Option<ParsedWorkflow> 
     })
 }
 
-pub fn canonical_workflow_path(
-    id: WorkflowDefinitionId,
-    name: &str,
-    project_name: Option<&str>,
-) -> String {
-    let id_uuid = uuid::Uuid::from(id);
-    let id_prefix = &id_uuid.to_string()[..8];
+pub fn canonical_workflow_path(name: &str, project_name: Option<&str>) -> String {
     let slug = slugify(name);
     match project_name {
-        Some(project) => format!("runtime/projects/{project}/workflows/{slug}-{id_prefix}.yml"),
-        None => format!("runtime/workflows/{slug}-{id_prefix}.yml"),
+        Some(project) => format!("runtime/projects/{project}/workflows/{slug}.yml"),
+        None => format!("runtime/workflows/{slug}.yml"),
     }
 }
 
@@ -480,7 +474,7 @@ mod tests {
         );
         assert!(!content.contains("whsec_should-not-be-serialized"));
 
-        let path = canonical_workflow_path(id, "alert-response", None);
+        let path = canonical_workflow_path("alert-response", None);
         let parsed = parse_workflow_yaml(&content, &path).expect("parses");
         assert!(!parsed.needs_rewrite);
 
@@ -514,7 +508,7 @@ mod tests {
             &WorkflowTrigger::Manual,
             &sample_sandboxes(),
         );
-        let path = canonical_workflow_path(id, "alert-response", None);
+        let path = canonical_workflow_path("alert-response", None);
         let parsed = parse_workflow_yaml(&content, &path).expect("parses");
         assert_eq!(parsed.sandboxes.len(), 1);
         assert_eq!(parsed.sandboxes[0].name(), "investigation");
@@ -529,12 +523,22 @@ mod tests {
 
     #[test]
     fn workflow_yaml_project_scoped_path() {
-        let id = WorkflowDefinitionId::new();
-        let id_prefix = &id.to_string()[..8];
-        let path = format!("runtime/projects/team/workflows/foo-{id_prefix}.yml");
+        let path = "runtime/projects/team/workflows/foo.yml";
         assert_eq!(
-            project_name_from_workflow_path(&path),
+            project_name_from_workflow_path(path),
             Some("team".to_string())
+        );
+    }
+
+    #[test]
+    fn canonical_workflow_path_omits_id_suffix() {
+        assert_eq!(
+            canonical_workflow_path("Hello World Workflow", Some("test")),
+            "runtime/projects/test/workflows/hello-world-workflow.yml"
+        );
+        assert_eq!(
+            canonical_workflow_path("alert-response", None),
+            "runtime/workflows/alert-response.yml"
         );
     }
 
@@ -568,7 +572,7 @@ steps:
         assert!(content.contains("schedule:"));
         assert!(content.contains("timezone: America/New_York"));
 
-        let path = canonical_workflow_path(id, "scheduled", None);
+        let path = canonical_workflow_path("scheduled", None);
         let parsed = parse_workflow_yaml(&content, &path).expect("parses");
         match parsed.trigger {
             WorkflowTrigger::Cron { schedule, timezone } => {
@@ -642,7 +646,7 @@ steps:
             content.contains("output_schema"),
             "custom schema must round-trip into the YAML"
         );
-        let path = canonical_workflow_path(id, "judge-flow", None);
+        let path = canonical_workflow_path("judge-flow", None);
         let parsed = parse_workflow_yaml(&content, &path).expect("parses");
         assert_eq!(parsed.steps.len(), 1);
         match &parsed.steps[0] {
@@ -712,7 +716,7 @@ steps:
         assert!(content.contains("type: repo"));
         assert!(content.contains("type: preexisting"));
         assert!(content.contains("config:"));
-        let path = canonical_workflow_path(id, "alert-response", None);
+        let path = canonical_workflow_path("alert-response", None);
         let parsed = parse_workflow_yaml(&content, &path).expect("parses");
         assert_eq!(parsed.sandboxes.len(), 3);
     }
@@ -731,7 +735,7 @@ steps:
         );
         assert!(content.contains("type: preexisting"));
 
-        let path = canonical_workflow_path(id, "uses-existing", None);
+        let path = canonical_workflow_path("uses-existing", None);
         let parsed = parse_workflow_yaml(&content, &path).expect("parses");
         assert_eq!(parsed.sandboxes.len(), 1);
         assert!(matches!(


### PR DESCRIPTION
## Summary
- Drops the `-{id8}` suffix from `canonical_workflow_path()` so workflows mirror the skills + notes path-identity convention (`{slug}.yml`, no UUID prefix).
- Removes the now-unused `id: WorkflowDefinitionId` parameter from `canonical_workflow_path()` and updates 3 callers.
- Adds a unit test pinning the new shape (`canonical_workflow_path_omits_id_suffix`).

## Repro (before fix)
File visible in the library during a test:
```
runtime/projects/test/workflows/hello-world-workflow-019dff58.yml
```

After fix:
```
runtime/projects/test/workflows/hello-world-workflow.yml
```

## Path-identity precedent
- Skills landed this in PR #266 + follow-up backfill (memory `019dfaa8`).
- Notes already produce no-suffix paths via `default_note_path()`.
- Workflows were the last domain still concatenating the id8 prefix.

## Breaking-change disclosure
**This is a breaking change for on-disk file layout in spaces git repos.**

- Existing workflows in production retain their suffixed `*-019dff58.yml` files in spaces git. After this lands, those files become orphans because:
  - `WorkflowDefinition::write_op()` will write to the new no-suffix path on next content event.
  - Existing workflows have `original_path = None` (set only by reverse-sync), so `WriteFileWithRename` won't fire — instead `WriteFile` writes the new path, leaving the old file orphaned.
- Acceptable for the current prod footprint (2 workflows; both will be manually deleted + recreated via the workflow tool).
- For future deploys with non-trivial workflow counts, mirror the skills/notes pattern (add `path` column to `workflow_definitions`, backfill, rely on `original_path != canonical` rename branch).

## Slug-collision policy
No new uniqueness index added. Workflow `name` is the slug source; the existing project-name index already prevents two workflows with the same name in a project, which transitively prevents path collisions (`slugify(name)` is deterministic per name).

## Migration
None. `workflow_definitions` has no `path` column — paths are computed on-the-fly via `canonical_workflow_path()`. The code change is the migration.

## Audit query (post-deploy verification)
After redeploy + re-creating the 2 prod workflows, confirm no suffixed files remain:
```
git -C <spaces-repo> ls-files 'runtime/projects/*/workflows/*-[0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f][0-9a-f].yml'
```
Should return nothing.

## Test plan
- [x] `nix flake check` passes (clippy --deny warnings, fmt, nextest, graphql-schema, default-config)
- [x] New unit test: `canonical_workflow_path_omits_id_suffix` asserts both project-scoped and global shapes
- [x] Existing 27 workflow tests pass (round-trip parse/render, cron, sandboxes, preexisting, etc.)
- [ ] Manual verification: delete + recreate the 2 prod workflows; confirm new file lands at `runtime/projects/test/workflows/hello-world-workflow.yml`

## Deferred
- Notes' path-identity migration (`20260506010000_notes_path_identity.sql`) backfilled with a `-{id8}` suffix in the fallback case. Live note rows whose `path` was filled from the `library_documents.path` projection are clean; only legacy rows that hit the fallback may still carry suffix. Not addressed here (no concrete repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)