### PR TITLE
feat(notes): top-level notes.delete arm

### DIFF
--- a/core/src/toolset/top_level/notes.rs
+++ b/core/src/toolset/top_level/notes.rs
@@ -49,6 +49,9 @@ enum NotesParams {
     Unpin {
         note_id: NoteId,
     },
+    Delete {
+        note_id: NoteId,
+    },
 }
 
 impl NotesParams {
@@ -66,6 +69,7 @@ impl NotesParams {
             Self::List { .. } => "list",
             Self::Pin { .. } => "pin",
             Self::Unpin { .. } => "unpin",
+            Self::Delete { .. } => "delete",
         }
     }
 }
@@ -106,7 +110,7 @@ static NOTES_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
         "properties": {
             "command": {
                 "type": "string",
-                "enum": ["store", "get", "search", "list", "pin", "unpin"],
+                "enum": ["store", "get", "search", "list", "pin", "unpin", "delete"],
                 "description": "Which notes operation to perform."
             },
             "title": {
@@ -125,7 +129,7 @@ static NOTES_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
             "note_id": {
                 "type": "string",
                 "format": "uuid",
-                "description": "Note ID. Required for get/pin/unpin; optional for store (omit to create, pass to update)."
+                "description": "Note ID. Required for get/pin/unpin/delete; optional for store (omit to create, pass to update)."
             },
             "query": {
                 "type": "string",
@@ -173,7 +177,9 @@ impl TopLevelTool for NotesTool {
          Store findings, decisions, and task outcomes so future agents benefit. \
          Commands: `store` (create/update), `get` (by ID), \
          `search` (hybrid keyword + semantic), `list` (recent first), \
-         `pin` (inject into all agents' context), `unpin` (remove from context)."
+         `pin` (inject into all agents' context), `unpin` (remove from context), \
+         `delete` (requires `note_id`; project-scoped only — for space-scoped \
+         notes use the `spaces` tool)."
     }
 
     fn input_schema(&self) -> &serde_json::Value {
@@ -330,6 +336,20 @@ impl TopLevelTool for NotesTool {
                     note_id: Some(note.id.to_string()),
                     title: Some(note.title.clone()),
                     pinned: Some(false),
+                    ..Default::default()
+                };
+                (text, out)
+            }
+
+            NotesParams::Delete { note_id } => {
+                self.notes
+                    .delete(subject, project_id, note_id)
+                    .await
+                    .map_err(|e| ToolSetsError::Note(e.to_string()))?;
+                let text = format!("Note deleted (id {note_id}).");
+                let out = NotesOutput {
+                    command: "delete".to_string(),
+                    note_id: Some(note_id.to_string()),
                     ..Default::default()
                 };
                 (text, out)


### PR DESCRIPTION
## Summary

Closes the last parity gap with PR #266 (delete-skill) for notes by adding
the `delete` command to the top-level `notes` MCP tool.

## Scope-mapping vs PR #266

The notes equivalent of PR #266 was already merged as PR #267
(`feat(notes): space-tier scoping with auto-pin from mounted spaces`),
which landed:

- ✅ `Notes::delete` — soft-delete + library forward-sync via
  `enqueue_full_in_op` + `WriteOp::DeleteFile`
- ✅ `Notes::delete_by_path_in_op` — reverse-sync helper
- ✅ `NotesImporter::delete_in_op` — reverse-sync via
  `library_documents.path` lookup (no id-prefix collision risk)
- ✅ `NoteError::SpaceScopedDeleteViaSpaces` guardrail — project-scope
  routes reject space-scoped notes
- ✅ `drua_admin_note { command: "delete" }` arm
- ✅ GraphQL `noteDelete(input: { id, projectId }): { deletedId }`
  mutation + schema
- ✅ `bats/notes.bats` end-to-end coverage (project delete +
  space-scoped guardrail + reverse-sync via `spaces edit op=delete`)

The **only** missing piece was the **top-level** `notes` tool — its
`NotesParams` enum had `Store/Get/Search/List/Pin/Unpin` but no
`Delete`. That's the gap this PR closes, mirroring the shape of the
existing `skill.delete` arm on `top_level/skill.rs`.

## Library-sync verification

Both directions verified clean on `main` — no fix needed as part of
this PR:

- **Forward (delete-out)**: `Notes::delete` calls
  `library.enqueue_full_in_op(... WriteOp::DeleteFile { path, message } ...)`
  inside the same `DbOp` as the soft-delete, with the search-store
  row wiped in lockstep.
- **Reverse (delete-in)**: `NotesImporter::delete_in_op` looks up
  `library_documents.path` by exact match, soft-deletes the row,
  and bumps the right `ContextGeneration`.

## Admin-arm policy

Not a question for notes — the admin `note delete` arm is already on
`main` (added in PR #267 mirroring the skills-only reversal of
`acca538`). No new policy decision needed.

## Test plan

- [x] `nix flake check` passes locally (clippy + fmt + nextest +
      graphql-schema + default-config) — all 7 checks green
- [ ] Existing `bats/notes.bats` coverage still passes in CI
- [ ] Top-level `notes { command: "delete", note_id: <uuid> }` deletes
      a project note and propagates through the same forward-sync
      path the admin route already exercises

## Out of scope

- No reverse-sync changes — already implemented on `main`
- No new bats coverage for the top-level surface specifically — the
  bats `AGENT_TOKEN` is admin-scoped without an implicit `project_id`,
  so a top-level `notes` call would short-circuit on
  `subject.project_id().ok_or(Unauthorized)`. The forward path is
  already validated end-to-end through the admin surface.

## References

- PR #266 (delete-skill end-to-end)
- PR #267 (delete-note end-to-end, parity with #266)
- Memory `019df72f` — delete-skill PR implementation notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new destructive `notes` operation at the top-level tool surface; while it reuses existing delete logic, mistakes in auth/scoping or client usage could result in unintended note removal.
> 
> **Overview**
> Adds **top-level support for deleting notes** via `notes { command: "delete", note_id: ... }`, wiring the new `Delete` variant through parameter parsing, auditing, and tool execution.
> 
> Updates the tool’s JSON input schema and description to advertise `delete` and clarify it is *project-scoped* (space-scoped deletes should go through `spaces`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d06b7945ed6117e400b32a01c8cfee1e57230e88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->