### PR TITLE
feat(workflow): ToolStep + ${{ … }} template substitution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "antlr4rust"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "093d520274bfff7278d776f7ea12981a0a0a6f96db90964658e0f38fc6e9a6a6"
+dependencies = [
+ "better_any",
+ "bit-set",
+ "byteorder",
+ "lazy_static",
+ "murmur3",
+ "once_cell",
+ "parking_lot",
+ "typed-arena",
+ "uuid",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,6 +583,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "better_any"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4372b9543397a4b86050cc5e7ee36953edf4bac9518e8a774c2da694977fb6e4"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +695,24 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
+]
+
+[[package]]
+name = "cel"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a40f338a8c3505921000b609279775792c07cc21f97a3011578c0c5e1738ae"
+dependencies = [
+ "antlr4rust",
+ "base64 0.22.1",
+ "chrono",
+ "lazy_static",
+ "nom",
+ "pastey",
+ "regex",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1410,6 +1466,7 @@ dependencies = [
  "async-graphql",
  "async-trait",
  "base64 0.22.1",
+ "cel",
  "chacha20poly1305",
  "chrono",
  "chrono-tz",
@@ -3249,6 +3306,15 @@ dependencies = [
  "mime",
  "spin",
  "version_check",
+]
+
+[[package]]
+name = "murmur3"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a198f9589efc03f544388dfc4a19fe8af4323662b62f598b8dcfdac62c14771c"
+dependencies = [
+ "byteorder",
 ]
 
 [[package]]
@@ -6336,6 +6402,12 @@ name = "twox-hash"
 version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"

--- a/bats/library-helpers.bash
+++ b/bats/library-helpers.bash
@@ -1,0 +1,129 @@
+# Shared bats helpers for e2e tests that need an isolated library
+# upstream. Tests that load this on top of `helpers.bash` get:
+#
+# - `setup_isolated_library`: seeds a bare git repo + working clone
+#   in `$BATS_FILE_TMPDIR`, renders a per-file `drua.yml` pointing
+#   the library service at the bare repo, and starts the drua
+#   server. Each test file gets its own isolated upstream — no
+#   network dependency, no cross-run state. Tests that need an
+#   admin token call `create_test_agent` themselves (per-test or
+#   in `setup_file` after this call).
+# - `reset_library_tables`: wipes the rows that linger between
+#   test runs when `SKIP_COMPOSE=1` is set (developer iteration
+#   against a persisted PG). Always wipes `jobs` + `library_documents`;
+#   callers pass entity-specific table names as extra args.
+# - `admin_call`: dispatches a `drua_admin_<tool>` searchable tool
+#   through the top-level `call_tool` meta-tool envelope.
+#
+# Tests are expected to call `reset_library_tables …` BEFORE
+# `setup_isolated_library` (otherwise the cleanup runs against an
+# already-rebooted server's state).
+
+# Seeds a bare git repo + working clone, renders the standard
+# test-config `drua.yml`, starts the server, and mints a test agent.
+#
+# Positional args are extra directories to seed under the working
+# repo root before the initial commit. Each one gets a `.gitkeep`
+# so the bare repo's HEAD has a tree the importers can diff against.
+# Without args the working repo has just the default git scaffolding;
+# pass e.g. `spaces` for tests that exercise the spaces tool, or
+# `runtime/workflows` for tests that exercise the workflow importer.
+setup_isolated_library() {
+  UPSTREAM_REPO="$BATS_FILE_TMPDIR/upstream.git"
+  WORKING_REPO="$BATS_FILE_TMPDIR/upstream-working"
+  mkdir -p "$WORKING_REPO"
+  git init --bare --initial-branch=main "$UPSTREAM_REPO" >/dev/null
+  git -C "$WORKING_REPO" init -q -b main
+  git -C "$WORKING_REPO" config user.email test@drua
+  git -C "$WORKING_REPO" config user.name "Drua Test"
+  for seed_dir in "$@"; do
+    mkdir -p "$WORKING_REPO/$seed_dir"
+    : > "$WORKING_REPO/$seed_dir/.gitkeep"
+  done
+  git -C "$WORKING_REPO" add -A
+  git -C "$WORKING_REPO" commit -q -m "init"
+  git -C "$WORKING_REPO" remote add origin "$UPSTREAM_REPO"
+  git -C "$WORKING_REPO" push -q origin main
+
+  cat > "$BATS_FILE_TMPDIR/drua.yml" <<EOF
+server:
+  port: 4200
+  host: "0.0.0.0"
+  secure_cookies: false
+  mcp_endpoint: "http://localhost:4200/mcp"
+oauth:
+  login: github
+  github_client_id: "test-client-id"
+  github_redirect_uri: "http://localhost:4200/auth/github/callback"
+  github_allowed_teams: []
+agents:
+  default_chain:
+    primary: { name: test-model }
+  builtin_roles:
+    project_lead:
+      compaction:
+        prune_after_seconds: 600
+    agent:
+      compaction:
+        prune_after_seconds: 600
+    workflow_step_agent:
+      compaction:
+        prune_after_seconds: 600
+providers:
+  - name: openai
+    base_url: http://127.0.0.1:9
+    models:
+      - name: test-model
+        max_tokens_per_response: 1024
+        context_window_tokens: 4096
+library:
+  data_dir: "$BATS_FILE_TMPDIR/library"
+  repo_url: "file://$UPSTREAM_REPO"
+  skill_sync_interval_secs: 1
+sandbox:
+  backend:
+    provider: local
+    sandbox_spawn_cmd: "true"
+    local_repo_root: "."
+EOF
+  export DRUA_CONFIG="$BATS_FILE_TMPDIR/drua.yml"
+  start_server
+}
+
+# Reset the rows that linger between bats runs when `SKIP_COMPOSE=1`
+# is set (developer iteration). Wipes `jobs` + `library_documents`
+# unconditionally — every library-using test needs them clean — plus
+# every additional table name passed as an extra arg.
+#
+# Each extra is `DELETE FROM <table>` so call sites can list both
+# the entity table and its events table (e.g.
+# `reset_library_tables skill_events skills`).
+reset_library_tables() {
+  if [ "${SKIP_COMPOSE:-0}" != "1" ]; then return 0; fi
+  local pg="${PG_CON:-postgres://user:password@localhost:5432/drua}"
+  local -a cmd=(
+    -q
+    -c "TRUNCATE job_events, job_executions CASCADE;"
+    -c "DELETE FROM jobs;"
+    -c "DELETE FROM library_documents;"
+  )
+  local table
+  for table in "$@"; do
+    cmd+=(-c "DELETE FROM $table;")
+  done
+  psql "$pg" "${cmd[@]}" > /dev/null 2>&1 || true
+}
+
+# Dispatch a `drua_admin_<tool>` searchable tool through the
+# top-level `call_tool` meta-tool envelope. Same shape every
+# admin-tier test uses.
+admin_call() {
+  local tool_name="$1"
+  local args_json="$2"
+  local body
+  body="$(jq -nc --arg t "drua_admin_$tool_name" --argjson a "$args_json" '{
+    name: "call_tool",
+    arguments: { tool_name: $t, arguments: $a }
+  }')"
+  mcp_call "$AGENT_TOKEN" "tools/call" "$body"
+}

--- a/bats/notes.bats
+++ b/bats/notes.bats
@@ -17,90 +17,15 @@
 # observe importer side-effects via psql.
 
 load helpers
+load library-helpers
 
 setup_file() {
-  if [ "${SKIP_COMPOSE:-0}" = "1" ]; then
-    psql "${PG_CON:-postgres://user:password@localhost:5432/drua}" \
-      -q -c "TRUNCATE job_events, job_executions CASCADE;" \
-      -c "DELETE FROM jobs;" \
-      -c "DELETE FROM note_events; DELETE FROM notes;" \
-      -c "DELETE FROM library_documents;" \
-      > /dev/null 2>&1 || true
-  fi
-
-  UPSTREAM_REPO="$BATS_FILE_TMPDIR/upstream.git"
-  WORKING_REPO="$BATS_FILE_TMPDIR/upstream-working"
-  mkdir -p "$WORKING_REPO"
-  git init --bare --initial-branch=main "$UPSTREAM_REPO" >/dev/null
-  git -C "$WORKING_REPO" init -q -b main
-  git -C "$WORKING_REPO" config user.email test@drua
-  git -C "$WORKING_REPO" config user.name "Drua Test"
-  mkdir -p "$WORKING_REPO/spaces"
-  : > "$WORKING_REPO/spaces/.gitkeep"
-  git -C "$WORKING_REPO" add -A
-  git -C "$WORKING_REPO" commit -q -m "init"
-  git -C "$WORKING_REPO" remote add origin "$UPSTREAM_REPO"
-  git -C "$WORKING_REPO" push -q origin main
-
-  cat > "$BATS_FILE_TMPDIR/drua.yml" <<EOF
-server:
-  port: 4200
-  host: "0.0.0.0"
-  secure_cookies: false
-  mcp_endpoint: "http://localhost:4200/mcp"
-oauth:
-  login: github
-  github_client_id: "test-client-id"
-  github_redirect_uri: "http://localhost:4200/auth/github/callback"
-  github_allowed_teams: []
-agents:
-  default_chain:
-    primary: { name: test-model }
-  builtin_roles:
-    project_lead:
-      compaction:
-        prune_after_seconds: 600
-    agent:
-      compaction:
-        prune_after_seconds: 600
-    workflow_step_agent:
-      compaction:
-        prune_after_seconds: 600
-providers:
-  - name: openai
-    base_url: http://127.0.0.1:9
-    models:
-      - name: test-model
-        max_tokens_per_response: 1024
-        context_window_tokens: 4096
-library:
-  data_dir: "$BATS_FILE_TMPDIR/library"
-  repo_url: "file://$UPSTREAM_REPO"
-  skill_sync_interval_secs: 1
-sandbox:
-  backend:
-    provider: local
-    sandbox_spawn_cmd: "true"
-    local_repo_root: "."
-EOF
-  export DRUA_CONFIG="$BATS_FILE_TMPDIR/drua.yml"
-  start_server
+  reset_library_tables note_events notes
+  setup_isolated_library spaces
 }
 
 teardown_file() {
   stop_server
-}
-
-# Calls a searchable admin tool.
-admin_call() {
-  local tool_name="$1"
-  local args_json="$2"
-  local body
-  body="$(jq -nc --arg t "drua_admin_$tool_name" --argjson a "$args_json" '{
-    name: "call_tool",
-    arguments: { tool_name: $t, arguments: $a }
-  }')"
-  mcp_call "$AGENT_TOKEN" "tools/call" "$body"
 }
 
 # Drop a note markdown into a space via `spaces edit op=write`.

--- a/bats/skills.bats
+++ b/bats/skills.bats
@@ -18,89 +18,11 @@
 # GitHub dependency.
 
 load helpers
+load library-helpers
 
 setup_file() {
-  # When sharing PG with other tests / repeated runs (SKIP_COMPOSE),
-  # `spawn_unique` on `library.sync` from a prior run leaves a stale
-  # row in `jobs` that prevents the job from re-queuing — so the
-  # importer never runs. Wipe the prior library/job state before
-  # the server boots. Skill / project rows from prior test cycles
-  # also linger; clean them to avoid name-uniqueness collisions.
-  if [ "${SKIP_COMPOSE:-0}" = "1" ]; then
-    psql "${PG_CON:-postgres://user:password@localhost:5432/drua}" \
-      -q -c "TRUNCATE job_events, job_executions CASCADE;" \
-      -c "DELETE FROM jobs;" \
-      -c "DELETE FROM skill_events; DELETE FROM skills;" \
-      -c "DELETE FROM library_documents;" \
-      > /dev/null 2>&1 || true
-  fi
-
-  # Stand up an isolated upstream library — a bare git repo seeded with
-  # one commit on `main`. The library service clones from this; writes
-  # flow back via git push (which works on the bare repo).
-  UPSTREAM_REPO="$BATS_FILE_TMPDIR/upstream.git"
-  WORKING_REPO="$BATS_FILE_TMPDIR/upstream-working"
-  mkdir -p "$WORKING_REPO"
-  git init --bare --initial-branch=main "$UPSTREAM_REPO" >/dev/null
-  git -C "$WORKING_REPO" init -q -b main
-  git -C "$WORKING_REPO" config user.email test@drua
-  git -C "$WORKING_REPO" config user.name "Drua Test"
-  # Spaces live at the repo root (`spaces/<slug>/...`) — not under
-  # `runtime/`. Seed the directory so the bare repo's HEAD has a tree
-  # the importer can diff against.
-  mkdir -p "$WORKING_REPO/spaces"
-  : > "$WORKING_REPO/spaces/.gitkeep"
-  git -C "$WORKING_REPO" add -A
-  git -C "$WORKING_REPO" commit -q -m "init"
-  git -C "$WORKING_REPO" remote add origin "$UPSTREAM_REPO"
-  git -C "$WORKING_REPO" push -q origin main
-
-  # Render a per-file drua.yml pointing at the upstream + an isolated
-  # data_dir. `skill_sync_interval_secs: 1` makes the importer tick
-  # every second so polls finish quickly.
-  cat > "$BATS_FILE_TMPDIR/drua.yml" <<EOF
-server:
-  port: 4200
-  host: "0.0.0.0"
-  secure_cookies: false
-  mcp_endpoint: "http://localhost:4200/mcp"
-oauth:
-  login: github
-  github_client_id: "test-client-id"
-  github_redirect_uri: "http://localhost:4200/auth/github/callback"
-  github_allowed_teams: []
-agents:
-  default_chain:
-    primary: { name: test-model }
-  builtin_roles:
-    project_lead:
-      compaction:
-        prune_after_seconds: 600
-    agent:
-      compaction:
-        prune_after_seconds: 600
-    workflow_step_agent:
-      compaction:
-        prune_after_seconds: 600
-providers:
-  - name: openai
-    base_url: http://127.0.0.1:9
-    models:
-      - name: test-model
-        max_tokens_per_response: 1024
-        context_window_tokens: 4096
-library:
-  data_dir: "$BATS_FILE_TMPDIR/library"
-  repo_url: "file://$UPSTREAM_REPO"
-  skill_sync_interval_secs: 1
-sandbox:
-  backend:
-    provider: local
-    sandbox_spawn_cmd: "true"
-    local_repo_root: "."
-EOF
-  export DRUA_CONFIG="$BATS_FILE_TMPDIR/drua.yml"
-  start_server
+  reset_library_tables skill_events skills
+  setup_isolated_library spaces
 }
 
 teardown_file() {
@@ -117,21 +39,6 @@ render_skill_md() {
   local body="$4"
   printf -- '---\nid: %s\nname: "%s"\ndescription: "%s"\ncreated: \nupdated: \n---\n\n%s\n' \
     "$id" "$name" "$description" "$body"
-}
-
-# Calls a searchable admin tool. The MCP gateway exposes admin tools
-# under the `drua_admin_<tool>` prefixed name dispatched through the
-# top-level `call_tool` meta-tool — same shape as other searchable
-# toolsets (honeycomb, github, etc.).
-admin_call() {
-  local tool_name="$1"
-  local args_json="$2"
-  local body
-  body="$(jq -nc --arg t "drua_admin_$tool_name" --argjson a "$args_json" '{
-    name: "call_tool",
-    arguments: { tool_name: $t, arguments: $a }
-  }')"
-  mcp_call "$AGENT_TOKEN" "tools/call" "$body"
 }
 
 # Drop a skill markdown file into a space via `spaces edit op=write`.

--- a/bats/workflow.bats
+++ b/bats/workflow.bats
@@ -135,6 +135,12 @@ extract_id_field() {
   local run_id_from_step1
   run_id_from_step1="$(echo "$step1_output" | jq -r '.workflow_run_id')"
   [ "$run_id_from_step1" = "$run_id" ]
+  # Definition id is part of the WorkflowExecutor identity — audit
+  # + observability link the dispatch back without a join through
+  # `workflow_runs`.
+  local def_id_from_step1
+  def_id_from_step1="$(echo "$step1_output" | jq -r '.workflow_definition_id')"
+  [ "$def_id_from_step1" = "$def_id" ]
 
   # 7. Step 2 (notes store) — proves that `${{ trigger.* }}` and
   #    `${{ steps.<n>.outputs.* }}` references substituted at run

--- a/bats/workflow.bats
+++ b/bats/workflow.bats
@@ -19,108 +19,18 @@
 # tool_step path.
 
 load helpers
+load library-helpers
 
 setup_file() {
-  # When sharing PG with other tests / repeated runs (SKIP_COMPOSE),
-  # `spawn_unique` on `library.sync` from a prior run leaves a stale
-  # row in `jobs` that prevents the job from re-queuing — so the
-  # importer never runs. Wipe the prior library/job state before the
-  # server boots. Workflow rows from prior cycles also linger;
-  # clean them to avoid name-uniqueness collisions on the
-  # `(project_id, name)` index.
-  if [ "${SKIP_COMPOSE:-0}" = "1" ]; then
-    psql "${PG_CON:-postgres://user:password@localhost:5432/drua}" \
-      -q -c "TRUNCATE job_events, job_executions CASCADE;" \
-      -c "DELETE FROM jobs;" \
-      -c "DELETE FROM workflow_run_events; DELETE FROM workflow_runs;" \
-      -c "DELETE FROM workflow_definition_events; DELETE FROM workflow_definitions;" \
-      -c "DELETE FROM library_documents;" \
-      > /dev/null 2>&1 || true
-  fi
-
-  # Stand up an isolated upstream library — a bare git repo seeded
-  # with one commit on `main`. Workflow creation through the admin
-  # MCP triggers a reverse-sync write into the library, so the
-  # service needs a writable upstream; the bare repo handles that.
-  # Same shape as `bats/skills.bats` so the two patterns stay
-  # interchangeable.
-  UPSTREAM_REPO="$BATS_FILE_TMPDIR/upstream.git"
-  WORKING_REPO="$BATS_FILE_TMPDIR/upstream-working"
-  mkdir -p "$WORKING_REPO"
-  git init --bare --initial-branch=main "$UPSTREAM_REPO" >/dev/null
-  git -C "$WORKING_REPO" init -q -b main
-  git -C "$WORKING_REPO" config user.email test@drua
-  git -C "$WORKING_REPO" config user.name "Drua Test"
-  # Seed an empty `runtime/workflows/` so the bare repo's HEAD has a
-  # tree the workflow importer can diff against without complaining.
-  mkdir -p "$WORKING_REPO/runtime/workflows"
-  : > "$WORKING_REPO/runtime/workflows/.gitkeep"
-  git -C "$WORKING_REPO" add -A
-  git -C "$WORKING_REPO" commit -q -m "init"
-  git -C "$WORKING_REPO" remote add origin "$UPSTREAM_REPO"
-  git -C "$WORKING_REPO" push -q origin main
-
-  cat > "$BATS_FILE_TMPDIR/drua.yml" <<EOF
-server:
-  port: 4200
-  host: "0.0.0.0"
-  secure_cookies: false
-  mcp_endpoint: "http://localhost:4200/mcp"
-oauth:
-  login: github
-  github_client_id: "test-client-id"
-  github_redirect_uri: "http://localhost:4200/auth/github/callback"
-  github_allowed_teams: []
-agents:
-  default_chain:
-    primary: { name: test-model }
-  builtin_roles:
-    project_lead:
-      compaction:
-        prune_after_seconds: 600
-    agent:
-      compaction:
-        prune_after_seconds: 600
-    workflow_step_agent:
-      compaction:
-        prune_after_seconds: 600
-providers:
-  - name: openai
-    base_url: http://127.0.0.1:9
-    models:
-      - name: test-model
-        max_tokens_per_response: 1024
-        context_window_tokens: 4096
-library:
-  data_dir: "$BATS_FILE_TMPDIR/library"
-  repo_url: "file://$UPSTREAM_REPO"
-  skill_sync_interval_secs: 1
-sandbox:
-  backend:
-    provider: local
-    sandbox_spawn_cmd: "true"
-    local_repo_root: "."
-EOF
-  export DRUA_CONFIG="$BATS_FILE_TMPDIR/drua.yml"
-  start_server
+  reset_library_tables \
+    workflow_run_events workflow_runs \
+    workflow_definition_events workflow_definitions
+  setup_isolated_library runtime/workflows
   create_test_agent
 }
 
 teardown_file() {
   stop_server
-}
-
-# Same admin-tier dispatch helper skills.bats uses — wraps
-# `drua_admin_<tool>` in the `call_tool` meta-tool envelope.
-admin_call() {
-  local tool_name="$1"
-  local args_json="$2"
-  local body
-  body="$(jq -nc --arg t "drua_admin_$tool_name" --argjson a "$args_json" '{
-    name: "call_tool",
-    arguments: { tool_name: $t, arguments: $a }
-  }')"
-  mcp_call "$AGENT_TOKEN" "tools/call" "$body"
 }
 
 # Admin tier renders `id: <uuid>` on a stable line in the create

--- a/bats/workflow.bats
+++ b/bats/workflow.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+
+# End-to-end glue test for `WorkflowStepDef::ToolStep`.
+#
+# Drives the full dispatch path with no LLM round-trips and no agent
+# steps:
+#
+#   1. admin `workflow create` lands a manual-trigger workflow with a
+#      single tool_step calling `whoami` (composable, declares an
+#      `output_schema`, returns deterministic structured content).
+#   2. admin `workflow trigger` spawns a run with a payload.
+#   3. admin `workflow await_run` blocks until terminal and surfaces
+#      the per-step structured outputs.
+#
+# The executor mints `AuthSubject::WorkflowExecutor(project_id, run_id)`
+# at dispatch time; `whoami` introspects the subject and writes the
+# resulting identity into its `structured_content`. Asserting that
+# field proves the new variant is wired through every layer of the
+# tool_step path.
+
+load helpers
+
+setup_file() {
+  start_server
+  create_test_agent
+}
+
+teardown_file() {
+  stop_server
+}
+
+# Same admin-tier dispatch helper skills.bats uses — wraps
+# `drua_admin_<tool>` in the `call_tool` meta-tool envelope.
+admin_call() {
+  local tool_name="$1"
+  local args_json="$2"
+  local body
+  body="$(jq -nc --arg t "drua_admin_$tool_name" --argjson a "$args_json" '{
+    name: "call_tool",
+    arguments: { tool_name: $t, arguments: $a }
+  }')"
+  mcp_call "$AGENT_TOKEN" "tools/call" "$body"
+}
+
+# Admin tier renders `id: <uuid>` on a stable line in the create
+# response's text body.
+extract_id_field() {
+  echo "$1" \
+    | jq -r '.result.content[0].text' \
+    | grep -oE '\bid: [0-9a-f-]+' \
+    | head -n1 \
+    | awk '{print $2}'
+}
+
+@test "workflow: tool_step dispatches whoami and surfaces workflow_executor identity" {
+  # Unique-per-run names so re-runs against a persisted PG (developer
+  # iteration with SKIP_COMPOSE=1) don't collide.
+  local suffix
+  suffix="$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)"
+  local proj_name="proj-toolstep-$suffix"
+
+  # 1. Project (auto-creates the lead agent).
+  run graphql_query "mutation { projectCreate(input: { name: \"$proj_name\" }) { project { id } } }" "$AGENT_TOKEN"
+  echo "$output"
+  local project_id
+  project_id="$(echo "$output" | jq -r '.data.projectCreate.project.id')"
+  [ -n "$project_id" ] && [ "$project_id" != "null" ]
+
+  # 2. Manual-trigger workflow with a single tool_step calling `whoami`.
+  #    `manual: true` keeps the trigger surface tiny — `trigger` /
+  #    `await_run` fire it directly without a webhook.
+  run admin_call "workflow" "$(jq -nc --arg pid "$project_id" '{
+    command: "create",
+    project_id: $pid,
+    name: "tool-step-whoami",
+    manual: true,
+    steps: [
+      { type: "tool_step", name: "identify", tool: "whoami", params: {} }
+    ]
+  }')"
+  echo "$output"
+  local def_id
+  def_id="$(extract_id_field "$output")"
+  [ -n "$def_id" ] || { echo "could not extract definition id"; return 1; }
+
+  # 3. Trigger a run with a payload.
+  run admin_call "workflow" "$(jq -nc --arg did "$def_id" '{
+    command: "trigger",
+    definition_id: $did,
+    payload: { build: 1234, pipeline: "galoy-bank" }
+  }')"
+  echo "$output"
+  local run_id
+  run_id="$(extract_id_field "$output")"
+  [ -n "$run_id" ] || { echo "could not extract run id"; return 1; }
+
+  # 4. Block until terminal and surface step outputs in the response.
+  run admin_call "workflow" "$(jq -nc --arg rid "$run_id" '{
+    command: "await_run",
+    run_id: $rid,
+    timeout_seconds: 60
+  }')"
+  echo "$output"
+  [[ "$output" == *"state: succeeded"* ]]
+
+  # 5. Pull the run's structured step output out of the
+  #    JSON-in-JSON envelope and assert against the parsed shape.
+  #    The synthesised identity must report the workflow_executor
+  #    variant, this project's id, and the implicit `ProjectAdmin`
+  #    scope minted by `AuthSubject::workflow_executor`.
+  local step_output
+  step_output="$(echo "$output" \
+    | jq -r '.result.content[0].text' \
+    | sed -n 's/^[[:space:]]*output: //p' \
+    | head -n1)"
+  echo "step output JSON: $step_output"
+  [ "$(echo "$step_output" | jq -r '.type')" = "workflow_executor" ]
+  [ "$(echo "$step_output" | jq -r '.project_id')" = "$project_id" ]
+  [[ "$(echo "$step_output" | jq -r '.scopes[]')" == *"project:$project_id:admin"* ]]
+
+  # 6. Read-back path: `run` after the run is already terminal must
+  #    surface the same step output shape.
+  run admin_call "workflow" "$(jq -nc --arg rid "$run_id" '{
+    command: "run", run_id: $rid
+  }')"
+  echo "$output"
+  [[ "$output" == *"state: succeeded"* ]]
+  [[ "$output" == *"workflow_executor"* ]]
+}

--- a/bats/workflow.bats
+++ b/bats/workflow.bats
@@ -241,4 +241,10 @@ extract_id_field() {
   # leaking through. That phrase must NOT appear.
   [[ "$output" != *"boolean \`false\`"* ]]
   [[ "$output" != *"boolean false"* ]]
+  # Error must surface the template-substitution trace so the
+  # author can immediately see WHICH `${{ … }}` reference produced
+  # the null. Asserts the path annotation + the actual ref body.
+  [[ "$output" == *"template substitutions"* ]]
+  [[ "$output" == *".tags[0]"* ]]
+  [[ "$output" == *"trigger.payload.pipeline"* ]]
 }

--- a/bats/workflow.bats
+++ b/bats/workflow.bats
@@ -21,6 +21,87 @@
 load helpers
 
 setup_file() {
+  # When sharing PG with other tests / repeated runs (SKIP_COMPOSE),
+  # `spawn_unique` on `library.sync` from a prior run leaves a stale
+  # row in `jobs` that prevents the job from re-queuing — so the
+  # importer never runs. Wipe the prior library/job state before the
+  # server boots. Workflow rows from prior cycles also linger;
+  # clean them to avoid name-uniqueness collisions on the
+  # `(project_id, name)` index.
+  if [ "${SKIP_COMPOSE:-0}" = "1" ]; then
+    psql "${PG_CON:-postgres://user:password@localhost:5432/drua}" \
+      -q -c "TRUNCATE job_events, job_executions CASCADE;" \
+      -c "DELETE FROM jobs;" \
+      -c "DELETE FROM workflow_run_events; DELETE FROM workflow_runs;" \
+      -c "DELETE FROM workflow_definition_events; DELETE FROM workflow_definitions;" \
+      -c "DELETE FROM library_documents;" \
+      > /dev/null 2>&1 || true
+  fi
+
+  # Stand up an isolated upstream library — a bare git repo seeded
+  # with one commit on `main`. Workflow creation through the admin
+  # MCP triggers a reverse-sync write into the library, so the
+  # service needs a writable upstream; the bare repo handles that.
+  # Same shape as `bats/skills.bats` so the two patterns stay
+  # interchangeable.
+  UPSTREAM_REPO="$BATS_FILE_TMPDIR/upstream.git"
+  WORKING_REPO="$BATS_FILE_TMPDIR/upstream-working"
+  mkdir -p "$WORKING_REPO"
+  git init --bare --initial-branch=main "$UPSTREAM_REPO" >/dev/null
+  git -C "$WORKING_REPO" init -q -b main
+  git -C "$WORKING_REPO" config user.email test@drua
+  git -C "$WORKING_REPO" config user.name "Drua Test"
+  # Seed an empty `runtime/workflows/` so the bare repo's HEAD has a
+  # tree the workflow importer can diff against without complaining.
+  mkdir -p "$WORKING_REPO/runtime/workflows"
+  : > "$WORKING_REPO/runtime/workflows/.gitkeep"
+  git -C "$WORKING_REPO" add -A
+  git -C "$WORKING_REPO" commit -q -m "init"
+  git -C "$WORKING_REPO" remote add origin "$UPSTREAM_REPO"
+  git -C "$WORKING_REPO" push -q origin main
+
+  cat > "$BATS_FILE_TMPDIR/drua.yml" <<EOF
+server:
+  port: 4200
+  host: "0.0.0.0"
+  secure_cookies: false
+  mcp_endpoint: "http://localhost:4200/mcp"
+oauth:
+  login: github
+  github_client_id: "test-client-id"
+  github_redirect_uri: "http://localhost:4200/auth/github/callback"
+  github_allowed_teams: []
+agents:
+  default_chain:
+    primary: { name: test-model }
+  builtin_roles:
+    project_lead:
+      compaction:
+        prune_after_seconds: 600
+    agent:
+      compaction:
+        prune_after_seconds: 600
+    workflow_step_agent:
+      compaction:
+        prune_after_seconds: 600
+providers:
+  - name: openai
+    base_url: http://127.0.0.1:9
+    models:
+      - name: test-model
+        max_tokens_per_response: 1024
+        context_window_tokens: 4096
+library:
+  data_dir: "$BATS_FILE_TMPDIR/library"
+  repo_url: "file://$UPSTREAM_REPO"
+  skill_sync_interval_secs: 1
+sandbox:
+  backend:
+    provider: local
+    sandbox_spawn_cmd: "true"
+    local_repo_root: "."
+EOF
+  export DRUA_CONFIG="$BATS_FILE_TMPDIR/drua.yml"
   start_server
   create_test_agent
 }

--- a/bats/workflow.bats
+++ b/bats/workflow.bats
@@ -75,7 +75,7 @@ extract_id_field() {
       { type: "tool_step", name: "identify", tool: "whoami", params: {} },
       {
         type: "tool_step",
-        name: "store-note",
+        name: "store_note",
         tool: "notes",
         params: {
           command: "store",
@@ -199,7 +199,7 @@ extract_id_field() {
       { type: "tool_step", name: "identify", tool: "whoami", params: {} },
       {
         type: "tool_step",
-        name: "store-note",
+        name: "store_note",
         tool: "notes",
         params: {
           command: "store",

--- a/bats/workflow.bats
+++ b/bats/workflow.bats
@@ -157,3 +157,88 @@ extract_id_field() {
   [[ "$output" == *"state: succeeded"* ]]
   [[ "$output" == *"workflow_executor"* ]]
 }
+
+@test "workflow: null trigger payload doesn't leak Bool(false) into substituted params" {
+  # Regression test for a bug surfaced by a manual run with no
+  # payload: CEL's `null.field` evaluates to `Bool(false)` rather
+  # than raising `NoSuchKey`, so `${{ trigger.payload.X }}` got
+  # spliced as `false` and the consuming tool's deserializer
+  # exploded with `expected a string, got boolean false`.
+  #
+  # Fix coerces non-object trigger payloads to an empty object
+  # before binding so the resolver's normal missing-key →
+  # null path runs unchanged. The downstream step still errors
+  # (notes' tags are `Vec<String>` and reject null), but the
+  # error now names the right thing — `null` instead of the
+  # mysterious `false`. This test asserts both: the run errors
+  # cleanly, and the error mentions `null` rather than `boolean`.
+
+  local suffix
+  suffix="$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)"
+  local proj_name="proj-toolstep-null-$suffix"
+
+  run graphql_query "mutation { projectCreate(input: { name: \"$proj_name\" }) { project { id } } }" "$AGENT_TOKEN"
+  local project_id
+  project_id="$(echo "$output" | jq -r '.data.projectCreate.project.id')"
+  [ -n "$project_id" ] && [ "$project_id" != "null" ]
+
+  # Same workflow shape as the happy-path test — depends on
+  # `${{ trigger.payload.* }}` for content and tags.
+  run admin_call "workflow" "$(jq -nc --arg pid "$project_id" '{
+    command: "create",
+    project_id: $pid,
+    name: "tool-step-null",
+    manual: true,
+    steps: [
+      { type: "tool_step", name: "identify", tool: "whoami", params: {} },
+      {
+        type: "tool_step",
+        name: "store-note",
+        tool: "notes",
+        params: {
+          command: "store",
+          title: "run-${{ steps.identify.outputs.workflow_run_id }}",
+          content: "Build ${{ trigger.payload.build }} on ${{ trigger.payload.pipeline }}",
+          tags: [
+            "${{ trigger.payload.pipeline }}",
+            "build-${{ trigger.payload.build }}"
+          ]
+        }
+      }
+    ]
+  }')"
+  echo "$output"
+  local def_id
+  def_id="$(extract_id_field "$output")"
+  [ -n "$def_id" ] || { echo "could not extract definition id"; return 1; }
+
+  # Trigger with NO payload — admin accepts a missing `payload`
+  # field; the run lands with `trigger_context: null`.
+  run admin_call "workflow" "$(jq -nc --arg did "$def_id" '{
+    command: "trigger",
+    definition_id: $did
+  }')"
+  echo "$output"
+  local run_id
+  run_id="$(extract_id_field "$output")"
+  [ -n "$run_id" ] || { echo "could not extract run id"; return 1; }
+
+  run admin_call "workflow" "$(jq -nc --arg rid "$run_id" '{
+    command: "await_run",
+    run_id: $rid,
+    timeout_seconds: 60
+  }')"
+  echo "$output"
+  # Step 1 (whoami, no payload deps) should succeed. Step 2
+  # (notes, depends on missing payload fields) errors — but
+  # cleanly, with `null`, not `false`. The run rolls up to
+  # `errored`.
+  [[ "$output" == *"state: errored"* ]]
+  [[ "$output" == *"workflow_executor"* ]]
+  [[ "$output" == *"expected a string"* ]]
+  [[ "$output" == *"null"* ]]
+  # Regression assertion: the original symptom was `boolean false`
+  # leaking through. That phrase must NOT appear.
+  [[ "$output" != *"boolean \`false\`"* ]]
+  [[ "$output" != *"boolean false"* ]]
+}

--- a/bats/workflow.bats
+++ b/bats/workflow.bats
@@ -66,16 +66,36 @@ extract_id_field() {
   project_id="$(echo "$output" | jq -r '.data.projectCreate.project.id')"
   [ -n "$project_id" ] && [ "$project_id" != "null" ]
 
-  # 2. Manual-trigger workflow with a single tool_step calling `whoami`.
-  #    `manual: true` keeps the trigger surface tiny — `trigger` /
-  #    `await_run` fire it directly without a webhook.
+  # 2. Manual-trigger workflow with two tool_steps. Step 1 calls
+  #    `whoami` to surface the synthesised auth subject; step 2
+  #    interpolates the trigger payload AND step 1's output into a
+  #    `notes store` call. The second step exists specifically to
+  #    exercise `${{ trigger.* }}` and `${{ steps.<n>.outputs.* }}`
+  #    substitution at runtime — the resulting note's `title` and
+  #    `tags` are surfaced in the step's structured output, which
+  #    `format_run` echoes back so the assertions below can grep
+  #    for the substituted values.
   run admin_call "workflow" "$(jq -nc --arg pid "$project_id" '{
     command: "create",
     project_id: $pid,
     name: "tool-step-whoami",
     manual: true,
     steps: [
-      { type: "tool_step", name: "identify", tool: "whoami", params: {} }
+      { type: "tool_step", name: "identify", tool: "whoami", params: {} },
+      {
+        type: "tool_step",
+        name: "store-note",
+        tool: "notes",
+        params: {
+          command: "store",
+          title: "run-${{ steps.identify.outputs.workflow_run_id }}",
+          content: "Build ${{ trigger.payload.build }} on ${{ trigger.payload.pipeline }} acked by ${{ steps.identify.outputs.type }}",
+          tags: [
+            "${{ trigger.payload.pipeline }}",
+            "build-${{ trigger.payload.build }}"
+          ]
+        }
+      }
     ]
   }')"
   echo "$output"
@@ -103,23 +123,42 @@ extract_id_field() {
   echo "$output"
   [[ "$output" == *"state: succeeded"* ]]
 
-  # 5. Pull the run's structured step output out of the
-  #    JSON-in-JSON envelope and assert against the parsed shape.
-  #    The synthesised identity must report the workflow_executor
-  #    variant, this project's id, and the implicit `ProjectAdmin`
-  #    scope minted by `AuthSubject::workflow_executor`.
-  local step_output
-  step_output="$(echo "$output" \
-    | jq -r '.result.content[0].text' \
-    | sed -n 's/^[[:space:]]*output: //p' \
-    | head -n1)"
-  echo "step output JSON: $step_output"
-  [ "$(echo "$step_output" | jq -r '.type')" = "workflow_executor" ]
-  [ "$(echo "$step_output" | jq -r '.project_id')" = "$project_id" ]
-  [[ "$(echo "$step_output" | jq -r '.scopes[]')" == *"project:$project_id:admin"* ]]
+  # 5. Pull each step's structured output out of `format_run`'s
+  #    inline-JSON envelope. `format_run` emits one
+  #    `      output: { … }` line per step; sed peels them off in
+  #    declaration order.
+  local outputs_text
+  outputs_text="$(echo "$output" | jq -r '.result.content[0].text')"
+  local step1_output step2_output
+  step1_output="$(echo "$outputs_text" | sed -n 's/^[[:space:]]*output: //p' | sed -n '1p')"
+  step2_output="$(echo "$outputs_text" | sed -n 's/^[[:space:]]*output: //p' | sed -n '2p')"
+  echo "step1 output: $step1_output"
+  echo "step2 output: $step2_output"
 
-  # 6. Read-back path: `run` after the run is already terminal must
-  #    surface the same step output shape.
+  # 6. Step 1 (whoami) — synthesised identity must report the
+  #    workflow_executor variant, this project's id, and the implicit
+  #    `ProjectAdmin` scope minted by `AuthSubject::workflow_executor`.
+  [ "$(echo "$step1_output" | jq -r '.type')" = "workflow_executor" ]
+  [ "$(echo "$step1_output" | jq -r '.project_id')" = "$project_id" ]
+  [[ "$(echo "$step1_output" | jq -r '.scopes[]')" == *"project:$project_id:admin"* ]]
+  local run_id_from_step1
+  run_id_from_step1="$(echo "$step1_output" | jq -r '.workflow_run_id')"
+  [ "$run_id_from_step1" = "$run_id" ]
+
+  # 7. Step 2 (notes store) — proves that `${{ trigger.* }}` and
+  #    `${{ steps.<n>.outputs.* }}` references substituted at run
+  #    time. The stored note's title and tags surface in the step's
+  #    structured output; the title carries the cross-step run_id
+  #    reference, the tags carry the trigger payload (one as a
+  #    whole-string splice, one as embedded interpolation).
+  [ "$(echo "$step2_output" | jq -r '.title')" = "run-$run_id" ]
+  local tags
+  tags="$(echo "$step2_output" | jq -r '.tags | join(",")')"
+  [[ "$tags" == *"galoy-bank"* ]]
+  [[ "$tags" == *"build-1234"* ]]
+
+  # 8. Read-back path: `run` after the run is already terminal must
+  #    surface the same shape.
   run admin_call "workflow" "$(jq -nc --arg rid "$run_id" '{
     command: "run", run_id: $rid
   }')"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -18,6 +18,7 @@ openai-client = { workspace = true }
 anyhow = { workspace = true }
 async-trait = "0.1"
 base64 = "0.22"
+cel = { version = "0.13", features = ["json"] }
 chacha20poly1305 = "0.10"
 concourse-client = { workspace = true }
 zenduty-client = { workspace = true }

--- a/core/src/audit/mod.rs
+++ b/core/src/audit/mod.rs
@@ -58,6 +58,10 @@ impl Audit {
                 Self::set_resource_id(ctx, "project_id", *project_id);
                 ctx.on_behalf_of_user_id = Some(*user_id);
             }
+            AuthSubject::WorkflowExecutor(project_id, run_id, _) => {
+                Self::set_resource_id(ctx, "project_id", *project_id);
+                Self::set_resource_id(ctx, "workflow_run_id", *run_id);
+            }
             AuthSubject::Anonymous => {}
         });
     }

--- a/core/src/audit/mod.rs
+++ b/core/src/audit/mod.rs
@@ -58,8 +58,9 @@ impl Audit {
                 Self::set_resource_id(ctx, "project_id", *project_id);
                 ctx.on_behalf_of_user_id = Some(*user_id);
             }
-            AuthSubject::WorkflowExecutor(project_id, run_id, _) => {
+            AuthSubject::WorkflowExecutor(project_id, definition_id, run_id, _) => {
                 Self::set_resource_id(ctx, "project_id", *project_id);
+                Self::set_resource_id(ctx, "workflow_id", *definition_id);
                 Self::set_resource_id(ctx, "workflow_run_id", *run_id);
             }
             AuthSubject::Anonymous => {}

--- a/core/src/auth/subject.rs
+++ b/core/src/auth/subject.rs
@@ -1,6 +1,7 @@
 use super::{error::AuthorizationError, AuthResource, AuthScope, AuthVerb};
 use crate::primitives::{
-    AgentId, McpCredsId, ProjectId, SandboxId, UserId, UserMessageSource, WorkflowRunId,
+    AgentId, McpCredsId, ProjectId, SandboxId, UserId, UserMessageSource, WorkflowDefinitionId,
+    WorkflowRunId,
 };
 
 /// Authentication subject resolved from session or bearer token.
@@ -16,8 +17,16 @@ pub enum AuthSubject {
     /// Workflow executor invoking a top-level tool from a `ToolStep`.
     /// Carries `ProjectAdmin(project_id)` scope so the step can act
     /// on any resource the workflow's project covers. Distinct from
-    /// `Agent` so audit + visibility paths can tell them apart.
-    WorkflowExecutor(ProjectId, WorkflowRunId, Vec<AuthScope>),
+    /// `Agent` so audit + visibility paths can tell them apart. Both
+    /// the definition id and the run id are part of the identity so
+    /// audit trails and observability link the dispatch back to the
+    /// definition without a second DB hop.
+    WorkflowExecutor(
+        ProjectId,
+        WorkflowDefinitionId,
+        WorkflowRunId,
+        Vec<AuthScope>,
+    ),
     Anonymous,
 }
 
@@ -44,7 +53,9 @@ impl AuthSubject {
             AuthSubject::ExportedAgent(_, _, _) => Err("ExportedAgent auth not allowed here"),
             AuthSubject::Agent(_, _, _) => Err("Agent auth not allowed here"),
             AuthSubject::AgentOnBehalfOfUser(_, _, _, _) => Err("Agent auth not allowed here"),
-            AuthSubject::WorkflowExecutor(_, _, _) => Err("WorkflowExecutor auth not allowed here"),
+            AuthSubject::WorkflowExecutor(_, _, _, _) => {
+                Err("WorkflowExecutor auth not allowed here")
+            }
             AuthSubject::Anonymous => Err("Authentication required"),
         }
     }
@@ -56,7 +67,7 @@ impl AuthSubject {
             AuthSubject::ExportedAgent(user_id, _, _) => Some(*user_id),
             AuthSubject::AgentOnBehalfOfUser(user_id, _, _, _) => Some(*user_id),
             AuthSubject::Agent(_, _, _)
-            | AuthSubject::WorkflowExecutor(_, _, _)
+            | AuthSubject::WorkflowExecutor(_, _, _, _)
             | AuthSubject::Anonymous => None,
         }
     }
@@ -65,7 +76,7 @@ impl AuthSubject {
         match self {
             AuthSubject::Agent(project_id, _, _) => Some(*project_id),
             AuthSubject::AgentOnBehalfOfUser(_, project_id, _, _) => Some(*project_id),
-            AuthSubject::WorkflowExecutor(project_id, _, _) => Some(*project_id),
+            AuthSubject::WorkflowExecutor(project_id, _, _, _) => Some(*project_id),
             _ => None,
         }
     }
@@ -82,7 +93,18 @@ impl AuthSubject {
     /// link a tool dispatch back to the workflow run that issued it.
     pub fn acting_workflow_run_id(&self) -> Option<WorkflowRunId> {
         match self {
-            AuthSubject::WorkflowExecutor(_, run_id, _) => Some(*run_id),
+            AuthSubject::WorkflowExecutor(_, _, run_id, _) => Some(*run_id),
+            _ => None,
+        }
+    }
+
+    /// `Some(_)` only for `WorkflowExecutor`. Names the definition
+    /// the dispatching run was spawned from — useful for audit
+    /// queries that filter by definition without joining through
+    /// `workflow_runs`.
+    pub fn acting_workflow_definition_id(&self) -> Option<WorkflowDefinitionId> {
+        match self {
+            AuthSubject::WorkflowExecutor(_, def_id, _, _) => Some(*def_id),
             _ => None,
         }
     }
@@ -92,7 +114,7 @@ impl AuthSubject {
             AuthSubject::ExportedAgent(_, _, scopes)
             | AuthSubject::Agent(_, _, scopes)
             | AuthSubject::AgentOnBehalfOfUser(_, _, _, scopes)
-            | AuthSubject::WorkflowExecutor(_, _, scopes) => scopes,
+            | AuthSubject::WorkflowExecutor(_, _, _, scopes) => scopes,
             _ => &[],
         }
     }
@@ -108,7 +130,7 @@ impl AuthSubject {
             AuthSubject::ExportedAgent(_, _, scopes)
             | AuthSubject::Agent(_, _, scopes)
             | AuthSubject::AgentOnBehalfOfUser(_, _, _, scopes)
-            | AuthSubject::WorkflowExecutor(_, _, scopes) => scopes.contains(scope),
+            | AuthSubject::WorkflowExecutor(_, _, _, scopes) => scopes.contains(scope),
             AuthSubject::Anonymous => false,
         }
     }
@@ -164,7 +186,7 @@ impl AuthSubject {
             | AuthSubject::AgentOnBehalfOfUser(_, _, agent_id, _) => UserMessageSource::Agent {
                 agent_id: *agent_id,
             },
-            AuthSubject::WorkflowExecutor(_, _, _) => {
+            AuthSubject::WorkflowExecutor(_, _, _, _) => {
                 panic!("WorkflowExecutor subject has no message source")
             }
             AuthSubject::Anonymous => panic!("Anonymous subject has no message source"),
@@ -175,11 +197,17 @@ impl AuthSubject {
 impl AuthSubject {
     /// Mints a `WorkflowExecutor` subject scoped to `project_id` with
     /// implicit `ProjectAdmin(project_id)` scope. The workflow tier
-    /// owns the run identity; the dispatched tool sees the project
-    /// authority it needs to read/write its own resources.
-    pub fn workflow_executor(project_id: ProjectId, run_id: WorkflowRunId) -> Self {
+    /// owns the definition + run identity; the dispatched tool sees
+    /// the project authority it needs to read/write its own
+    /// resources.
+    pub fn workflow_executor(
+        project_id: ProjectId,
+        definition_id: WorkflowDefinitionId,
+        run_id: WorkflowRunId,
+    ) -> Self {
         AuthSubject::WorkflowExecutor(
             project_id,
+            definition_id,
             run_id,
             vec![AuthScope::ProjectAdmin(project_id)],
         )

--- a/core/src/auth/subject.rs
+++ b/core/src/auth/subject.rs
@@ -1,5 +1,7 @@
 use super::{error::AuthorizationError, AuthResource, AuthScope, AuthVerb};
-use crate::primitives::{AgentId, McpCredsId, ProjectId, SandboxId, UserId, UserMessageSource};
+use crate::primitives::{
+    AgentId, McpCredsId, ProjectId, SandboxId, UserId, UserMessageSource, WorkflowRunId,
+};
 
 /// Authentication subject resolved from session or bearer token.
 #[derive(Debug, Clone)]
@@ -11,6 +13,11 @@ pub enum AuthSubject {
     /// Agent acting on behalf of a `User` or `ExportedAgent` originator,
     /// so downstream actions are attributable back to the user.
     AgentOnBehalfOfUser(UserId, ProjectId, AgentId, Vec<AuthScope>),
+    /// Workflow executor invoking a top-level tool from a `ToolStep`.
+    /// Carries `ProjectAdmin(project_id)` scope so the step can act
+    /// on any resource the workflow's project covers. Distinct from
+    /// `Agent` so audit + visibility paths can tell them apart.
+    WorkflowExecutor(ProjectId, WorkflowRunId, Vec<AuthScope>),
     Anonymous,
 }
 
@@ -37,17 +44,20 @@ impl AuthSubject {
             AuthSubject::ExportedAgent(_, _, _) => Err("ExportedAgent auth not allowed here"),
             AuthSubject::Agent(_, _, _) => Err("Agent auth not allowed here"),
             AuthSubject::AgentOnBehalfOfUser(_, _, _, _) => Err("Agent auth not allowed here"),
+            AuthSubject::WorkflowExecutor(_, _, _) => Err("WorkflowExecutor auth not allowed here"),
             AuthSubject::Anonymous => Err("Authentication required"),
         }
     }
 
-    /// `None` for unattributed `Agent` and `Anonymous`.
+    /// `None` for unattributed `Agent`, `WorkflowExecutor`, and `Anonymous`.
     pub fn originating_user_id(&self) -> Option<UserId> {
         match self {
             AuthSubject::User(user_id) => Some(*user_id),
             AuthSubject::ExportedAgent(user_id, _, _) => Some(*user_id),
             AuthSubject::AgentOnBehalfOfUser(user_id, _, _, _) => Some(*user_id),
-            AuthSubject::Agent(_, _, _) | AuthSubject::Anonymous => None,
+            AuthSubject::Agent(_, _, _)
+            | AuthSubject::WorkflowExecutor(_, _, _)
+            | AuthSubject::Anonymous => None,
         }
     }
 
@@ -55,6 +65,7 @@ impl AuthSubject {
         match self {
             AuthSubject::Agent(project_id, _, _) => Some(*project_id),
             AuthSubject::AgentOnBehalfOfUser(_, project_id, _, _) => Some(*project_id),
+            AuthSubject::WorkflowExecutor(project_id, _, _) => Some(*project_id),
             _ => None,
         }
     }
@@ -67,11 +78,21 @@ impl AuthSubject {
         }
     }
 
+    /// `Some(_)` only for `WorkflowExecutor`. Lets audit/inspection
+    /// link a tool dispatch back to the workflow run that issued it.
+    pub fn acting_workflow_run_id(&self) -> Option<WorkflowRunId> {
+        match self {
+            AuthSubject::WorkflowExecutor(_, run_id, _) => Some(*run_id),
+            _ => None,
+        }
+    }
+
     pub fn scopes(&self) -> &[AuthScope] {
         match self {
             AuthSubject::ExportedAgent(_, _, scopes)
             | AuthSubject::Agent(_, _, scopes)
-            | AuthSubject::AgentOnBehalfOfUser(_, _, _, scopes) => scopes,
+            | AuthSubject::AgentOnBehalfOfUser(_, _, _, scopes)
+            | AuthSubject::WorkflowExecutor(_, _, scopes) => scopes,
             _ => &[],
         }
     }
@@ -86,7 +107,8 @@ impl AuthSubject {
             AuthSubject::User(_) => true,
             AuthSubject::ExportedAgent(_, _, scopes)
             | AuthSubject::Agent(_, _, scopes)
-            | AuthSubject::AgentOnBehalfOfUser(_, _, _, scopes) => scopes.contains(scope),
+            | AuthSubject::AgentOnBehalfOfUser(_, _, _, scopes)
+            | AuthSubject::WorkflowExecutor(_, _, scopes) => scopes.contains(scope),
             AuthSubject::Anonymous => false,
         }
     }
@@ -128,7 +150,9 @@ impl AuthSubject {
         })
     }
 
-    /// Panics for `Anonymous` (callers must authenticate first).
+    /// Panics for `Anonymous` and `WorkflowExecutor` — neither sends
+    /// chat messages directly (the executor dispatches top-level tools
+    /// rather than driving an agent session).
     pub fn to_message_source(&self) -> UserMessageSource {
         match self {
             AuthSubject::User(user_id) => UserMessageSource::User { user_id: *user_id },
@@ -140,8 +164,25 @@ impl AuthSubject {
             | AuthSubject::AgentOnBehalfOfUser(_, _, agent_id, _) => UserMessageSource::Agent {
                 agent_id: *agent_id,
             },
+            AuthSubject::WorkflowExecutor(_, _, _) => {
+                panic!("WorkflowExecutor subject has no message source")
+            }
             AuthSubject::Anonymous => panic!("Anonymous subject has no message source"),
         }
+    }
+}
+
+impl AuthSubject {
+    /// Mints a `WorkflowExecutor` subject scoped to `project_id` with
+    /// implicit `ProjectAdmin(project_id)` scope. The workflow tier
+    /// owns the run identity; the dispatched tool sees the project
+    /// authority it needs to read/write its own resources.
+    pub fn workflow_executor(project_id: ProjectId, run_id: WorkflowRunId) -> Self {
+        AuthSubject::WorkflowExecutor(
+            project_id,
+            run_id,
+            vec![AuthScope::ProjectAdmin(project_id)],
+        )
     }
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -240,6 +240,7 @@ impl App {
             Arc::clone(&agents),
             Arc::clone(&sandboxes),
             Arc::clone(&users),
+            Arc::clone(&toolsets),
             &mut jobs,
         ));
 

--- a/core/src/toolset/error.rs
+++ b/core/src/toolset/error.rs
@@ -49,3 +49,20 @@ pub enum ToolSetsError {
     #[error("ToolSetsError - Unauthorized")]
     Unauthorized,
 }
+
+/// Why a top-level tool can't be invoked from a workflow `tool_step`.
+/// Returned by [`super::ToolSets::find_for_workflow`]; both
+/// parse-time validation (`workflow create`/`update`) and runtime
+/// dispatch (`Executor::execute_tool_step`) route through that
+/// helper so the contract is declared in exactly one place.
+#[derive(Error, Debug)]
+pub enum WorkflowToolLookupError {
+    #[error("tool '{0}' is not registered")]
+    NotRegistered(String),
+    #[error(
+        "tool '{0}' is not composable; only `composable: true` tools can be called from a workflow step"
+    )]
+    NotComposable(String),
+    #[error("tool '{0}' does not declare an output_schema; tool_step requires structured output")]
+    NoOutputSchema(String),
+}

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -383,13 +383,33 @@ impl ToolSets {
             .into_iter()
     }
 
-    /// Direct lookup by name, bypassing visibility. Used by the
-    /// workflow executor + parse-time validator to resolve a
-    /// `tool_step.tool` reference; the dispatch path still routes
-    /// through `call_top_level_tool` which threads `subject`.
-    pub fn find_top_level_tool(&self, name: &str) -> Option<Arc<dyn TopLevelTool>> {
-        let map = self.top_level.read().expect("top_level lock poisoned");
-        map.get(name).cloned()
+    /// Resolve a top-level tool that satisfies the workflow
+    /// `tool_step` contract: must be registered, `composable:
+    /// true`, and declare an `output_schema()`. Both parse-time
+    /// validation (`Workflows::validate_steps`) and the runtime
+    /// executor (`Executor::execute_tool_step`) call this so the
+    /// rules are declared in one place — tool authors changing
+    /// `composable()` or dropping `output_schema()` ripple
+    /// identically through both layers.
+    ///
+    /// Bypasses [`TopLevelTool::is_visible`] — visibility is for
+    /// catalogue listing, not for workflow dispatch.
+    pub fn find_for_workflow(
+        &self,
+        name: &str,
+    ) -> Result<Arc<dyn TopLevelTool>, WorkflowToolLookupError> {
+        let tool = {
+            let map = self.top_level.read().expect("top_level lock poisoned");
+            map.get(name).cloned()
+        }
+        .ok_or_else(|| WorkflowToolLookupError::NotRegistered(name.to_string()))?;
+        if !tool.composable() {
+            return Err(WorkflowToolLookupError::NotComposable(name.to_string()));
+        }
+        if tool.output_schema().is_none() {
+            return Err(WorkflowToolLookupError::NoOutputSchema(name.to_string()));
+        }
+        Ok(tool)
     }
 
     /// Visible top-level tools converted to wire `ToolDefinition`s
@@ -836,5 +856,91 @@ mod tests {
             required, props,
             "every key in properties must appear in required for strict mode"
         );
+    }
+
+    /// Stub TopLevelTool used to exercise `find_for_workflow`'s
+    /// gates without standing up a real tool. The `composable` and
+    /// `output_schema` flags are pulled into individual fields so
+    /// each test case can flip exactly the bit under test.
+    struct StubTopLevelTool {
+        name: String,
+        composable: bool,
+        output_schema: Option<serde_json::Value>,
+    }
+
+    impl StubTopLevelTool {
+        fn new(name: &str, composable: bool, has_output_schema: bool) -> Self {
+            Self {
+                name: name.to_string(),
+                composable,
+                output_schema: has_output_schema.then(|| serde_json::json!({ "type": "object" })),
+            }
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl TopLevelTool for StubTopLevelTool {
+        fn name(&self) -> &str {
+            &self.name
+        }
+        fn description(&self) -> &str {
+            "stub"
+        }
+        fn input_schema(&self) -> &serde_json::Value {
+            static EMPTY: std::sync::OnceLock<serde_json::Value> = std::sync::OnceLock::new();
+            EMPTY.get_or_init(|| serde_json::json!({ "type": "object" }))
+        }
+        fn output_schema(&self) -> Option<&serde_json::Value> {
+            self.output_schema.as_ref()
+        }
+        fn composable(&self) -> bool {
+            self.composable
+        }
+        async fn call(
+            &self,
+            _subject: &AuthSubject,
+            _arguments: Option<JsonObject>,
+        ) -> Result<CallToolResult, ToolSetsError> {
+            unreachable!("stub tool not invoked in find_for_workflow tests")
+        }
+    }
+
+    #[test]
+    fn find_for_workflow_accepts_composable_tool_with_output_schema() {
+        let toolsets = ToolSets::empty_for_test();
+        toolsets.register_top_level(StubTopLevelTool::new("ok", true, true));
+        let resolved = toolsets.find_for_workflow("ok").expect("accepted");
+        assert_eq!(resolved.name(), "ok");
+    }
+
+    #[test]
+    fn find_for_workflow_rejects_unregistered_tool() {
+        let toolsets = ToolSets::empty_for_test();
+        match toolsets.find_for_workflow("ghost") {
+            Err(WorkflowToolLookupError::NotRegistered(name)) => assert_eq!(name, "ghost"),
+            _ => panic!("expected NotRegistered"),
+        }
+    }
+
+    #[test]
+    fn find_for_workflow_rejects_non_composable_tool() {
+        let toolsets = ToolSets::empty_for_test();
+        toolsets.register_top_level(StubTopLevelTool::new("non_composable", false, true));
+        match toolsets.find_for_workflow("non_composable") {
+            Err(WorkflowToolLookupError::NotComposable(name)) => {
+                assert_eq!(name, "non_composable")
+            }
+            _ => panic!("expected NotComposable"),
+        }
+    }
+
+    #[test]
+    fn find_for_workflow_rejects_tool_without_output_schema() {
+        let toolsets = ToolSets::empty_for_test();
+        toolsets.register_top_level(StubTopLevelTool::new("no_schema", true, false));
+        match toolsets.find_for_workflow("no_schema") {
+            Err(WorkflowToolLookupError::NoOutputSchema(name)) => assert_eq!(name, "no_schema"),
+            _ => panic!("expected NoOutputSchema"),
+        }
     }
 }

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -383,6 +383,15 @@ impl ToolSets {
             .into_iter()
     }
 
+    /// Direct lookup by name, bypassing visibility. Used by the
+    /// workflow executor + parse-time validator to resolve a
+    /// `tool_step.tool` reference; the dispatch path still routes
+    /// through `call_top_level_tool` which threads `subject`.
+    pub fn find_top_level_tool(&self, name: &str) -> Option<Arc<dyn TopLevelTool>> {
+        let map = self.top_level.read().expect("top_level lock poisoned");
+        map.get(name).cloned()
+    }
+
     /// Visible top-level tools converted to wire `ToolDefinition`s
     /// for the session layer. When `output_schema` is `Some` the
     /// `submit_output` entry's `input_schema` is replaced with the

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -19,14 +19,15 @@ use crate::auth::{AuthResource, AuthSubject, AuthVerb};
 use crate::library::{AuthedSearch, AuthedSpaces};
 use crate::note::{Note, Notes};
 use crate::primitives::{
-    AgentId, NoteId, ProjectId, SandboxId, SkillId, UserId, WorkflowDefinitionId,
+    AgentId, NoteId, ProjectId, SandboxId, SkillId, UserId, WorkflowDefinitionId, WorkflowRunId,
 };
 use crate::project::{Project, Projects};
 use crate::sandbox::{Sandbox, SandboxAgentMode, SandboxMode, SandboxSpecs, Sandboxes};
 use crate::skill::{ScopedSkill, Skill, SkillSource, Skills};
 use crate::space_fs::SpaceFs;
 use crate::workflow::{
-    WorkflowDefinition, WorkflowSandboxDecl, WorkflowStepDef, WorkflowTrigger, Workflows,
+    WorkflowDefinition, WorkflowRun, WorkflowRunState, WorkflowSandboxDecl, WorkflowStepDef,
+    WorkflowTrigger, Workflows,
 };
 
 use super::super::error::ToolSetsError;
@@ -318,49 +319,96 @@ enum WorkflowCommand {
     List,
     Get,
     Update,
+    /// Spawn a run with the given trigger payload. Returns the run id.
+    Trigger,
+    /// Block until a run reaches a terminal state, then surface the
+    /// per-step outputs verbatim (full JSON, not truncated).
+    AwaitRun,
+    /// Read a single run with full per-step outputs.
+    Run,
 }
 
+/// Tagged step input. `type: agent_step` (the historical default,
+/// inferred when omitted) reuses the existing AgentStep shape;
+/// `type: tool_step` dispatches a single top-level MCP tool with
+/// `${{ … }}`-substituted params.
 #[derive(Deserialize, schemars::JsonSchema)]
-struct WorkflowStepParams {
-    name: String,
-    /// NAME of an existing skill in the target project.
-    skill: String,
-    #[serde(default)]
-    sandbox: Option<String>,
-    #[serde(default)]
-    sandbox_mode: Option<SandboxAgentMode>,
-    #[serde(default)]
-    timeout_seconds: Option<u64>,
-    #[serde(default)]
-    model_chain: Option<llm::ModelChain>,
-    /// JSON Schema (root must be `type: object`) for this step's
-    /// structured output. Omit to fall back to the default `{success,
-    /// reason}` schema. Surfaced to the agent as the `submit_output`
-    /// tool's `input_schema`.
-    #[serde(default)]
-    output_schema: Option<serde_json::Value>,
+#[serde(tag = "type", rename_all = "snake_case")]
+enum WorkflowStepParams {
+    AgentStep {
+        name: String,
+        /// NAME of an existing skill in the target project.
+        skill: String,
+        #[serde(default)]
+        sandbox: Option<String>,
+        #[serde(default)]
+        sandbox_mode: Option<SandboxAgentMode>,
+        #[serde(default)]
+        timeout_seconds: Option<u64>,
+        #[serde(default)]
+        model_chain: Option<llm::ModelChain>,
+        /// JSON Schema (root must be `type: object`) for this step's
+        /// structured output. Omit to fall back to the default
+        /// `{success, output, reason}` schema.
+        #[serde(default)]
+        output_schema: Option<serde_json::Value>,
+    },
+    ToolStep {
+        name: String,
+        /// Top-level tool name (e.g. `"whoami"`, `"workflow"`). Must
+        /// be `composable: true` and declare an `output_schema`.
+        tool: String,
+        /// Pre-substitution params; `${{ trigger.X }}` and
+        /// `${{ steps.<name>.outputs.Y }}` resolve at run time.
+        #[serde(default)]
+        params: serde_json::Value,
+        #[serde(default)]
+        timeout_seconds: Option<u64>,
+    },
 }
 
 impl WorkflowStepParams {
     fn into_step(self) -> Result<WorkflowStepDef, ToolSetsError> {
-        let output_schema = match self.output_schema {
-            Some(value) => serde_json::from_value(value).map_err(|e| {
-                ToolSetsError::MissingArgument(format!(
-                    "step '{}': output_schema invalid (root must be `type: object` per MCP): {e}",
-                    self.name
-                ))
-            })?,
-            None => crate::workflow::default_output_schema(),
-        };
-        Ok(WorkflowStepDef::AgentStep {
-            name: self.name,
-            skill: self.skill,
-            sandbox: self.sandbox,
-            sandbox_mode: self.sandbox_mode,
-            timeout_seconds: self.timeout_seconds,
-            model_chain: self.model_chain,
-            output_schema: Box::new(output_schema),
-        })
+        match self {
+            WorkflowStepParams::AgentStep {
+                name,
+                skill,
+                sandbox,
+                sandbox_mode,
+                timeout_seconds,
+                model_chain,
+                output_schema,
+            } => {
+                let output_schema = match output_schema {
+                    Some(value) => serde_json::from_value(value).map_err(|e| {
+                        ToolSetsError::MissingArgument(format!(
+                            "step '{name}': output_schema invalid (root must be `type: object` per MCP): {e}"
+                        ))
+                    })?,
+                    None => crate::workflow::default_output_schema(),
+                };
+                Ok(WorkflowStepDef::AgentStep {
+                    name,
+                    skill,
+                    sandbox,
+                    sandbox_mode,
+                    timeout_seconds,
+                    model_chain,
+                    output_schema: Box::new(output_schema),
+                })
+            }
+            WorkflowStepParams::ToolStep {
+                name,
+                tool,
+                params,
+                timeout_seconds,
+            } => Ok(WorkflowStepDef::ToolStep {
+                name,
+                tool,
+                params,
+                timeout_seconds,
+            }),
+        }
     }
 }
 
@@ -448,9 +496,24 @@ struct WorkflowParams {
     #[schemars(with = "Option<uuid::Uuid>")]
     project_id: Option<ProjectId>,
 
-    /// Required for `get`, `update`.
+    /// Required for `get`, `update`, `trigger`. UUID — admin tier
+    /// keeps it strict; the top-level `workflow` tool accepts
+    /// names too for skill-author ergonomics.
     #[schemars(with = "Option<uuid::Uuid>")]
     definition_id: Option<WorkflowDefinitionId>,
+
+    /// Required for `await_run`, `run`.
+    #[schemars(with = "Option<uuid::Uuid>")]
+    run_id: Option<WorkflowRunId>,
+
+    /// `trigger`: webhook-equivalent payload bound to the run's
+    /// `trigger.*` template namespace. Defaults to `{}`.
+    #[serde(default)]
+    payload: Option<serde_json::Value>,
+
+    /// `await_run`: wait budget in seconds. Defaults to 360.
+    #[serde(default)]
+    timeout_seconds: Option<u64>,
 
     /// `create`: required. `update`: optional rename.
     name: Option<String>,
@@ -1364,6 +1427,57 @@ impl AdminToolSet {
                     format_workflow(&definition, false),
                 )]))
             }
+
+            WorkflowCommand::Trigger => {
+                let definition_id = params.definition_id.ok_or_else(|| {
+                    ToolSetsError::MissingArgument(
+                        "definition_id is required for trigger".to_string(),
+                    )
+                })?;
+                Audit::record_action("workflow.trigger");
+                let payload = params
+                    .payload
+                    .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
+                let run = self
+                    .workflows
+                    .trigger_run(subject, definition_id, payload)
+                    .await
+                    .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
+                Ok(CallToolResult::success(vec![Content::text(format_run(
+                    &run,
+                ))]))
+            }
+
+            WorkflowCommand::AwaitRun => {
+                let run_id = params.run_id.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("run_id is required for await_run".to_string())
+                })?;
+                Audit::record_action("workflow.await_run");
+                let timeout = std::time::Duration::from_secs(params.timeout_seconds.unwrap_or(360));
+                let run = self
+                    .workflows
+                    .await_run_completion(subject, run_id, Some(timeout))
+                    .await
+                    .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
+                Ok(CallToolResult::success(vec![Content::text(format_run(
+                    &run,
+                ))]))
+            }
+
+            WorkflowCommand::Run => {
+                let run_id = params.run_id.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("run_id is required for run".to_string())
+                })?;
+                Audit::record_action("workflow.run");
+                let run = self
+                    .workflows
+                    .find_run_by_id(subject, run_id)
+                    .await
+                    .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
+                Ok(CallToolResult::success(vec![Content::text(format_run(
+                    &run,
+                ))]))
+            }
         }
     }
 
@@ -1943,6 +2057,38 @@ fn format_workflow(d: &WorkflowDefinition, created: bool) -> String {
     )
 }
 
+/// Renders a `WorkflowRun` as text. Step outputs are emitted as
+/// compact JSON (one per line) so callers can read the structured
+/// payload directly without a second round-trip through the inspect
+/// MCP. Used by `trigger`, `await_run`, and `run`.
+fn format_run(r: &WorkflowRun) -> String {
+    let state = match r.state {
+        WorkflowRunState::Pending => "pending",
+        WorkflowRunState::Running => "running",
+        WorkflowRunState::Succeeded => "succeeded",
+        WorkflowRunState::Failed => "failed",
+    };
+    let mut out = format!(
+        "Run:\n  id: {}\n  definition_id: {}\n  project_id: {}\n  state: {}\n",
+        r.id, r.definition_id, r.project_id, state,
+    );
+    if !r.step_results.is_empty() {
+        out.push_str("  steps:\n");
+        for step in &r.step_results {
+            out.push_str(&format!("    - name: {}\n", step.name));
+            if let Some(err) = &step.error {
+                out.push_str(&format!("      error: {err}\n"));
+            }
+            if let Some(value) = &step.output {
+                let json =
+                    serde_json::to_string(value).unwrap_or_else(|_| "<unserializable>".to_string());
+                out.push_str(&format!("      output: {json}\n"));
+            }
+        }
+    }
+    out
+}
+
 fn format_workflows(defs: &[WorkflowDefinition]) -> String {
     if defs.is_empty() {
         return "No workflows found.".to_string();
@@ -2428,7 +2574,7 @@ mod tests {
             "description": "Run nightly checks",
             "manual": true,
             "steps": [
-                { "name": "step", "skill": "audit", "timeout_seconds": 60 }
+                { "type": "agent_step", "name": "step", "skill": "audit", "timeout_seconds": 60 }
             ],
             "sandboxes": [
                 { "type": "scratch", "name": "sb1" }
@@ -2468,6 +2614,35 @@ mod tests {
     }
 
     #[test]
+    fn workflow_create_parses_tool_step() {
+        let project_id = uuid::Uuid::new_v4();
+        let p: WorkflowParams = parse_params(args(serde_json::json!({
+            "command": "create",
+            "project_id": project_id,
+            "name": "dispatch-flow",
+            "manual": true,
+            "steps": [
+                {
+                    "type": "tool_step",
+                    "name": "identify",
+                    "tool": "whoami",
+                    "params": {}
+                }
+            ],
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, WorkflowCommand::Create));
+        assert_eq!(p.steps.len(), 1);
+        match &p.steps[0] {
+            WorkflowStepParams::ToolStep { name, tool, .. } => {
+                assert_eq!(name, "identify");
+                assert_eq!(tool, "whoami");
+            }
+            _ => panic!("expected ToolStep"),
+        }
+    }
+
+    #[test]
     fn workflow_update_parses_partial_fields() {
         let definition_id = uuid::Uuid::new_v4();
         let p: WorkflowParams = parse_params(args(serde_json::json!({
@@ -2476,7 +2651,7 @@ mod tests {
             "name": "renamed",
             "update_steps": true,
             "steps": [
-                { "name": "s1", "skill": "audit" }
+                { "type": "agent_step", "name": "s1", "skill": "audit" }
             ],
         })))
         .expect("parse");

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -2067,6 +2067,7 @@ fn format_run(r: &WorkflowRun) -> String {
         WorkflowRunState::Running => "running",
         WorkflowRunState::Succeeded => "succeeded",
         WorkflowRunState::Failed => "failed",
+        WorkflowRunState::Errored => "errored",
     };
     let mut out = format!(
         "Run:\n  id: {}\n  definition_id: {}\n  project_id: {}\n  state: {}\n",

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -359,7 +359,7 @@ impl WorkflowStepParams {
             sandbox_mode: self.sandbox_mode,
             timeout_seconds: self.timeout_seconds,
             model_chain: self.model_chain,
-            output_schema,
+            output_schema: Box::new(output_schema),
         })
     }
 }

--- a/core/src/toolset/top_level/whoami.rs
+++ b/core/src/toolset/top_level/whoami.rs
@@ -32,7 +32,7 @@ static WHOAMI_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
 
 #[derive(Default, serde::Serialize, schemars::JsonSchema)]
 struct WhoAmIOutput {
-    /// user, exported_agent, agent, agent_on_behalf_of_user, or anonymous.
+    /// user, exported_agent, agent, agent_on_behalf_of_user, workflow_executor, or anonymous.
     #[serde(rename = "type")]
     identity_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -43,6 +43,8 @@ struct WhoAmIOutput {
     project_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     agent_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workflow_run_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     scopes: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -114,6 +116,13 @@ impl TopLevelTool for WhoAmI {
                     ..Default::default()
                 }
             }
+            AuthSubject::WorkflowExecutor(project_id, run_id, scopes) => WhoAmIOutput {
+                identity_type: "workflow_executor".into(),
+                project_id: Some(project_id.to_string()),
+                workflow_run_id: Some(run_id.to_string()),
+                scopes: Some(scopes_list(scopes)),
+                ..Default::default()
+            },
             AuthSubject::Anonymous => WhoAmIOutput {
                 identity_type: "anonymous".into(),
                 ..Default::default()

--- a/core/src/toolset/top_level/whoami.rs
+++ b/core/src/toolset/top_level/whoami.rs
@@ -44,6 +44,8 @@ struct WhoAmIOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     agent_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    workflow_definition_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     workflow_run_id: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     scopes: Option<Vec<String>>,
@@ -116,13 +118,16 @@ impl TopLevelTool for WhoAmI {
                     ..Default::default()
                 }
             }
-            AuthSubject::WorkflowExecutor(project_id, run_id, scopes) => WhoAmIOutput {
-                identity_type: "workflow_executor".into(),
-                project_id: Some(project_id.to_string()),
-                workflow_run_id: Some(run_id.to_string()),
-                scopes: Some(scopes_list(scopes)),
-                ..Default::default()
-            },
+            AuthSubject::WorkflowExecutor(project_id, definition_id, run_id, scopes) => {
+                WhoAmIOutput {
+                    identity_type: "workflow_executor".into(),
+                    project_id: Some(project_id.to_string()),
+                    workflow_definition_id: Some(definition_id.to_string()),
+                    workflow_run_id: Some(run_id.to_string()),
+                    scopes: Some(scopes_list(scopes)),
+                    ..Default::default()
+                }
+            }
             AuthSubject::Anonymous => WhoAmIOutput {
                 identity_type: "anonymous".into(),
                 ..Default::default()

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -57,7 +57,10 @@ enum WorkflowParams {
         definition_id: WorkflowDefinitionId,
     },
     Trigger {
-        definition_id: WorkflowDefinitionId,
+        /// Either the definition's UUID or its project-scoped name.
+        /// UUID parsing is tried first; on failure the value is
+        /// resolved against the project's `list_for_project`.
+        definition_id: String,
         #[serde(default)]
         payload: Option<serde_json::Value>,
     },
@@ -166,50 +169,90 @@ fn specs_from_parts(
     }
 }
 
+/// Tagged step input. `type: agent_step` (the historical default,
+/// inferred when omitted) reuses the existing AgentStep shape; `type:
+/// tool_step` dispatches a single top-level MCP tool.
 #[derive(Deserialize, schemars::JsonSchema)]
-struct WorkflowStepParam {
-    name: String,
-    /// NAME of an existing skill in this project (created via the
-    /// `skill` tool). NOT an inline body — the runtime looks up the
-    /// skill by this name at trigger time.
-    skill: String,
-    /// Name of a sandbox declared in this workflow's top-level
-    /// `sandboxes` array.
-    #[serde(default)]
-    sandbox: Option<String>,
-    #[serde(default)]
-    sandbox_mode: Option<SandboxAgentMode>,
-    #[serde(default)]
-    timeout_seconds: Option<u64>,
-    #[serde(default)]
-    model_chain: Option<llm::ModelChain>,
-    /// JSON Schema (root must be `type: object`) for the step's
-    /// structured output. Omit to fall back to the default `{success,
-    /// reason}` schema.
-    #[serde(default)]
-    output_schema: Option<serde_json::Value>,
+#[serde(tag = "type", rename_all = "snake_case")]
+enum WorkflowStepParam {
+    AgentStep {
+        name: String,
+        /// NAME of an existing skill in this project (created via the
+        /// `skill` tool). NOT an inline body — the runtime looks up the
+        /// skill by this name at trigger time.
+        skill: String,
+        /// Name of a sandbox declared in this workflow's top-level
+        /// `sandboxes` array.
+        #[serde(default)]
+        sandbox: Option<String>,
+        #[serde(default)]
+        sandbox_mode: Option<SandboxAgentMode>,
+        #[serde(default)]
+        timeout_seconds: Option<u64>,
+        #[serde(default)]
+        model_chain: Option<llm::ModelChain>,
+        /// JSON Schema (root must be `type: object`) for the step's
+        /// structured output. Omit to fall back to the default
+        /// `{success, output, reason}` schema.
+        #[serde(default)]
+        output_schema: Option<serde_json::Value>,
+    },
+    ToolStep {
+        name: String,
+        /// Top-level tool name (e.g. `"workflow"`). Must be
+        /// `composable: true`. Dispatched with `AuthSubject::WorkflowExecutor`.
+        tool: String,
+        /// Pre-substitution params; `${{ trigger.X }}` and
+        /// `${{ steps.<name>.outputs.Y }}` resolve at run time.
+        #[serde(default)]
+        params: serde_json::Value,
+        #[serde(default)]
+        timeout_seconds: Option<u64>,
+    },
 }
 
 impl WorkflowStepParam {
     fn into_step(self) -> Result<WorkflowStepDef, ToolSetsError> {
-        let output_schema = match self.output_schema {
-            Some(value) => serde_json::from_value(value).map_err(|e| {
-                ToolSetsError::MissingArgument(format!(
-                    "step '{}': output_schema invalid (root must be `type: object` per MCP): {e}",
-                    self.name
-                ))
-            })?,
-            None => crate::workflow::default_output_schema(),
-        };
-        Ok(WorkflowStepDef::AgentStep {
-            name: self.name,
-            skill: self.skill,
-            sandbox: self.sandbox,
-            sandbox_mode: self.sandbox_mode,
-            timeout_seconds: self.timeout_seconds,
-            model_chain: self.model_chain,
-            output_schema,
-        })
+        match self {
+            WorkflowStepParam::AgentStep {
+                name,
+                skill,
+                sandbox,
+                sandbox_mode,
+                timeout_seconds,
+                model_chain,
+                output_schema,
+            } => {
+                let output_schema = match output_schema {
+                    Some(value) => serde_json::from_value(value).map_err(|e| {
+                        ToolSetsError::MissingArgument(format!(
+                            "step '{name}': output_schema invalid (root must be `type: object` per MCP): {e}"
+                        ))
+                    })?,
+                    None => crate::workflow::default_output_schema(),
+                };
+                Ok(WorkflowStepDef::AgentStep {
+                    name,
+                    skill,
+                    sandbox,
+                    sandbox_mode,
+                    timeout_seconds,
+                    model_chain,
+                    output_schema: Box::new(output_schema),
+                })
+            }
+            WorkflowStepParam::ToolStep {
+                name,
+                tool,
+                params,
+                timeout_seconds,
+            } => Ok(WorkflowStepDef::ToolStep {
+                name,
+                tool,
+                params,
+                timeout_seconds,
+            }),
+        }
     }
 }
 
@@ -317,9 +360,13 @@ struct WorkflowSandboxOutput {
 #[derive(serde::Serialize, schemars::JsonSchema)]
 struct WorkflowStepOutput {
     name: String,
-    /// `"agent_step"`.
+    /// `"agent_step"` or `"tool_step"`.
     step_type: String,
+    /// Empty string for `tool_step`.
     skill: String,
+    /// Set on `tool_step`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    tool: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     sandbox: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -445,8 +492,7 @@ static WORKFLOW_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
             },
             "definition_id": {
                 "type": "string",
-                "format": "uuid",
-                "description": "Workflow definition ID (get / trigger / runs)."
+                "description": "Workflow definition ID — UUID for `get`/`runs`/`update`, UUID-or-name for `trigger` (the project-scoped workflow name resolves identically)."
             },
             "run_id": {
                 "type": "string",
@@ -493,6 +539,35 @@ static WORKFLOW_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
         "additionalProperties": false
     })
 });
+
+/// Resolve a `definition_id` field that may be either a UUID or a
+/// project-scoped workflow name. UUID parsing wins; the name path is
+/// the fallback so callers can write `workflow.trigger
+/// definition_id="drua-test-failure"` without doing a `list` lookup
+/// first (memo `019e01a4` open Q1).
+async fn resolve_definition_id_or_name(
+    workflows: &Arc<Workflows>,
+    subject: &AuthSubject,
+    project_id: crate::primitives::ProjectId,
+    raw: &str,
+) -> Result<WorkflowDefinitionId, ToolSetsError> {
+    if let Ok(uuid) = uuid::Uuid::parse_str(raw) {
+        return Ok(WorkflowDefinitionId::from(uuid));
+    }
+    let definitions = workflows
+        .list_for_project(subject, project_id)
+        .await
+        .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
+    definitions
+        .iter()
+        .find(|d| d.name == raw)
+        .map(|d| d.id)
+        .ok_or_else(|| {
+            ToolSetsError::MissingArgument(format!(
+                "no workflow named '{raw}' in this project (and `{raw}` is not a valid UUID)"
+            ))
+        })
+}
 
 #[async_trait::async_trait]
 impl TopLevelTool for WorkflowTool {
@@ -593,7 +668,7 @@ impl TopLevelTool for WorkflowTool {
                         sandbox_mode,
                         timeout_seconds,
                         model_chain: None,
-                        output_schema: crate::workflow::default_output_schema(),
+                        output_schema: Box::new(crate::workflow::default_output_schema()),
                     }]
                 };
 
@@ -668,11 +743,18 @@ impl TopLevelTool for WorkflowTool {
                 definition_id,
                 payload,
             } => {
+                let resolved_id = resolve_definition_id_or_name(
+                    &self.workflows,
+                    subject,
+                    project_id,
+                    &definition_id,
+                )
+                .await?;
                 let payload =
                     payload.unwrap_or_else(|| serde_json::Value::Object(Default::default()));
                 let run = self
                     .workflows
-                    .trigger_run(subject, definition_id, payload)
+                    .trigger_run(subject, resolved_id, payload)
                     .await
                     .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
                 let text = format_run_text(&run);
@@ -903,6 +985,20 @@ fn step_to_output(s: &WorkflowStepDef) -> WorkflowStepOutput {
             skill: skill.clone(),
             sandbox: sandbox.clone(),
             timeout_seconds: *timeout_seconds,
+            tool: None,
+        },
+        WorkflowStepDef::ToolStep {
+            name,
+            tool,
+            timeout_seconds,
+            ..
+        } => WorkflowStepOutput {
+            name: name.clone(),
+            step_type: "tool_step".to_string(),
+            skill: String::new(),
+            sandbox: None,
+            timeout_seconds: *timeout_seconds,
+            tool: Some(tool.clone()),
         },
     }
 }
@@ -1096,6 +1192,16 @@ fn format_get_text(d: &WorkflowDefinition) -> String {
                         .as_ref()
                         .map(|c| format!("{}+{}", c.primary.name, c.fallbacks.len()))
                         .unwrap_or_else(|| "<inherit>".into())
+                ));
+            }
+            WorkflowStepDef::ToolStep {
+                name,
+                tool,
+                timeout_seconds,
+                ..
+            } => {
+                out.push_str(&format!(
+                    "  - tool_step name={name} tool={tool} timeout_s={timeout_seconds:?}\n"
                 ));
             }
         }

--- a/core/src/workflow/definition.rs
+++ b/core/src/workflow/definition.rs
@@ -388,8 +388,14 @@ mod tests {
         assert!(back.model_chain().is_none());
     }
 
+    /// `params` deserializes to `Value::Null` when omitted (serde
+    /// default for an untagged `serde_json::Value`). The executor
+    /// treats that as "no arguments" — see the
+    /// `Value::Null => None` arm of the dispatch path in
+    /// `executor::execute_tool_step`. The wire null is the
+    /// idiomatic absent-marker; we don't rewrite it to `{}`.
     #[test]
-    fn tool_step_params_default_to_empty_object() {
+    fn tool_step_omitted_params_deserializes_as_null() {
         let json = serde_json::json!({
             "type": "tool_step",
             "name": "noop",

--- a/core/src/workflow/definition.rs
+++ b/core/src/workflow/definition.rs
@@ -128,9 +128,33 @@ pub enum WorkflowStepDef {
         /// root is guaranteed `type: "object"` (enforced by
         /// [`OutputSchema`] validation on construction/deserialization).
         /// Old workflows / inputs that omit the field hydrate as
-        /// [`default_output_schema`] (`{success, reason}`).
-        #[serde(default = "default_output_schema")]
-        output_schema: OutputSchema,
+        /// [`default_output_schema`] (`{success, reason}`). Boxed
+        /// to keep the [`WorkflowStepDef`] enum's `AgentStep` and
+        /// `ToolStep` variants close in size (clippy
+        /// `large_enum_variant`).
+        #[serde(default = "default_output_schema_boxed")]
+        output_schema: Box<OutputSchema>,
+    },
+    /// Deterministic single-tool dispatch — no agent loop, no LLM.
+    /// `params` is the raw `arguments` object handed to the named
+    /// top-level MCP tool after `${{ … }}` substitution against the
+    /// run's trigger context and prior step outputs. The tool is
+    /// dispatched as `AuthSubject::WorkflowExecutor` with the
+    /// workflow's project authority; only `composable: true` tools
+    /// can be invoked. The tool's `structured_content` becomes
+    /// `StepResult.output`; `is_error: true` fails the step.
+    ToolStep {
+        name: String,
+        /// Top-level tool name, e.g. `"workflow"` for sub-workflow
+        /// dispatch via `command: trigger`.
+        tool: String,
+        /// Pre-substitution params; `${{ … }}` references are resolved
+        /// against [`crate::workflow::template::TemplateContext`]
+        /// at execution time.
+        #[serde(default)]
+        params: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timeout_seconds: Option<u64>,
     },
 }
 
@@ -138,25 +162,31 @@ impl WorkflowStepDef {
     pub fn name(&self) -> &str {
         match self {
             WorkflowStepDef::AgentStep { name, .. } => name,
+            WorkflowStepDef::ToolStep { name, .. } => name,
         }
     }
 
     pub fn model_chain(&self) -> Option<&ModelChain> {
         match self {
             WorkflowStepDef::AgentStep { model_chain, .. } => model_chain.as_ref(),
+            WorkflowStepDef::ToolStep { .. } => None,
         }
     }
 
-    /// Every AgentStep produces a structured output via the
-    /// synthesised `submit_output` tool. The schema defaults to
-    /// [`default_output_schema`] (`{success, reason}`) when the step
-    /// doesn't declare its own; there is no schemaless free-text
-    /// passthrough.
-    pub fn output_schema(&self) -> &OutputSchema {
+    /// AgentSteps carry an explicit `output_schema` enforced via the
+    /// synthesised `submit_output` tool. ToolSteps have none — the
+    /// called tool's own declared schema is the contract.
+    pub fn output_schema(&self) -> Option<&OutputSchema> {
         match self {
-            WorkflowStepDef::AgentStep { output_schema, .. } => output_schema,
+            WorkflowStepDef::AgentStep { output_schema, .. } => Some(output_schema.as_ref()),
+            WorkflowStepDef::ToolStep { .. } => None,
         }
     }
+}
+
+/// Boxed factory used by `serde(default = …)` on the `AgentStep` variant.
+fn default_output_schema_boxed() -> Box<OutputSchema> {
+    Box::new(default_output_schema())
 }
 
 /// Default `output_schema` injected when an `AgentStep` doesn't declare
@@ -311,9 +341,9 @@ mod tests {
             sandbox_mode: None,
             timeout_seconds: None,
             model_chain: None,
-            output_schema: custom,
+            output_schema: Box::new(custom),
         };
-        let actual = serde_json::to_value(step.output_schema()).unwrap();
+        let actual = serde_json::to_value(step.output_schema().expect("AgentStep")).unwrap();
         assert_eq!(actual, custom_value);
     }
 
@@ -330,8 +360,48 @@ mod tests {
         });
         let step: WorkflowStepDef = serde_json::from_value(json).unwrap();
         let default = serde_json::to_value(default_output_schema()).unwrap();
-        let actual = serde_json::to_value(step.output_schema()).unwrap();
+        let actual = serde_json::to_value(step.output_schema().expect("AgentStep")).unwrap();
         assert_eq!(actual, default);
+    }
+
+    #[test]
+    fn tool_step_round_trips_through_serde() {
+        let step = WorkflowStepDef::ToolStep {
+            name: "dispatch".into(),
+            tool: "workflow".into(),
+            params: serde_json::json!({
+                "command": "trigger",
+                "definition_id": "drua-test-failure",
+                "payload": "${{ steps.triage.outputs.args }}"
+            }),
+            timeout_seconds: Some(60),
+        };
+        let value = serde_json::to_value(&step).unwrap();
+        assert_eq!(
+            value.get("type").and_then(|v| v.as_str()),
+            Some("tool_step")
+        );
+        assert_eq!(value.get("tool").and_then(|v| v.as_str()), Some("workflow"));
+        let back: WorkflowStepDef = serde_json::from_value(value).unwrap();
+        assert_eq!(back.name(), "dispatch");
+        assert!(back.output_schema().is_none());
+        assert!(back.model_chain().is_none());
+    }
+
+    #[test]
+    fn tool_step_params_default_to_empty_object() {
+        let json = serde_json::json!({
+            "type": "tool_step",
+            "name": "noop",
+            "tool": "whoami"
+        });
+        let step: WorkflowStepDef = serde_json::from_value(json).unwrap();
+        match step {
+            WorkflowStepDef::ToolStep { params, .. } => {
+                assert_eq!(params, serde_json::Value::Null);
+            }
+            _ => panic!("expected ToolStep"),
+        }
     }
 
     #[test]
@@ -343,7 +413,7 @@ mod tests {
             sandbox_mode: None,
             timeout_seconds: None,
             model_chain: None,
-            output_schema: default_output_schema(),
+            output_schema: Box::new(default_output_schema()),
         };
         let value = serde_json::to_value(&step).unwrap();
         assert!(

--- a/core/src/workflow/entity.rs
+++ b/core/src/workflow/entity.rs
@@ -425,7 +425,7 @@ mod tests {
             sandbox_mode: None,
             timeout_seconds: Some(60),
             model_chain: None,
-            output_schema: default_output_schema(),
+            output_schema: Box::new(default_output_schema()),
         }
     }
 
@@ -465,7 +465,7 @@ mod tests {
             sandbox_mode: None,
             timeout_seconds: None,
             model_chain: Some(step_chain.clone()),
-            output_schema: default_output_schema(),
+            output_schema: Box::new(default_output_schema()),
         }];
         assert_eq!(
             def.resolve_step_chain(&def.steps[0]).unwrap().primary.name,
@@ -479,7 +479,7 @@ mod tests {
             sandbox_mode: None,
             timeout_seconds: None,
             model_chain: None,
-            output_schema: default_output_schema(),
+            output_schema: Box::new(default_output_schema()),
         }];
         assert_eq!(
             def.resolve_step_chain(&def.steps[0]).unwrap().primary.name,

--- a/core/src/workflow/error.rs
+++ b/core/src/workflow/error.rs
@@ -35,6 +35,14 @@ pub enum WorkflowError {
     BuildEntity(String),
     #[error("WorkflowError - InvalidDefinition: {0}")]
     InvalidDefinition(String),
+    #[error("WorkflowError - InvalidStep: {0}")]
+    InvalidStep(String),
+    #[error("WorkflowError - InvalidTemplateRef: {0}")]
+    InvalidTemplateRef(String),
+    #[error("WorkflowError - ToolNotFound: {0}")]
+    ToolNotFound(String),
+    #[error("WorkflowError - ToolDispatch: {0}")]
+    ToolDispatch(String),
     #[error("WorkflowError - InvalidCronExpression: {0}")]
     InvalidCronExpression(String),
     #[error("WorkflowError - InvalidTimezone: {0}")]

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -17,9 +17,7 @@ use super::definition::{WorkflowSandboxDecl, WorkflowStepDef};
 use super::error::WorkflowError;
 use super::repo::WorkflowDefinitionRepo;
 use super::run::{StepResult, WorkflowRunRepo, WorkflowRunState};
-use super::template::{
-    format_template_diagnostics, substitute_value, template_diagnostics, TemplateContext,
-};
+use super::template::{format_template_diagnostics, template_diagnostics, TemplateContext};
 
 /// Hard cap on the pre-flight per-sandbox readiness wait. Protects the
 /// queue from a stuck infrastructure step.
@@ -475,9 +473,9 @@ impl Executor {
                     trigger: trigger_context,
                     steps: step_outputs,
                 };
-                let templated_body =
-                    super::template::substitute_in_string(&raw_body, &template_ctx)
-                        .map_err(|e| WorkflowError::Skill(e.to_string()))?;
+                let templated_body = template_ctx
+                    .substitute_in_string(&raw_body)
+                    .map_err(|e| WorkflowError::Skill(e.to_string()))?;
                 let prompt =
                     crate::skill::SkillBody::new(templated_body).interpolate(Some(&arguments));
 
@@ -740,7 +738,8 @@ impl Executor {
             trigger: trigger_context,
             steps: step_outputs,
         };
-        let resolved_params = substitute_value(params, &template_ctx)
+        let resolved_params = template_ctx
+            .substitute(params)
             .map_err(|e| WorkflowError::InvalidTemplateRef(e.to_string()))?;
         // Walk the params/resolved trees once up front so the
         // happy path drops `resolved_params` cleanly into the

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -5,20 +5,58 @@ use std::time::Duration;
 
 use crate::agent::session::message::SUBMIT_OUTPUT_TOOL_NAME;
 use crate::agent::{Agent, Agents};
+use crate::auth::AuthSubject;
 use crate::primitives::{
     AgentId, ChatOutputEvent, ProjectId, SandboxId, WorkflowDefinitionId, WorkflowRunId,
 };
 use crate::sandbox::{Sandbox, SandboxAgentMode, SandboxSpecs, SandboxState, Sandboxes};
 use crate::skill::Skills;
+use crate::toolset::ToolSets;
 
 use super::definition::{WorkflowSandboxDecl, WorkflowStepDef};
 use super::error::WorkflowError;
 use super::repo::WorkflowDefinitionRepo;
-use super::run::{WorkflowRunRepo, WorkflowRunState};
+use super::run::{StepResult, WorkflowRunRepo, WorkflowRunState};
+use super::template::{substitute_value, TemplateContext};
 
 /// Hard cap on the pre-flight per-sandbox readiness wait. Protects the
 /// queue from a stuck infrastructure step.
 const SANDBOX_READY_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Default per-`ToolStep` dispatch timeout when the step doesn't
+/// specify one. Same shape as the agent step's idle timeout default.
+const DEFAULT_TOOL_STEP_TIMEOUT_SECS: u64 = 300;
+
+/// Build the `steps` slice of the template context from the run's
+/// completed-step outputs. Skips entries with no recorded output
+/// (pending or failed steps).
+fn collect_step_outputs(results: &[StepResult]) -> HashMap<String, serde_json::Value> {
+    let mut out = HashMap::with_capacity(results.len());
+    for r in results {
+        if let Some(value) = &r.output {
+            out.insert(r.name.clone(), value.clone());
+        }
+    }
+    out
+}
+
+fn first_text_content(result: &rmcp::model::CallToolResult) -> Option<String> {
+    result.content.iter().find_map(|c| match &c.raw {
+        rmcp::model::RawContent::Text(t) => Some(t.text.clone()),
+        _ => None,
+    })
+}
+
+fn type_label(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
+    }
+}
 
 pub struct Executor {
     runs: WorkflowRunRepo,
@@ -26,6 +64,9 @@ pub struct Executor {
     agents: Arc<Agents>,
     skills: Arc<Skills>,
     sandboxes: Arc<Sandboxes>,
+    /// Used by `ToolStep` dispatch; held here rather than passed per
+    /// call so the agent-step path is unchanged.
+    toolsets: Arc<ToolSets>,
 }
 
 impl Executor {
@@ -35,6 +76,7 @@ impl Executor {
         agents: Arc<Agents>,
         skills: Arc<Skills>,
         sandboxes: Arc<Sandboxes>,
+        toolsets: Arc<ToolSets>,
     ) -> Self {
         Self {
             runs,
@@ -42,6 +84,7 @@ impl Executor {
             agents,
             skills,
             sandboxes,
+            toolsets,
         }
     }
 
@@ -134,6 +177,7 @@ impl Executor {
                 self.runs.update(&mut run).await?;
             }
 
+            let step_outputs = collect_step_outputs(&run.step_results);
             let outcome = self
                 .execute_step(
                     project_id,
@@ -141,6 +185,7 @@ impl Executor {
                     run_id,
                     step,
                     &trigger_context,
+                    &step_outputs,
                     &sandbox_ids,
                     &preexisting_ids,
                     &mut borrowed_preexisting,
@@ -373,6 +418,7 @@ impl Executor {
         run_id: WorkflowRunId,
         step: &WorkflowStepDef,
         trigger_context: &serde_json::Value,
+        step_outputs: &HashMap<String, serde_json::Value>,
         sandbox_ids: &HashMap<String, SandboxId>,
         preexisting_ids: &HashSet<SandboxId>,
         borrowed_preexisting: &mut HashSet<SandboxId>,
@@ -385,6 +431,7 @@ impl Executor {
                 sandbox,
                 sandbox_mode,
                 timeout_seconds,
+                output_schema,
                 ..
             } => {
                 let attach_sandbox = match sandbox.as_deref() {
@@ -400,12 +447,24 @@ impl Executor {
                 let arguments = serde_json::to_string_pretty(trigger_context)
                     .unwrap_or_else(|_| trigger_context.to_string());
                 let sandbox_id = attach_sandbox.map(|(id, _)| id);
-                let prompt = self
+                let raw_prompt = self
                     .skills
                     .interpolate_skill(skill, Some(project_id), sandbox_id, Some(&arguments))
                     .await
                     .map_err(|e| WorkflowError::Skill(e.to_string()))?
                     .ok_or_else(|| WorkflowError::SkillNotFound(skill.clone()))?;
+
+                // Layer `${{ trigger.X }}` / `${{ steps.<n>.outputs.Y }}`
+                // substitution on top of the existing `$ARGUMENTS` /
+                // `$N` handling that `interpolate_skill` already
+                // applied. Errors propagate as `Skill` failures
+                // (template syntax is the skill body author's concern).
+                let template_ctx = TemplateContext {
+                    trigger: trigger_context,
+                    steps: step_outputs,
+                };
+                let prompt = super::template::substitute_in_string(&raw_prompt, &template_ctx)
+                    .map_err(|e| WorkflowError::Skill(e.to_string()))?;
 
                 let agent_name = format!("workflow-{}-{name}", run_id.short());
                 let mut op = self
@@ -447,7 +506,7 @@ impl Executor {
                             &agent_name,
                             attach_sandbox,
                             chain_override,
-                            step.output_schema().clone(),
+                            output_schema.as_ref().clone(),
                         )
                         .await
                         .map_err(|e| WorkflowError::Agent(e.to_string()))?;
@@ -489,6 +548,24 @@ impl Executor {
                 }
 
                 result
+            }
+            WorkflowStepDef::ToolStep {
+                name,
+                tool,
+                params,
+                timeout_seconds,
+            } => {
+                self.execute_tool_step(
+                    project_id,
+                    run_id,
+                    name,
+                    tool,
+                    params,
+                    *timeout_seconds,
+                    trigger_context,
+                    step_outputs,
+                )
+                .await
             }
         }
     }
@@ -612,6 +689,100 @@ impl Executor {
             .submitted_output(agent.id)
             .await
             .map_err(|e| WorkflowError::Agent(e.to_string()))
+    }
+
+    /// Dispatch a single top-level MCP tool with `${{ … }}`-substituted
+    /// params. Mints an `AuthSubject::WorkflowExecutor` carrying the
+    /// workflow's project authority. The called tool MUST declare
+    /// `output_schema()` (Q9-c, memo `019e01a4`); the resulting
+    /// `structured_content` is what flows into `StepResult.output`.
+    /// Tool errors (`is_error: true` or absent structured content)
+    /// fail the step.
+    #[allow(clippy::too_many_arguments)]
+    async fn execute_tool_step(
+        &self,
+        project_id: ProjectId,
+        run_id: WorkflowRunId,
+        step_name: &str,
+        tool_name: &str,
+        params: &serde_json::Value,
+        timeout_seconds: Option<u64>,
+        trigger_context: &serde_json::Value,
+        step_outputs: &HashMap<String, serde_json::Value>,
+    ) -> Result<serde_json::Value, WorkflowError> {
+        let tool = self
+            .toolsets
+            .find_top_level_tool(tool_name)
+            .ok_or_else(|| WorkflowError::ToolNotFound(tool_name.to_string()))?;
+
+        if !tool.composable() {
+            return Err(WorkflowError::InvalidStep(format!(
+                "tool_step '{step_name}': tool '{tool_name}' is not composable; \
+                 only `composable: true` tools can be called from a workflow step"
+            )));
+        }
+        if tool.output_schema().is_none() {
+            return Err(WorkflowError::InvalidStep(format!(
+                "tool_step '{step_name}': tool '{tool_name}' does not declare an \
+                 output_schema; tool_step requires structured output"
+            )));
+        }
+
+        let template_ctx = TemplateContext {
+            trigger: trigger_context,
+            steps: step_outputs,
+        };
+        let resolved_params = substitute_value(params, &template_ctx)
+            .map_err(|e| WorkflowError::InvalidTemplateRef(e.to_string()))?;
+
+        // Top-level tools accept `Option<JsonObject>`. Coerce non-objects
+        // to an empty object — the tool's input schema rejects the
+        // missing-field case with a clear error if it cared.
+        let arguments = match resolved_params {
+            serde_json::Value::Object(map) => Some(map),
+            serde_json::Value::Null => None,
+            other => {
+                return Err(WorkflowError::InvalidStep(format!(
+                    "tool_step '{step_name}': resolved params must be a JSON object, got {}",
+                    type_label(&other)
+                )));
+            }
+        };
+
+        let subject = AuthSubject::workflow_executor(project_id, run_id);
+        let timeout =
+            Duration::from_secs(timeout_seconds.unwrap_or(DEFAULT_TOOL_STEP_TIMEOUT_SECS));
+
+        let call = self
+            .toolsets
+            .call_top_level_tool(&subject, tool_name, arguments);
+        let result = match tokio::time::timeout(timeout, call).await {
+            Ok(r) => r.map_err(|e| WorkflowError::ToolDispatch(e.to_string()))?,
+            Err(_) => {
+                return Err(WorkflowError::StepFailed {
+                    step: step_name.to_string(),
+                    reason: format!("tool '{tool_name}' timed out after {}s", timeout.as_secs()),
+                })
+            }
+        };
+
+        if result.is_error.unwrap_or(false) {
+            let detail = first_text_content(&result)
+                .unwrap_or_else(|| "tool returned is_error: true with no text content".to_string());
+            return Err(WorkflowError::StepFailed {
+                step: step_name.to_string(),
+                reason: format!("tool '{tool_name}' failed: {detail}"),
+            });
+        }
+
+        result
+            .structured_content
+            .ok_or_else(|| WorkflowError::StepFailed {
+                step: step_name.to_string(),
+                reason: format!(
+                    "tool '{tool_name}' returned no structured_content; tool_step requires it"
+                ),
+            })
     }
 
     async fn detach_step_sandbox(&self, sandbox_id: SandboxId, agent_id: AgentId) {

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -17,7 +17,9 @@ use super::definition::{WorkflowSandboxDecl, WorkflowStepDef};
 use super::error::WorkflowError;
 use super::repo::WorkflowDefinitionRepo;
 use super::run::{StepResult, WorkflowRunRepo, WorkflowRunState};
-use super::template::{substitute_value, TemplateContext};
+use super::template::{
+    format_template_diagnostics, substitute_value, template_diagnostics, TemplateContext,
+};
 
 /// Hard cap on the pre-flight per-sandbox readiness wait. Protects the
 /// queue from a stuck infrastructure step.
@@ -734,6 +736,11 @@ impl Executor {
         };
         let resolved_params = substitute_value(params, &template_ctx)
             .map_err(|e| WorkflowError::InvalidTemplateRef(e.to_string()))?;
+        // Pre-compute the diagnostic trace once so any of the
+        // tool-rejection paths below can include it without
+        // re-walking the params tree.
+        let diagnostics = template_diagnostics(params, &resolved_params);
+        let diagnostics_block = format_template_diagnostics(&diagnostics);
 
         // Top-level tools accept `Option<JsonObject>`. Coerce non-objects
         // to an empty object — the tool's input schema rejects the
@@ -757,7 +764,12 @@ impl Executor {
             .toolsets
             .call_top_level_tool(&subject, tool_name, arguments);
         let result = match tokio::time::timeout(timeout, call).await {
-            Ok(r) => r.map_err(|e| WorkflowError::ToolDispatch(e.to_string()))?,
+            Ok(Ok(r)) => r,
+            Ok(Err(e)) => {
+                return Err(WorkflowError::ToolDispatch(format!(
+                    "tool '{tool_name}': {e}{diagnostics_block}"
+                )));
+            }
             Err(_) => {
                 return Err(WorkflowError::StepErrored {
                     step: step_name.to_string(),
@@ -771,7 +783,7 @@ impl Executor {
                 .unwrap_or_else(|| "tool returned is_error: true with no text content".to_string());
             return Err(WorkflowError::StepErrored {
                 step: step_name.to_string(),
-                reason: format!("tool '{tool_name}' failed: {detail}"),
+                reason: format!("tool '{tool_name}' failed: {detail}{diagnostics_block}"),
             });
         }
 

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -727,23 +727,14 @@ impl Executor {
         trigger_context: &serde_json::Value,
         step_outputs: &HashMap<String, serde_json::Value>,
     ) -> Result<serde_json::Value, WorkflowError> {
-        let tool = self
-            .toolsets
-            .find_top_level_tool(tool_name)
-            .ok_or_else(|| WorkflowError::ToolNotFound(tool_name.to_string()))?;
-
-        if !tool.composable() {
-            return Err(WorkflowError::InvalidStep(format!(
-                "tool_step '{step_name}': tool '{tool_name}' is not composable; \
-                 only `composable: true` tools can be called from a workflow step"
-            )));
-        }
-        if tool.output_schema().is_none() {
-            return Err(WorkflowError::InvalidStep(format!(
-                "tool_step '{step_name}': tool '{tool_name}' does not declare an \
-                 output_schema; tool_step requires structured output"
-            )));
-        }
+        // Workflow contract is enforced by `find_for_workflow`
+        // (registered + composable + declares output_schema). The
+        // same check runs at workflow-create / update time in
+        // `Workflows::validate_steps`, so this branch is defensive
+        // — top-level tool registration is build-time only.
+        self.toolsets
+            .find_for_workflow(tool_name)
+            .map_err(|e| WorkflowError::ToolNotFound(format!("tool_step '{step_name}': {e}")))?;
 
         let template_ctx = TemplateContext {
             trigger: trigger_context,

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -449,24 +449,37 @@ impl Executor {
                 let arguments = serde_json::to_string_pretty(trigger_context)
                     .unwrap_or_else(|_| trigger_context.to_string());
                 let sandbox_id = attach_sandbox.map(|(id, _)| id);
-                let raw_prompt = self
+
+                // Two-pass interpolation, ORDER MATTERS for security:
+                //
+                //   1. Resolve `${{ trigger.X }}` / `${{ steps.<n>.outputs.Y }}`
+                //      against the raw skill body. The skill author's
+                //      template references resolve here.
+                //   2. Then expand `$ARGUMENTS` / `$N` — the JSON-
+                //      serialised trigger payload is spliced in as
+                //      OPAQUE text. A literal `${{ … }}` in user-
+                //      controlled payload content (a commit message,
+                //      a webhook field, …) survives this expansion
+                //      but is no longer re-evaluated, so an attacker
+                //      cannot leak prior step outputs into the
+                //      prompt by smuggling templates through the
+                //      trigger.
+                let raw_body: String = self
                     .skills
-                    .interpolate_skill(skill, Some(project_id), sandbox_id, Some(&arguments))
+                    .find_by_name(skill, Some(project_id), sandbox_id)
                     .await
                     .map_err(|e| WorkflowError::Skill(e.to_string()))?
-                    .ok_or_else(|| WorkflowError::SkillNotFound(skill.clone()))?;
-
-                // Layer `${{ trigger.X }}` / `${{ steps.<n>.outputs.Y }}`
-                // substitution on top of the existing `$ARGUMENTS` /
-                // `$N` handling that `interpolate_skill` already
-                // applied. Errors propagate as `Skill` failures
-                // (template syntax is the skill body author's concern).
+                    .ok_or_else(|| WorkflowError::SkillNotFound(skill.clone()))?
+                    .into();
                 let template_ctx = TemplateContext {
                     trigger: trigger_context,
                     steps: step_outputs,
                 };
-                let prompt = super::template::substitute_in_string(&raw_prompt, &template_ctx)
-                    .map_err(|e| WorkflowError::Skill(e.to_string()))?;
+                let templated_body =
+                    super::template::substitute_in_string(&raw_body, &template_ctx)
+                        .map_err(|e| WorkflowError::Skill(e.to_string()))?;
+                let prompt =
+                    crate::skill::SkillBody::new(templated_body).interpolate(Some(&arguments));
 
                 let agent_name = format!("workflow-{}-{name}", run_id.short());
                 let mut op = self
@@ -559,6 +572,7 @@ impl Executor {
             } => {
                 self.execute_tool_step(
                     project_id,
+                    workflow_id,
                     run_id,
                     name,
                     tool,
@@ -704,6 +718,7 @@ impl Executor {
     async fn execute_tool_step(
         &self,
         project_id: ProjectId,
+        workflow_id: WorkflowDefinitionId,
         run_id: WorkflowRunId,
         step_name: &str,
         tool_name: &str,
@@ -756,7 +771,7 @@ impl Executor {
             }
         };
 
-        let subject = AuthSubject::workflow_executor(project_id, run_id);
+        let subject = AuthSubject::workflow_executor(project_id, workflow_id, run_id);
         let timeout =
             Duration::from_secs(timeout_seconds.unwrap_or(DEFAULT_TOOL_STEP_TIMEOUT_SECS));
 

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -759,7 +759,7 @@ impl Executor {
         let result = match tokio::time::timeout(timeout, call).await {
             Ok(r) => r.map_err(|e| WorkflowError::ToolDispatch(e.to_string()))?,
             Err(_) => {
-                return Err(WorkflowError::StepFailed {
+                return Err(WorkflowError::StepErrored {
                     step: step_name.to_string(),
                     reason: format!("tool '{tool_name}' timed out after {}s", timeout.as_secs()),
                 })
@@ -769,7 +769,7 @@ impl Executor {
         if result.is_error.unwrap_or(false) {
             let detail = first_text_content(&result)
                 .unwrap_or_else(|| "tool returned is_error: true with no text content".to_string());
-            return Err(WorkflowError::StepFailed {
+            return Err(WorkflowError::StepErrored {
                 step: step_name.to_string(),
                 reason: format!("tool '{tool_name}' failed: {detail}"),
             });
@@ -777,7 +777,7 @@ impl Executor {
 
         result
             .structured_content
-            .ok_or_else(|| WorkflowError::StepFailed {
+            .ok_or_else(|| WorkflowError::StepErrored {
                 step: step_name.to_string(),
                 reason: format!(
                     "tool '{tool_name}' returned no structured_content; tool_step requires it"

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -751,11 +751,13 @@ impl Executor {
         };
         let resolved_params = substitute_value(params, &template_ctx)
             .map_err(|e| WorkflowError::InvalidTemplateRef(e.to_string()))?;
-        // Pre-compute the diagnostic trace once so any of the
-        // tool-rejection paths below can include it without
-        // re-walking the params tree.
+        // Walk the params/resolved trees once up front so the
+        // happy path drops `resolved_params` cleanly into the
+        // dispatch arguments below; the rejection paths share the
+        // same `diagnostics` slice and only pay the formatting
+        // cost when they fire.
         let diagnostics = template_diagnostics(params, &resolved_params);
-        let diagnostics_block = format_template_diagnostics(&diagnostics);
+        let diagnose = || format_template_diagnostics(&diagnostics);
 
         // Top-level tools accept `Option<JsonObject>`. Coerce non-objects
         // to an empty object — the tool's input schema rejects the
@@ -782,7 +784,8 @@ impl Executor {
             Ok(Ok(r)) => r,
             Ok(Err(e)) => {
                 return Err(WorkflowError::ToolDispatch(format!(
-                    "tool '{tool_name}': {e}{diagnostics_block}"
+                    "tool '{tool_name}': {e}{}",
+                    diagnose()
                 )));
             }
             Err(_) => {
@@ -798,7 +801,7 @@ impl Executor {
                 .unwrap_or_else(|| "tool returned is_error: true with no text content".to_string());
             return Err(WorkflowError::StepErrored {
                 step: step_name.to_string(),
-                reason: format!("tool '{tool_name}' failed: {detail}{diagnostics_block}"),
+                reason: format!("tool '{tool_name}' failed: {detail}{}", diagnose()),
             });
         }
 

--- a/core/src/workflow/job.rs
+++ b/core/src/workflow/job.rs
@@ -8,6 +8,7 @@ use crate::agent::Agents;
 use crate::primitives::WorkflowRunId;
 use crate::sandbox::Sandboxes;
 use crate::skill::Skills;
+use crate::toolset::ToolSets;
 
 use super::error::WorkflowError;
 use super::executor::Executor;
@@ -27,6 +28,7 @@ pub struct ExecuteRunJobInitializer {
     agents: Arc<Agents>,
     skills: Arc<Skills>,
     sandboxes: Arc<Sandboxes>,
+    toolsets: Arc<ToolSets>,
 }
 
 impl ExecuteRunJobInitializer {
@@ -36,6 +38,7 @@ impl ExecuteRunJobInitializer {
         agents: Arc<Agents>,
         skills: Arc<Skills>,
         sandboxes: Arc<Sandboxes>,
+        toolsets: Arc<ToolSets>,
     ) -> Self {
         Self {
             runs,
@@ -43,6 +46,7 @@ impl ExecuteRunJobInitializer {
             agents,
             skills,
             sandboxes,
+            toolsets,
         }
     }
 }
@@ -66,6 +70,7 @@ impl JobInitializer for ExecuteRunJobInitializer {
             Arc::clone(&self.agents),
             Arc::clone(&self.skills),
             Arc::clone(&self.sandboxes),
+            Arc::clone(&self.toolsets),
         );
         Ok(Box::new(ExecuteRunRunner { executor, config }))
     }

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -38,43 +38,27 @@ use cron_job::{cron_queue_id, TriggerCronConfig, TriggerCronJobInitializer};
 use job::{ExecuteRunConfig, ExecuteRunJobInitializer};
 use repo::WorkflowDefinitionRepo;
 use run::entity::NewWorkflowRun;
-use template::{PathSegment, TemplateRef};
+use template::TemplateRef;
 
 /// Reject `${{ steps.X.outputs.… }}` refs whose `X` hasn't been
-/// validated yet. Trigger refs always pass (their schema check is
-/// deferred — memo `019e01a4` open Q6: skip provider-payload
-/// validation in MVP).
+/// validated yet. Trigger refs always pass (provider payload schema
+/// validation deferred — memo `019e01a4` open Q6).
 fn validate_ref_against_prior_steps(
     step_name: &str,
     r: &TemplateRef,
     seen: &std::collections::HashSet<String>,
 ) -> Result<(), WorkflowError> {
-    let mut iter = r.path.iter();
-    match iter.next() {
-        Some(PathSegment::Field(s)) if s == "trigger" => Ok(()),
-        Some(PathSegment::Field(s)) if s == "steps" => {
-            let target = match iter.next() {
-                Some(PathSegment::Field(n)) => n.clone(),
-                _ => {
-                    return Err(WorkflowError::InvalidTemplateRef(format!(
-                        "step '{step_name}': {} — `steps.<name>` requires a step name",
-                        r.raw
-                    )))
-                }
-            };
-            if !seen.contains(&target) {
-                return Err(WorkflowError::InvalidTemplateRef(format!(
-                    "step '{step_name}': {} — references step '{target}' which is not declared earlier in the workflow",
-                    r.raw
-                )));
-            }
-            Ok(())
+    template::validate_root(r)
+        .map_err(|e| WorkflowError::InvalidTemplateRef(format!("step '{step_name}': {e}")))?;
+    for target in template::referenced_step_names(r) {
+        if !seen.contains(&target) {
+            return Err(WorkflowError::InvalidTemplateRef(format!(
+                "step '{step_name}': {} — references step '{target}' which is not declared earlier in the workflow",
+                r.raw
+            )));
         }
-        _ => Err(WorkflowError::InvalidTemplateRef(format!(
-            "step '{step_name}': {} — root must be `trigger` or `steps`",
-            r.raw
-        ))),
     }
+    Ok(())
 }
 
 #[derive(Clone)]

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -7,6 +7,7 @@ pub mod importer;
 pub(crate) mod job;
 pub(crate) mod repo;
 pub mod run;
+pub mod template;
 pub mod yaml;
 
 pub use importer::WorkflowsImporter;
@@ -20,6 +21,7 @@ use crate::agent::Agents;
 use crate::primitives::*;
 use crate::sandbox::Sandboxes;
 use crate::skill::Skills;
+use crate::toolset::ToolSets;
 use crate::user::Users;
 
 pub const WORKFLOW_DOC_TYPE: drua_library::DocType = drua_library::DocType::new("workflow");
@@ -36,6 +38,44 @@ use cron_job::{cron_queue_id, TriggerCronConfig, TriggerCronJobInitializer};
 use job::{ExecuteRunConfig, ExecuteRunJobInitializer};
 use repo::WorkflowDefinitionRepo;
 use run::entity::NewWorkflowRun;
+use template::{PathSegment, TemplateRef};
+
+/// Reject `${{ steps.X.outputs.… }}` refs whose `X` hasn't been
+/// validated yet. Trigger refs always pass (their schema check is
+/// deferred — memo `019e01a4` open Q6: skip provider-payload
+/// validation in MVP).
+fn validate_ref_against_prior_steps(
+    step_name: &str,
+    r: &TemplateRef,
+    seen: &std::collections::HashSet<String>,
+) -> Result<(), WorkflowError> {
+    let mut iter = r.path.iter();
+    match iter.next() {
+        Some(PathSegment::Field(s)) if s == "trigger" => Ok(()),
+        Some(PathSegment::Field(s)) if s == "steps" => {
+            let target = match iter.next() {
+                Some(PathSegment::Field(n)) => n.clone(),
+                _ => {
+                    return Err(WorkflowError::InvalidTemplateRef(format!(
+                        "step '{step_name}': {} — `steps.<name>` requires a step name",
+                        r.raw
+                    )))
+                }
+            };
+            if !seen.contains(&target) {
+                return Err(WorkflowError::InvalidTemplateRef(format!(
+                    "step '{step_name}': {} — references step '{target}' which is not declared earlier in the workflow",
+                    r.raw
+                )));
+            }
+            Ok(())
+        }
+        _ => Err(WorkflowError::InvalidTemplateRef(format!(
+            "step '{step_name}': {} — root must be `trigger` or `steps`",
+            r.raw
+        ))),
+    }
+}
 
 #[derive(Clone)]
 pub struct Workflows {
@@ -43,6 +83,10 @@ pub struct Workflows {
     run_repo: WorkflowRunRepo,
     skills: Arc<Skills>,
     users: Arc<Users>,
+    /// Held for parse-time `${{ … }}` reference validation in
+    /// `tool_step.params` — looks up the called tool's
+    /// `output_schema()` + `composable()` flag.
+    toolsets: Arc<ToolSets>,
     execute_run_spawner: ::job::JobSpawner<ExecuteRunConfig>,
     cron_spawner: ::job::JobSpawner<TriggerCronConfig>,
     /// Cloned `Jobs` handle so `await_run_completion` can block on the
@@ -63,6 +107,7 @@ impl Workflows {
         agents: Arc<Agents>,
         sandboxes: Arc<Sandboxes>,
         users: Arc<Users>,
+        toolsets: Arc<ToolSets>,
         jobs: &mut ::job::Jobs,
     ) -> Self {
         let execute_run_spawner = jobs.add_initializer(ExecuteRunJobInitializer::new(
@@ -71,6 +116,7 @@ impl Workflows {
             agents,
             Arc::clone(&skills),
             sandboxes,
+            Arc::clone(&toolsets),
         ));
         let cron_spawner = jobs.add_initializer(TriggerCronJobInitializer::new(
             WorkflowDefinitionRepo::new_without_library(pool),
@@ -82,6 +128,7 @@ impl Workflows {
             run_repo: WorkflowRunRepo::new(pool),
             skills,
             users,
+            toolsets,
             execute_run_spawner,
             cron_spawner,
             jobs: jobs.clone(),
@@ -226,6 +273,12 @@ impl Workflows {
         // sees the full list (rather than fixing one and re-running).
         let mut missing_skills: Vec<(String, String)> = Vec::new();
         let mut undeclared_sandboxes: Vec<(String, String)> = Vec::new();
+        // Names of steps that have already been validated, in order;
+        // a step's `${{ steps.X.outputs.… }}` refs may only point at
+        // entries already in this set (i.e. earlier in the linear
+        // step list).
+        let mut seen_step_names: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
 
         for step in steps {
             match step {
@@ -262,7 +315,46 @@ impl Workflows {
                     // invariant at construction/deserialization
                     // (memo 019dfc8c). Bad schemas can't reach here.
                 }
+                WorkflowStepDef::ToolStep {
+                    name, tool, params, ..
+                } => {
+                    if tool.trim().is_empty() {
+                        return Err(WorkflowError::InvalidStep(format!(
+                            "tool_step '{name}': `tool` is required and must be non-empty"
+                        )));
+                    }
+                    let resolved = self.toolsets.find_top_level_tool(tool).ok_or_else(|| {
+                        WorkflowError::ToolNotFound(format!(
+                            "tool_step '{name}': tool '{tool}' is not registered"
+                        ))
+                    })?;
+                    if !resolved.composable() {
+                        return Err(WorkflowError::InvalidStep(format!(
+                            "tool_step '{name}': tool '{tool}' is not composable; \
+                             only `composable: true` tools can be called from a workflow step"
+                        )));
+                    }
+                    if resolved.output_schema().is_none() {
+                        return Err(WorkflowError::InvalidStep(format!(
+                            "tool_step '{name}': tool '{tool}' does not declare an \
+                             output_schema; tool_step requires structured output"
+                        )));
+                    }
+
+                    let refs = template::extract_refs_in_value(params).map_err(|e| {
+                        WorkflowError::InvalidTemplateRef(format!("tool_step '{name}': {e}"))
+                    })?;
+                    for r in &refs {
+                        if let Err(e) = template::validate_root(r) {
+                            return Err(WorkflowError::InvalidTemplateRef(format!(
+                                "tool_step '{name}': {e}"
+                            )));
+                        }
+                        validate_ref_against_prior_steps(name, r, &seen_step_names)?;
+                    }
+                }
             }
+            seen_step_names.insert(step.name().to_string());
         }
 
         if !missing_skills.is_empty() {
@@ -721,5 +813,36 @@ mod tests {
         })
         .unwrap_err();
         assert!(matches!(err, WorkflowError::InvalidTimezone(_)));
+    }
+
+    #[test]
+    fn template_ref_against_prior_steps_accepts_trigger() {
+        let r = template::parse_path("trigger.payload.build").unwrap();
+        let seen = std::collections::HashSet::new();
+        validate_ref_against_prior_steps("any", &r, &seen).expect("trigger refs always accepted");
+    }
+
+    #[test]
+    fn template_ref_against_prior_steps_accepts_seen_step() {
+        let r = template::parse_path("steps.triage.outputs.workflow").unwrap();
+        let mut seen = std::collections::HashSet::new();
+        seen.insert("triage".to_string());
+        validate_ref_against_prior_steps("dispatch", &r, &seen).unwrap();
+    }
+
+    #[test]
+    fn template_ref_against_prior_steps_rejects_forward_ref() {
+        let r = template::parse_path("steps.later.outputs.x").unwrap();
+        let seen = std::collections::HashSet::new();
+        let err = validate_ref_against_prior_steps("first", &r, &seen).unwrap_err();
+        assert!(matches!(err, WorkflowError::InvalidTemplateRef(_)));
+    }
+
+    #[test]
+    fn template_ref_against_prior_steps_rejects_unknown_root() {
+        let r = template::parse_path("env.HOME").unwrap();
+        let seen = std::collections::HashSet::new();
+        let err = validate_ref_against_prior_steps("any", &r, &seen).unwrap_err();
+        assert!(matches!(err, WorkflowError::InvalidTemplateRef(_)));
     }
 }

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -40,6 +40,19 @@ use repo::WorkflowDefinitionRepo;
 use run::entity::NewWorkflowRun;
 use template::TemplateRef;
 
+/// CEL identifier shape — `[A-Za-z_][A-Za-z0-9_]*`. Step names
+/// must conform so `${{ steps.<name>.outputs.… }}` parses as a
+/// field path rather than an arithmetic expression. Mirrors the
+/// regex in `template::referenced_step_names`.
+fn is_cel_identifier(s: &str) -> bool {
+    let mut chars = s.chars();
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return false,
+    }
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
 /// Reject `${{ steps.X.outputs.… }}` refs whose `X` hasn't been
 /// validated yet. Trigger refs always pass (provider payload schema
 /// validation deferred — memo `019e01a4` open Q6).
@@ -264,6 +277,25 @@ impl Workflows {
         let mut seen_step_names: std::collections::HashSet<String> =
             std::collections::HashSet::new();
 
+        // Step names appear inside `${{ steps.<name>.outputs.… }}`
+        // and must therefore be valid CEL identifiers — anything
+        // else (hyphens, spaces, leading digits, …) is parsed by
+        // CEL as a different expression entirely (e.g.
+        // `steps.store-note.outputs.x` becomes
+        // `(steps.store) - (note.outputs.x)`). Reject at parse time
+        // so authors learn at create time, not when a downstream
+        // template silently fails to resolve.
+        for step in steps {
+            if !is_cel_identifier(step.name()) {
+                return Err(WorkflowError::InvalidStep(format!(
+                    "step '{}': name must be a CEL identifier (letters, digits, \
+                     underscores; first char a letter or underscore) so it can be \
+                     referenced via `${{{{ steps.<name>.outputs.… }}}}`",
+                    step.name()
+                )));
+            }
+        }
+
         for step in steps {
             match step {
                 WorkflowStepDef::AgentStep {
@@ -302,28 +334,15 @@ impl Workflows {
                 WorkflowStepDef::ToolStep {
                     name, tool, params, ..
                 } => {
-                    if tool.trim().is_empty() {
-                        return Err(WorkflowError::InvalidStep(format!(
-                            "tool_step '{name}': `tool` is required and must be non-empty"
-                        )));
-                    }
-                    let resolved = self.toolsets.find_top_level_tool(tool).ok_or_else(|| {
-                        WorkflowError::ToolNotFound(format!(
-                            "tool_step '{name}': tool '{tool}' is not registered"
-                        ))
+                    // The lookup enforces every workflow `tool_step`
+                    // contract in one place: registered, composable,
+                    // declares an output_schema. The runtime
+                    // executor calls the same helper, so a workflow
+                    // that passes `validate_steps` cannot fail
+                    // dispatch on these checks at run time.
+                    self.toolsets.find_for_workflow(tool).map_err(|e| {
+                        WorkflowError::InvalidStep(format!("tool_step '{name}': {e}"))
                     })?;
-                    if !resolved.composable() {
-                        return Err(WorkflowError::InvalidStep(format!(
-                            "tool_step '{name}': tool '{tool}' is not composable; \
-                             only `composable: true` tools can be called from a workflow step"
-                        )));
-                    }
-                    if resolved.output_schema().is_none() {
-                        return Err(WorkflowError::InvalidStep(format!(
-                            "tool_step '{name}': tool '{tool}' does not declare an \
-                             output_schema; tool_step requires structured output"
-                        )));
-                    }
 
                     // `validate_ref_against_prior_steps` runs
                     // `template::validate_root` internally — no need
@@ -826,5 +845,21 @@ mod tests {
         let seen = std::collections::HashSet::new();
         let err = validate_ref_against_prior_steps("any", &r, &seen).unwrap_err();
         assert!(matches!(err, WorkflowError::InvalidTemplateRef(_)));
+    }
+
+    #[test]
+    fn cel_identifier_accepts_underscore_and_alphanumerics() {
+        assert!(is_cel_identifier("step1"));
+        assert!(is_cel_identifier("_leading_underscore"));
+        assert!(is_cel_identifier("Camel_Snake_42"));
+    }
+
+    #[test]
+    fn cel_identifier_rejects_hyphen_leading_digit_and_empty() {
+        assert!(!is_cel_identifier(""));
+        assert!(!is_cel_identifier("store-note"));
+        assert!(!is_cel_identifier("1step"));
+        assert!(!is_cel_identifier("has space"));
+        assert!(!is_cel_identifier("dot.in.middle"));
     }
 }

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -325,15 +325,13 @@ impl Workflows {
                         )));
                     }
 
+                    // `validate_ref_against_prior_steps` runs
+                    // `template::validate_root` internally — no need
+                    // to repeat it here.
                     let refs = template::extract_refs_in_value(params).map_err(|e| {
                         WorkflowError::InvalidTemplateRef(format!("tool_step '{name}': {e}"))
                     })?;
                     for r in &refs {
-                        if let Err(e) = template::validate_root(r) {
-                            return Err(WorkflowError::InvalidTemplateRef(format!(
-                                "tool_step '{name}': {e}"
-                            )));
-                        }
                         validate_ref_against_prior_steps(name, r, &seen_step_names)?;
                     }
                 }

--- a/core/src/workflow/run/entity.rs
+++ b/core/src/workflow/run/entity.rs
@@ -399,7 +399,7 @@ mod tests {
             sandbox_mode: None,
             timeout_seconds: None,
             model_chain: None,
-            output_schema: default_output_schema(),
+            output_schema: Box::new(default_output_schema()),
         }
     }
 

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -130,11 +130,8 @@ impl TemplateContext<'_> {
     /// `None` when the path doesn't exist at this point in time
     /// (parse-time validation should already have rejected refs
     /// that can never resolve, but optional fields surface here).
-    ///
-    /// Convenience wrapper that builds the CEL context per call —
-    /// fine for one-off resolutions; the substitution walks reuse
-    /// a built context across all string leaves to amortise the
-    /// `trigger` / `steps` clones.
+    /// Builds a fresh CEL context per call; the `substitute*`
+    /// methods reuse one internally across all string leaves.
     pub fn resolve(&self, r: &TemplateRef) -> Option<Value> {
         let built = self.build_cel_context().ok()?;
         resolve_with_built(&built, r)
@@ -563,7 +560,9 @@ mod tests {
             trigger: &trigger,
             steps: &steps,
         };
-        let s = ctx.substitute_in_string("ids=${{ trigger.payload.list }}").unwrap();
+        let s = ctx
+            .substitute_in_string("ids=${{ trigger.payload.list }}")
+            .unwrap();
         assert_eq!(s, "ids=[1,2,3]");
     }
 
@@ -589,7 +588,8 @@ mod tests {
             steps: &steps,
         };
         assert_eq!(
-            ctx.substitute_in_string("[${{ trigger.payload.x }}]").unwrap(),
+            ctx.substitute_in_string("[${{ trigger.payload.x }}]")
+                .unwrap(),
             "[]"
         );
     }
@@ -619,7 +619,9 @@ mod tests {
             trigger: &trigger,
             steps: &steps,
         };
-        let s = ctx.substitute_in_string("build-${{ trigger.payload.build }}").unwrap();
+        let s = ctx
+            .substitute_in_string("build-${{ trigger.payload.build }}")
+            .unwrap();
         assert_eq!(s, "build-");
     }
 

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -73,8 +73,17 @@ pub struct TemplateContext<'a> {
     pub steps: &'a std::collections::HashMap<String, Value>,
 }
 
+/// CEL context built from a [`TemplateContext`], cached so a single
+/// `substitute_value` / `substitute_in_string` pass binds `trigger`
+/// and `steps` exactly once instead of cloning the whole map per
+/// reference. Held only for the duration of a substitution call —
+/// no shared state across passes.
+struct BuiltContext {
+    cel: Context<'static>,
+}
+
 impl TemplateContext<'_> {
-    fn build_cel_context(&self) -> Result<Context<'static>, TemplateError> {
+    fn build_cel_context(&self) -> Result<BuiltContext, TemplateError> {
         let mut ctx = Context::default();
         // GHA / Swamp convention: `${{ trigger.payload.X }}` for the
         // run's user payload, leaving room for future trigger
@@ -115,25 +124,31 @@ impl TemplateContext<'_> {
         );
         ctx.add_variable("steps", steps_value)
             .map_err(|e| TemplateError::Resolve("<context>".to_string(), format!("steps: {e}")))?;
-        Ok(ctx)
+        Ok(BuiltContext { cel: ctx })
     }
 
     /// `None` when the path doesn't exist at this point in time
     /// (parse-time validation should already have rejected refs
     /// that can never resolve, but optional fields surface here).
+    ///
+    /// Convenience wrapper that builds the CEL context per call —
+    /// fine for one-off resolutions; the substitution walks reuse
+    /// a built context across all string leaves to amortise the
+    /// `trigger` / `steps` clones.
     pub fn resolve(&self, r: &TemplateRef) -> Option<Value> {
-        let program = match Program::compile(&r.body) {
-            Ok(p) => p,
-            Err(_) => return None,
-        };
-        let ctx = self.build_cel_context().ok()?;
-        let value = program.execute(&ctx).ok()?;
-        // `value.json()` errors only on values CEL can produce that
-        // JSON can't represent (functions, durations beyond i64
-        // nanoseconds, …); not reachable for paths into JSON-typed
-        // inputs, so silent-on-error is acceptable here.
-        value.json().ok()
+        let built = self.build_cel_context().ok()?;
+        resolve_with_built(&built, r)
     }
+}
+
+fn resolve_with_built(built: &BuiltContext, r: &TemplateRef) -> Option<Value> {
+    let program = Program::compile(&r.body).ok()?;
+    let value = program.execute(&built.cel).ok()?;
+    // `value.json()` errors only on values CEL can produce that
+    // JSON can't represent (functions, durations beyond i64
+    // nanoseconds, …); not reachable for paths into JSON-typed
+    // inputs, so silent-on-error is acceptable here.
+    value.json().ok()
 }
 
 /// Parse the body of a `${{ … }}` reference (delimiters already
@@ -232,24 +247,29 @@ fn coerce_embedded(v: Value, out: &mut String) {
 /// Walk a JSON tree and substitute every string leaf. Whole-string
 /// `${{ x }}` matches splice; embedded matches stringify.
 pub fn substitute_value(value: &Value, ctx: &TemplateContext) -> Result<Value, TemplateError> {
+    let built = ctx.build_cel_context()?;
+    substitute_value_with_built(value, &built)
+}
+
+fn substitute_value_with_built(value: &Value, built: &BuiltContext) -> Result<Value, TemplateError> {
     match value {
         Value::String(s) => {
             if let Some(r) = whole_string_ref(s)? {
-                return Ok(ctx.resolve(&r).unwrap_or(Value::Null));
+                return Ok(resolve_with_built(built, &r).unwrap_or(Value::Null));
             }
-            Ok(Value::String(substitute_in_string(s, ctx)?))
+            Ok(Value::String(substitute_in_string_with_built(s, built)?))
         }
         Value::Array(arr) => {
             let mut out = Vec::with_capacity(arr.len());
             for v in arr {
-                out.push(substitute_value(v, ctx)?);
+                out.push(substitute_value_with_built(v, built)?);
             }
             Ok(Value::Array(out))
         }
         Value::Object(map) => {
             let mut out = serde_json::Map::with_capacity(map.len());
             for (k, v) in map {
-                out.insert(k.clone(), substitute_value(v, ctx)?);
+                out.insert(k.clone(), substitute_value_with_built(v, built)?);
             }
             Ok(Value::Object(out))
         }
@@ -261,6 +281,14 @@ pub fn substitute_value(value: &Value, ctx: &TemplateContext) -> Result<Value, T
 /// surrounding container is itself text. Non-scalar resolved values
 /// are JSON-encoded.
 pub fn substitute_in_string(s: &str, ctx: &TemplateContext) -> Result<String, TemplateError> {
+    let built = ctx.build_cel_context()?;
+    substitute_in_string_with_built(s, &built)
+}
+
+fn substitute_in_string_with_built(
+    s: &str,
+    built: &BuiltContext,
+) -> Result<String, TemplateError> {
     let mut out = String::with_capacity(s.len());
     let mut rest = s;
     while let Some(open_idx) = rest.find(OPEN) {
@@ -274,7 +302,7 @@ pub fn substitute_in_string(s: &str, ctx: &TemplateContext) -> Result<String, Te
         })?;
         let body = &after_open[..close_idx];
         let r = parse_path(body)?;
-        let resolved = ctx.resolve(&r).unwrap_or(Value::Null);
+        let resolved = resolve_with_built(built, &r).unwrap_or(Value::Null);
         coerce_embedded(resolved, &mut out);
         rest = &after_open[close_idx + CLOSE.len()..];
     }

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -251,7 +251,10 @@ pub fn substitute_value(value: &Value, ctx: &TemplateContext) -> Result<Value, T
     substitute_value_with_built(value, &built)
 }
 
-fn substitute_value_with_built(value: &Value, built: &BuiltContext) -> Result<Value, TemplateError> {
+fn substitute_value_with_built(
+    value: &Value,
+    built: &BuiltContext,
+) -> Result<Value, TemplateError> {
     match value {
         Value::String(s) => {
             if let Some(r) = whole_string_ref(s)? {
@@ -285,10 +288,7 @@ pub fn substitute_in_string(s: &str, ctx: &TemplateContext) -> Result<String, Te
     substitute_in_string_with_built(s, &built)
 }
 
-fn substitute_in_string_with_built(
-    s: &str,
-    built: &BuiltContext,
-) -> Result<String, TemplateError> {
+fn substitute_in_string_with_built(s: &str, built: &BuiltContext) -> Result<String, TemplateError> {
     let mut out = String::with_capacity(s.len());
     let mut rest = s;
     while let Some(open_idx) = rest.find(OPEN) {

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -315,6 +315,91 @@ pub fn extract_refs_in_string(s: &str) -> Result<Vec<TemplateRef>, TemplateError
     Ok(refs)
 }
 
+/// One template substitution captured during a `substitute_value`
+/// pass — used by callers that want to report which `${{ … }}`
+/// reference produced which value when downstream consumers reject
+/// the resolved tree.
+#[derive(Debug, Clone)]
+pub struct TemplateDiagnostic {
+    /// JSON-pointer-style path into the params tree (e.g.
+    /// `.tags[0]`, `.title`).
+    pub json_path: String,
+    /// The literal string from the original params, including the
+    /// `${{ … }}` markers — useful when a single string carries
+    /// multiple refs and surrounding literal text.
+    pub source: String,
+    /// The substituted value — what the consuming tool actually
+    /// saw. Surfaces nulls, empty strings, and unexpected scalars
+    /// in error messages.
+    pub resolved: Value,
+}
+
+/// Walk the original and resolved params trees in parallel and
+/// collect a diagnostic for every string leaf in `original` that
+/// contained a `${{ … }}` reference. The list is the input/output
+/// trace the executor includes when a tool dispatch rejects the
+/// substituted params.
+pub fn template_diagnostics(original: &Value, resolved: &Value) -> Vec<TemplateDiagnostic> {
+    let mut out = Vec::new();
+    walk_diagnostics(original, resolved, "", &mut out);
+    out
+}
+
+fn walk_diagnostics(
+    original: &Value,
+    resolved: &Value,
+    path: &str,
+    acc: &mut Vec<TemplateDiagnostic>,
+) {
+    match (original, resolved) {
+        (Value::String(s), r) if s.contains(OPEN) => {
+            acc.push(TemplateDiagnostic {
+                json_path: if path.is_empty() {
+                    ".".to_string()
+                } else {
+                    path.to_string()
+                },
+                source: s.clone(),
+                resolved: r.clone(),
+            });
+        }
+        (Value::Object(o), Value::Object(r)) => {
+            for (k, ov) in o {
+                let next = format!("{path}.{k}");
+                let rv = r.get(k).unwrap_or(&Value::Null);
+                walk_diagnostics(ov, rv, &next, acc);
+            }
+        }
+        (Value::Array(o), Value::Array(r)) => {
+            for (i, ov) in o.iter().enumerate() {
+                let next = format!("{path}[{i}]");
+                let rv = r.get(i).unwrap_or(&Value::Null);
+                walk_diagnostics(ov, rv, &next, acc);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Render a `Vec<TemplateDiagnostic>` as a human-readable multi-line
+/// block suited for embedding in a `WorkflowError` reason. Empty
+/// slices produce empty output.
+pub fn format_template_diagnostics(diags: &[TemplateDiagnostic]) -> String {
+    if diags.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("\n  template substitutions:\n");
+    for d in diags {
+        let resolved = serde_json::to_string(&d.resolved).unwrap_or_else(|_| "<?>".to_string());
+        let source_escaped = d.source.replace('\n', "\\n");
+        out.push_str(&format!(
+            "    {}: {} → {}\n",
+            d.json_path, source_escaped, resolved
+        ));
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -549,6 +634,46 @@ mod tests {
         .unwrap();
         let names = referenced_step_names(&r);
         assert_eq!(names, vec!["triage".to_string(), "dispatch".to_string()]);
+    }
+
+    #[test]
+    fn template_diagnostics_records_path_source_and_resolved() {
+        let trigger = json!(null);
+        let mut steps = HashMap::new();
+        steps.insert(
+            "identify".into(),
+            json!({ "workflow_run_id": "abc-123", "type": "workflow_executor" }),
+        );
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let original = json!({
+            "title": "run-${{ steps.identify.outputs.workflow_run_id }}",
+            "tags": [
+                "${{ trigger.payload.pipeline }}",
+                "build-${{ trigger.payload.build }}"
+            ]
+        });
+        let resolved = substitute_value(&original, &ctx).unwrap();
+        let diags = template_diagnostics(&original, &resolved);
+        assert_eq!(diags.len(), 3);
+
+        let title = diags.iter().find(|d| d.json_path == ".title").unwrap();
+        assert_eq!(title.resolved, json!("run-abc-123"));
+
+        let pipeline = diags.iter().find(|d| d.json_path == ".tags[0]").unwrap();
+        assert!(pipeline.source.contains("trigger.payload.pipeline"));
+        assert_eq!(pipeline.resolved, Value::Null);
+
+        let build = diags.iter().find(|d| d.json_path == ".tags[1]").unwrap();
+        assert_eq!(build.resolved, json!("build-"));
+
+        let formatted = format_template_diagnostics(&diags);
+        assert!(formatted.contains(".title"));
+        assert!(formatted.contains(".tags[0]"));
+        assert!(formatted.contains("trigger.payload.pipeline"));
+        assert!(formatted.contains("null"));
     }
 
     #[test]

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -7,200 +7,167 @@
 //!   (the namespace mirrors GitHub Actions' `steps.<id>.outputs.<name>`
 //!   so authors familiar with one syntax read the other).
 //!
-//! Path syntax is dot-walk plus bracket indexing for arrays
-//! (`items[0].name`); no filter / wildcard / function shape.
+//! The expression body inside the delimiters is plain CEL evaluated by
+//! the `cel` crate (Common Expression Language — same family Swamp
+//! and GHA use). The two namespace identifiers `trigger` and `steps`
+//! are bound as variables on the evaluation context; everything else
+//! the language offers (boolean operators, `size(…)`, `has(…)`,
+//! `map`/`filter` macros, …) comes for free.
 //!
 //! Substitution semantics (memo `019e01a4`, §"what's new §2"):
 //!
 //! - Whole-string match — a JSON string whose trimmed value is
-//!   exactly `${{ path }}` — splices the resolved JSON value (object,
-//!   array, number, etc.) directly. This lets `payload: "${{
-//!   steps.triage.outputs.args }}"` produce a JSON object payload
-//!   rather than the stringified form.
-//! - Embedded match — `${{ … }}` inside a longer string — interpolates:
-//!   strings/booleans/numbers are coerced naturally; objects/arrays
-//!   are JSON-encoded.
-//! - Missing path — both modes resolve to `null` (whole-string) or
-//!   empty string (embedded). Parse-time validation rejects refs
-//!   that are structurally unreachable; runtime null is "the field
-//!   was optional and absent."
+//!   exactly `${{ … }}` — splices the resolved JSON value (object,
+//!   array, number, etc.) directly. Authors write
+//!   `payload: "${{ steps.triage.outputs.args }}"` and get a JSON
+//!   object payload, not the stringified form.
+//! - Embedded match — `${{ … }}` inside a longer string —
+//!   interpolates: strings/booleans/numbers coerce naturally,
+//!   objects/arrays JSON-encode.
+//! - Missing path / null result — both modes resolve to `null`
+//!   (whole-string) or empty string (embedded). Parse-time
+//!   validation rejects refs that are structurally unreachable;
+//!   runtime null is "the field was optional and absent."
 
-use std::collections::HashMap;
+use std::collections::HashSet;
+use std::sync::OnceLock;
 
+use cel::{Context, Program};
+use regex::Regex;
 use serde_json::Value;
 use thiserror::Error;
 
 const OPEN: &str = "${{";
 const CLOSE: &str = "}}";
 
-/// One parsed `${{ … }}` reference. Carries enough context for
-/// parse-time validation and runtime resolution.
+/// One parsed `${{ … }}` reference. Holds the body text plus the
+/// surrounding lexeme for error messages; the CEL program is
+/// recompiled on demand to keep `TemplateRef` cheaply `Clone`-able
+/// (`cel::Program` is not `Clone`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TemplateRef {
-    /// Raw lexeme including delimiters, used for error messages.
     pub raw: String,
-    pub path: Vec<PathSegment>,
-}
-
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum PathSegment {
-    Field(String),
-    Index(usize),
+    pub body: String,
 }
 
 #[derive(Debug, Error, PartialEq, Eq)]
 pub enum TemplateError {
     #[error("template ref starting with `{0}` is unterminated; expected `}}}}`")]
     Unterminated(String),
-    #[error("template ref `{0}`: empty path")]
+    #[error("template ref `{0}`: empty expression")]
     EmptyPath(String),
-    #[error("template ref `{0}`: malformed segment near `{1}`")]
-    MalformedSegment(String, String),
-    #[error("template ref `{0}`: unknown context root `{1}` (expected `trigger` or `steps`)")]
+    #[error("template ref `{0}`: failed to compile CEL expression: {1}")]
+    Compile(String, String),
+    #[error("template ref `{0}`: references unknown identifier `{1}` (only `trigger` and `steps` are bound)")]
     UnknownRoot(String, String),
-    #[error("template ref `{0}`: `steps.<name>` requires the literal `outputs.` namespace next")]
-    MissingOutputsNamespace(String),
+    #[error("template ref `{0}`: failed to evaluate at run time: {1}")]
+    Resolve(String, String),
+    #[error("template ref `{0}`: result could not be converted to JSON: {1}")]
+    JsonConvert(String, String),
 }
 
-/// Resolution context borrowed for one substitution pass.
+/// Resolution context borrowed for one substitution pass. The two
+/// namespaces are bound as CEL variables of the matching name.
 pub struct TemplateContext<'a> {
     pub trigger: &'a Value,
-    pub steps: &'a HashMap<String, Value>,
+    pub steps: &'a std::collections::HashMap<String, Value>,
 }
 
 impl TemplateContext<'_> {
+    fn build_cel_context(&self) -> Result<Context<'static>, TemplateError> {
+        let mut ctx = Context::default();
+        ctx.add_variable("trigger", self.trigger.clone())
+            .map_err(|e| {
+                TemplateError::Resolve("<context>".to_string(), format!("trigger: {e}"))
+            })?;
+        // GHA / Swamp convention: `steps.<id>.outputs.<field>`. Wrap
+        // each step's recorded output under an `outputs` key so the
+        // literal namespace traverses naturally as a CEL field access.
+        let steps_value = Value::Object(
+            self.steps
+                .iter()
+                .map(|(k, v)| {
+                    let mut wrapper = serde_json::Map::with_capacity(1);
+                    wrapper.insert("outputs".to_string(), v.clone());
+                    (k.clone(), Value::Object(wrapper))
+                })
+                .collect(),
+        );
+        ctx.add_variable("steps", steps_value)
+            .map_err(|e| TemplateError::Resolve("<context>".to_string(), format!("steps: {e}")))?;
+        Ok(ctx)
+    }
+
     /// `None` when the path doesn't exist at this point in time
     /// (parse-time validation should already have rejected refs
     /// that can never resolve, but optional fields surface here).
     pub fn resolve(&self, r: &TemplateRef) -> Option<Value> {
-        let mut iter = r.path.iter();
-        let root_name = match iter.next()? {
-            PathSegment::Field(s) => s.as_str(),
-            PathSegment::Index(_) => return None,
+        let program = match Program::compile(&r.body) {
+            Ok(p) => p,
+            Err(_) => return None,
         };
-        let mut cur = match root_name {
-            "trigger" => self.trigger.clone(),
-            "steps" => {
-                let step_name = match iter.next()? {
-                    PathSegment::Field(s) => s.as_str(),
-                    PathSegment::Index(_) => return None,
-                };
-                match iter.next()? {
-                    PathSegment::Field(s) if s == "outputs" => {}
-                    _ => return None,
-                }
-                self.steps.get(step_name)?.clone()
-            }
-            _ => return None,
-        };
-        for seg in iter {
-            cur = match (cur, seg) {
-                (Value::Object(map), PathSegment::Field(k)) => map.get(k).cloned()?,
-                (Value::Array(arr), PathSegment::Index(i)) => arr.get(*i).cloned()?,
-                _ => return None,
-            };
-        }
-        Some(cur)
+        let ctx = self.build_cel_context().ok()?;
+        let value = program.execute(&ctx).ok()?;
+        // `value.json()` errors only on values CEL can produce that
+        // JSON can't represent (functions, durations beyond i64
+        // nanoseconds, …); not reachable for paths into JSON-typed
+        // inputs, so silent-on-error is acceptable here.
+        value.json().ok()
     }
 }
 
 /// Parse the body of a `${{ … }}` reference (delimiters already
-/// stripped). Whitespace is tolerated around segments.
+/// stripped). Compiles the CEL expression once to surface syntax
+/// errors at parse time while keeping `TemplateRef` `Clone`-able.
 pub fn parse_path(body: &str) -> Result<TemplateRef, TemplateError> {
-    let raw = format!("{OPEN} {} {CLOSE}", body.trim());
     let trimmed = body.trim();
+    let raw = format!("{OPEN} {trimmed} {CLOSE}");
     if trimmed.is_empty() {
         return Err(TemplateError::EmptyPath(raw));
     }
-
-    let mut segments = Vec::new();
-    let mut cur = String::new();
-    let mut chars = trimmed.chars().peekable();
-
-    while let Some(c) = chars.next() {
-        match c {
-            '.' => {
-                if !cur.is_empty() {
-                    segments.push(PathSegment::Field(std::mem::take(&mut cur)));
-                }
-            }
-            '[' => {
-                if !cur.is_empty() {
-                    segments.push(PathSegment::Field(std::mem::take(&mut cur)));
-                }
-                let mut idx_str = String::new();
-                let mut closed = false;
-                for ic in chars.by_ref() {
-                    if ic == ']' {
-                        closed = true;
-                        break;
-                    }
-                    idx_str.push(ic);
-                }
-                if !closed {
-                    return Err(TemplateError::MalformedSegment(
-                        raw.clone(),
-                        format!("[{idx_str}"),
-                    ));
-                }
-                let n: usize = idx_str
-                    .trim()
-                    .parse()
-                    .map_err(|_| TemplateError::MalformedSegment(raw.clone(), idx_str))?;
-                segments.push(PathSegment::Index(n));
-            }
-            c if c.is_alphanumeric() || c == '_' || c == '-' => cur.push(c),
-            c if c.is_whitespace() => {}
-            other => {
-                return Err(TemplateError::MalformedSegment(raw, other.to_string()));
-            }
-        }
-    }
-    if !cur.is_empty() {
-        segments.push(PathSegment::Field(cur));
-    }
-
-    if segments.is_empty() {
-        return Err(TemplateError::EmptyPath(raw));
-    }
-
+    Program::compile(trimmed).map_err(|e| TemplateError::Compile(raw.clone(), e.to_string()))?;
     Ok(TemplateRef {
         raw,
-        path: segments,
+        body: trimmed.to_string(),
     })
 }
 
-/// Statically validate the root of a parsed ref. `steps.<n>.outputs.…`
-/// must include the literal `outputs` namespace; trigger refs only
-/// require the `trigger` root.
+/// Reject expressions that reference identifiers other than the two
+/// bound namespaces (`trigger`, `steps`). Stops mistakes like
+/// `${{ env.HOME }}` from compiling cleanly only to silently resolve
+/// to nothing at runtime.
 pub fn validate_root(r: &TemplateRef) -> Result<(), TemplateError> {
-    let mut iter = r.path.iter();
-    let root = iter
-        .next()
-        .ok_or_else(|| TemplateError::EmptyPath(r.raw.clone()))?;
-    let root_name = match root {
-        PathSegment::Field(s) => s.as_str(),
-        PathSegment::Index(_) => {
-            return Err(TemplateError::UnknownRoot(
-                r.raw.clone(),
-                "<index>".to_string(),
-            ))
+    let program = Program::compile(&r.body)
+        .map_err(|e| TemplateError::Compile(r.raw.clone(), e.to_string()))?;
+    for ident in program.references().variables() {
+        if ident != "trigger" && ident != "steps" {
+            return Err(TemplateError::UnknownRoot(r.raw.clone(), ident.to_string()));
         }
-    };
-    match root_name {
-        "trigger" => Ok(()),
-        "steps" => {
-            // steps.<name>.outputs.<...>
-            let _name = iter
-                .next()
-                .ok_or_else(|| TemplateError::EmptyPath(r.raw.clone()))?;
-            match iter.next() {
-                Some(PathSegment::Field(s)) if s == "outputs" => Ok(()),
-                _ => Err(TemplateError::MissingOutputsNamespace(r.raw.clone())),
-            }
-        }
-        other => Err(TemplateError::UnknownRoot(r.raw.clone(), other.to_string())),
     }
+    Ok(())
+}
+
+/// Names of every step referenced via `steps.<name>` in the
+/// expression body. Used by parse-time forward-reference checking;
+/// extracts via lexical scan rather than CEL AST walking (which would
+/// require depending on the crate's internal `Expr` types). Ignores
+/// bracket-style indexing (`steps["x"]`) — workflows must use
+/// dot-syntax for static analyzability.
+pub fn referenced_step_names(r: &TemplateRef) -> Vec<String> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| Regex::new(r"\bsteps\.([A-Za-z_][A-Za-z0-9_-]*)").unwrap());
+    let mut out: Vec<String> = Vec::new();
+    let mut seen = HashSet::new();
+    for cap in re.captures_iter(&r.body) {
+        let name = cap
+            .get(1)
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        if seen.insert(name.clone()) {
+            out.push(name);
+        }
+    }
+    out
 }
 
 /// Returns `Some(ref)` when the trimmed string is exactly one
@@ -332,6 +299,7 @@ pub fn extract_refs_in_string(s: &str) -> Result<Vec<TemplateRef>, TemplateError
 mod tests {
     use super::*;
     use serde_json::json;
+    use std::collections::HashMap;
 
     fn ctx_with(trigger: Value, steps: HashMap<String, Value>) -> (Value, HashMap<String, Value>) {
         (trigger, steps)
@@ -340,30 +308,13 @@ mod tests {
     #[test]
     fn parse_simple_dot_path() {
         let r = parse_path(" trigger.payload.build ").unwrap();
-        assert_eq!(
-            r.path,
-            vec![
-                PathSegment::Field("trigger".into()),
-                PathSegment::Field("payload".into()),
-                PathSegment::Field("build".into()),
-            ]
-        );
+        assert_eq!(r.body, "trigger.payload.build");
     }
 
     #[test]
     fn parse_bracket_index() {
         let r = parse_path("steps.x.outputs.items[2].name").unwrap();
-        assert_eq!(
-            r.path,
-            vec![
-                PathSegment::Field("steps".into()),
-                PathSegment::Field("x".into()),
-                PathSegment::Field("outputs".into()),
-                PathSegment::Field("items".into()),
-                PathSegment::Index(2),
-                PathSegment::Field("name".into()),
-            ]
-        );
+        assert_eq!(r.body, "steps.x.outputs.items[2].name");
     }
 
     #[test]
@@ -378,7 +329,7 @@ mod tests {
     fn parse_rejects_unclosed_bracket() {
         assert!(matches!(
             parse_path("a[3"),
-            Err(TemplateError::MalformedSegment(_, _))
+            Err(TemplateError::Compile(_, _))
         ));
     }
 
@@ -401,11 +352,10 @@ mod tests {
     }
 
     #[test]
-    fn validate_root_rejects_steps_without_outputs() {
-        assert!(matches!(
-            validate_root(&parse_path("steps.foo.bar").unwrap()),
-            Err(TemplateError::MissingOutputsNamespace(_))
-        ));
+    fn validate_root_accepts_function_calls_over_bound_vars() {
+        // `size`/`has` etc. are CEL standard library — they're
+        // functions, not variables, so they don't count as new roots.
+        validate_root(&parse_path("size(steps.x.outputs.list) > 0").unwrap()).unwrap();
     }
 
     #[test]
@@ -419,7 +369,15 @@ mod tests {
         };
         let input = json!({ "payload": "${{ steps.triage.outputs.args }}" });
         let out = substitute_value(&input, &ctx).unwrap();
-        assert_eq!(out, json!({ "payload": { "build": 1234 } }));
+        // CEL surfaces the inner map; we splice it as the JSON object
+        // it represents. Field names round-trip; numeric types might
+        // become integer-typed even if the input was an i64 literal.
+        assert_eq!(
+            out.get("payload")
+                .and_then(|p| p.get("build"))
+                .and_then(|b| b.as_i64()),
+            Some(1234)
+        );
     }
 
     #[test]
@@ -501,10 +459,10 @@ mod tests {
         });
         let refs = extract_refs_in_value(&v).unwrap();
         assert_eq!(refs.len(), 3);
-        let raws: Vec<_> = refs.iter().map(|r| r.raw.clone()).collect();
-        assert!(raws.iter().any(|r| r.contains("trigger.a")));
-        assert!(raws.iter().any(|r| r.contains("trigger.b")));
-        assert!(raws.iter().any(|r| r.contains("trigger.c")));
+        let bodies: Vec<_> = refs.iter().map(|r| r.body.clone()).collect();
+        assert!(bodies.iter().any(|b| b == "trigger.a"));
+        assert!(bodies.iter().any(|b| b == "trigger.b"));
+        assert!(bodies.iter().any(|b| b == "trigger.c"));
     }
 
     #[test]
@@ -529,5 +487,21 @@ mod tests {
         };
         let v = json!({ "k": "no templates here" });
         assert_eq!(substitute_value(&v, &ctx).unwrap(), v);
+    }
+
+    #[test]
+    fn referenced_step_names_extracts_unique_ordered() {
+        let r = parse_path(
+            "steps.triage.outputs.x + steps.dispatch.outputs.y + steps.triage.outputs.z",
+        )
+        .unwrap();
+        let names = referenced_step_names(&r);
+        assert_eq!(names, vec!["triage".to_string(), "dispatch".to_string()]);
+    }
+
+    #[test]
+    fn referenced_step_names_ignores_trigger() {
+        let r = parse_path("trigger.payload.build").unwrap();
+        assert!(referenced_step_names(&r).is_empty());
     }
 }

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -76,13 +76,19 @@ pub struct TemplateContext<'a> {
 impl TemplateContext<'_> {
     fn build_cel_context(&self) -> Result<Context<'static>, TemplateError> {
         let mut ctx = Context::default();
-        ctx.add_variable("trigger", self.trigger.clone())
-            .map_err(|e| {
-                TemplateError::Resolve("<context>".to_string(), format!("trigger: {e}"))
-            })?;
-        // GHA / Swamp convention: `steps.<id>.outputs.<field>`. Wrap
-        // each step's recorded output under an `outputs` key so the
-        // literal namespace traverses naturally as a CEL field access.
+        // GHA / Swamp convention: `${{ trigger.payload.X }}` for the
+        // run's user payload, leaving room for future trigger
+        // metadata (`trigger.received_at`, etc.) without breaking
+        // existing references. The executor passes the raw payload;
+        // wrapping happens here so callers don't have to.
+        let trigger_value = serde_json::json!({ "payload": self.trigger.clone() });
+        ctx.add_variable("trigger", trigger_value).map_err(|e| {
+            TemplateError::Resolve("<context>".to_string(), format!("trigger: {e}"))
+        })?;
+        // Same convention for `${{ steps.<id>.outputs.<field> }}` —
+        // wrap each step's recorded output under an `outputs` key so
+        // the literal namespace traverses naturally as a CEL field
+        // access.
         let steps_value = Value::Object(
             self.steps
                 .iter()
@@ -382,7 +388,10 @@ mod tests {
 
     #[test]
     fn embedded_stringifies_scalars_naturally() {
-        let trigger = json!({ "payload": { "build": 1234, "pipeline": "galoy-bank" } });
+        // `TemplateContext.trigger` is the raw user payload; the
+        // resolver wraps it under `payload` automatically so
+        // `${{ trigger.payload.X }}` matches the GHA convention.
+        let trigger = json!({ "build": 1234, "pipeline": "galoy-bank" });
         let steps = HashMap::new();
         let ctx = TemplateContext {
             trigger: &trigger,
@@ -397,7 +406,7 @@ mod tests {
 
     #[test]
     fn embedded_json_encodes_non_scalars() {
-        let trigger = json!({ "payload": { "list": [1, 2, 3] } });
+        let trigger = json!({ "list": [1, 2, 3] });
         let steps = HashMap::new();
         let ctx = TemplateContext {
             trigger: &trigger,
@@ -409,7 +418,7 @@ mod tests {
 
     #[test]
     fn missing_path_resolves_to_null_in_splice() {
-        let trigger = json!({ "payload": {} });
+        let trigger = json!({});
         let steps = HashMap::new();
         let ctx = TemplateContext {
             trigger: &trigger,
@@ -429,7 +438,7 @@ mod tests {
             steps: &steps,
         };
         assert_eq!(
-            substitute_in_string("[${{ trigger.x }}]", &ctx).unwrap(),
+            substitute_in_string("[${{ trigger.payload.x }}]", &ctx).unwrap(),
             "[]"
         );
     }

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -74,8 +74,8 @@ pub struct TemplateContext<'a> {
 }
 
 /// CEL context built from a [`TemplateContext`], cached so a single
-/// `substitute_value` / `substitute_in_string` pass binds `trigger`
-/// and `steps` exactly once instead of cloning the whole map per
+/// `substitute` / `substitute_in_string` pass binds `trigger` and
+/// `steps` exactly once instead of cloning the whole map per
 /// reference. Held only for the duration of a substitution call —
 /// no shared state across passes.
 struct BuiltContext {
@@ -138,6 +138,24 @@ impl TemplateContext<'_> {
     pub fn resolve(&self, r: &TemplateRef) -> Option<Value> {
         let built = self.build_cel_context().ok()?;
         resolve_with_built(&built, r)
+    }
+
+    /// Walk a JSON tree and substitute every string leaf.
+    /// Whole-string `${{ x }}` matches splice; embedded matches
+    /// stringify. Builds the CEL context once and threads it
+    /// through the recursion.
+    pub fn substitute(&self, value: &Value) -> Result<Value, TemplateError> {
+        let built = self.build_cel_context()?;
+        substitute_value_with_built(value, &built)
+    }
+
+    /// String-only substitution — used for skill bodies, where the
+    /// surrounding container is itself text. Non-scalar resolved
+    /// values are JSON-encoded. Builds the CEL context once and
+    /// threads it through the scan.
+    pub fn substitute_in_string(&self, s: &str) -> Result<String, TemplateError> {
+        let built = self.build_cel_context()?;
+        substitute_in_string_with_built(s, &built)
     }
 }
 
@@ -253,13 +271,6 @@ fn coerce_embedded(v: Value, out: &mut String) {
     }
 }
 
-/// Walk a JSON tree and substitute every string leaf. Whole-string
-/// `${{ x }}` matches splice; embedded matches stringify.
-pub fn substitute_value(value: &Value, ctx: &TemplateContext) -> Result<Value, TemplateError> {
-    let built = ctx.build_cel_context()?;
-    substitute_value_with_built(value, &built)
-}
-
 fn substitute_value_with_built(
     value: &Value,
     built: &BuiltContext,
@@ -287,14 +298,6 @@ fn substitute_value_with_built(
         }
         other => Ok(other.clone()),
     }
-}
-
-/// String-only substitution — used for skill bodies, where the
-/// surrounding container is itself text. Non-scalar resolved values
-/// are JSON-encoded.
-pub fn substitute_in_string(s: &str, ctx: &TemplateContext) -> Result<String, TemplateError> {
-    let built = ctx.build_cel_context()?;
-    substitute_in_string_with_built(s, &built)
 }
 
 fn substitute_in_string_with_built(s: &str, built: &BuiltContext) -> Result<String, TemplateError> {
@@ -364,10 +367,10 @@ pub fn extract_refs_in_string(s: &str) -> Result<Vec<TemplateRef>, TemplateError
     Ok(refs)
 }
 
-/// One template substitution captured during a `substitute_value`
-/// pass — used by callers that want to report which `${{ … }}`
-/// reference produced which value when downstream consumers reject
-/// the resolved tree.
+/// One template substitution captured during a `substitute` pass
+/// — used by callers that want to report which `${{ … }}` reference
+/// produced which value when downstream consumers reject the
+/// resolved tree.
 #[derive(Debug, Clone)]
 pub struct TemplateDiagnostic {
     /// JSON-pointer-style path into the params tree (e.g.
@@ -522,7 +525,7 @@ mod tests {
             steps: &steps,
         };
         let input = json!({ "payload": "${{ steps.triage.outputs.args }}" });
-        let out = substitute_value(&input, &ctx).unwrap();
+        let out = ctx.substitute(&input).unwrap();
         // CEL surfaces the inner map; we splice it as the JSON object
         // it represents. Field names round-trip; numeric types might
         // become integer-typed even if the input was an i64 literal.
@@ -548,7 +551,7 @@ mod tests {
         let input = json!({
             "note": "Build ${{ trigger.payload.build }} failed in ${{ trigger.payload.pipeline }}."
         });
-        let out = substitute_value(&input, &ctx).unwrap();
+        let out = ctx.substitute(&input).unwrap();
         assert_eq!(out, json!({ "note": "Build 1234 failed in galoy-bank." }));
     }
 
@@ -560,7 +563,7 @@ mod tests {
             trigger: &trigger,
             steps: &steps,
         };
-        let s = substitute_in_string("ids=${{ trigger.payload.list }}", &ctx).unwrap();
+        let s = ctx.substitute_in_string("ids=${{ trigger.payload.list }}").unwrap();
         assert_eq!(s, "ids=[1,2,3]");
     }
 
@@ -573,7 +576,7 @@ mod tests {
             steps: &steps,
         };
         let input = json!({ "x": "${{ trigger.payload.absent }}" });
-        let out = substitute_value(&input, &ctx).unwrap();
+        let out = ctx.substitute(&input).unwrap();
         assert_eq!(out, json!({ "x": null }));
     }
 
@@ -586,7 +589,7 @@ mod tests {
             steps: &steps,
         };
         assert_eq!(
-            substitute_in_string("[${{ trigger.payload.x }}]", &ctx).unwrap(),
+            ctx.substitute_in_string("[${{ trigger.payload.x }}]").unwrap(),
             "[]"
         );
     }
@@ -604,7 +607,7 @@ mod tests {
             steps: &steps,
         };
         let input = json!({ "x": "${{ trigger.payload.pipeline }}" });
-        let out = substitute_value(&input, &ctx).unwrap();
+        let out = ctx.substitute(&input).unwrap();
         assert_eq!(out, json!({ "x": null }));
     }
 
@@ -616,7 +619,7 @@ mod tests {
             trigger: &trigger,
             steps: &steps,
         };
-        let s = substitute_in_string("build-${{ trigger.payload.build }}", &ctx).unwrap();
+        let s = ctx.substitute_in_string("build-${{ trigger.payload.build }}").unwrap();
         assert_eq!(s, "build-");
     }
 
@@ -632,7 +635,9 @@ mod tests {
             trigger: &trigger,
             steps: &steps,
         };
-        let s = substitute_in_string("${{ steps.s.outputs.items[1].name }}", &ctx).unwrap();
+        let s = ctx
+            .substitute_in_string("${{ steps.s.outputs.items[1].name }}")
+            .unwrap();
         assert_eq!(s, "b");
     }
 
@@ -653,13 +658,13 @@ mod tests {
 
     #[test]
     fn unterminated_template_errors() {
-        let res = substitute_in_string(
-            "build ${{ trigger.x is unterminated",
-            &TemplateContext {
-                trigger: &json!({}),
-                steps: &HashMap::new(),
-            },
-        );
+        let trigger = json!({});
+        let steps = HashMap::new();
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let res = ctx.substitute_in_string("build ${{ trigger.x is unterminated");
         assert!(matches!(res, Err(TemplateError::Unterminated(_))));
     }
 
@@ -686,7 +691,9 @@ mod tests {
             trigger: &trigger,
             steps: &steps,
         };
-        let out = substitute_in_string("commit: ${{ trigger.payload.commit_msg }}", &ctx).unwrap();
+        let out = ctx
+            .substitute_in_string("commit: ${{ trigger.payload.commit_msg }}")
+            .unwrap();
         // Literal `${{ steps.victim.outputs.secret }}` survives as
         // text. `hunter2` does NOT appear.
         assert!(out.contains("${{ steps.victim.outputs.secret }}"));
@@ -707,7 +714,7 @@ mod tests {
             steps: &steps,
         };
         let input = json!({ "v": "${{ trigger.payload.x }} suffix }}" });
-        let out = substitute_value(&input, &ctx).unwrap();
+        let out = ctx.substitute(&input).unwrap();
         // Embedded interpolation: the `${{ … }}` resolves to "X",
         // the trailing literal " suffix }}" is preserved verbatim.
         assert_eq!(out, json!({ "v": "X suffix }}" }));
@@ -722,7 +729,7 @@ mod tests {
             steps: &steps,
         };
         let v = json!({ "k": "no templates here" });
-        assert_eq!(substitute_value(&v, &ctx).unwrap(), v);
+        assert_eq!(ctx.substitute(&v).unwrap(), v);
     }
 
     #[test]
@@ -754,7 +761,7 @@ mod tests {
                 "build-${{ trigger.payload.build }}"
             ]
         });
-        let resolved = substitute_value(&original, &ctx).unwrap();
+        let resolved = ctx.substitute(&original).unwrap();
         let diags = template_diagnostics(&original, &resolved);
         assert_eq!(diags.len(), 3);
 

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -184,13 +184,22 @@ pub fn validate_root(r: &TemplateRef) -> Result<(), TemplateError> {
 
 /// Names of every step referenced via `steps.<name>` in the
 /// expression body. Used by parse-time forward-reference checking;
-/// extracts via lexical scan rather than CEL AST walking (which would
-/// require depending on the crate's internal `Expr` types). Ignores
-/// bracket-style indexing (`steps["x"]`) — workflows must use
-/// dot-syntax for static analyzability.
+/// extracts via lexical scan rather than CEL AST walking (which
+/// would require depending on the crate's internal `Expr` types).
+/// Ignores bracket-style indexing (`steps["x"]`) — workflows must
+/// use dot-syntax for static analyzability.
+///
+/// Pattern matches CEL identifier shape exactly
+/// (`[A-Za-z_][A-Za-z0-9_]*`). Hyphens are NOT included: CEL parses
+/// `steps.store-note.outputs.x` as `(steps.store) - (note.outputs.x)`,
+/// so a hyphenated step name could never resolve at runtime even if
+/// the regex accepted it. `Workflows::validate_steps` rejects step
+/// names that violate this shape at create time so the regex never
+/// sees hyphens in practice — narrow regex stays as a belt-and-
+/// braces match against the validation contract.
 pub fn referenced_step_names(r: &TemplateRef) -> Vec<String> {
     static RE: OnceLock<Regex> = OnceLock::new();
-    let re = RE.get_or_init(|| Regex::new(r"\bsteps\.([A-Za-z_][A-Za-z0-9_-]*)").unwrap());
+    let re = RE.get_or_init(|| Regex::new(r"\bsteps\.([A-Za-z_][A-Za-z0-9_]*)").unwrap());
     let mut out: Vec<String> = Vec::new();
     let mut seen = HashSet::new();
     for cap in re.captures_iter(&r.body) {
@@ -770,5 +779,28 @@ mod tests {
     fn referenced_step_names_ignores_trigger() {
         let r = parse_path("trigger.payload.build").unwrap();
         assert!(referenced_step_names(&r).is_empty());
+    }
+
+    /// Hyphens fall outside the CEL identifier alphabet, so the
+    /// regex stops at `steps.store` rather than capturing
+    /// `store-note`. CEL would parse the full ref as subtraction;
+    /// `Workflows::validate_steps` rejects hyphenated step names
+    /// at create time, so this case is unreachable in practice —
+    /// the test pins the narrow extraction behaviour as a
+    /// belt-and-braces match against that validation contract.
+    #[test]
+    fn referenced_step_names_stops_at_hyphen() {
+        // We can't `parse_path("steps.store-note.outputs.x")`
+        // because CEL itself would parse it as subtraction and the
+        // CEL parse would still succeed (`-` is a valid op). Build
+        // a synthetic `TemplateRef` that bypasses parse-time CEL
+        // validation to exercise the lexical regex directly.
+        let r = TemplateRef {
+            raw: "${{ steps.store-note.outputs.x }}".to_string(),
+            body: "steps.store-note.outputs.x".to_string(),
+        };
+        // `store` is captured (the prefix up to the hyphen). The
+        // hyphen + suffix are NOT mistakenly attached to it.
+        assert_eq!(referenced_step_names(&r), vec!["store".to_string()]);
     }
 }

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -81,7 +81,21 @@ impl TemplateContext<'_> {
         // metadata (`trigger.received_at`, etc.) without breaking
         // existing references. The executor passes the raw payload;
         // wrapping happens here so callers don't have to.
-        let trigger_value = serde_json::json!({ "payload": self.trigger.clone() });
+        //
+        // Null / non-object payloads (manual `trigger` with no
+        // arguments, webhook with empty body, …) are coerced to an
+        // empty object before binding. Without this, CEL evaluates
+        // `null.field` to `Bool(false)` rather than raising
+        // `NoSuchKey`, and the `false` ends up spliced into the
+        // params tree — surprising the consuming tool with a bool
+        // where it expected a string. The empty-object form lets
+        // every `trigger.payload.X` reference resolve cleanly to
+        // `null` via the existing missing-key path.
+        let payload = match &self.trigger {
+            Value::Object(_) => self.trigger.clone(),
+            _ => Value::Object(serde_json::Map::new()),
+        };
+        let trigger_value = serde_json::json!({ "payload": payload });
         ctx.add_variable("trigger", trigger_value).map_err(|e| {
             TemplateError::Resolve("<context>".to_string(), format!("trigger: {e}"))
         })?;
@@ -441,6 +455,35 @@ mod tests {
             substitute_in_string("[${{ trigger.payload.x }}]", &ctx).unwrap(),
             "[]"
         );
+    }
+
+    /// Run triggered with no payload — `trigger_context` arrives as
+    /// JSON `null`. Templates referring into the (absent) payload
+    /// must resolve silently, not produce a CEL error or splice a
+    /// surprise scalar like `false`.
+    #[test]
+    fn null_payload_resolves_silently_in_splice() {
+        let trigger = json!(null);
+        let steps = HashMap::new();
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let input = json!({ "x": "${{ trigger.payload.pipeline }}" });
+        let out = substitute_value(&input, &ctx).unwrap();
+        assert_eq!(out, json!({ "x": null }));
+    }
+
+    #[test]
+    fn null_payload_resolves_silently_in_embed() {
+        let trigger = json!(null);
+        let steps = HashMap::new();
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let s = substitute_in_string("build-${{ trigger.payload.build }}", &ctx).unwrap();
+        assert_eq!(s, "build-");
     }
 
     #[test]

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -1,0 +1,533 @@
+//! `${{ … }}` template substitution for workflow steps.
+//!
+//! Two contexts are addressable:
+//!
+//! - `${{ trigger.X.Y }}` — fields of `WorkflowRun.trigger_context`.
+//! - `${{ steps.<name>.outputs.X.Y }}` — prior-step `StepResult.output`
+//!   (the namespace mirrors GitHub Actions' `steps.<id>.outputs.<name>`
+//!   so authors familiar with one syntax read the other).
+//!
+//! Path syntax is dot-walk plus bracket indexing for arrays
+//! (`items[0].name`); no filter / wildcard / function shape.
+//!
+//! Substitution semantics (memo `019e01a4`, §"what's new §2"):
+//!
+//! - Whole-string match — a JSON string whose trimmed value is
+//!   exactly `${{ path }}` — splices the resolved JSON value (object,
+//!   array, number, etc.) directly. This lets `payload: "${{
+//!   steps.triage.outputs.args }}"` produce a JSON object payload
+//!   rather than the stringified form.
+//! - Embedded match — `${{ … }}` inside a longer string — interpolates:
+//!   strings/booleans/numbers are coerced naturally; objects/arrays
+//!   are JSON-encoded.
+//! - Missing path — both modes resolve to `null` (whole-string) or
+//!   empty string (embedded). Parse-time validation rejects refs
+//!   that are structurally unreachable; runtime null is "the field
+//!   was optional and absent."
+
+use std::collections::HashMap;
+
+use serde_json::Value;
+use thiserror::Error;
+
+const OPEN: &str = "${{";
+const CLOSE: &str = "}}";
+
+/// One parsed `${{ … }}` reference. Carries enough context for
+/// parse-time validation and runtime resolution.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemplateRef {
+    /// Raw lexeme including delimiters, used for error messages.
+    pub raw: String,
+    pub path: Vec<PathSegment>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum PathSegment {
+    Field(String),
+    Index(usize),
+}
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum TemplateError {
+    #[error("template ref starting with `{0}` is unterminated; expected `}}}}`")]
+    Unterminated(String),
+    #[error("template ref `{0}`: empty path")]
+    EmptyPath(String),
+    #[error("template ref `{0}`: malformed segment near `{1}`")]
+    MalformedSegment(String, String),
+    #[error("template ref `{0}`: unknown context root `{1}` (expected `trigger` or `steps`)")]
+    UnknownRoot(String, String),
+    #[error("template ref `{0}`: `steps.<name>` requires the literal `outputs.` namespace next")]
+    MissingOutputsNamespace(String),
+}
+
+/// Resolution context borrowed for one substitution pass.
+pub struct TemplateContext<'a> {
+    pub trigger: &'a Value,
+    pub steps: &'a HashMap<String, Value>,
+}
+
+impl TemplateContext<'_> {
+    /// `None` when the path doesn't exist at this point in time
+    /// (parse-time validation should already have rejected refs
+    /// that can never resolve, but optional fields surface here).
+    pub fn resolve(&self, r: &TemplateRef) -> Option<Value> {
+        let mut iter = r.path.iter();
+        let root_name = match iter.next()? {
+            PathSegment::Field(s) => s.as_str(),
+            PathSegment::Index(_) => return None,
+        };
+        let mut cur = match root_name {
+            "trigger" => self.trigger.clone(),
+            "steps" => {
+                let step_name = match iter.next()? {
+                    PathSegment::Field(s) => s.as_str(),
+                    PathSegment::Index(_) => return None,
+                };
+                match iter.next()? {
+                    PathSegment::Field(s) if s == "outputs" => {}
+                    _ => return None,
+                }
+                self.steps.get(step_name)?.clone()
+            }
+            _ => return None,
+        };
+        for seg in iter {
+            cur = match (cur, seg) {
+                (Value::Object(map), PathSegment::Field(k)) => map.get(k).cloned()?,
+                (Value::Array(arr), PathSegment::Index(i)) => arr.get(*i).cloned()?,
+                _ => return None,
+            };
+        }
+        Some(cur)
+    }
+}
+
+/// Parse the body of a `${{ … }}` reference (delimiters already
+/// stripped). Whitespace is tolerated around segments.
+pub fn parse_path(body: &str) -> Result<TemplateRef, TemplateError> {
+    let raw = format!("{OPEN} {} {CLOSE}", body.trim());
+    let trimmed = body.trim();
+    if trimmed.is_empty() {
+        return Err(TemplateError::EmptyPath(raw));
+    }
+
+    let mut segments = Vec::new();
+    let mut cur = String::new();
+    let mut chars = trimmed.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            '.' => {
+                if !cur.is_empty() {
+                    segments.push(PathSegment::Field(std::mem::take(&mut cur)));
+                }
+            }
+            '[' => {
+                if !cur.is_empty() {
+                    segments.push(PathSegment::Field(std::mem::take(&mut cur)));
+                }
+                let mut idx_str = String::new();
+                let mut closed = false;
+                for ic in chars.by_ref() {
+                    if ic == ']' {
+                        closed = true;
+                        break;
+                    }
+                    idx_str.push(ic);
+                }
+                if !closed {
+                    return Err(TemplateError::MalformedSegment(
+                        raw.clone(),
+                        format!("[{idx_str}"),
+                    ));
+                }
+                let n: usize = idx_str
+                    .trim()
+                    .parse()
+                    .map_err(|_| TemplateError::MalformedSegment(raw.clone(), idx_str))?;
+                segments.push(PathSegment::Index(n));
+            }
+            c if c.is_alphanumeric() || c == '_' || c == '-' => cur.push(c),
+            c if c.is_whitespace() => {}
+            other => {
+                return Err(TemplateError::MalformedSegment(raw, other.to_string()));
+            }
+        }
+    }
+    if !cur.is_empty() {
+        segments.push(PathSegment::Field(cur));
+    }
+
+    if segments.is_empty() {
+        return Err(TemplateError::EmptyPath(raw));
+    }
+
+    Ok(TemplateRef {
+        raw,
+        path: segments,
+    })
+}
+
+/// Statically validate the root of a parsed ref. `steps.<n>.outputs.…`
+/// must include the literal `outputs` namespace; trigger refs only
+/// require the `trigger` root.
+pub fn validate_root(r: &TemplateRef) -> Result<(), TemplateError> {
+    let mut iter = r.path.iter();
+    let root = iter
+        .next()
+        .ok_or_else(|| TemplateError::EmptyPath(r.raw.clone()))?;
+    let root_name = match root {
+        PathSegment::Field(s) => s.as_str(),
+        PathSegment::Index(_) => {
+            return Err(TemplateError::UnknownRoot(
+                r.raw.clone(),
+                "<index>".to_string(),
+            ))
+        }
+    };
+    match root_name {
+        "trigger" => Ok(()),
+        "steps" => {
+            // steps.<name>.outputs.<...>
+            let _name = iter
+                .next()
+                .ok_or_else(|| TemplateError::EmptyPath(r.raw.clone()))?;
+            match iter.next() {
+                Some(PathSegment::Field(s)) if s == "outputs" => Ok(()),
+                _ => Err(TemplateError::MissingOutputsNamespace(r.raw.clone())),
+            }
+        }
+        other => Err(TemplateError::UnknownRoot(r.raw.clone(), other.to_string())),
+    }
+}
+
+/// Returns `Some(ref)` when the trimmed string is exactly one
+/// `${{ … }}` lexeme — the whole-string splice case.
+fn whole_string_ref(s: &str) -> Result<Option<TemplateRef>, TemplateError> {
+    let trimmed = s.trim();
+    if !trimmed.starts_with(OPEN) || !trimmed.ends_with(CLOSE) {
+        return Ok(None);
+    }
+    let inner = &trimmed[OPEN.len()..trimmed.len() - CLOSE.len()];
+    if inner.contains(OPEN) {
+        // multiple expressions; not a whole-string splice
+        return Ok(None);
+    }
+    Ok(Some(parse_path(inner)?))
+}
+
+fn coerce_embedded(v: Value, out: &mut String) {
+    match v {
+        Value::String(s) => out.push_str(&s),
+        Value::Null => {}
+        Value::Bool(b) => out.push_str(if b { "true" } else { "false" }),
+        Value::Number(n) => out.push_str(&n.to_string()),
+        other => {
+            out.push_str(&serde_json::to_string(&other).unwrap_or_default());
+        }
+    }
+}
+
+/// Walk a JSON tree and substitute every string leaf. Whole-string
+/// `${{ x }}` matches splice; embedded matches stringify.
+pub fn substitute_value(value: &Value, ctx: &TemplateContext) -> Result<Value, TemplateError> {
+    match value {
+        Value::String(s) => {
+            if let Some(r) = whole_string_ref(s)? {
+                return Ok(ctx.resolve(&r).unwrap_or(Value::Null));
+            }
+            Ok(Value::String(substitute_in_string(s, ctx)?))
+        }
+        Value::Array(arr) => {
+            let mut out = Vec::with_capacity(arr.len());
+            for v in arr {
+                out.push(substitute_value(v, ctx)?);
+            }
+            Ok(Value::Array(out))
+        }
+        Value::Object(map) => {
+            let mut out = serde_json::Map::with_capacity(map.len());
+            for (k, v) in map {
+                out.insert(k.clone(), substitute_value(v, ctx)?);
+            }
+            Ok(Value::Object(out))
+        }
+        other => Ok(other.clone()),
+    }
+}
+
+/// String-only substitution — used for skill bodies, where the
+/// surrounding container is itself text. Non-scalar resolved values
+/// are JSON-encoded.
+pub fn substitute_in_string(s: &str, ctx: &TemplateContext) -> Result<String, TemplateError> {
+    let mut out = String::with_capacity(s.len());
+    let mut rest = s;
+    while let Some(open_idx) = rest.find(OPEN) {
+        out.push_str(&rest[..open_idx]);
+        let after_open = &rest[open_idx + OPEN.len()..];
+        let close_idx = after_open.find(CLOSE).ok_or_else(|| {
+            TemplateError::Unterminated(format!(
+                "{OPEN}{}",
+                &after_open[..after_open.len().min(40)]
+            ))
+        })?;
+        let body = &after_open[..close_idx];
+        let r = parse_path(body)?;
+        let resolved = ctx.resolve(&r).unwrap_or(Value::Null);
+        coerce_embedded(resolved, &mut out);
+        rest = &after_open[close_idx + CLOSE.len()..];
+    }
+    out.push_str(rest);
+    Ok(out)
+}
+
+/// Extract every `${{ … }}` reference from a JSON tree (string
+/// leaves only). Used for parse-time validation; runtime
+/// substitution does its own pass.
+pub fn extract_refs_in_value(v: &Value) -> Result<Vec<TemplateRef>, TemplateError> {
+    let mut acc = Vec::new();
+    extract_refs_in_value_inner(v, &mut acc)?;
+    Ok(acc)
+}
+
+fn extract_refs_in_value_inner(v: &Value, acc: &mut Vec<TemplateRef>) -> Result<(), TemplateError> {
+    match v {
+        Value::String(s) => acc.extend(extract_refs_in_string(s)?),
+        Value::Array(arr) => {
+            for v in arr {
+                extract_refs_in_value_inner(v, acc)?;
+            }
+        }
+        Value::Object(map) => {
+            for v in map.values() {
+                extract_refs_in_value_inner(v, acc)?;
+            }
+        }
+        _ => {}
+    }
+    Ok(())
+}
+
+pub fn extract_refs_in_string(s: &str) -> Result<Vec<TemplateRef>, TemplateError> {
+    let mut refs = Vec::new();
+    let mut rest = s;
+    while let Some(open_idx) = rest.find(OPEN) {
+        let after_open = &rest[open_idx + OPEN.len()..];
+        let close_idx = after_open.find(CLOSE).ok_or_else(|| {
+            TemplateError::Unterminated(format!(
+                "{OPEN}{}",
+                &after_open[..after_open.len().min(40)]
+            ))
+        })?;
+        let body = &after_open[..close_idx];
+        refs.push(parse_path(body)?);
+        rest = &after_open[close_idx + CLOSE.len()..];
+    }
+    Ok(refs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn ctx_with(trigger: Value, steps: HashMap<String, Value>) -> (Value, HashMap<String, Value>) {
+        (trigger, steps)
+    }
+
+    #[test]
+    fn parse_simple_dot_path() {
+        let r = parse_path(" trigger.payload.build ").unwrap();
+        assert_eq!(
+            r.path,
+            vec![
+                PathSegment::Field("trigger".into()),
+                PathSegment::Field("payload".into()),
+                PathSegment::Field("build".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_bracket_index() {
+        let r = parse_path("steps.x.outputs.items[2].name").unwrap();
+        assert_eq!(
+            r.path,
+            vec![
+                PathSegment::Field("steps".into()),
+                PathSegment::Field("x".into()),
+                PathSegment::Field("outputs".into()),
+                PathSegment::Field("items".into()),
+                PathSegment::Index(2),
+                PathSegment::Field("name".into()),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_rejects_empty_path() {
+        assert!(matches!(
+            parse_path("   "),
+            Err(TemplateError::EmptyPath(_))
+        ));
+    }
+
+    #[test]
+    fn parse_rejects_unclosed_bracket() {
+        assert!(matches!(
+            parse_path("a[3"),
+            Err(TemplateError::MalformedSegment(_, _))
+        ));
+    }
+
+    #[test]
+    fn validate_root_accepts_trigger() {
+        validate_root(&parse_path("trigger.x").unwrap()).unwrap();
+    }
+
+    #[test]
+    fn validate_root_accepts_steps_outputs() {
+        validate_root(&parse_path("steps.foo.outputs.bar").unwrap()).unwrap();
+    }
+
+    #[test]
+    fn validate_root_rejects_unknown() {
+        assert!(matches!(
+            validate_root(&parse_path("env.HOME").unwrap()),
+            Err(TemplateError::UnknownRoot(_, _))
+        ));
+    }
+
+    #[test]
+    fn validate_root_rejects_steps_without_outputs() {
+        assert!(matches!(
+            validate_root(&parse_path("steps.foo.bar").unwrap()),
+            Err(TemplateError::MissingOutputsNamespace(_))
+        ));
+    }
+
+    #[test]
+    fn whole_string_splices_object() {
+        let mut steps = HashMap::new();
+        steps.insert("triage".into(), json!({ "args": { "build": 1234 } }));
+        let (trigger, steps) = ctx_with(json!({}), steps);
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let input = json!({ "payload": "${{ steps.triage.outputs.args }}" });
+        let out = substitute_value(&input, &ctx).unwrap();
+        assert_eq!(out, json!({ "payload": { "build": 1234 } }));
+    }
+
+    #[test]
+    fn embedded_stringifies_scalars_naturally() {
+        let trigger = json!({ "payload": { "build": 1234, "pipeline": "galoy-bank" } });
+        let steps = HashMap::new();
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let input = json!({
+            "note": "Build ${{ trigger.payload.build }} failed in ${{ trigger.payload.pipeline }}."
+        });
+        let out = substitute_value(&input, &ctx).unwrap();
+        assert_eq!(out, json!({ "note": "Build 1234 failed in galoy-bank." }));
+    }
+
+    #[test]
+    fn embedded_json_encodes_non_scalars() {
+        let trigger = json!({ "payload": { "list": [1, 2, 3] } });
+        let steps = HashMap::new();
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let s = substitute_in_string("ids=${{ trigger.payload.list }}", &ctx).unwrap();
+        assert_eq!(s, "ids=[1,2,3]");
+    }
+
+    #[test]
+    fn missing_path_resolves_to_null_in_splice() {
+        let trigger = json!({ "payload": {} });
+        let steps = HashMap::new();
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let input = json!({ "x": "${{ trigger.payload.absent }}" });
+        let out = substitute_value(&input, &ctx).unwrap();
+        assert_eq!(out, json!({ "x": null }));
+    }
+
+    #[test]
+    fn missing_path_resolves_to_empty_in_embed() {
+        let trigger = json!({});
+        let steps = HashMap::new();
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        assert_eq!(
+            substitute_in_string("[${{ trigger.x }}]", &ctx).unwrap(),
+            "[]"
+        );
+    }
+
+    #[test]
+    fn array_indexing_resolves() {
+        let mut steps = HashMap::new();
+        steps.insert(
+            "s".into(),
+            json!({ "items": [{ "name": "a" }, { "name": "b" }] }),
+        );
+        let trigger = json!({});
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let s = substitute_in_string("${{ steps.s.outputs.items[1].name }}", &ctx).unwrap();
+        assert_eq!(s, "b");
+    }
+
+    #[test]
+    fn extract_refs_walks_nested_json() {
+        let v = json!({
+            "outer": "${{ trigger.a }}",
+            "list": ["${{ trigger.b }}", "literal"],
+            "nested": { "x": "literal ${{ trigger.c }} more" }
+        });
+        let refs = extract_refs_in_value(&v).unwrap();
+        assert_eq!(refs.len(), 3);
+        let raws: Vec<_> = refs.iter().map(|r| r.raw.clone()).collect();
+        assert!(raws.iter().any(|r| r.contains("trigger.a")));
+        assert!(raws.iter().any(|r| r.contains("trigger.b")));
+        assert!(raws.iter().any(|r| r.contains("trigger.c")));
+    }
+
+    #[test]
+    fn unterminated_template_errors() {
+        let res = substitute_in_string(
+            "build ${{ trigger.x is unterminated",
+            &TemplateContext {
+                trigger: &json!({}),
+                steps: &HashMap::new(),
+            },
+        );
+        assert!(matches!(res, Err(TemplateError::Unterminated(_))));
+    }
+
+    #[test]
+    fn pure_literal_is_unchanged() {
+        let trigger = json!({});
+        let steps = HashMap::new();
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let v = json!({ "k": "no templates here" });
+        assert_eq!(substitute_value(&v, &ctx).unwrap(), v);
+    }
+}

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -191,18 +191,30 @@ pub fn referenced_step_names(r: &TemplateRef) -> Vec<String> {
 }
 
 /// Returns `Some(ref)` when the trimmed string is exactly one
-/// `${{ … }}` lexeme — the whole-string splice case.
+/// `${{ … }}` lexeme with no surrounding literal text — the
+/// whole-string splice case. Inputs like
+/// `"${{ x }} suffix"` (embedded with trailing literal) or
+/// `"${{ a }}${{ b }}"` (multiple lexemes) return `None` and fall
+/// through to embedded interpolation, which preserves the literal
+/// text and stringifies each ref individually.
 fn whole_string_ref(s: &str) -> Result<Option<TemplateRef>, TemplateError> {
     let trimmed = s.trim();
-    if !trimmed.starts_with(OPEN) || !trimmed.ends_with(CLOSE) {
+    if !trimmed.starts_with(OPEN) {
         return Ok(None);
     }
-    let inner = &trimmed[OPEN.len()..trimmed.len() - CLOSE.len()];
-    if inner.contains(OPEN) {
-        // multiple expressions; not a whole-string splice
+    let after_open = &trimmed[OPEN.len()..];
+    // Find the first `}}`; if anything follows it (or another `${{`
+    // appears inside the body), this isn't a whole-string splice.
+    let close_idx = match after_open.find(CLOSE) {
+        Some(i) => i,
+        None => return Ok(None),
+    };
+    let body = &after_open[..close_idx];
+    let after_close = &after_open[close_idx + CLOSE.len()..];
+    if !after_close.is_empty() || body.contains(OPEN) {
         return Ok(None);
     }
-    Ok(Some(parse_path(inner)?))
+    Ok(Some(parse_path(body)?))
 }
 
 fn coerce_embedded(v: Value, out: &mut String) {
@@ -612,6 +624,56 @@ mod tests {
             },
         );
         assert!(matches!(res, Err(TemplateError::Unterminated(_))));
+    }
+
+    /// Trigger payload data is passed in opaquely (it may carry
+    /// user-controlled text from a webhook). A literal `${{ … }}`
+    /// in the payload must NOT be re-evaluated when it lands in
+    /// substituted output — otherwise the consumer would gain a
+    /// path to leak prior step outputs by reflecting them through
+    /// `${{ steps.X.outputs.Y }}` smuggled through the trigger.
+    ///
+    /// `substitute_in_string` makes one pass over its input; the
+    /// resolved values are spliced verbatim. This test pins that
+    /// behaviour: the literal `${{ steps.victim.outputs.secret }}`
+    /// inside `trigger.payload.commit_msg` survives substitution
+    /// as text without being interpreted as a template ref.
+    #[test]
+    fn substitute_does_not_re_evaluate_literals_from_resolved_values() {
+        let trigger = json!({
+            "commit_msg": "Fix typo. Side note: ${{ steps.victim.outputs.secret }}"
+        });
+        let mut steps = HashMap::new();
+        steps.insert("victim".into(), json!({ "secret": "hunter2" }));
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let out = substitute_in_string("commit: ${{ trigger.payload.commit_msg }}", &ctx).unwrap();
+        // Literal `${{ steps.victim.outputs.secret }}` survives as
+        // text. `hunter2` does NOT appear.
+        assert!(out.contains("${{ steps.victim.outputs.secret }}"));
+        assert!(!out.contains("hunter2"));
+    }
+
+    /// `"${{ x }} suffix }}"` ends with `}}` and has no second
+    /// `${{` — a naive whole-string check would treat it as a splice,
+    /// then try to compile `x }} suffix` as a CEL expression and
+    /// return an unhelpful compile error. Detection must require an
+    /// EMPTY tail after the first `}}` to count as whole-string.
+    #[test]
+    fn embedded_match_with_trailing_close_chars_is_not_a_whole_string_splice() {
+        let trigger = json!({ "x": "X" });
+        let steps = HashMap::new();
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let input = json!({ "v": "${{ trigger.payload.x }} suffix }}" });
+        let out = substitute_value(&input, &ctx).unwrap();
+        // Embedded interpolation: the `${{ … }}` resolves to "X",
+        // the trailing literal " suffix }}" is preserved verbatim.
+        assert_eq!(out, json!({ "v": "X suffix }}" }));
     }
 
     #[test]

--- a/core/src/workflow/yaml.rs
+++ b/core/src/workflow/yaml.rs
@@ -8,6 +8,10 @@ use crate::primitives::WorkflowDefinitionId;
 use crate::sandbox::{SandboxAgentMode, SandboxMode, SandboxSpecs};
 
 use super::definition::{default_output_schema, OutputSchema};
+
+fn default_output_schema_boxed() -> Box<OutputSchema> {
+    Box::new(default_output_schema())
+}
 use crate::skill::file::slugify;
 use crate::skill::name_from_filename;
 
@@ -212,8 +216,16 @@ enum WorkflowStepYaml {
         timeout_seconds: Option<u64>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         model_chain: Option<ModelChain>,
-        #[serde(default = "default_output_schema")]
-        output_schema: OutputSchema,
+        #[serde(default = "default_output_schema_boxed")]
+        output_schema: Box<OutputSchema>,
+    },
+    ToolStep {
+        name: String,
+        tool: String,
+        #[serde(default, skip_serializing_if = "serde_json::Value::is_null")]
+        params: serde_json::Value,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        timeout_seconds: Option<u64>,
     },
 }
 
@@ -237,6 +249,17 @@ impl WorkflowStepYaml {
                 model_chain: model_chain.clone(),
                 output_schema: output_schema.clone(),
             },
+            WorkflowStepDef::ToolStep {
+                name,
+                tool,
+                params,
+                timeout_seconds,
+            } => WorkflowStepYaml::ToolStep {
+                name: name.clone(),
+                tool: tool.clone(),
+                params: params.clone(),
+                timeout_seconds: *timeout_seconds,
+            },
         }
     }
 
@@ -258,6 +281,17 @@ impl WorkflowStepYaml {
                 timeout_seconds,
                 model_chain,
                 output_schema,
+            },
+            WorkflowStepYaml::ToolStep {
+                name,
+                tool,
+                params,
+                timeout_seconds,
+            } => WorkflowStepDef::ToolStep {
+                name,
+                tool,
+                params,
+                timeout_seconds,
             },
         }
     }
@@ -426,7 +460,7 @@ mod tests {
             sandbox_mode: None,
             timeout_seconds: Some(120),
             model_chain: None,
-            output_schema: default_output_schema(),
+            output_schema: Box::new(default_output_schema()),
         }]
     }
 
@@ -629,7 +663,7 @@ steps:
             sandbox_mode: None,
             timeout_seconds: None,
             model_chain: None,
-            output_schema: schema,
+            output_schema: Box::new(schema),
         }];
         let content = render_workflow_yaml(
             id,
@@ -654,6 +688,7 @@ steps:
                 let actual = serde_json::to_value(output_schema).unwrap();
                 assert_eq!(actual, schema_value);
             }
+            other => panic!("expected AgentStep, got {other:?}"),
         }
     }
 
@@ -674,7 +709,7 @@ steps:
         let parsed = parse_workflow_yaml(yaml_without_field, "runtime/workflows/simple-flow.yml")
             .expect("parses");
         let step = &parsed.steps[0];
-        let actual = serde_json::to_value(step.output_schema()).unwrap();
+        let actual = serde_json::to_value(step.output_schema().expect("AgentStep")).unwrap();
         let default = serde_json::to_value(default_output_schema()).unwrap();
         assert_eq!(actual, default);
         // Re-rendered YAML now contains the default schema explicitly.

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1813,7 +1813,21 @@ fn workflow_step_to_view(s: &domain::workflow::WorkflowStepDef) -> WorkflowStepV
             name: name.clone(),
             step_type: "agent_step".to_string(),
             skill: skill.clone(),
+            tool: None,
             sandbox: sandbox.clone(),
+            timeout_seconds: *timeout_seconds,
+        },
+        domain::workflow::WorkflowStepDef::ToolStep {
+            name,
+            tool,
+            timeout_seconds,
+            ..
+        } => WorkflowStepView {
+            name: name.clone(),
+            step_type: "tool_step".to_string(),
+            skill: String::new(),
+            tool: Some(tool.clone()),
+            sandbox: None,
             timeout_seconds: *timeout_seconds,
         },
     }

--- a/server/src/templates.rs
+++ b/server/src/templates.rs
@@ -259,6 +259,8 @@ pub struct WorkflowStepView {
     pub name: String,
     pub step_type: String,
     pub skill: String,
+    /// Set on `tool_step` rows.
+    pub tool: Option<String>,
     pub sandbox: Option<String>,
     pub timeout_seconds: Option<u64>,
 }


### PR DESCRIPTION
## Summary

Workflow steps can now dispatch a single composable MCP tool directly — no agent loop, no LLM round-trip — and `${{ … }}` references in the dispatched params resolve against the trigger payload and prior step outputs.

Builds the foundation memo `019e01a4` calls out: a deterministic ToolStep primitive paired with a CEL-based template engine. The driving use case is the `concourse-failure-triage` workflow that calls `workflow.trigger` to dispatch sub-workflows, but the same primitive is useful for any deterministic in-workflow tool call.

### What's new

- **`WorkflowStepDef::ToolStep { name, tool, params, timeout_seconds }`** — dispatches a top-level MCP tool with the workflow's project authority. The called tool MUST be `composable: true` and declare an `output_schema`; its `structured_content` becomes `StepResult.output`.
- **`AuthSubject::WorkflowExecutor(ProjectId, WorkflowRunId, Vec<AuthScope>)`** — new variant minted at dispatch time with implicit `ProjectAdmin(project_id)` scope. Symmetric in cost to AgentStep's per-step Agent but doesn't drive an LLM session.
- **`core/src/workflow/template.rs`** — `${{ trigger.payload.X }}` and `${{ steps.<name>.outputs.Y }}` substitution layered on the [`cel`](https://crates.io/crates/cel) crate (same CEL spec Swamp / GHA use). JSON-shape-aware: whole-string `"${{ x }}"` splices the resolved value as JSON; embedded `${{ x }}` interpolates as text. Dot-walk + bracket indexing. Silent on null.
- **Templates apply to** ToolStep `params` AND AgentStep skill bodies (layered atop existing `$ARGUMENTS` handling).
- **Parse-time validation** rejects unknown roots, forward step refs, non-composable tools, and tools without `output_schema()`.
- **`workflow.trigger`** `definition_id` accepts UUID *or* project-scoped name (memo open Q1).
- **Admin tier gap-fill** (`drua_admin_workflow`): adds `Trigger` / `AwaitRun` / `Run` command arms and `tool_step` param shape so the bats e2e — and ops generally — can fire and inspect runs without webhook plumbing.

### What's deferred (per PM acks on the design memo)

- Cycle guard / `parent_run_id` lineage (Phase 2).
- `toJSON` / `fromJSON` template helpers (not needed with structured outputs).
- `if:` conditionals / per-provider trigger payload schemas.
- Deep JSON-schema-walk validation of `${{ }}` paths (MVP only does structural root + step-existence check).

## Commits

1. `feat(workflow): add ToolStep variant + ${{ … }} template substitution` — surface, executor wiring, parse-time validation
2. `refactor(workflow): replace hand-rolled template engine with cel crate` — swap to spec-compliant CEL (matches Swamp's choice; ~150 LoC of bespoke parser/resolver dropped)
3. `test(workflow): bats e2e for ToolStep dispatch via admin trigger/await_run` — admin tier extension + first bats test
4. `test(workflow): chain a second tool_step that consumes prior output via templates` — second step exercises every substitution path
5. `chore: adapt to upstream after rebase onto main` — `StepFailed → StepErrored` per #296, plus the `Errored` arm in admin's `format_run`

## Test plan

- [x] 408 core unit tests pass (`cargo nextest run -p drua-core --lib`)
- [x] Template engine has 19 dedicated unit tests covering parse, splice, embed, missing path, indexing, extract, unterminated, root validation, function calls
- [x] Parse-time forward-ref validation has 4 tests
- [x] `bats/workflow.bats` exercises end-to-end (`SKIP_COMPOSE=1 nix develop -c bats bats/workflow.bats`):
  - admin `workflow create` with two tool_steps (no agent_step, no LLM)
  - admin `workflow trigger` with `{ build: 1234, pipeline: "galoy-bank" }` payload
  - admin `workflow await_run` blocks until terminal and surfaces step outputs as inline JSON
  - asserts step 1 (whoami) reports `type: workflow_executor`, project_id matches, `ProjectAdmin` scope present
  - asserts step 2 (notes store) reflects substituted values: `title = run-<run_id>`, tags contain whole-string-spliced `galoy-bank` AND embedded `build-1234`
  - asserts read-back via `workflow run`
- [x] clippy clean, fmt clean, `nix flake check` green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it adds a new workflow execution mode that directly invokes top-level tools with a new privileged `AuthSubject::WorkflowExecutor`, plus a CEL-based templating engine that influences runtime parameters and skill prompts.
> 
> **Overview**
> Adds **deterministic workflow `tool_step` support**: workflows can now call a single *composable* top-level MCP tool (must declare `output_schema`) and store its `structured_content` as the step output, with runtime execution using a new `AuthSubject::WorkflowExecutor` identity (project-admin scoped) and richer audit tagging.
> 
> Introduces a **CEL-powered `${{ … }}` template engine** (`core/src/workflow/template.rs`) for substituting `trigger.payload.*` and `steps.<name>.outputs.*` into tool params *and* agent-step skill bodies, including parse-time validation (identifier rules, forward-ref checks, tool contract checks) and improved error diagnostics.
> 
> Extends the workflow admin/tool surfaces and tests: admin workflow commands now include `trigger`/`await_run`/`run` with run formatting, `workflow.trigger` accepts UUID-or-name, server/API views include `tool_step` fields, and new Bats e2e tests + shared `library-helpers.bash` validate end-to-end dispatch and null-payload substitution behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea870f5bd2d3aa31ca84b8cea54d92621c8460c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->