### PR TITLE
feat(workflow): per-step `condition:` CEL gate (skip semantics)

### DIFF
--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -352,6 +352,10 @@ enum WorkflowStepParams {
         /// `{success, output, reason}` schema.
         #[serde(default)]
         output_schema: Option<serde_json::Value>,
+        /// Bare CEL boolean expression — when present and false, the
+        /// step is skipped (run continues to the next step).
+        #[serde(default)]
+        condition: Option<String>,
     },
     ToolStep {
         name: String,
@@ -364,6 +368,9 @@ enum WorkflowStepParams {
         params: serde_json::Value,
         #[serde(default)]
         timeout_seconds: Option<u64>,
+        /// See `AgentStep::condition` — same semantics for ToolSteps.
+        #[serde(default)]
+        condition: Option<String>,
     },
 }
 
@@ -378,6 +385,7 @@ impl WorkflowStepParams {
                 timeout_seconds,
                 model_chain,
                 output_schema,
+                condition,
             } => {
                 let output_schema = match output_schema {
                     Some(value) => serde_json::from_value(value).map_err(|e| {
@@ -395,6 +403,7 @@ impl WorkflowStepParams {
                     timeout_seconds,
                     model_chain,
                     output_schema: Box::new(output_schema),
+                    condition,
                 })
             }
             WorkflowStepParams::ToolStep {
@@ -402,11 +411,13 @@ impl WorkflowStepParams {
                 tool,
                 params,
                 timeout_seconds,
+                condition,
             } => Ok(WorkflowStepDef::ToolStep {
                 name,
                 tool,
                 params,
                 timeout_seconds,
+                condition,
             }),
         }
     }
@@ -2079,6 +2090,9 @@ fn format_run(r: &WorkflowRun) -> String {
             out.push_str(&format!("    - name: {}\n", step.name));
             if let Some(err) = &step.error {
                 out.push_str(&format!("      error: {err}\n"));
+            }
+            if let Some(body) = &step.skipped {
+                out.push_str(&format!("      skipped: {body}\n"));
             }
             if let Some(value) = &step.output {
                 let json =

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -196,6 +196,11 @@ enum WorkflowStepParam {
         /// `{success, output, reason}` schema.
         #[serde(default)]
         output_schema: Option<serde_json::Value>,
+        /// Bare CEL boolean expression — when present and false, the
+        /// step is skipped (run continues to the next step). Evaluated
+        /// against `(trigger, steps)` like `${{ … }}` substitution.
+        #[serde(default)]
+        condition: Option<String>,
     },
     ToolStep {
         name: String,
@@ -208,6 +213,9 @@ enum WorkflowStepParam {
         params: serde_json::Value,
         #[serde(default)]
         timeout_seconds: Option<u64>,
+        /// See `AgentStep::condition` — same semantics for ToolSteps.
+        #[serde(default)]
+        condition: Option<String>,
     },
 }
 
@@ -222,6 +230,7 @@ impl WorkflowStepParam {
                 timeout_seconds,
                 model_chain,
                 output_schema,
+                condition,
             } => {
                 let output_schema = match output_schema {
                     Some(value) => serde_json::from_value(value).map_err(|e| {
@@ -239,6 +248,7 @@ impl WorkflowStepParam {
                     timeout_seconds,
                     model_chain,
                     output_schema: Box::new(output_schema),
+                    condition,
                 })
             }
             WorkflowStepParam::ToolStep {
@@ -246,11 +256,13 @@ impl WorkflowStepParam {
                 tool,
                 params,
                 timeout_seconds,
+                condition,
             } => Ok(WorkflowStepDef::ToolStep {
                 name,
                 tool,
                 params,
                 timeout_seconds,
+                condition,
             }),
         }
     }
@@ -395,6 +407,11 @@ struct StepResultOutput {
     error: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     completed_at: Option<String>,
+    /// `Some(<cel-body>)` when the step was skipped because its
+    /// `condition:` evaluated to false. Mutually exclusive with
+    /// `output` and `error`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    skipped: Option<String>,
 }
 
 pub struct WorkflowTool {
@@ -669,6 +686,7 @@ impl TopLevelTool for WorkflowTool {
                         timeout_seconds,
                         model_chain: None,
                         output_schema: Box::new(crate::workflow::default_output_schema()),
+                        condition: None,
                     }]
                 };
 
@@ -1021,6 +1039,7 @@ fn step_result_to_output(sr: &StepResult) -> StepResultOutput {
         output: sr.output.clone(),
         error: sr.error.clone(),
         completed_at: sr.completed_at.map(|t| t.to_rfc3339()),
+        skipped: sr.skipped.clone(),
     }
 }
 
@@ -1286,6 +1305,8 @@ fn format_run_text(r: &WorkflowRun) -> String {
     for (i, sr) in r.step_results.iter().enumerate() {
         let state = if sr.error.is_some() {
             "FAILED"
+        } else if sr.skipped.is_some() {
+            "SKIPPED"
         } else if sr.completed_at.is_some() {
             "OK"
         } else {
@@ -1297,6 +1318,9 @@ fn format_run_text(r: &WorkflowRun) -> String {
         }
         if let Some(err) = &sr.error {
             out.push_str(&format!("error: {err}\n"));
+        }
+        if let Some(body) = &sr.skipped {
+            out.push_str(&format!("condition (false): {body}\n"));
         }
         if let Some(v) = &sr.output {
             let text = match v {

--- a/core/src/workflow/definition.rs
+++ b/core/src/workflow/definition.rs
@@ -134,6 +134,17 @@ pub enum WorkflowStepDef {
         /// `large_enum_variant`).
         #[serde(default = "default_output_schema_boxed")]
         output_schema: Box<OutputSchema>,
+        /// Bare CEL boolean expression evaluated against the same
+        /// `(trigger, steps)` context as `${{ … }}` substitution.
+        /// `None` → step always runs (back-compat). `Some(expr)` and
+        /// `expr` evaluates to `false` → step is skipped: emits
+        /// `WorkflowRunEvent::StepSkipped`, the run continues to the
+        /// next step. Downstream `${{ steps.<this>.outputs.X }}` refs
+        /// resolve to `null` (whole-string splice) or `""` (embedded)
+        /// per the existing CEL missing-key semantics. Compiled and
+        /// validated at workflow create/update time.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        condition: Option<String>,
     },
     /// Deterministic single-tool dispatch — no agent loop, no LLM.
     /// `params` is the raw `arguments` object handed to the named
@@ -155,6 +166,9 @@ pub enum WorkflowStepDef {
         params: serde_json::Value,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timeout_seconds: Option<u64>,
+        /// See `AgentStep::condition` — same semantics for ToolSteps.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        condition: Option<String>,
     },
 }
 
@@ -180,6 +194,15 @@ impl WorkflowStepDef {
         match self {
             WorkflowStepDef::AgentStep { output_schema, .. } => Some(output_schema.as_ref()),
             WorkflowStepDef::ToolStep { .. } => None,
+        }
+    }
+
+    /// Bare CEL boolean expression that gates step execution. `None`
+    /// → step always runs.
+    pub fn condition(&self) -> Option<&str> {
+        match self {
+            WorkflowStepDef::AgentStep { condition, .. }
+            | WorkflowStepDef::ToolStep { condition, .. } => condition.as_deref(),
         }
     }
 }
@@ -342,6 +365,7 @@ mod tests {
             timeout_seconds: None,
             model_chain: None,
             output_schema: Box::new(custom),
+            condition: None,
         };
         let actual = serde_json::to_value(step.output_schema().expect("AgentStep")).unwrap();
         assert_eq!(actual, custom_value);
@@ -375,6 +399,7 @@ mod tests {
                 "payload": "${{ steps.triage.outputs.args }}"
             }),
             timeout_seconds: Some(60),
+            condition: None,
         };
         let value = serde_json::to_value(&step).unwrap();
         assert_eq!(
@@ -420,6 +445,7 @@ mod tests {
             timeout_seconds: None,
             model_chain: None,
             output_schema: Box::new(default_output_schema()),
+            condition: None,
         };
         let value = serde_json::to_value(&step).unwrap();
         assert!(

--- a/core/src/workflow/entity.rs
+++ b/core/src/workflow/entity.rs
@@ -426,6 +426,7 @@ mod tests {
             timeout_seconds: Some(60),
             model_chain: None,
             output_schema: Box::new(default_output_schema()),
+            condition: None,
         }
     }
 
@@ -466,6 +467,7 @@ mod tests {
             timeout_seconds: None,
             model_chain: Some(step_chain.clone()),
             output_schema: Box::new(default_output_schema()),
+            condition: None,
         }];
         assert_eq!(
             def.resolve_step_chain(&def.steps[0]).unwrap().primary.name,
@@ -480,6 +482,7 @@ mod tests {
             timeout_seconds: None,
             model_chain: None,
             output_schema: Box::new(default_output_schema()),
+            condition: None,
         }];
         assert_eq!(
             def.resolve_step_chain(&def.steps[0]).unwrap().primary.name,

--- a/core/src/workflow/error.rs
+++ b/core/src/workflow/error.rs
@@ -39,6 +39,14 @@ pub enum WorkflowError {
     InvalidStep(String),
     #[error("WorkflowError - InvalidTemplateRef: {0}")]
     InvalidTemplateRef(String),
+    #[error("WorkflowError - InvalidCondition: {0}")]
+    InvalidCondition(String),
+    #[error("WorkflowError - ConditionNotBoolean: step '{step}' condition `{body}` evaluated to {value} (expected bool)")]
+    ConditionNotBoolean {
+        step: String,
+        body: String,
+        value: String,
+    },
     #[error("WorkflowError - ToolNotFound: {0}")]
     ToolNotFound(String),
     #[error("WorkflowError - ToolDispatch: {0}")]

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -18,8 +18,7 @@ use super::error::WorkflowError;
 use super::repo::WorkflowDefinitionRepo;
 use super::run::{StepResult, WorkflowRunRepo, WorkflowRunState};
 use super::template::{
-    evaluate_condition, format_template_diagnostics, parse_condition, template_diagnostics,
-    ConditionOutcome, TemplateContext,
+    format_template_diagnostics, template_diagnostics, ConditionOutcome, TemplateContext,
 };
 
 /// Hard cap on the pre-flight per-sandbox readiness wait. Protects the
@@ -191,47 +190,27 @@ impl Executor {
 
             // Condition gate. Evaluated BEFORE `step_started`: a
             // skipped step never enters Running state — it's
-            // terminally Skipped from the start. Validation at
-            // create time guarantees `parse_condition` succeeds, so
-            // the only remaining failure modes here are a CEL
-            // runtime error (type mismatch, etc.) or a body that
-            // resolves to a non-bool — both classified as
-            // infrastructure errors (`step_errored` → run
-            // aggregates Errored).
+            // terminally Skipped from the start. `evaluate_condition`
+            // folds parse + execute into one call; create-time
+            // validation guarantees the body compiles, so an `Err`
+            // here is a CEL runtime error (type mismatch, etc.).
             if let Some(body) = step.condition() {
                 let step_outputs = collect_step_outputs(&run.step_results);
                 let ctx = TemplateContext {
                     trigger: &trigger_context,
                     steps: &step_outputs,
                 };
-                // `parse_condition` re-compiles for evaluation; the
-                // create-time pass already proved it parses cleanly,
-                // so an error here would be a defensive arm.
-                let parsed = match parse_condition(body) {
-                    Ok(p) => p,
-                    Err(e) => {
-                        let err =
-                            WorkflowError::InvalidCondition(format!("step '{step_name}': {e}"));
-                        if run
-                            .step_errored(step_name.clone(), err.to_string())
-                            .did_execute()
-                        {
-                            self.runs.update(&mut run).await?;
-                        }
-                        break;
-                    }
-                };
-                match evaluate_condition(&ctx, &parsed) {
-                    Some(ConditionOutcome::True) => {
+                match ctx.evaluate_condition(body) {
+                    Ok(ConditionOutcome::True) => {
                         // Fall through to step_started + execute_step.
                     }
-                    Some(ConditionOutcome::False) => {
+                    Ok(ConditionOutcome::False) => {
                         if run.step_skipped(step_name, body.to_string()).did_execute() {
                             self.runs.update(&mut run).await?;
                         }
                         continue;
                     }
-                    Some(ConditionOutcome::NotBoolean(rendered)) => {
+                    Ok(ConditionOutcome::NotBoolean(rendered)) => {
                         let err = WorkflowError::ConditionNotBoolean {
                             step: step_name.clone(),
                             body: body.to_string(),
@@ -242,10 +221,9 @@ impl Executor {
                         }
                         break;
                     }
-                    None => {
-                        let err = WorkflowError::InvalidCondition(format!(
-                            "step '{step_name}': CEL runtime error evaluating `{body}`"
-                        ));
+                    Err(e) => {
+                        let err =
+                            WorkflowError::InvalidCondition(format!("step '{step_name}': {e}"));
                         if run.step_errored(step_name, err.to_string()).did_execute() {
                             self.runs.update(&mut run).await?;
                         }

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -17,7 +17,10 @@ use super::definition::{WorkflowSandboxDecl, WorkflowStepDef};
 use super::error::WorkflowError;
 use super::repo::WorkflowDefinitionRepo;
 use super::run::{StepResult, WorkflowRunRepo, WorkflowRunState};
-use super::template::{format_template_diagnostics, template_diagnostics, TemplateContext};
+use super::template::{
+    evaluate_condition, format_template_diagnostics, parse_condition, template_diagnostics,
+    ConditionOutcome, TemplateContext,
+};
 
 /// Hard cap on the pre-flight per-sandbox readiness wait. Protects the
 /// queue from a stuck infrastructure step.
@@ -28,13 +31,26 @@ const SANDBOX_READY_TIMEOUT: Duration = Duration::from_secs(180);
 const DEFAULT_TOOL_STEP_TIMEOUT_SECS: u64 = 300;
 
 /// Build the `steps` slice of the template context from the run's
-/// completed-step outputs. Skips entries with no recorded output
-/// (pending or failed steps).
+/// recorded step results. Completed steps surface their structured
+/// `output`; skipped / errored / pending steps surface as
+/// `Value::Null`. Including the latter keeps CEL from raising
+/// `NoSuchKey` when a downstream `${{ steps.<skipped>.outputs.X }}`
+/// or `condition: steps.<skipped>.outputs.X` refers to a step that
+/// didn't produce one — the access becomes `null.outputs.X` which
+/// CEL coerces to `false` per the same quirk documented at
+/// `template::TemplateContext::build_cel_context`. Net effect: the
+/// "downstream null-coalesce" contract documented in memo
+/// `019e06a1` falls out for free.
 fn collect_step_outputs(results: &[StepResult]) -> HashMap<String, serde_json::Value> {
     let mut out = HashMap::with_capacity(results.len());
     for r in results {
-        if let Some(value) = &r.output {
-            out.insert(r.name.clone(), value.clone());
+        match &r.output {
+            Some(value) => {
+                out.insert(r.name.clone(), value.clone());
+            }
+            None => {
+                out.insert(r.name.clone(), serde_json::Value::Null);
+            }
         }
     }
     out
@@ -171,6 +187,71 @@ impl Executor {
 
             if cancel.load(Ordering::Relaxed) {
                 return Err(WorkflowError::Cancelled);
+            }
+
+            // Condition gate. Evaluated BEFORE `step_started`: a
+            // skipped step never enters Running state — it's
+            // terminally Skipped from the start. Validation at
+            // create time guarantees `parse_condition` succeeds, so
+            // the only remaining failure modes here are a CEL
+            // runtime error (type mismatch, etc.) or a body that
+            // resolves to a non-bool — both classified as
+            // infrastructure errors (`step_errored` → run
+            // aggregates Errored).
+            if let Some(body) = step.condition() {
+                let step_outputs = collect_step_outputs(&run.step_results);
+                let ctx = TemplateContext {
+                    trigger: &trigger_context,
+                    steps: &step_outputs,
+                };
+                // `parse_condition` re-compiles for evaluation; the
+                // create-time pass already proved it parses cleanly,
+                // so an error here would be a defensive arm.
+                let parsed = match parse_condition(body) {
+                    Ok(p) => p,
+                    Err(e) => {
+                        let err =
+                            WorkflowError::InvalidCondition(format!("step '{step_name}': {e}"));
+                        if run
+                            .step_errored(step_name.clone(), err.to_string())
+                            .did_execute()
+                        {
+                            self.runs.update(&mut run).await?;
+                        }
+                        break;
+                    }
+                };
+                match evaluate_condition(&ctx, &parsed) {
+                    Some(ConditionOutcome::True) => {
+                        // Fall through to step_started + execute_step.
+                    }
+                    Some(ConditionOutcome::False) => {
+                        if run.step_skipped(step_name, body.to_string()).did_execute() {
+                            self.runs.update(&mut run).await?;
+                        }
+                        continue;
+                    }
+                    Some(ConditionOutcome::NotBoolean(rendered)) => {
+                        let err = WorkflowError::ConditionNotBoolean {
+                            step: step_name.clone(),
+                            body: body.to_string(),
+                            value: rendered,
+                        };
+                        if run.step_errored(step_name, err.to_string()).did_execute() {
+                            self.runs.update(&mut run).await?;
+                        }
+                        break;
+                    }
+                    None => {
+                        let err = WorkflowError::InvalidCondition(format!(
+                            "step '{step_name}': CEL runtime error evaluating `{body}`"
+                        ));
+                        if run.step_errored(step_name, err.to_string()).did_execute() {
+                            self.runs.update(&mut run).await?;
+                        }
+                        break;
+                    }
+                }
             }
 
             if run.step_started(step_name.clone()).did_execute() {
@@ -567,6 +648,7 @@ impl Executor {
                 tool,
                 params,
                 timeout_seconds,
+                ..
             } => {
                 self.execute_tool_step(
                     project_id,

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -297,6 +297,16 @@ impl Workflows {
         }
 
         for step in steps {
+            // Compile + root-validate + forward-ref-check the
+            // optional `condition:` body. Lives on both step kinds,
+            // so factor the check out of the per-variant arms.
+            if let Some(body) = step.condition() {
+                let r = template::parse_condition(body).map_err(|e| {
+                    WorkflowError::InvalidCondition(format!("step '{}': {e}", step.name()))
+                })?;
+                validate_ref_against_prior_steps(step.name(), &r, &seen_step_names)?;
+            }
+
             match step {
                 WorkflowStepDef::AgentStep {
                     name,

--- a/core/src/workflow/run/entity.rs
+++ b/core/src/workflow/run/entity.rs
@@ -236,6 +236,13 @@ impl WorkflowRun {
     /// `condition_body` is the raw CEL expression — kept on the
     /// event so `runs --include=steps` can render which gate fired.
     ///
+    /// The executor calls this directly (without a prior
+    /// `step_started`) when the gate evaluates false, so this method
+    /// must drive the same Pending → Running state transition that
+    /// `step_started` does — otherwise a run with every step gated
+    /// out would jump from Pending straight to Succeeded at
+    /// `run_completed`, with no `Running` phase in its event log.
+    ///
     /// No-op if the step already terminated.
     pub fn step_skipped(&mut self, step_name: String, condition_body: String) -> Idempotent<()> {
         idempotency_guard!(
@@ -259,6 +266,9 @@ impl WorkflowRun {
                 completed_at: Some(now),
                 skipped: Some(condition_body.clone()),
             });
+        }
+        if self.state == WorkflowRunState::Pending {
+            self.state = WorkflowRunState::Running;
         }
         self.events.push(WorkflowRunEvent::StepSkipped {
             step_name,
@@ -406,6 +416,7 @@ impl TryFromEvents<WorkflowRunEvent> for WorkflowRun {
                     condition_body,
                     completed_at: ts,
                 } => {
+                    state = WorkflowRunState::Running;
                     if let Some(r) = results.iter_mut().find(|r| &r.name == step_name) {
                         r.skipped = Some(condition_body.clone());
                         r.completed_at = Some(*ts);
@@ -656,20 +667,53 @@ mod tests {
         );
     }
 
+    /// Production calls `step_skipped` directly (no prior
+    /// `step_started`) when the condition gate evaluates false —
+    /// the executor's "skipped steps never enter Running state"
+    /// invariant. This test mirrors that path: the `else` branch in
+    /// `step_skipped` (push fresh `StepResult`) is the production
+    /// path; the `if let Some` branch only fires on hydration replay.
     #[test]
     fn run_state_succeeded_when_only_step_was_skipped() {
-        // Skipped steps fold into the Succeeded classification: a
-        // run whose every step was gated out is a clean "no-op".
         let mut run = fresh_run(&["only"]);
-        start(&mut run, "only");
         skip(&mut run, "only", "trigger.payload.flag == true");
         assert_eq!(finalize(&mut run), WorkflowRunState::Succeeded);
+    }
+
+    /// `step_skipped` mirrors `step_started`'s Pending → Running
+    /// transition. Without it, an all-skipped run would stay
+    /// Pending throughout the executor loop and only flip to a
+    /// terminal state at `run_completed` — leaving no `Running`
+    /// phase in the event log. This test pins the transition.
+    #[test]
+    fn step_skipped_transitions_pending_to_running() {
+        let mut run = fresh_run(&["only"]);
+        assert_eq!(run.state, WorkflowRunState::Pending);
+        skip(&mut run, "only", "trigger.payload.flag == true");
+        assert_eq!(run.state, WorkflowRunState::Running);
+    }
+
+    /// The production path creates a fresh `StepResult` (the `else`
+    /// branch of `step_skipped`) since the executor never called
+    /// `step_started` for a gated-out step. Verify the new entry
+    /// is well-formed: condition body recorded, no output, no
+    /// error, `completed_at` set.
+    #[test]
+    fn step_skipped_creates_fresh_step_result() {
+        let mut run = fresh_run(&["only"]);
+        skip(&mut run, "only", "trigger.payload.flag == true");
+        assert_eq!(run.step_results.len(), 1);
+        let r = &run.step_results[0];
+        assert_eq!(r.name, "only");
+        assert_eq!(r.skipped.as_deref(), Some("trigger.payload.flag == true"));
+        assert!(r.output.is_none());
+        assert!(r.error.is_none());
+        assert!(r.completed_at.is_some());
     }
 
     #[test]
     fn run_state_succeeded_when_skip_mixes_with_success() {
         let mut run = fresh_run(&["a", "b"]);
-        start(&mut run, "a");
         skip(&mut run, "a", "trigger.payload.flag == true");
         start(&mut run, "b");
         complete(
@@ -683,7 +727,6 @@ mod tests {
     #[test]
     fn run_state_failed_when_skip_mixes_with_agent_failure() {
         let mut run = fresh_run(&["a", "b"]);
-        start(&mut run, "a");
         skip(&mut run, "a", "trigger.payload.flag == true");
         start(&mut run, "b");
         complete(
@@ -697,7 +740,6 @@ mod tests {
     #[test]
     fn run_state_errored_when_skip_mixes_with_infra_error() {
         let mut run = fresh_run(&["a", "b"]);
-        start(&mut run, "a");
         skip(&mut run, "a", "trigger.payload.flag == true");
         start(&mut run, "b");
         error(&mut run, "b", "sandbox not ready");
@@ -707,7 +749,6 @@ mod tests {
     #[test]
     fn step_skipped_is_idempotent_against_retry() {
         let mut run = fresh_run(&["only"]);
-        start(&mut run, "only");
         skip(&mut run, "only", "x == 'y'");
         // Replay the same event — should be a no-op.
         let outcome = run.step_skipped("only".into(), "x == 'y'".into());
@@ -717,7 +758,6 @@ mod tests {
     #[test]
     fn step_skipped_blocks_subsequent_completed_or_errored() {
         let mut run = fresh_run(&["only"]);
-        start(&mut run, "only");
         skip(&mut run, "only", "x == 'y'");
         // Subsequent terminal mutations are no-ops.
         let outcome = run.step_completed("only".into(), json!({ "success": true }));
@@ -729,7 +769,6 @@ mod tests {
     #[test]
     fn step_skipped_hydrates_from_events() {
         let mut run = fresh_run(&["only"]);
-        start(&mut run, "only");
         skip(&mut run, "only", "trigger.payload.x == 'y'");
         let events = run.events;
         let rehydrated = WorkflowRun::try_from_events(events).unwrap();
@@ -741,5 +780,9 @@ mod tests {
         assert!(rehydrated.step_results[0].output.is_none());
         assert!(rehydrated.step_results[0].error.is_none());
         assert!(rehydrated.step_results[0].completed_at.is_some());
+        // Pending → Running transition replays from the StepSkipped
+        // event in the same way StepStarted drives it, so a run
+        // hydrated mid-flight reflects the live state.
+        assert_eq!(rehydrated.state, WorkflowRunState::Running);
     }
 }

--- a/core/src/workflow/run/entity.rs
+++ b/core/src/workflow/run/entity.rs
@@ -30,6 +30,13 @@ pub struct StepResult {
     pub output: Option<serde_json::Value>,
     pub error: Option<String>,
     pub completed_at: Option<DateTime<Utc>>,
+    /// `Some(condition_body)` if the step was skipped because its
+    /// `condition:` evaluated to false. Mutually exclusive with
+    /// `output` and `error` — the executor records exactly one of
+    /// the three terminal states. `#[serde(default)]` so older
+    /// `StepResult` rows hydrate cleanly.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub skipped: Option<String>,
 }
 
 #[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
@@ -59,6 +66,17 @@ pub enum WorkflowRunEvent {
     StepErrored {
         step_name: String,
         error: String,
+        completed_at: DateTime<Utc>,
+    },
+    /// The step's `condition:` evaluated to `false`. The run
+    /// continues to the next step. Folds into run-state aggregation
+    /// as Succeeded (skipped steps are invisible to the
+    /// Errored/Failed/Succeeded classification).
+    StepSkipped {
+        step_name: String,
+        /// Raw CEL body that was false at evaluation time. Kept on
+        /// the event for forensic visibility in `runs --include=steps`.
+        condition_body: String,
         completed_at: DateTime<Utc>,
     },
     RunCompleted {
@@ -116,6 +134,8 @@ impl WorkflowRun {
                 WorkflowRunEvent::StepCompleted { step_name: n, .. } if n == &step_name,
             already_applied:
                 WorkflowRunEvent::StepErrored { step_name: n, .. } if n == &step_name,
+            already_applied:
+                WorkflowRunEvent::StepSkipped { step_name: n, .. } if n == &step_name,
         );
         let now = Utc::now();
         if !self.step_results.iter().any(|r| r.name == step_name) {
@@ -124,6 +144,7 @@ impl WorkflowRun {
                 output: None,
                 error: None,
                 completed_at: None,
+                skipped: None,
             });
         }
         if self.state == WorkflowRunState::Pending {
@@ -148,6 +169,8 @@ impl WorkflowRun {
                 WorkflowRunEvent::StepCompleted { step_name: n, .. } if n == &step_name,
             already_applied:
                 WorkflowRunEvent::StepErrored { step_name: n, .. } if n == &step_name,
+            already_applied:
+                WorkflowRunEvent::StepSkipped { step_name: n, .. } if n == &step_name,
         );
         let now = Utc::now();
         if let Some(r) = self.step_results.iter_mut().find(|r| r.name == step_name) {
@@ -159,6 +182,7 @@ impl WorkflowRun {
                 output: Some(output.clone()),
                 error: None,
                 completed_at: Some(now),
+                skipped: None,
             });
         }
         self.events.push(WorkflowRunEvent::StepCompleted {
@@ -183,6 +207,8 @@ impl WorkflowRun {
                 WorkflowRunEvent::StepErrored { step_name: n, .. } if n == &step_name,
             already_applied:
                 WorkflowRunEvent::StepCompleted { step_name: n, .. } if n == &step_name,
+            already_applied:
+                WorkflowRunEvent::StepSkipped { step_name: n, .. } if n == &step_name,
         );
         let now = Utc::now();
         if let Some(r) = self.step_results.iter_mut().find(|r| r.name == step_name) {
@@ -194,11 +220,49 @@ impl WorkflowRun {
                 output: None,
                 error: Some(error.clone()),
                 completed_at: Some(now),
+                skipped: None,
             });
         }
         self.events.push(WorkflowRunEvent::StepErrored {
             step_name,
             error,
+            completed_at: now,
+        });
+        Idempotent::Executed(())
+    }
+
+    /// Records that the step was skipped because its `condition:`
+    /// evaluated to false. The run continues to the next step.
+    /// `condition_body` is the raw CEL expression — kept on the
+    /// event so `runs --include=steps` can render which gate fired.
+    ///
+    /// No-op if the step already terminated.
+    pub fn step_skipped(&mut self, step_name: String, condition_body: String) -> Idempotent<()> {
+        idempotency_guard!(
+            self.events.iter_all().rev(),
+            already_applied:
+                WorkflowRunEvent::StepSkipped { step_name: n, .. } if n == &step_name,
+            already_applied:
+                WorkflowRunEvent::StepCompleted { step_name: n, .. } if n == &step_name,
+            already_applied:
+                WorkflowRunEvent::StepErrored { step_name: n, .. } if n == &step_name,
+        );
+        let now = Utc::now();
+        if let Some(r) = self.step_results.iter_mut().find(|r| r.name == step_name) {
+            r.skipped = Some(condition_body.clone());
+            r.completed_at = Some(now);
+        } else {
+            self.step_results.push(StepResult {
+                name: step_name.clone(),
+                output: None,
+                error: None,
+                completed_at: Some(now),
+                skipped: Some(condition_body.clone()),
+            });
+        }
+        self.events.push(WorkflowRunEvent::StepSkipped {
+            step_name,
+            condition_body,
             completed_at: now,
         });
         Idempotent::Executed(())
@@ -235,12 +299,13 @@ impl WorkflowRun {
 }
 
 /// True when a cleanly-completed step's structured output carries
-/// `success: false` (top-level boolean). Infrastructure-errored steps
-/// return false here — they're classified as `Errored`, not `Failed`.
+/// `success: false` (top-level boolean). Infrastructure-errored and
+/// condition-skipped steps return false here — they're classified
+/// as `Errored` and Succeeded respectively, never `Failed`.
 /// Missing or non-boolean `success` defaults to "no agent-reported
 /// failure" (back-compat for non-default-schema steps).
 fn step_reported_agent_failure(step: &StepResult) -> bool {
-    if step.error.is_some() {
+    if step.error.is_some() || step.skipped.is_some() {
         return false;
     }
     let reported_success = step
@@ -296,6 +361,7 @@ impl TryFromEvents<WorkflowRunEvent> for WorkflowRun {
                             output: None,
                             error: None,
                             completed_at: None,
+                            skipped: None,
                         });
                     }
                 }
@@ -313,6 +379,7 @@ impl TryFromEvents<WorkflowRunEvent> for WorkflowRun {
                             output: Some(output.clone()),
                             error: None,
                             completed_at: Some(*ts),
+                            skipped: None,
                         });
                     }
                 }
@@ -330,6 +397,25 @@ impl TryFromEvents<WorkflowRunEvent> for WorkflowRun {
                             output: None,
                             error: Some(error.clone()),
                             completed_at: Some(*ts),
+                            skipped: None,
+                        });
+                    }
+                }
+                WorkflowRunEvent::StepSkipped {
+                    step_name,
+                    condition_body,
+                    completed_at: ts,
+                } => {
+                    if let Some(r) = results.iter_mut().find(|r| &r.name == step_name) {
+                        r.skipped = Some(condition_body.clone());
+                        r.completed_at = Some(*ts);
+                    } else {
+                        results.push(StepResult {
+                            name: step_name.clone(),
+                            output: None,
+                            error: None,
+                            completed_at: Some(*ts),
+                            skipped: Some(condition_body.clone()),
                         });
                     }
                 }
@@ -400,6 +486,7 @@ mod tests {
             timeout_seconds: None,
             model_chain: None,
             output_schema: Box::new(default_output_schema()),
+            condition: None,
         }
     }
 
@@ -424,6 +511,10 @@ mod tests {
 
     fn error(run: &mut WorkflowRun, name: &str, err: &str) {
         run.step_errored(name.into(), err.into()).did_execute();
+    }
+
+    fn skip(run: &mut WorkflowRun, name: &str, body: &str) {
+        run.step_skipped(name.into(), body.into()).did_execute();
     }
 
     fn finalize(run: &mut WorkflowRun) -> WorkflowRunState {
@@ -548,5 +639,107 @@ mod tests {
         );
 
         assert_eq!(finalize(&mut run), WorkflowRunState::Succeeded);
+    }
+
+    #[test]
+    fn step_skipped_event_wire_format() {
+        let ev = WorkflowRunEvent::StepSkipped {
+            step_name: "s".into(),
+            condition_body: "trigger.payload.x == 'y'".into(),
+            completed_at: Utc::now(),
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(v.get("type").and_then(|t| t.as_str()), Some("step_skipped"));
+        assert_eq!(
+            v.get("condition_body").and_then(|c| c.as_str()),
+            Some("trigger.payload.x == 'y'")
+        );
+    }
+
+    #[test]
+    fn run_state_succeeded_when_only_step_was_skipped() {
+        // Skipped steps fold into the Succeeded classification: a
+        // run whose every step was gated out is a clean "no-op".
+        let mut run = fresh_run(&["only"]);
+        start(&mut run, "only");
+        skip(&mut run, "only", "trigger.payload.flag == true");
+        assert_eq!(finalize(&mut run), WorkflowRunState::Succeeded);
+    }
+
+    #[test]
+    fn run_state_succeeded_when_skip_mixes_with_success() {
+        let mut run = fresh_run(&["a", "b"]);
+        start(&mut run, "a");
+        skip(&mut run, "a", "trigger.payload.flag == true");
+        start(&mut run, "b");
+        complete(
+            &mut run,
+            "b",
+            json!({ "success": true, "output": "did the thing" }),
+        );
+        assert_eq!(finalize(&mut run), WorkflowRunState::Succeeded);
+    }
+
+    #[test]
+    fn run_state_failed_when_skip_mixes_with_agent_failure() {
+        let mut run = fresh_run(&["a", "b"]);
+        start(&mut run, "a");
+        skip(&mut run, "a", "trigger.payload.flag == true");
+        start(&mut run, "b");
+        complete(
+            &mut run,
+            "b",
+            json!({ "success": false, "reason": "no", "output": "" }),
+        );
+        assert_eq!(finalize(&mut run), WorkflowRunState::Failed);
+    }
+
+    #[test]
+    fn run_state_errored_when_skip_mixes_with_infra_error() {
+        let mut run = fresh_run(&["a", "b"]);
+        start(&mut run, "a");
+        skip(&mut run, "a", "trigger.payload.flag == true");
+        start(&mut run, "b");
+        error(&mut run, "b", "sandbox not ready");
+        assert_eq!(finalize(&mut run), WorkflowRunState::Errored);
+    }
+
+    #[test]
+    fn step_skipped_is_idempotent_against_retry() {
+        let mut run = fresh_run(&["only"]);
+        start(&mut run, "only");
+        skip(&mut run, "only", "x == 'y'");
+        // Replay the same event — should be a no-op.
+        let outcome = run.step_skipped("only".into(), "x == 'y'".into());
+        assert!(matches!(outcome, Idempotent::AlreadyApplied));
+    }
+
+    #[test]
+    fn step_skipped_blocks_subsequent_completed_or_errored() {
+        let mut run = fresh_run(&["only"]);
+        start(&mut run, "only");
+        skip(&mut run, "only", "x == 'y'");
+        // Subsequent terminal mutations are no-ops.
+        let outcome = run.step_completed("only".into(), json!({ "success": true }));
+        assert!(matches!(outcome, Idempotent::AlreadyApplied));
+        let outcome = run.step_errored("only".into(), "boom".into());
+        assert!(matches!(outcome, Idempotent::AlreadyApplied));
+    }
+
+    #[test]
+    fn step_skipped_hydrates_from_events() {
+        let mut run = fresh_run(&["only"]);
+        start(&mut run, "only");
+        skip(&mut run, "only", "trigger.payload.x == 'y'");
+        let events = run.events;
+        let rehydrated = WorkflowRun::try_from_events(events).unwrap();
+        assert_eq!(rehydrated.step_results.len(), 1);
+        assert_eq!(
+            rehydrated.step_results[0].skipped.as_deref(),
+            Some("trigger.payload.x == 'y'")
+        );
+        assert!(rehydrated.step_results[0].output.is_none());
+        assert!(rehydrated.step_results[0].error.is_none());
+        assert!(rehydrated.step_results[0].completed_at.is_some());
     }
 }

--- a/core/src/workflow/run/entity.rs
+++ b/core/src/workflow/run/entity.rs
@@ -199,6 +199,14 @@ impl WorkflowRun {
     /// here — those are aggregated into `WorkflowRunState::Failed`,
     /// while errors aggregated here become `WorkflowRunState::Errored`.
     ///
+    /// Drives the same Pending → Running transition that
+    /// `step_started` and `step_skipped` do — the executor's
+    /// condition-gate error paths call this directly without a
+    /// prior `step_started`, so without the transition a run whose
+    /// very first step's condition errored would jump from Pending
+    /// straight to Errored, leaving no `Running` phase in the
+    /// event log.
+    ///
     /// No-op if the step already terminated.
     pub fn step_errored(&mut self, step_name: String, error: String) -> Idempotent<()> {
         idempotency_guard!(
@@ -222,6 +230,9 @@ impl WorkflowRun {
                 completed_at: Some(now),
                 skipped: None,
             });
+        }
+        if self.state == WorkflowRunState::Pending {
+            self.state = WorkflowRunState::Running;
         }
         self.events.push(WorkflowRunEvent::StepErrored {
             step_name,
@@ -398,6 +409,7 @@ impl TryFromEvents<WorkflowRunEvent> for WorkflowRun {
                     error,
                     completed_at: ts,
                 } => {
+                    state = WorkflowRunState::Running;
                     if let Some(r) = results.iter_mut().find(|r| &r.name == step_name) {
                         r.error = Some(error.clone());
                         r.completed_at = Some(*ts);
@@ -592,6 +604,59 @@ mod tests {
         error(&mut run, "only", "sandbox not ready");
 
         assert_eq!(finalize(&mut run), WorkflowRunState::Errored);
+    }
+
+    /// The executor's condition-gate error paths
+    /// (`ConditionOutcome::NotBoolean`, CEL runtime error, parse
+    /// error) call `step_errored` directly without a prior
+    /// `step_started`. Same wart as `step_skipped` had — without
+    /// the Pending → Running transition on `step_errored`, a run
+    /// whose very first step's condition errored would jump from
+    /// Pending straight to Errored at `run_completed`, with no
+    /// `Running` phase ever recorded.
+    #[test]
+    fn step_errored_transitions_pending_to_running() {
+        let mut run = fresh_run(&["only"]);
+        assert_eq!(run.state, WorkflowRunState::Pending);
+        error(&mut run, "only", "condition body returned non-boolean");
+        assert_eq!(run.state, WorkflowRunState::Running);
+    }
+
+    /// Production condition-gate error path (`else` branch of
+    /// `step_errored`): no prior `step_started`, fresh `StepResult`
+    /// pushed with the error message.
+    #[test]
+    fn step_errored_creates_fresh_step_result() {
+        let mut run = fresh_run(&["only"]);
+        error(&mut run, "only", "condition body returned non-boolean");
+        assert_eq!(run.step_results.len(), 1);
+        let r = &run.step_results[0];
+        assert_eq!(r.name, "only");
+        assert_eq!(
+            r.error.as_deref(),
+            Some("condition body returned non-boolean")
+        );
+        assert!(r.output.is_none());
+        assert!(r.skipped.is_none());
+        assert!(r.completed_at.is_some());
+    }
+
+    /// Mid-flight rehydration: a run whose only event is
+    /// `StepErrored` (no prior `StepStarted`) must reflect Running
+    /// state, mirroring the live mutation. Same fix as the
+    /// `StepSkipped` arm.
+    #[test]
+    fn step_errored_hydrates_with_running_state() {
+        let mut run = fresh_run(&["only"]);
+        error(&mut run, "only", "condition body returned non-boolean");
+        let events = run.events;
+        let rehydrated = WorkflowRun::try_from_events(events).unwrap();
+        assert_eq!(rehydrated.state, WorkflowRunState::Running);
+        assert_eq!(rehydrated.step_results.len(), 1);
+        assert_eq!(
+            rehydrated.step_results[0].error.as_deref(),
+            Some("condition body returned non-boolean")
+        );
     }
 
     #[test]

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -154,6 +154,37 @@ impl TemplateContext<'_> {
         let built = self.build_cel_context()?;
         substitute_in_string_with_built(s, &built)
     }
+
+    /// Compile and evaluate a step `condition:` body in this
+    /// context — single entry point for the executor's gate. Returns
+    /// `Ok(ConditionOutcome::True/False)` on a clean boolean,
+    /// `Ok(ConditionOutcome::NotBoolean(rendered))` when the body
+    /// evaluated cleanly but produced a non-boolean (caller turns
+    /// this into a `StepErrored`), and `Err(TemplateError)` for
+    /// compile errors and CEL runtime errors (type mismatch, etc.).
+    ///
+    /// Truthy-coercion (treating `0`, `""`, `null`, etc. as false)
+    /// is intentionally NOT supported — non-boolean bodies surface
+    /// as a hard error so authors fix the typing.
+    pub fn evaluate_condition(&self, body: &str) -> Result<ConditionOutcome, TemplateError> {
+        let r = parse_condition(body)?;
+        let built = self.build_cel_context()?;
+        let program = Program::compile(&r.body)
+            .map_err(|e| TemplateError::Compile(r.raw.clone(), e.to_string()))?;
+        let value = program
+            .execute(&built.cel)
+            .map_err(|e| TemplateError::Resolve(r.raw.clone(), e.to_string()))?;
+        let json = value
+            .json()
+            .map_err(|e| TemplateError::JsonConvert(r.raw.clone(), e.to_string()))?;
+        Ok(match json {
+            Value::Bool(true) => ConditionOutcome::True,
+            Value::Bool(false) => ConditionOutcome::False,
+            other => ConditionOutcome::NotBoolean(
+                serde_json::to_string(&other).unwrap_or_else(|_| "<?>".to_string()),
+            ),
+        })
+    }
 }
 
 fn resolve_with_built(built: &BuiltContext, r: &TemplateRef) -> Option<Value> {
@@ -202,30 +233,6 @@ pub fn parse_condition(body: &str) -> Result<TemplateRef, TemplateError> {
     let r = parse_path(body)?;
     validate_root(&r)?;
     Ok(r)
-}
-
-/// Evaluate a previously-compiled condition reference against the
-/// given context. `None` indicates a CEL runtime error (caller
-/// surfaces it as a `StepErrored`); `Some(ConditionOutcome)` carries
-/// the boolean decision or a "not-a-bool" diagnostic.
-///
-/// Conversion rules: only literal `Bool(true)` / `Bool(false)` are
-/// accepted. Truthy-coercion (treating `0`, `""`, `null`, etc. as
-/// false) is intentionally NOT supported — non-boolean bodies
-/// surface as `StepErrored` so authors fix the typing rather than
-/// rely on coercion.
-pub fn evaluate_condition(ctx: &TemplateContext<'_>, r: &TemplateRef) -> Option<ConditionOutcome> {
-    let built = ctx.build_cel_context().ok()?;
-    let program = Program::compile(&r.body).ok()?;
-    let value = program.execute(&built.cel).ok()?;
-    let json = value.json().ok()?;
-    Some(match json {
-        Value::Bool(true) => ConditionOutcome::True,
-        Value::Bool(false) => ConditionOutcome::False,
-        other => ConditionOutcome::NotBoolean(
-            serde_json::to_string(&other).unwrap_or_else(|_| "<?>".to_string()),
-        ),
-    })
 }
 
 /// Reject expressions that reference identifiers other than the two
@@ -857,8 +864,11 @@ mod tests {
             trigger: &trigger,
             steps: &steps,
         };
-        let r = parse_condition("steps.triage.outputs.kind == 'autofix'").unwrap();
-        assert_eq!(evaluate_condition(&ctx, &r), Some(ConditionOutcome::True));
+        assert_eq!(
+            ctx.evaluate_condition("steps.triage.outputs.kind == 'autofix'")
+                .unwrap(),
+            ConditionOutcome::True
+        );
     }
 
     #[test]
@@ -870,8 +880,11 @@ mod tests {
             trigger: &trigger,
             steps: &steps,
         };
-        let r = parse_condition("steps.triage.outputs.kind == 'autofix'").unwrap();
-        assert_eq!(evaluate_condition(&ctx, &r), Some(ConditionOutcome::False));
+        assert_eq!(
+            ctx.evaluate_condition("steps.triage.outputs.kind == 'autofix'")
+                .unwrap(),
+            ConditionOutcome::False
+        );
     }
 
     #[test]
@@ -884,9 +897,8 @@ mod tests {
             steps: &steps,
         };
         // String concat → string; not a bool.
-        let r = parse_condition("steps.triage.outputs.kind + '!'").unwrap();
-        match evaluate_condition(&ctx, &r) {
-            Some(ConditionOutcome::NotBoolean(rendered)) => {
+        match ctx.evaluate_condition("steps.triage.outputs.kind + '!'") {
+            Ok(ConditionOutcome::NotBoolean(rendered)) => {
                 assert!(rendered.contains("autofix"));
             }
             other => panic!("expected NotBoolean, got {other:?}"),
@@ -910,8 +922,35 @@ mod tests {
             trigger: &trigger,
             steps: &steps,
         };
-        let r = parse_condition("steps.triage.outputs.kind == 'autofix'").unwrap();
-        assert_eq!(evaluate_condition(&ctx, &r), Some(ConditionOutcome::False));
+        assert_eq!(
+            ctx.evaluate_condition("steps.triage.outputs.kind == 'autofix'")
+                .unwrap(),
+            ConditionOutcome::False
+        );
+    }
+
+    #[test]
+    fn evaluate_condition_propagates_compile_error() {
+        let trigger = json!({});
+        let steps = HashMap::new();
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let err = ctx.evaluate_condition("steps.x ==").unwrap_err();
+        assert!(matches!(err, TemplateError::Compile(_, _)));
+    }
+
+    #[test]
+    fn evaluate_condition_rejects_unknown_root() {
+        let trigger = json!({});
+        let steps = HashMap::new();
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let err = ctx.evaluate_condition("env.HOME == 'x'").unwrap_err();
+        assert!(matches!(err, TemplateError::UnknownRoot(_, _)));
     }
 
     #[test]

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -161,22 +161,36 @@ impl TemplateContext<'_> {
     /// `Ok(ConditionOutcome::NotBoolean(rendered))` when the body
     /// evaluated cleanly but produced a non-boolean (caller turns
     /// this into a `StepErrored`), and `Err(TemplateError)` for
-    /// compile errors and CEL runtime errors (type mismatch, etc.).
+    /// compile errors and CEL runtime errors (type mismatch,
+    /// reference to an unknown identifier, etc.).
+    ///
+    /// Compiles the CEL expression exactly once. The static
+    /// parse-time checks (`parse_path` body shape + `validate_root`
+    /// identifier scope) are workflow create/update concerns —
+    /// `Workflows::validate_steps` runs them via `parse_condition`
+    /// before any run is ever spawned. By the time this method
+    /// runs, the body is known-good against those static rules; an
+    /// `Err` here is a CEL evaluation failure (or, defensively, a
+    /// recompile failure).
     ///
     /// Truthy-coercion (treating `0`, `""`, `null`, etc. as false)
     /// is intentionally NOT supported — non-boolean bodies surface
-    /// as a hard error so authors fix the typing.
+    /// as `ConditionOutcome::NotBoolean` so authors fix the typing.
     pub fn evaluate_condition(&self, body: &str) -> Result<ConditionOutcome, TemplateError> {
-        let r = parse_condition(body)?;
+        let trimmed = body.trim();
+        let raw = format!("{OPEN} {trimmed} {CLOSE}");
+        if trimmed.is_empty() {
+            return Err(TemplateError::EmptyPath(raw));
+        }
         let built = self.build_cel_context()?;
-        let program = Program::compile(&r.body)
-            .map_err(|e| TemplateError::Compile(r.raw.clone(), e.to_string()))?;
+        let program = Program::compile(trimmed)
+            .map_err(|e| TemplateError::Compile(raw.clone(), e.to_string()))?;
         let value = program
             .execute(&built.cel)
-            .map_err(|e| TemplateError::Resolve(r.raw.clone(), e.to_string()))?;
+            .map_err(|e| TemplateError::Resolve(raw.clone(), e.to_string()))?;
         let json = value
             .json()
-            .map_err(|e| TemplateError::JsonConvert(r.raw.clone(), e.to_string()))?;
+            .map_err(|e| TemplateError::JsonConvert(raw.clone(), e.to_string()))?;
         Ok(match json {
             Value::Bool(true) => ConditionOutcome::True,
             Value::Bool(false) => ConditionOutcome::False,
@@ -941,8 +955,13 @@ mod tests {
         assert!(matches!(err, TemplateError::Compile(_, _)));
     }
 
+    /// Unknown roots aren't statically rejected by `evaluate_condition`
+    /// (that's `parse_condition`'s job at create time, exercised by
+    /// `parse_condition_rejects_unknown_root`). At runtime an
+    /// unbound identifier surfaces as a CEL `Resolve` error — the
+    /// runtime context simply doesn't have `env` bound.
     #[test]
-    fn evaluate_condition_rejects_unknown_root() {
+    fn evaluate_condition_unknown_identifier_surfaces_as_runtime_error() {
         let trigger = json!({});
         let steps = HashMap::new();
         let ctx = TemplateContext {
@@ -950,7 +969,19 @@ mod tests {
             steps: &steps,
         };
         let err = ctx.evaluate_condition("env.HOME == 'x'").unwrap_err();
-        assert!(matches!(err, TemplateError::UnknownRoot(_, _)));
+        assert!(matches!(err, TemplateError::Resolve(_, _)));
+    }
+
+    #[test]
+    fn evaluate_condition_rejects_empty_body() {
+        let trigger = json!({});
+        let steps = HashMap::new();
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let err = ctx.evaluate_condition("   ").unwrap_err();
+        assert!(matches!(err, TemplateError::EmptyPath(_)));
     }
 
     #[test]

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -182,6 +182,52 @@ pub fn parse_path(body: &str) -> Result<TemplateRef, TemplateError> {
     })
 }
 
+/// Outcome of evaluating a step `condition:` body — distinguishes
+/// the three cases the executor must react to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConditionOutcome {
+    /// The expression evaluated to `true` — run the step.
+    True,
+    /// The expression evaluated to `false` — skip the step.
+    False,
+    /// The expression evaluated to a non-boolean. The step should
+    /// be `step_errored` with a message naming the offending value.
+    NotBoolean(String),
+}
+
+/// Compile-time parse + root validation for a step `condition:`.
+/// Same shape as `parse_path` + `validate_root`; bundled because
+/// the two checks always run together for conditions.
+pub fn parse_condition(body: &str) -> Result<TemplateRef, TemplateError> {
+    let r = parse_path(body)?;
+    validate_root(&r)?;
+    Ok(r)
+}
+
+/// Evaluate a previously-compiled condition reference against the
+/// given context. `None` indicates a CEL runtime error (caller
+/// surfaces it as a `StepErrored`); `Some(ConditionOutcome)` carries
+/// the boolean decision or a "not-a-bool" diagnostic.
+///
+/// Conversion rules: only literal `Bool(true)` / `Bool(false)` are
+/// accepted. Truthy-coercion (treating `0`, `""`, `null`, etc. as
+/// false) is intentionally NOT supported — non-boolean bodies
+/// surface as `StepErrored` so authors fix the typing rather than
+/// rely on coercion.
+pub fn evaluate_condition(ctx: &TemplateContext<'_>, r: &TemplateRef) -> Option<ConditionOutcome> {
+    let built = ctx.build_cel_context().ok()?;
+    let program = Program::compile(&r.body).ok()?;
+    let value = program.execute(&built.cel).ok()?;
+    let json = value.json().ok()?;
+    Some(match json {
+        Value::Bool(true) => ConditionOutcome::True,
+        Value::Bool(false) => ConditionOutcome::False,
+        other => ConditionOutcome::NotBoolean(
+            serde_json::to_string(&other).unwrap_or_else(|_| "<?>".to_string()),
+        ),
+    })
+}
+
 /// Reject expressions that reference identifiers other than the two
 /// bound namespaces (`trigger`, `steps`). Stops mistakes like
 /// `${{ env.HOME }}` from compiling cleanly only to silently resolve
@@ -782,6 +828,90 @@ mod tests {
         assert!(formatted.contains(".tags[0]"));
         assert!(formatted.contains("trigger.payload.pipeline"));
         assert!(formatted.contains("null"));
+    }
+
+    #[test]
+    fn parse_condition_accepts_simple_predicate() {
+        let r = parse_condition("steps.triage.outputs.kind == 'autofix'").unwrap();
+        assert_eq!(r.body, "steps.triage.outputs.kind == 'autofix'");
+    }
+
+    #[test]
+    fn parse_condition_rejects_unknown_root() {
+        let err = parse_condition("env.HOME == 'x'").unwrap_err();
+        assert!(matches!(err, TemplateError::UnknownRoot(_, _)));
+    }
+
+    #[test]
+    fn parse_condition_rejects_compile_error() {
+        let err = parse_condition("steps.x ==").unwrap_err();
+        assert!(matches!(err, TemplateError::Compile(_, _)));
+    }
+
+    #[test]
+    fn evaluate_condition_true() {
+        let mut steps = HashMap::new();
+        steps.insert("triage".into(), json!({ "kind": "autofix" }));
+        let trigger = json!({});
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let r = parse_condition("steps.triage.outputs.kind == 'autofix'").unwrap();
+        assert_eq!(evaluate_condition(&ctx, &r), Some(ConditionOutcome::True));
+    }
+
+    #[test]
+    fn evaluate_condition_false() {
+        let mut steps = HashMap::new();
+        steps.insert("triage".into(), json!({ "kind": "flake_bump" }));
+        let trigger = json!({});
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let r = parse_condition("steps.triage.outputs.kind == 'autofix'").unwrap();
+        assert_eq!(evaluate_condition(&ctx, &r), Some(ConditionOutcome::False));
+    }
+
+    #[test]
+    fn evaluate_condition_not_boolean_when_body_returns_string() {
+        let mut steps = HashMap::new();
+        steps.insert("triage".into(), json!({ "kind": "autofix" }));
+        let trigger = json!({});
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        // String concat → string; not a bool.
+        let r = parse_condition("steps.triage.outputs.kind + '!'").unwrap();
+        match evaluate_condition(&ctx, &r) {
+            Some(ConditionOutcome::NotBoolean(rendered)) => {
+                assert!(rendered.contains("autofix"));
+            }
+            other => panic!("expected NotBoolean, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evaluate_condition_skipped_step_null_coalesces_to_false() {
+        // `Executor::collect_step_outputs` populates skipped /
+        // errored / pending steps with `Value::Null` so CEL's
+        // null-coalesce path takes over here — `null.outputs.kind`
+        // evaluates to `Bool(false)` (same quirk as the trigger
+        // payload normalisation in `build_cel_context`), and
+        // `false == 'autofix'` is `false`. The whole condition
+        // collapses to `false`, the dependent step is skipped
+        // (cascading naturally without a transitive-skip mechanism).
+        let mut steps = HashMap::new();
+        steps.insert("triage".into(), json!(null));
+        let trigger = json!({});
+        let ctx = TemplateContext {
+            trigger: &trigger,
+            steps: &steps,
+        };
+        let r = parse_condition("steps.triage.outputs.kind == 'autofix'").unwrap();
+        assert_eq!(evaluate_condition(&ctx, &r), Some(ConditionOutcome::False));
     }
 
     #[test]

--- a/core/src/workflow/yaml.rs
+++ b/core/src/workflow/yaml.rs
@@ -218,6 +218,8 @@ enum WorkflowStepYaml {
         model_chain: Option<ModelChain>,
         #[serde(default = "default_output_schema_boxed")]
         output_schema: Box<OutputSchema>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        condition: Option<String>,
     },
     ToolStep {
         name: String,
@@ -226,6 +228,8 @@ enum WorkflowStepYaml {
         params: serde_json::Value,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timeout_seconds: Option<u64>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        condition: Option<String>,
     },
 }
 
@@ -240,6 +244,7 @@ impl WorkflowStepYaml {
                 timeout_seconds,
                 model_chain,
                 output_schema,
+                condition,
             } => WorkflowStepYaml::AgentStep {
                 name: name.clone(),
                 skill: skill.clone(),
@@ -248,17 +253,20 @@ impl WorkflowStepYaml {
                 timeout_seconds: *timeout_seconds,
                 model_chain: model_chain.clone(),
                 output_schema: output_schema.clone(),
+                condition: condition.clone(),
             },
             WorkflowStepDef::ToolStep {
                 name,
                 tool,
                 params,
                 timeout_seconds,
+                condition,
             } => WorkflowStepYaml::ToolStep {
                 name: name.clone(),
                 tool: tool.clone(),
                 params: params.clone(),
                 timeout_seconds: *timeout_seconds,
+                condition: condition.clone(),
             },
         }
     }
@@ -273,6 +281,7 @@ impl WorkflowStepYaml {
                 timeout_seconds,
                 model_chain,
                 output_schema,
+                condition,
             } => WorkflowStepDef::AgentStep {
                 name,
                 skill,
@@ -281,17 +290,20 @@ impl WorkflowStepYaml {
                 timeout_seconds,
                 model_chain,
                 output_schema,
+                condition,
             },
             WorkflowStepYaml::ToolStep {
                 name,
                 tool,
                 params,
                 timeout_seconds,
+                condition,
             } => WorkflowStepDef::ToolStep {
                 name,
                 tool,
                 params,
                 timeout_seconds,
+                condition,
             },
         }
     }
@@ -461,6 +473,7 @@ mod tests {
             timeout_seconds: Some(120),
             model_chain: None,
             output_schema: Box::new(default_output_schema()),
+            condition: None,
         }]
     }
 
@@ -664,6 +677,7 @@ steps:
             timeout_seconds: None,
             model_chain: None,
             output_schema: Box::new(schema),
+            condition: None,
         }];
         let content = render_workflow_yaml(
             id,


### PR DESCRIPTION
## Summary

Adds a per-step `condition:` field to gate step execution. Bare CEL boolean expression evaluated against the same `(trigger, steps)` context as `${{ … }}` substitution (commit `b18d5829`). False → step skipped (new `WorkflowRunEvent::StepSkipped`); absent → step always runs (back-compat).

```yaml
- type: agent_step
  name: linter_autofix
  skill: rust-linter-autofix
  condition: steps.triage.outputs.kind == 'autofix'
```

Per design memo `019e06a1`. PM-confirmed scope: skip-only MVP; stop semantics (`require:`/`assert:`) and GHA-style status macros (`always()`, `failure()`, `success()`) deferred.

## Behaviour

- **Default skip.** False condition → `StepSkipped` event recorded, run continues to next step.
- **Downstream null-coalesce.** `collect_step_outputs` now populates skipped / errored / pending steps with `Value::Null` so `steps.<skipped>.outputs.X` resolves to `null` (or `false` via CEL's null-coalesce path) instead of raising `NoSuchKey`. Authors who want cascade write `condition: steps.<upstream>.outputs.success` explicitly — no transitive auto-skip.
- **Strict boolean coercion.** Non-bool body or CEL runtime error → `StepErrored` → run aggregates `Errored`. No truthy coercion.
- **Parse-time validation.** `parse_condition` (compile + `validate_root`) + forward-ref check via existing `validate_ref_against_prior_steps` at workflow create/update.
- **Run-state aggregation unchanged.** Skipped steps fold in as Succeeded; Errored > Failed > Succeeded precedence preserved. A run with all-skipped steps ends Succeeded.
- **Inspector** renders `[SKIPPED]` state with the failed condition body in `runs --include=steps`.

## Code surface

- `template.rs` — `parse_condition()`, `evaluate_condition()`, `ConditionOutcome` + 6 unit tests.
- `definition.rs` — `condition` field on both variants + `condition()` accessor.
- `error.rs` — `InvalidCondition`, `ConditionNotBoolean` variants.
- `mod.rs::validate_steps` — parse-time gate.
- `run/entity.rs` — `StepSkipped` event, `StepResult.skipped: Option<String>`, `step_skipped()` mutation, idempotency-guard updates, hydration arm, `step_reported_agent_failure` early-exit, + 7 unit tests covering wire format, idempotency, hydration, and 4 aggregation paths (skip-only / skip+success / skip+failure / skip+error).
- `executor.rs` — condition gate evaluated *before* `step_started` (skipped steps never enter Running state); `collect_step_outputs` populates skipped steps as `null`.
- `yaml.rs` — round-trip plumbing.
- `toolset/{searchable/admin, top_level/workflow}.rs` — input/output schemas + inspector rendering.

The new `StepSkipped` event is automatically audited via the event-sourced `WorkflowRunRepo` — no separate audit emission needed.

+512 / −8 across 10 files.

## Test plan

- [x] `cargo check -p drua-core`
- [x] `cargo clippy --workspace --tests --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p drua-core --lib` → 440 passed, 0 failed (94 workflow-related)
- [x] `cargo test --workspace --lib` → all green across 16 crates
- [ ] Manual smoke: create a workflow with a `condition:` referencing `trigger.payload.X`, trigger with payload that should skip, verify `runs --include=steps` shows `[SKIPPED]` + condition body
- [ ] Manual smoke: condition with non-bool body → run aggregates `Errored` with `ConditionNotBoolean` reason

## Cross-references

- Design memo: `019e06a1` — Workflow Step Condition Key — Design Research
- CEL substrate landed in commit `b18d5829`
- ToolStep + template substitution landed in #306
- Companion handoff/routing memo: `019e01a4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow execution and event-sourcing by adding conditional step skipping and new run event/state fields, which could affect run state aggregation and downstream template references. Risk is mitigated by create-time validation and extensive unit test coverage but still touches core workflow runtime behavior.
> 
> **Overview**
> Adds an optional per-step `condition:` (CEL boolean) to both agent and tool workflow steps; when the condition evaluates to `false`, the step is **skipped** and the run continues.
> 
> Implements skip tracking end-to-end: create/update validation for condition expressions, executor-side condition evaluation before `step_started`, new `WorkflowRunEvent::StepSkipped` plus `StepResult.skipped`, and updated run aggregation/printing to treat skipped steps as non-failing while surfacing the skipped condition body in admin/top-level tooling and inspectors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16c86f9e9de487878b8cfb681b25ef1d02dcdc60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->