### PR TITLE
fix(ci): expose gnused in apps.bats PATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -296,6 +296,7 @@
                 pkgs.coreutils
                 pkgs.gawk
                 pkgs.gnugrep
+                pkgs.gnused
                 pkgs.postgresql
                 pkgs.procps
                 pkgs.util-linux


### PR DESCRIPTION
## Summary

Concourse `test-bats` build #597 failed on `bats/workflow.bats:124`:

\`\`\`
/tmp/build/.../bats/workflow.bats: line 124: sed: command not found
\`\`\`

The `apps.bats` derivation in `flake.nix` declares the runner's PATH explicitly. It already lists `coreutils`, `gawk`, `gnugrep` — but `sed` lives in `gnused`, which wasn't in the list. macOS pulled `sed` from elsewhere on PATH locally so the gap slipped past pre-merge testing.

`bats/workflow.bats` is the only consumer today (added in #306), but adding the package matches the rest of the standard text-tool surface every bats file expects.

## Test plan

- [x] One-line addition to flake.nix; no source-code change
- [x] Concourse `test-bats` rerun should now pass — `sed` is on PATH inside the bats runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a Nix flake wiring change that only expands the `apps.bats` PATH to include `sed`, with no runtime or business-logic impact beyond CI/test execution.
> 
> **Overview**
> Fixes failing Concourse Bats runs by adding `pkgs.gnused` to the explicitly constructed PATH for `apps.bats` in `flake.nix`, ensuring `sed` is available during Bats test execution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a6726e9df0fcff2f8bf3d3ab340643f8afeef0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->