### PR TITLE
feat(toolset): structured-elision recovery + classifier passes (terraform, rsync, image layers)

### DIFF
--- a/core/crates/tool-cache/src/lib.rs
+++ b/core/crates/tool-cache/src/lib.rs
@@ -302,8 +302,7 @@ pub fn apply_fetch_query(
         FetchQuery::JsonPath { path } => {
             let root = structured.ok_or_else(|| {
                 ToolInvocationError::InvalidPattern(
-                    "json_path requested but invocation has no structured_content"
-                        .to_string(),
+                    "json_path requested but invocation has no structured_content".to_string(),
                 )
             })?;
             let value = resolve_json_path(root, path).ok_or_else(|| {
@@ -581,7 +580,8 @@ mod tests {
 
     #[test]
     fn range_slices_bytes() {
-        let r = apply_fetch_query(sample(), None, &FetchQuery::Range { offset: 0, len: 5 }).unwrap();
+        let r =
+            apply_fetch_query(sample(), None, &FetchQuery::Range { offset: 0, len: 5 }).unwrap();
         assert_eq!(r.content, "alpha");
     }
 

--- a/core/crates/tool-cache/src/lib.rs
+++ b/core/crates/tool-cache/src/lib.rs
@@ -15,7 +15,7 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::instrument;
 
-use drua_tool_classifier::{Classification, ToolResultSummary};
+use drua_tool_classifier::{Classification, ToolResultSummary, RECOVERY_INVOCATION_PLACEHOLDER};
 use repo::ToolInvocationRepo;
 
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
@@ -29,6 +29,18 @@ pub enum FetchQuery {
     },
     Range {
         offset: u64,
+        len: u32,
+    },
+    /// JSON-path lookup against the persisted `original_structured`.
+    /// `path` like `$.foo.bar[3]`; returns the value at that path.
+    JsonPath {
+        path: String,
+    },
+    /// JSON-path lookup that resolves to an array, then slices it.
+    /// `path` like `$.hits`; returns `array[offset..offset+len]`.
+    JsonArraySlice {
+        path: String,
+        offset: u32,
         len: u32,
     },
     /// Line-grep with rg-style flags; cross-line patterns not supported.
@@ -117,7 +129,11 @@ impl ToolInvocations {
         query: FetchQuery,
     ) -> Result<FetchResult, ToolInvocationError> {
         let invocation = self.repo.find_by_id(id).await?;
-        apply_fetch_query(&invocation.raw_text, &query)
+        apply_fetch_query(
+            &invocation.raw_text,
+            invocation.original_structured.as_ref(),
+            &query,
+        )
     }
 
     #[instrument(name = "tool_cache.find_for_diff", skip(self))]
@@ -225,9 +241,13 @@ impl ToolInvocations {
             )
             .await?;
 
+        let invocation_id_str = uuid::Uuid::from(persisted.invocation_id).to_string();
+        let mut summary_value = persisted.summary_value;
+        substitute_recovery_placeholder(&mut summary_value, &invocation_id_str);
+
         let envelope = serde_json::json!({
-            "invocation_id": uuid::Uuid::from(persisted.invocation_id).to_string(),
-            "summary": persisted.summary_value,
+            "invocation_id": invocation_id_str,
+            "summary": summary_value,
         });
 
         let mut wrapped = raw.clone();
@@ -252,13 +272,71 @@ fn envelope_text(summary: &ToolResultSummary, id: ToolInvocationId, raw_size_byt
     summary.render_envelope_text(&uuid::Uuid::from(id).to_string(), raw_size_bytes)
 }
 
+pub fn substitute_recovery_placeholder(value: &mut serde_json::Value, invocation_id: &str) {
+    match value {
+        serde_json::Value::String(s) if s == RECOVERY_INVOCATION_PLACEHOLDER => {
+            *s = invocation_id.to_string();
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                substitute_recovery_placeholder(item, invocation_id);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for v in map.values_mut() {
+                substitute_recovery_placeholder(v, invocation_id);
+            }
+        }
+        _ => {}
+    }
+}
+
 pub fn apply_fetch_query(
     raw: &str,
+    structured: Option<&serde_json::Value>,
     query: &FetchQuery,
 ) -> Result<FetchResult, ToolInvocationError> {
     let total_bytes = raw.len() as u64;
 
     let content = match query {
+        FetchQuery::JsonPath { path } => {
+            let root = structured.ok_or_else(|| {
+                ToolInvocationError::InvalidPattern(
+                    "json_path requested but invocation has no structured_content"
+                        .to_string(),
+                )
+            })?;
+            let value = resolve_json_path(root, path).ok_or_else(|| {
+                ToolInvocationError::InvalidPattern(format!(
+                    "json_path {path:?} did not resolve in structured_content"
+                ))
+            })?;
+            serde_json::to_string_pretty(value).unwrap_or_default()
+        }
+        FetchQuery::JsonArraySlice { path, offset, len } => {
+            let root = structured.ok_or_else(|| {
+                ToolInvocationError::InvalidPattern(
+                    "json_array_slice requested but invocation has no structured_content"
+                        .to_string(),
+                )
+            })?;
+            let value = resolve_json_path(root, path).ok_or_else(|| {
+                ToolInvocationError::InvalidPattern(format!(
+                    "json_array_slice path {path:?} did not resolve in structured_content"
+                ))
+            })?;
+            let array = value.as_array().ok_or_else(|| {
+                ToolInvocationError::InvalidPattern(format!(
+                    "json_array_slice path {path:?} resolved to {} not an array",
+                    json_kind_name(value)
+                ))
+            })?;
+            let total = array.len();
+            let start = (*offset as usize).min(total);
+            let end = (start + *len as usize).min(total);
+            let slice: Vec<&serde_json::Value> = array[start..end].iter().collect();
+            serde_json::to_string_pretty(&slice).unwrap_or_default()
+        }
         FetchQuery::Tail { lines } => {
             let n = *lines as usize;
             let collected: Vec<&str> = raw.lines().collect();
@@ -395,6 +473,75 @@ fn refine_hint(query: &FetchQuery) -> String {
             ));
             parts.join("; ")
         }
+        FetchQuery::JsonPath { path } => format!(
+            "narrow `path` (currently {path:?}); or switch to `json_array_slice` for an array slice"
+        ),
+        FetchQuery::JsonArraySlice { path, len, .. } => format!(
+            "lower `len` (currently {len}) at `path` {path:?}; or step the slice with `offset`"
+        ),
+    }
+}
+
+pub fn resolve_json_path<'a>(
+    root: &'a serde_json::Value,
+    path: &str,
+) -> Option<&'a serde_json::Value> {
+    let trimmed = path.trim();
+    let trimmed = trimmed.strip_prefix('$').unwrap_or(trimmed);
+    let trimmed = trimmed.strip_prefix('.').unwrap_or(trimmed);
+    if trimmed.is_empty() {
+        return Some(root);
+    }
+    let mut current = root;
+    let mut segment = String::new();
+    let mut chars = trimmed.chars().peekable();
+    while let Some(c) = chars.next() {
+        match c {
+            '.' => {
+                if !segment.is_empty() {
+                    current = current.get(segment.as_str())?;
+                    segment.clear();
+                }
+            }
+            '[' => {
+                if !segment.is_empty() {
+                    current = current.get(segment.as_str())?;
+                    segment.clear();
+                }
+                let mut idx = String::new();
+                let mut closed = false;
+                while let Some(&c) = chars.peek() {
+                    if c == ']' {
+                        chars.next();
+                        closed = true;
+                        break;
+                    }
+                    idx.push(c);
+                    chars.next();
+                }
+                if !closed {
+                    return None;
+                }
+                let i: usize = idx.parse().ok()?;
+                current = current.get(i)?;
+            }
+            _ => segment.push(c),
+        }
+    }
+    if !segment.is_empty() {
+        current = current.get(segment.as_str())?;
+    }
+    Some(current)
+}
+
+fn json_kind_name(v: &serde_json::Value) -> &'static str {
+    match v {
+        serde_json::Value::Null => "null",
+        serde_json::Value::Bool(_) => "bool",
+        serde_json::Value::Number(_) => "number",
+        serde_json::Value::String(_) => "string",
+        serde_json::Value::Array(_) => "array",
+        serde_json::Value::Object(_) => "object",
     }
 }
 
@@ -420,7 +567,7 @@ mod tests {
 
     #[test]
     fn tail_returns_last_n_lines() {
-        let r = apply_fetch_query(sample(), &FetchQuery::Tail { lines: 2 }).unwrap();
+        let r = apply_fetch_query(sample(), None, &FetchQuery::Tail { lines: 2 }).unwrap();
         assert_eq!(r.content, "echo\nfoxtrot");
         assert!(r.elision.is_none());
         assert_eq!(r.total_bytes, sample().len() as u64);
@@ -428,13 +575,13 @@ mod tests {
 
     #[test]
     fn head_returns_first_n_lines() {
-        let r = apply_fetch_query(sample(), &FetchQuery::Head { lines: 1 }).unwrap();
+        let r = apply_fetch_query(sample(), None, &FetchQuery::Head { lines: 1 }).unwrap();
         assert_eq!(r.content, "alpha");
     }
 
     #[test]
     fn range_slices_bytes() {
-        let r = apply_fetch_query(sample(), &FetchQuery::Range { offset: 0, len: 5 }).unwrap();
+        let r = apply_fetch_query(sample(), None, &FetchQuery::Range { offset: 0, len: 5 }).unwrap();
         assert_eq!(r.content, "alpha");
     }
 
@@ -453,7 +600,7 @@ mod tests {
 
     #[test]
     fn grep_matches_lines() {
-        let r = apply_fetch_query(sample(), &grep_pattern("error")).unwrap();
+        let r = apply_fetch_query(sample(), None, &grep_pattern("error")).unwrap();
         assert_eq!(r.content, "bravo error one\ndelta error two");
     }
 
@@ -463,13 +610,13 @@ mod tests {
         if let FetchQuery::Grep { context, .. } = &mut q {
             *context = Some(1);
         }
-        let r = apply_fetch_query(sample(), &q).unwrap();
+        let r = apply_fetch_query(sample(), None, &q).unwrap();
         assert_eq!(r.content, "alpha\nbravo error one\ncharlie");
     }
 
     #[test]
     fn grep_invalid_regex_errors() {
-        let err = apply_fetch_query(sample(), &grep_pattern("[invalid")).unwrap_err();
+        let err = apply_fetch_query(sample(), None, &grep_pattern("[invalid")).unwrap_err();
         assert!(matches!(err, ToolInvocationError::InvalidPattern(_)));
     }
 
@@ -482,7 +629,7 @@ mod tests {
         {
             *case_insensitive = true;
         }
-        let r = apply_fetch_query(sample(), &q).unwrap();
+        let r = apply_fetch_query(sample(), None, &q).unwrap();
         assert_eq!(r.content, "bravo error one\ndelta error two");
     }
 
@@ -492,7 +639,7 @@ mod tests {
         if let FetchQuery::Grep { invert_match, .. } = &mut q {
             *invert_match = true;
         }
-        let r = apply_fetch_query(sample(), &q).unwrap();
+        let r = apply_fetch_query(sample(), None, &q).unwrap();
         assert_eq!(r.content, "alpha\ncharlie\necho\nfoxtrot");
     }
 
@@ -502,7 +649,7 @@ mod tests {
         if let FetchQuery::Grep { line_numbers, .. } = &mut q {
             *line_numbers = true;
         }
-        let r = apply_fetch_query(sample(), &q).unwrap();
+        let r = apply_fetch_query(sample(), None, &q).unwrap();
         assert_eq!(r.content, "2:bravo error one\n4:delta error two");
     }
 
@@ -512,7 +659,7 @@ mod tests {
         if let FetchQuery::Grep { after_context, .. } = &mut q {
             *after_context = Some(1);
         }
-        let r = apply_fetch_query(sample(), &q).unwrap();
+        let r = apply_fetch_query(sample(), None, &q).unwrap();
         assert_eq!(r.content, "bravo error one\ncharlie");
     }
 
@@ -522,7 +669,7 @@ mod tests {
         if let FetchQuery::Grep { head_limit, .. } = &mut q {
             *head_limit = Some(1);
         }
-        let r = apply_fetch_query(sample(), &q).unwrap();
+        let r = apply_fetch_query(sample(), None, &q).unwrap();
         assert_eq!(r.content, "bravo error one");
     }
 
@@ -531,6 +678,7 @@ mod tests {
         let big = "x".repeat(MAX_FETCH_RESPONSE_BYTES + 1024);
         let r = apply_fetch_query(
             &big,
+            None,
             &FetchQuery::Range {
                 offset: 0,
                 len: u32::MAX,
@@ -588,5 +736,118 @@ mod tests {
         assert_eq!(floor_char_boundary(s, 3), 2);
         assert_eq!(floor_char_boundary(s, 6), 6);
         assert_eq!(floor_char_boundary(s, 100), s.len());
+    }
+
+    #[test]
+    fn resolve_json_path_root() {
+        let v = serde_json::json!({"a": 1});
+        assert_eq!(resolve_json_path(&v, "$"), Some(&v));
+        assert_eq!(resolve_json_path(&v, ""), Some(&v));
+    }
+
+    #[test]
+    fn resolve_json_path_nested_keys_and_index() {
+        let v = serde_json::json!({"hits": [{"id": 1}, {"id": 2}, {"id": 3}]});
+        assert_eq!(
+            resolve_json_path(&v, "$.hits[1].id"),
+            Some(&serde_json::json!(2))
+        );
+        assert_eq!(
+            resolve_json_path(&v, "hits[0]"),
+            Some(&serde_json::json!({"id": 1}))
+        );
+    }
+
+    #[test]
+    fn resolve_json_path_missing_returns_none() {
+        let v = serde_json::json!({"a": 1});
+        assert!(resolve_json_path(&v, "$.b").is_none());
+        assert!(resolve_json_path(&v, "$.a[0]").is_none());
+    }
+
+    #[test]
+    fn json_path_query_returns_value_at_path() {
+        let structured = serde_json::json!({"user": {"name": "alice", "id": 42}});
+        let r = apply_fetch_query(
+            "irrelevant raw",
+            Some(&structured),
+            &FetchQuery::JsonPath {
+                path: "$.user.name".into(),
+            },
+        )
+        .unwrap();
+        assert_eq!(r.content.trim(), "\"alice\"");
+    }
+
+    #[test]
+    fn json_array_slice_returns_requested_range() {
+        let structured = serde_json::json!({
+            "hits": [
+                {"id": 0}, {"id": 1}, {"id": 2}, {"id": 3}, {"id": 4},
+                {"id": 5}, {"id": 6}, {"id": 7}, {"id": 8}, {"id": 9}
+            ]
+        });
+        let r = apply_fetch_query(
+            "irrelevant raw",
+            Some(&structured),
+            &FetchQuery::JsonArraySlice {
+                path: "$.hits".into(),
+                offset: 3,
+                len: 4,
+            },
+        )
+        .unwrap();
+        assert!(r.content.contains("\"id\": 3"));
+        assert!(r.content.contains("\"id\": 6"));
+        assert!(!r.content.contains("\"id\": 7"));
+        assert!(!r.content.contains("\"id\": 2"));
+    }
+
+    #[test]
+    fn json_array_slice_clamps_to_array_length() {
+        let structured = serde_json::json!({"hits": [0, 1, 2]});
+        let r = apply_fetch_query(
+            "irrelevant raw",
+            Some(&structured),
+            &FetchQuery::JsonArraySlice {
+                path: "$.hits".into(),
+                offset: 1,
+                len: 100,
+            },
+        )
+        .unwrap();
+        assert!(r.content.contains('1'));
+        assert!(r.content.contains('2'));
+    }
+
+    #[test]
+    fn json_path_without_structured_errors_helpfully() {
+        let err = apply_fetch_query(
+            "raw text only",
+            None,
+            &FetchQuery::JsonPath {
+                path: "$.foo".into(),
+            },
+        )
+        .unwrap_err();
+        let s = err.to_string().to_lowercase();
+        assert!(s.contains("structured_content"));
+    }
+
+    #[test]
+    fn json_array_slice_on_non_array_errors() {
+        let structured = serde_json::json!({"foo": "not an array"});
+        let err = apply_fetch_query(
+            "raw text only",
+            Some(&structured),
+            &FetchQuery::JsonArraySlice {
+                path: "$.foo".into(),
+                offset: 0,
+                len: 10,
+            },
+        )
+        .unwrap_err();
+        let s = err.to_string().to_lowercase();
+        assert!(s.contains("not an array") || s.contains("string"));
     }
 }

--- a/core/crates/tool-classifier/src/lib.rs
+++ b/core/crates/tool-classifier/src/lib.rs
@@ -17,7 +17,7 @@ pub use concourse::{ConcourseBuildLogClassifier, ConcourseBuildLogPreprocessor};
 pub use git::GitCloneProgress;
 pub use nix::{
     NixBuildingRun, NixCacheActivity, NixCopyRun, NixDerivationPreprocessor, NixDrvList,
-    NixFetchList,
+    NixFetchList, NixImageLayerRun,
 };
 pub use string_summarizer::{
     build_marker, close_tag, open_tag, BulkElide, SegmentedText, StringSummarizer,
@@ -275,6 +275,7 @@ pub fn default_summarizer_chain() -> StringSummarizerChain {
         .register(nix::NixCopyRun)
         .register(nix::NixBuildingRun)
         .register(nix::NixCacheActivity)
+        .register(nix::NixImageLayerRun)
         .register(cargo::CargoDownloadRun)
         .register(cargo::CargoCompileRun)
         .register(cargo::CargoCheckRun)

--- a/core/crates/tool-classifier/src/lib.rs
+++ b/core/crates/tool-classifier/src/lib.rs
@@ -27,9 +27,9 @@ pub use string_summarizer::{
     build_marker, close_tag, open_tag, BulkElide, SegmentedText, StringSummarizer,
     StringSummarizerChain, VerbatimRegion,
 };
-pub use walker::RECOVERY_INVOCATION_PLACEHOLDER;
 pub use terraform_install::TerraformInstallRun;
 pub use terraform_state::{TerraformDataSourceRun, TerraformRefreshRun};
+pub use walker::RECOVERY_INVOCATION_PLACEHOLDER;
 
 pub const DEFAULT_GENERIC_THRESHOLD_BYTES: usize = 8192;
 

--- a/core/crates/tool-classifier/src/lib.rs
+++ b/core/crates/tool-classifier/src/lib.rs
@@ -27,10 +27,11 @@ pub use string_summarizer::{
     build_marker, close_tag, open_tag, BulkElide, SegmentedText, StringSummarizer,
     StringSummarizerChain, VerbatimRegion,
 };
+pub use walker::RECOVERY_INVOCATION_PLACEHOLDER;
 pub use terraform_install::TerraformInstallRun;
 pub use terraform_state::{TerraformDataSourceRun, TerraformRefreshRun};
 
-pub const DEFAULT_GENERIC_THRESHOLD_BYTES: usize = 4096;
+pub const DEFAULT_GENERIC_THRESHOLD_BYTES: usize = 8192;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]

--- a/core/crates/tool-classifier/src/lib.rs
+++ b/core/crates/tool-classifier/src/lib.rs
@@ -8,6 +8,7 @@ mod cargo;
 mod concourse;
 mod git;
 mod nix;
+mod rsync;
 mod string_summarizer;
 mod terraform_install;
 mod terraform_state;
@@ -21,6 +22,7 @@ pub use nix::{
     NixBuildingRun, NixCacheActivity, NixCopyRun, NixDerivationPreprocessor, NixDrvList,
     NixFetchList, NixImageLayerRun,
 };
+pub use rsync::RsyncFileList;
 pub use string_summarizer::{
     build_marker, close_tag, open_tag, BulkElide, SegmentedText, StringSummarizer,
     StringSummarizerChain, VerbatimRegion,
@@ -286,6 +288,7 @@ pub fn default_summarizer_chain() -> StringSummarizerChain {
         .register(terraform_install::TerraformInstallRun)
         .register(terraform_state::TerraformRefreshRun)
         .register(terraform_state::TerraformDataSourceRun)
+        .register(rsync::RsyncFileList)
         .register(git::GitCloneProgress)
         .register(string_summarizer::BulkElide::default())
 }

--- a/core/crates/tool-classifier/src/lib.rs
+++ b/core/crates/tool-classifier/src/lib.rs
@@ -389,7 +389,7 @@ mod tests {
 
     #[test]
     fn large_text_input_emits_structured_elision_with_string_kept() {
-        let lines: Vec<String> = (0..500).map(|i| format!("line-{i:04}")).collect();
+        let lines: Vec<String> = (0..1000).map(|i| format!("line-{i:04}")).collect();
         let body = lines.join("\n");
         assert!(body.len() >= DEFAULT_GENERIC_THRESHOLD_BYTES);
         let raw = result_with(&body);

--- a/core/crates/tool-classifier/src/lib.rs
+++ b/core/crates/tool-classifier/src/lib.rs
@@ -10,6 +10,7 @@ mod git;
 mod nix;
 mod string_summarizer;
 mod terraform_install;
+mod terraform_state;
 mod walker;
 
 pub use bash::BashClassifier;
@@ -25,6 +26,7 @@ pub use string_summarizer::{
     StringSummarizerChain, VerbatimRegion,
 };
 pub use terraform_install::TerraformInstallRun;
+pub use terraform_state::{TerraformDataSourceRun, TerraformRefreshRun};
 
 pub const DEFAULT_GENERIC_THRESHOLD_BYTES: usize = 4096;
 
@@ -282,6 +284,8 @@ pub fn default_summarizer_chain() -> StringSummarizerChain {
         .register(cargo::CargoCompileRun)
         .register(cargo::CargoCheckRun)
         .register(terraform_install::TerraformInstallRun)
+        .register(terraform_state::TerraformRefreshRun)
+        .register(terraform_state::TerraformDataSourceRun)
         .register(git::GitCloneProgress)
         .register(string_summarizer::BulkElide::default())
 }

--- a/core/crates/tool-classifier/src/lib.rs
+++ b/core/crates/tool-classifier/src/lib.rs
@@ -406,7 +406,7 @@ mod tests {
                 assert!((kept_bytes as u64) < total_bytes);
                 let kept_str = kept.as_str().expect("string-typed kept");
                 assert!(kept_str.starts_with("line-0000"));
-                assert!(kept_str.ends_with("line-0499"));
+                assert!(kept_str.ends_with("line-0999"));
                 assert_eq!(elided_paths.len(), 1);
                 assert_eq!(elided_paths[0].path, "$");
                 assert!(matches!(elided_paths[0].kind, ElisionKind::String));

--- a/core/crates/tool-classifier/src/lib.rs
+++ b/core/crates/tool-classifier/src/lib.rs
@@ -9,6 +9,7 @@ mod concourse;
 mod git;
 mod nix;
 mod string_summarizer;
+mod terraform_install;
 mod walker;
 
 pub use bash::BashClassifier;
@@ -23,6 +24,7 @@ pub use string_summarizer::{
     build_marker, close_tag, open_tag, BulkElide, SegmentedText, StringSummarizer,
     StringSummarizerChain, VerbatimRegion,
 };
+pub use terraform_install::TerraformInstallRun;
 
 pub const DEFAULT_GENERIC_THRESHOLD_BYTES: usize = 4096;
 
@@ -279,6 +281,7 @@ pub fn default_summarizer_chain() -> StringSummarizerChain {
         .register(cargo::CargoDownloadRun)
         .register(cargo::CargoCompileRun)
         .register(cargo::CargoCheckRun)
+        .register(terraform_install::TerraformInstallRun)
         .register(git::GitCloneProgress)
         .register(string_summarizer::BulkElide::default())
 }

--- a/core/crates/tool-classifier/src/nix.rs
+++ b/core/crates/tool-classifier/src/nix.rs
@@ -11,6 +11,7 @@ pub struct NixDrvList;
 pub struct NixFetchList;
 pub struct NixBuildingRun;
 pub struct NixCacheActivity;
+pub struct NixImageLayerRun;
 
 const COPYING_PREFIX: &str = "copying path '/nix/store/";
 const DRV_LIST_HEADER_SUFFIX: &str = "derivations will be built:";
@@ -18,6 +19,12 @@ const FETCH_LIST_HEADER_INFIX: &str = "paths will be fetched";
 const STORE_PATH_PREFIX: &str = "/nix/store/";
 const BUILDING_PREFIX: &str = "building '/nix/store/";
 const NIX_CACHE_PREFIX: &str = "nix-cache: ";
+const IMAGE_LAYER_PREFIX: &str = "Creating layer ";
+const IMAGE_LAYER_INFIX: &str = " from paths: ";
+
+fn is_image_layer_line(line: &str) -> bool {
+    line.starts_with(IMAGE_LAYER_PREFIX) && line.contains(IMAGE_LAYER_INFIX)
+}
 
 fn is_drv_list_header(line: &str) -> bool {
     let t = line.trim_end();
@@ -73,6 +80,22 @@ impl StringSummarizer for NixCacheActivity {
         let runs = collect_runs(ctx, |line| line.starts_with(NIX_CACHE_PREFIX));
         apply_runs(ctx, runs, "nix-cache", |count, _bytes| {
             format!("{count} cache activity lines\n")
+        })
+    }
+}
+
+impl StringSummarizer for NixImageLayerRun {
+    fn name(&self) -> &'static str {
+        "nix-image-layers"
+    }
+    fn can_summarize(&self, ctx: &SegmentedText) -> bool {
+        ctx.verbatim_regions()
+            .any(|r| r.text.lines().any(is_image_layer_line))
+    }
+    fn apply(&self, ctx: &mut SegmentedText) -> bool {
+        let runs = collect_runs(ctx, is_image_layer_line);
+        apply_runs(ctx, runs, "nix-image-layers", |count, _bytes| {
+            format!("{count} layers\n")
         })
     }
 }
@@ -260,6 +283,32 @@ mod tests {
         assert_eq!(derivation_prefix("plain line\n"), None);
         assert_eq!(derivation_prefix(">> not a prefix\n"), None);
         assert_eq!(derivation_prefix("> empty prefix\n"), None);
+    }
+
+    #[test]
+    fn nix_image_layer_run_collapses_creating_layer_lines_inside_derivation_wrap() {
+        let raw = "checking outputs of '/nix/store/aaa-drua.tar.gz.drv'...\n\
+                   drua.tar.gz> No 'fromImage' provided\n\
+                   drua.tar.gz> Creating layer 1 from paths: ['/nix/store/aaa-foo']\n\
+                   drua.tar.gz> Creating layer 2 from paths: ['/nix/store/bbb-bar']\n\
+                   drua.tar.gz> Creating layer 3 from paths: ['/nix/store/ccc-baz']\n\
+                   drua.tar.gz> Creating layer 4 with customisation...\n\
+                   drua.tar.gz> Adding manifests...\n\
+                   drua.tar.gz> Done.\n";
+        let mut ctx = SegmentedText::from_initial(raw);
+        let chain = StringSummarizerChain::new()
+            .register(NixDerivationPreprocessor)
+            .register(NixImageLayerRun);
+        chain.run(&mut ctx);
+        let log = ctx.log();
+        assert!(log.contains("<nix-derivation name=\"drua.tar.gz\">"));
+        assert!(log.contains("<nix-image-layers"));
+        assert!(log.contains("3 layers"));
+        assert!(log.contains("Creating layer 4 with customisation"));
+        assert!(log.contains("Adding manifests"));
+        assert!(log.contains("Done."));
+        assert!(!log.contains("Creating layer 1 from paths"));
+        assert!(!log.contains("drua.tar.gz> "));
     }
 
     #[test]

--- a/core/crates/tool-classifier/src/rsync.rs
+++ b/core/crates/tool-classifier/src/rsync.rs
@@ -110,7 +110,8 @@ mod tests {
 
     #[test]
     fn indented_path_lines_not_collapsed() {
-        let raw = "header\n   indented/path1.tf\n   indented/path2.tf\n   indented/path3.tf\nfooter\n";
+        let raw =
+            "header\n   indented/path1.tf\n   indented/path2.tf\n   indented/path3.tf\nfooter\n";
         let ctx = run(raw);
         let log = ctx.log();
         assert!(!log.contains("<rsync-files"));

--- a/core/crates/tool-classifier/src/rsync.rs
+++ b/core/crates/tool-classifier/src/rsync.rs
@@ -15,11 +15,24 @@ fn is_rsync_path_line(line: &str) -> bool {
     line.contains('/') || line.contains('.') || line == "./"
 }
 
+fn is_rsync_anchor(line: &str) -> bool {
+    line.starts_with("sending incremental file list")
+        || line.starts_with("receiving incremental file list")
+        || line.starts_with("total size is ")
+        || (line.starts_with("sent ") && line.contains(" received ") && line.contains(" bytes"))
+}
+
 impl StringSummarizer for RsyncFileList {
     fn name(&self) -> &'static str {
         "rsync-files"
     }
     fn can_summarize(&self, ctx: &SegmentedText) -> bool {
+        let has_anchor = ctx
+            .verbatim_regions()
+            .any(|r| r.text.lines().any(is_rsync_anchor));
+        if !has_anchor {
+            return false;
+        }
         ctx.verbatim_regions()
             .any(|r| r.text.lines().any(is_rsync_path_line))
     }
@@ -116,5 +129,15 @@ mod tests {
         let log = ctx.log();
         assert!(!log.contains("<rsync-files"));
         assert!(log.contains("indented/path1.tf"));
+    }
+
+    #[test]
+    fn ls_output_without_rsync_anchor_passes_through() {
+        let raw = "file1.txt\nfile2.txt\nfile3.txt\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(!log.contains("<rsync-files"));
+        assert!(log.contains("file1.txt"));
+        assert!(log.contains("file3.txt"));
     }
 }

--- a/core/crates/tool-classifier/src/rsync.rs
+++ b/core/crates/tool-classifier/src/rsync.rs
@@ -1,0 +1,119 @@
+use crate::string_summarizer::{apply_runs, collect_runs, SegmentedText, StringSummarizer};
+
+pub struct RsyncFileList;
+
+fn is_rsync_path_line(line: &str) -> bool {
+    if line.is_empty() {
+        return false;
+    }
+    if line.starts_with(' ') || line.starts_with('\t') {
+        return false;
+    }
+    if line.contains(' ') {
+        return false;
+    }
+    line.contains('/') || line.contains('.') || line == "./"
+}
+
+impl StringSummarizer for RsyncFileList {
+    fn name(&self) -> &'static str {
+        "rsync-files"
+    }
+    fn can_summarize(&self, ctx: &SegmentedText) -> bool {
+        ctx.verbatim_regions()
+            .any(|r| r.text.lines().any(is_rsync_path_line))
+    }
+    fn apply(&self, ctx: &mut SegmentedText) -> bool {
+        let runs = collect_runs(ctx, is_rsync_path_line);
+        apply_runs(ctx, runs, "rsync-files", |count, _| {
+            format!("{count} paths\n")
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::string_summarizer::StringSummarizerChain;
+
+    fn run(raw: &str) -> SegmentedText {
+        let mut ctx = SegmentedText::from_initial(raw);
+        let chain = StringSummarizerChain::new().register(RsyncFileList);
+        chain.run(&mut ctx);
+        ctx
+    }
+
+    #[test]
+    fn rsync_path_region_collapses() {
+        let raw = "sending incremental file list\n\
+                   created directory repo\n\
+                   ./\n\
+                   .gitignore\n\
+                   gcloud-creds.json\n\
+                   .git/\n\
+                   .git/FETCH_HEAD\n\
+                   .git/HEAD\n\
+                   .git/cepler_environment\n\
+                   modules/services/galoy-deps/vendor/galoy-deps/chart/\n\
+                   modules/services/galoy-deps/vendor/galoy-deps/chart/templates/\n\
+                   modules/services/workers/main.tf\n\
+                   modules/services/workers/workers-values.yml.tmpl\n\
+                   vendir/\n\
+                   \n\
+                   sent 11,493,167 bytes  received 11,273 bytes  2,091,716.36 bytes/sec\n\
+                   total size is 11,441,431  speedup is 0.99\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(log.contains("<rsync-files"));
+        assert!(log.contains("paths"));
+        assert!(log.contains("</rsync-files>"));
+        assert!(log.contains("sending incremental file list"));
+        assert!(log.contains("created directory repo"));
+        assert!(log.contains("sent 11,493,167 bytes"));
+        assert!(log.contains("total size is 11,441,431"));
+        assert!(!log.contains(".git/FETCH_HEAD"));
+        assert!(!log.contains("workers-values.yml.tmpl"));
+    }
+
+    #[test]
+    fn plain_prose_passes_through() {
+        let raw = "Hello world\n\
+                   This is just some prose with several lines.\n\
+                   Nothing here looks like a path list.\n\
+                   Goodbye.\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(!log.contains("<rsync-files"));
+        assert!(log.contains("Hello world"));
+        assert!(log.contains("Goodbye."));
+    }
+
+    #[test]
+    fn lone_path_not_collapsed() {
+        let raw = "header\nfile.txt\ntail with space\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(!log.contains("<rsync-files"));
+        assert!(log.contains("file.txt"));
+    }
+
+    #[test]
+    fn terraform_refreshing_state_not_collapsed() {
+        let raw = "module.a.kubernetes_secret.x: Refreshing state... [id=ns/x]\n\
+                   module.b.kubernetes_secret.y: Refreshing state... [id=ns/y]\n\
+                   module.c.kubernetes_secret.z: Refreshing state... [id=ns/z]\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(!log.contains("<rsync-files"));
+        assert!(log.contains("Refreshing state"));
+    }
+
+    #[test]
+    fn indented_path_lines_not_collapsed() {
+        let raw = "header\n   indented/path1.tf\n   indented/path2.tf\n   indented/path3.tf\nfooter\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(!log.contains("<rsync-files"));
+        assert!(log.contains("indented/path1.tf"));
+    }
+}

--- a/core/crates/tool-classifier/src/terraform_install.rs
+++ b/core/crates/tool-classifier/src/terraform_install.rs
@@ -1,0 +1,89 @@
+use crate::string_summarizer::{apply_runs, collect_runs, SegmentedText, StringSummarizer};
+
+pub struct TerraformInstallRun;
+
+const FINDING_PREFIX: &str = "- Finding latest version of ";
+const INSTALLING_PREFIX: &str = "- Installing ";
+const INSTALLED_PREFIX: &str = "- Installed ";
+
+fn is_install_line(line: &str) -> bool {
+    let t = line.trim_start();
+    t.starts_with(FINDING_PREFIX)
+        || t.starts_with(INSTALLING_PREFIX)
+        || t.starts_with(INSTALLED_PREFIX)
+}
+
+impl StringSummarizer for TerraformInstallRun {
+    fn name(&self) -> &'static str {
+        "terraform-install"
+    }
+    fn can_summarize(&self, ctx: &SegmentedText) -> bool {
+        ctx.verbatim_regions()
+            .any(|r| r.text.lines().any(is_install_line))
+    }
+    fn apply(&self, ctx: &mut SegmentedText) -> bool {
+        let runs = collect_runs(ctx, is_install_line);
+        apply_runs(ctx, runs, "terraform-install", |count, _| {
+            format!("{count} provider lines\n")
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::string_summarizer::StringSummarizerChain;
+
+    fn run(raw: &str) -> SegmentedText {
+        let mut ctx = SegmentedText::from_initial(raw);
+        let chain = StringSummarizerChain::new().register(TerraformInstallRun);
+        chain.run(&mut ctx);
+        ctx
+    }
+
+    #[test]
+    fn provider_install_block_collapses() {
+        let raw = "\
+Initializing the backend...
+- Finding latest version of hashicorp/google...
+- Finding latest version of hashicorp/google-beta...
+- Finding latest version of hashicorp/kubernetes...
+- Finding latest version of hashicorp/helm...
+- Installing hashicorp/google-beta v7.30.0...
+- Installed hashicorp/google-beta v7.30.0 (signed, key ID 0C0AF313E5FD9F80)
+- Installing hashicorp/kubernetes v3.1.0...
+- Installed hashicorp/kubernetes v3.1.0 (signed, key ID 0C0AF313E5FD9F80)
+- Installing hashicorp/helm v3.1.1...
+- Installed hashicorp/helm v3.1.1 (signed, key ID 0C0AF313E5FD9F80)
+- Installing hashicorp/google v7.30.0...
+- Installed hashicorp/google v7.30.0 (signed, key ID 0C0AF313E5FD9F80)
+done.
+";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(log.contains("<terraform-install"));
+        assert!(log.contains("12 provider lines"));
+        assert!(log.contains("Initializing the backend..."));
+        assert!(log.contains("done."));
+        assert!(!log.contains("hashicorp/google-beta v7.30.0"));
+    }
+
+    #[test]
+    fn non_matching_block_passes_through() {
+        let raw = "header\nplain text\nmore plain text\ntail\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(!log.contains("<terraform-install"));
+        assert!(log.contains("plain text"));
+        assert!(log.contains("more plain text"));
+    }
+
+    #[test]
+    fn isolated_single_line_passes_through() {
+        let raw = "header\n- Installing hashicorp/google v7.30.0...\ntail\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(!log.contains("<terraform-install"));
+        assert!(log.contains("- Installing hashicorp/google v7.30.0..."));
+    }
+}

--- a/core/crates/tool-classifier/src/terraform_state.rs
+++ b/core/crates/tool-classifier/src/terraform_state.rs
@@ -1,0 +1,142 @@
+use crate::string_summarizer::{apply_runs, collect_runs, SegmentedText, StringSummarizer};
+
+pub struct TerraformRefreshRun;
+pub struct TerraformDataSourceRun;
+
+fn is_refresh_line(line: &str) -> bool {
+    let t = line.trim_start();
+    t.contains(": Refreshing state... [id=")
+}
+
+fn is_data_source_line(line: &str) -> bool {
+    let t = line.trim_start();
+    if !t.starts_with("data.") {
+        return false;
+    }
+    t.contains(": Reading...") || t.contains(": Read complete after ")
+}
+
+impl StringSummarizer for TerraformRefreshRun {
+    fn name(&self) -> &'static str {
+        "terraform-refresh"
+    }
+    fn can_summarize(&self, ctx: &SegmentedText) -> bool {
+        ctx.verbatim_regions()
+            .any(|r| r.text.lines().any(is_refresh_line))
+    }
+    fn apply(&self, ctx: &mut SegmentedText) -> bool {
+        let runs = collect_runs(ctx, is_refresh_line);
+        apply_runs(ctx, runs, "terraform-refresh", |count, _| {
+            format!("{count} resources refreshed\n")
+        })
+    }
+}
+
+impl StringSummarizer for TerraformDataSourceRun {
+    fn name(&self) -> &'static str {
+        "terraform-data-source"
+    }
+    fn can_summarize(&self, ctx: &SegmentedText) -> bool {
+        ctx.verbatim_regions()
+            .any(|r| r.text.lines().any(is_data_source_line))
+    }
+    fn apply(&self, ctx: &mut SegmentedText) -> bool {
+        let runs = collect_runs(ctx, is_data_source_line);
+        apply_runs(ctx, runs, "terraform-data-source", |count, _| {
+            format!("{count} data-source lines\n")
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::string_summarizer::StringSummarizerChain;
+
+    fn run(raw: &str) -> SegmentedText {
+        let mut ctx = SegmentedText::from_initial(raw);
+        let chain = StringSummarizerChain::new()
+            .register(TerraformRefreshRun)
+            .register(TerraformDataSourceRun);
+        chain.run(&mut ctx);
+        ctx
+    }
+
+    #[test]
+    fn refresh_run_collapses_contiguous_lines() {
+        let raw = "header\n\
+                   module.workers.kubernetes_namespace_v1.workers: Refreshing state... [id=galoy-agents-concourse]\n\
+                   module.workers.kubernetes_secret_v1.concourse_worker: Refreshing state... [id=galoy-agents-concourse/galoy-agents-concourse-worker]\n\
+                   module.workers.helm_release.workers: Refreshing state... [id=galoy-agents-concourse]\n\
+                   tail\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(log.contains("<terraform-refresh"));
+        assert!(log.contains("3 resources refreshed"));
+        assert!(log.contains("</terraform-refresh>"));
+        assert!(log.contains("header"));
+        assert!(log.contains("tail"));
+        assert!(!log.contains("Refreshing state..."));
+    }
+
+    #[test]
+    fn refresh_non_matching_passes_through() {
+        let raw = "Plan: 3 to add, 0 to change, 0 to destroy.\n\
+                   Apply complete! Resources: 3 added.\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(!log.contains("<terraform-refresh"));
+        assert!(log.contains("Plan: 3 to add"));
+        assert!(log.contains("Apply complete!"));
+    }
+
+    #[test]
+    fn lone_refresh_line_left_alone() {
+        let raw = "header\n\
+                   module.workers.helm_release.workers: Refreshing state... [id=foo]\n\
+                   tail\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(!log.contains("<terraform-refresh"));
+        assert!(log.contains("Refreshing state..."));
+    }
+
+    #[test]
+    fn data_source_run_collapses_contiguous_lines() {
+        let raw = "header\n\
+                   data.google_client_config.default: Reading...\n\
+                   data.google_container_cluster.primary: Reading...\n\
+                   data.google_client_config.default: Read complete after 0s [id=projects//regions//zones/]\n\
+                   data.google_container_cluster.primary: Read complete after 0s [id=projects/galoy-agents/locations/.../clusters/galoy-agents-cluster]\n\
+                   tail\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(log.contains("<terraform-data-source"));
+        assert!(log.contains("4 data-source lines"));
+        assert!(log.contains("</terraform-data-source>"));
+        assert!(log.contains("header"));
+        assert!(log.contains("tail"));
+        assert!(!log.contains("data.google_client_config"));
+    }
+
+    #[test]
+    fn data_source_non_matching_passes_through() {
+        let raw = "Initializing the backend...\n\
+                   Initializing provider plugins...\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(!log.contains("<terraform-data-source"));
+        assert!(log.contains("Initializing the backend"));
+    }
+
+    #[test]
+    fn lone_data_source_line_left_alone() {
+        let raw = "header\n\
+                   data.google_client_config.default: Reading...\n\
+                   tail\n";
+        let ctx = run(raw);
+        let log = ctx.log();
+        assert!(!log.contains("<terraform-data-source"));
+        assert!(log.contains("data.google_client_config.default: Reading..."));
+    }
+}

--- a/core/crates/tool-classifier/src/walker.rs
+++ b/core/crates/tool-classifier/src/walker.rs
@@ -184,9 +184,7 @@ fn walk_array(
 }
 
 fn sentinel_budget(threshold: usize) -> usize {
-    threshold
-        .min(SENTINEL_HARD_CAP_BYTES)
-        .max(SENTINEL_MIN_BYTES)
+    threshold.clamp(SENTINEL_MIN_BYTES, SENTINEL_HARD_CAP_BYTES)
 }
 
 fn sentinel_array(

--- a/core/crates/tool-classifier/src/walker.rs
+++ b/core/crates/tool-classifier/src/walker.rs
@@ -12,7 +12,10 @@ const STRING_ELIDE_MARKER: &str = "…";
 const ARRAY_SENTINEL_HEAD: usize = 3;
 const ARRAY_SENTINEL_TAIL: usize = 3;
 
-const SENTINEL_BYTE_BUDGET: usize = 2048;
+const SENTINEL_HARD_CAP_BYTES: usize = 16 * 1024;
+const SENTINEL_MIN_BYTES: usize = 512;
+
+pub const RECOVERY_INVOCATION_PLACEHOLDER: &str = "<this-invocation>";
 
 #[derive(Debug)]
 pub enum WalkOutcome {
@@ -177,7 +180,13 @@ fn walk_array(
         return walked_value;
     }
     paths.truncate(paths_before);
-    sentinel_array(&walked, items.len(), path, paths, original_bytes)
+    sentinel_array(&walked, items.len(), path, paths, original_bytes, threshold)
+}
+
+fn sentinel_budget(threshold: usize) -> usize {
+    threshold
+        .min(SENTINEL_HARD_CAP_BYTES)
+        .max(SENTINEL_MIN_BYTES)
 }
 
 fn sentinel_array(
@@ -186,7 +195,9 @@ fn sentinel_array(
     path: &str,
     paths: &mut Vec<ElidedPath>,
     original_bytes: usize,
+    threshold: usize,
 ) -> Value {
+    let budget = sentinel_budget(threshold);
     let mut head_count = ARRAY_SENTINEL_HEAD.min(walked_items.len());
     let max_tail = walked_items.len().saturating_sub(head_count);
     let mut tail_count = ARRAY_SENTINEL_TAIL.min(max_tail);
@@ -196,8 +207,9 @@ fn sentinel_array(
         tail_count,
         original_length,
         original_bytes,
+        path,
     );
-    while json_size(&sentinel) > SENTINEL_BYTE_BUDGET && (head_count > 0 || tail_count > 0) {
+    while json_size(&sentinel) > budget && (head_count > 0 || tail_count > 0) {
         if tail_count > 0 {
             tail_count -= 1;
         } else {
@@ -209,6 +221,7 @@ fn sentinel_array(
             tail_count,
             original_length,
             original_bytes,
+            path,
         );
     }
     paths.push(ElidedPath {
@@ -227,6 +240,7 @@ fn make_array_sentinel(
     tail_count: usize,
     length: usize,
     bytes: usize,
+    path: &str,
 ) -> Value {
     let head: Vec<Value> = walked_items.iter().take(head_count).cloned().collect();
     let tail: Vec<Value> = walked_items
@@ -236,6 +250,21 @@ fn make_array_sentinel(
         .rev()
         .cloned()
         .collect();
+    let missing_offset = head_count;
+    let missing_len = length.saturating_sub(head_count + tail_count);
+    let recover = serde_json::json!({
+        "tool": "tool_output_fetch",
+        "args_template": {
+            "invocation_id": RECOVERY_INVOCATION_PLACEHOLDER,
+            "view": "original",
+            "query": {
+                "mode": "json_array_slice",
+                "path": path,
+                "offset": missing_offset,
+                "len": missing_len,
+            },
+        },
+    });
     serde_json::json!({
         "_elided": true,
         "kind": "array",
@@ -243,6 +272,7 @@ fn make_array_sentinel(
         "bytes": bytes,
         "head": head,
         "tail": tail,
+        "_recover": recover,
     })
 }
 
@@ -475,6 +505,81 @@ mod tests {
         assert!(elided_paths
             .iter()
             .any(|p| p.path == "$" && matches!(p.kind, ElisionKind::Array)));
+    }
+
+    #[test]
+    fn array_sentinel_carries_recover_template_with_placeholder() {
+        let items: Vec<Value> = (0..50)
+            .map(|i| serde_json::json!({"id": i, "blob": "z".repeat(200)}))
+            .collect();
+        let v = serde_json::json!({"hits": items});
+        let outcome = classify_value(&v, 4096, None);
+        let WalkOutcome::Elided { kept, .. } = outcome else {
+            panic!("expected Elided");
+        };
+        let hits = kept.get("hits").expect("hits key present");
+        assert_eq!(hits.get("_elided"), Some(&Value::Bool(true)));
+        let recover = hits.get("_recover").expect("_recover present");
+        assert_eq!(
+            recover.get("tool"),
+            Some(&Value::String("tool_output_fetch".to_string()))
+        );
+        let args = recover.get("args_template").expect("args_template");
+        assert_eq!(
+            args.get("invocation_id"),
+            Some(&Value::String(RECOVERY_INVOCATION_PLACEHOLDER.to_string()))
+        );
+        assert_eq!(
+            args.get("view"),
+            Some(&Value::String("original".to_string()))
+        );
+        let q = args.get("query").expect("query");
+        assert_eq!(
+            q.get("mode"),
+            Some(&Value::String("json_array_slice".to_string()))
+        );
+        assert_eq!(q.get("path"), Some(&Value::String("$.hits".to_string())));
+        assert!(q.get("offset").and_then(|v| v.as_u64()).is_some());
+        assert!(q.get("len").and_then(|v| v.as_u64()).is_some());
+    }
+
+    #[test]
+    fn floating_sentinel_budget_keeps_more_items_when_threshold_allows() {
+        let items: Vec<Value> = (0..30)
+            .map(|i| serde_json::json!({"id": i, "name": format!("entry-{i:02}")}))
+            .collect();
+        let v = serde_json::json!({"hits": items});
+        let small_budget = classify_value(&v, 4096, None);
+        let large_budget = classify_value(&v, 16 * 1024, None);
+        match (small_budget, large_budget) {
+            (
+                WalkOutcome::Elided {
+                    kept: small_kept, ..
+                },
+                WalkOutcome::Elided {
+                    kept: large_kept, ..
+                },
+            ) => {
+                let small_head = small_kept
+                    .get("hits")
+                    .and_then(|v| v.get("head"))
+                    .and_then(|h| h.as_array())
+                    .expect("small budget head");
+                let large_head = large_kept
+                    .get("hits")
+                    .and_then(|v| v.get("head"))
+                    .and_then(|h| h.as_array())
+                    .expect("large budget head");
+                assert!(
+                    large_head.len() >= small_head.len(),
+                    "larger threshold should keep at least as many head items \
+                     (small={} large={})",
+                    small_head.len(),
+                    large_head.len(),
+                );
+            }
+            outcomes => panic!("expected both Elided, got {outcomes:?}"),
+        }
     }
 
     /// Cursor #3212527301: byte-elide reports original pre-walk size.

--- a/core/crates/tool-classifier/src/walker.rs
+++ b/core/crates/tool-classifier/src/walker.rs
@@ -544,7 +544,13 @@ mod tests {
     #[test]
     fn floating_sentinel_budget_keeps_more_items_when_threshold_allows() {
         let items: Vec<Value> = (0..30)
-            .map(|i| serde_json::json!({"id": i, "name": format!("entry-{i:02}")}))
+            .map(|i| {
+                serde_json::json!({
+                    "id": i,
+                    "name": format!("entry-{i:02}"),
+                    "blob": "z".repeat(800),
+                })
+            })
             .collect();
         let v = serde_json::json!({"hits": items});
         let small_budget = classify_value(&v, 4096, None);

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -21,7 +21,8 @@ pub use config::*;
 pub use error::*;
 pub use searchable::*;
 pub use tool_invocations::{
-    FetchQuery, FetchResult, InvocationOwner, NewToolInvocation, ToolInvocation,
+    substitute_recovery_placeholder, FetchQuery, FetchResult, InvocationOwner, NewToolInvocation,
+    ToolInvocation,
     ToolInvocationError, ToolInvocationId, ToolInvocationOwnerId, ToolInvocations,
 };
 pub use top_level::{

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -22,8 +22,7 @@ pub use error::*;
 pub use searchable::*;
 pub use tool_invocations::{
     substitute_recovery_placeholder, FetchQuery, FetchResult, InvocationOwner, NewToolInvocation,
-    ToolInvocation,
-    ToolInvocationError, ToolInvocationId, ToolInvocationOwnerId, ToolInvocations,
+    ToolInvocation, ToolInvocationError, ToolInvocationId, ToolInvocationOwnerId, ToolInvocations,
 };
 pub use top_level::{
     Bash, CallCatalogTool, ComposeTool, ComposeTypes, Delete, DescribeCatalogTool, GlobTool, Grep,

--- a/core/src/toolset/searchable/upstream.rs
+++ b/core/src/toolset/searchable/upstream.rs
@@ -234,11 +234,10 @@ fn reify_json_structured_content(result: &mut CallToolResult) {
     if !(trimmed.starts_with('{') || trimmed.starts_with('[')) {
         return;
     }
-    match serde_json::from_str::<serde_json::Value>(trimmed) {
-        Ok(v @ (serde_json::Value::Object(_) | serde_json::Value::Array(_))) => {
-            result.structured_content = Some(v);
-        }
-        _ => {}
+    if let Ok(v @ (serde_json::Value::Object(_) | serde_json::Value::Array(_))) =
+        serde_json::from_str::<serde_json::Value>(trimmed)
+    {
+        result.structured_content = Some(v);
     }
 }
 

--- a/core/src/toolset/searchable/upstream.rs
+++ b/core/src/toolset/searchable/upstream.rs
@@ -217,13 +217,6 @@ impl SearchableToolSet for UpstreamToolSet {
     }
 }
 
-/// When an upstream MCP tool returns its result as JSON-encoded text in
-/// `content[].text` without populating `structured_content`, parse it
-/// and stash the parsed value on `structured_content` so the classifier
-/// walker can do tree-aware elision instead of falling back to byte
-/// head/tail. No-op when the tool already provided structured content,
-/// when the text isn't JSON-shaped, or when parsing yields a scalar
-/// (only `Object`/`Array` are worth reifying).
 fn reify_json_structured_content(result: &mut CallToolResult) {
     if result.structured_content.is_some() {
         return;
@@ -365,8 +358,7 @@ mod tests {
 
     #[test]
     fn reify_handles_leading_whitespace() {
-        let mut r =
-            CallToolResult::success(vec![Content::text("  \n\t  [1,2,3]\n".to_string())]);
+        let mut r = CallToolResult::success(vec![Content::text("  \n\t  [1,2,3]\n".to_string())]);
         reify_json_structured_content(&mut r);
         assert!(r.structured_content.unwrap().is_array());
     }

--- a/core/src/toolset/searchable/upstream.rs
+++ b/core/src/toolset/searchable/upstream.rs
@@ -211,8 +211,41 @@ impl SearchableToolSet for UpstreamToolSet {
             params = params.with_arguments(args);
         }
         let client = self.client.read().await;
-        let result = client.peer().call_tool(params).await?;
+        let mut result = client.peer().call_tool(params).await?;
+        reify_json_structured_content(&mut result);
         Ok(result)
+    }
+}
+
+/// When an upstream MCP tool returns its result as JSON-encoded text in
+/// `content[].text` without populating `structured_content`, parse it
+/// and stash the parsed value on `structured_content` so the classifier
+/// walker can do tree-aware elision instead of falling back to byte
+/// head/tail. No-op when the tool already provided structured content,
+/// when the text isn't JSON-shaped, or when parsing yields a scalar
+/// (only `Object`/`Array` are worth reifying).
+fn reify_json_structured_content(result: &mut CallToolResult) {
+    if result.structured_content.is_some() {
+        return;
+    }
+    let mut combined = String::new();
+    for part in &result.content {
+        if let rmcp::model::RawContent::Text(t) = &part.raw {
+            if !combined.is_empty() {
+                combined.push('\n');
+            }
+            combined.push_str(&t.text);
+        }
+    }
+    let trimmed = combined.trim_start();
+    if !(trimmed.starts_with('{') || trimmed.starts_with('[')) {
+        return;
+    }
+    match serde_json::from_str::<serde_json::Value>(trimmed) {
+        Ok(v @ (serde_json::Value::Object(_) | serde_json::Value::Array(_))) => {
+            result.structured_content = Some(v);
+        }
+        _ => {}
     }
 }
 
@@ -266,5 +299,75 @@ mod tests {
     #[test]
     fn internal_only_unset_visible_to_user() {
         assert!(visible(false, &user_subject()));
+    }
+
+    use rmcp::model::Content;
+
+    #[test]
+    fn reify_object_text_into_structured_content() {
+        let mut r = CallToolResult::success(vec![Content::text(
+            r#"{"total":2,"items":[{"id":1},{"id":2}]}"#.to_string(),
+        )]);
+        reify_json_structured_content(&mut r);
+        let sc = r.structured_content.expect("structured_content set");
+        assert_eq!(sc.get("total"), Some(&serde_json::json!(2)));
+        assert!(sc.get("items").unwrap().is_array());
+    }
+
+    #[test]
+    fn reify_array_text_into_structured_content() {
+        let mut r = CallToolResult::success(vec![Content::text(
+            r#"[{"a":1},{"a":2},{"a":3}]"#.to_string(),
+        )]);
+        reify_json_structured_content(&mut r);
+        let sc = r.structured_content.expect("structured_content set");
+        assert!(sc.is_array());
+        assert_eq!(sc.as_array().unwrap().len(), 3);
+    }
+
+    #[test]
+    fn reify_skips_when_structured_content_already_set() {
+        let mut r = CallToolResult::success(vec![Content::text(r#"{"a":1}"#.to_string())]);
+        r.structured_content = Some(serde_json::json!({"existing": true}));
+        reify_json_structured_content(&mut r);
+        assert_eq!(
+            r.structured_content,
+            Some(serde_json::json!({"existing": true}))
+        );
+    }
+
+    #[test]
+    fn reify_skips_non_json_text() {
+        let mut r = CallToolResult::success(vec![Content::text(
+            "NAME    READY   STATUS\nfoo     1/1     Running\n".to_string(),
+        )]);
+        reify_json_structured_content(&mut r);
+        assert!(r.structured_content.is_none());
+    }
+
+    #[test]
+    fn reify_skips_scalar_json() {
+        let mut r = CallToolResult::success(vec![Content::text("42".to_string())]);
+        reify_json_structured_content(&mut r);
+        assert!(r.structured_content.is_none());
+
+        let mut r = CallToolResult::success(vec![Content::text(r#""just a string""#.to_string())]);
+        reify_json_structured_content(&mut r);
+        assert!(r.structured_content.is_none());
+    }
+
+    #[test]
+    fn reify_skips_truncated_or_invalid_json() {
+        let mut r = CallToolResult::success(vec![Content::text(r#"{"a": 1, "b":"#.to_string())]);
+        reify_json_structured_content(&mut r);
+        assert!(r.structured_content.is_none());
+    }
+
+    #[test]
+    fn reify_handles_leading_whitespace() {
+        let mut r =
+            CallToolResult::success(vec![Content::text("  \n\t  [1,2,3]\n".to_string())]);
+        reify_json_structured_content(&mut r);
+        assert!(r.structured_content.unwrap().is_array());
     }
 }

--- a/core/src/toolset/top_level/tool_output_fetch.rs
+++ b/core/src/toolset/top_level/tool_output_fetch.rs
@@ -56,12 +56,16 @@ const DESCRIPTION: &str = "Fetch a previously-persisted tool result. Same respon
      structured_content; `view: 'summary'` returns the typed \
      classifier summary instead. \
      `query` is optional — when present, content[].text carries a \
-     slice (`tail`/`head`/`range`/`grep`); when absent, no slicing. \
-     Per-mode args: `tail`/`head` take `lines`; `range` takes \
-     `offset` + `len`; `grep` takes `pattern` plus rg-style flags — \
-     `-i` (case_insensitive), `-A`/`-B`/`-C` (context, asymmetric or \
-     symmetric), `-n` (line numbers, default true), `invert_match` \
-     (`-v`), and `head_limit` (cap kept lines).";
+     slice. Modes: `tail`/`head` (lines), `range` (offset+len bytes), \
+     `grep` (pattern + rg-style flags), `json_path` (resolve a path \
+     in structured_content), `json_array_slice` (resolve a path to \
+     an array, return [offset..offset+len]). Per-mode args: \
+     `tail`/`head` take `lines`; `range` takes `offset` + `len`; \
+     `grep` takes `pattern` plus `-i`/`-A`/`-B`/`-C`/`-n`/`invert_match`/`head_limit`; \
+     `json_path` takes `path` (e.g. `$.data.rows`); `json_array_slice` \
+     takes `path` + `offset` + `len`. The `_recover` template inside \
+     elided array sentinels gives you ready-made `json_array_slice` \
+     args.";
 
 #[async_trait::async_trait]
 impl TopLevelTool for ToolOutputFetch {
@@ -121,15 +125,26 @@ impl TopLevelTool for ToolOutputFetch {
             )]));
         }
 
+        let invocation_id_str = uuid::Uuid::from(invocation.id).to_string();
         let structured = match input.view {
             FetchView::Original => invocation.original_structured.clone(),
-            FetchView::Summary => Some(invocation.summary.clone()),
+            FetchView::Summary => {
+                let mut s = invocation.summary.clone();
+                crate::toolset::tool_invocations::substitute_recovery_placeholder(
+                    &mut s,
+                    &invocation_id_str,
+                );
+                Some(s)
+            }
         };
 
         let content_text = match input.query {
             Some(q) => {
-                match crate::toolset::tool_invocations::apply_fetch_query(&invocation.raw_text, &q)
-                {
+                match crate::toolset::tool_invocations::apply_fetch_query(
+                    &invocation.raw_text,
+                    invocation.original_structured.as_ref(),
+                    &q,
+                ) {
                     Ok(r) => r.content,
                     Err(e) => {
                         return Ok(CallToolResult::error(vec![Content::text(format!(
@@ -221,6 +236,19 @@ mod tests {
             (
                 "grep",
                 serde_json::json!({"mode": "grep", "pattern": "error"}),
+            ),
+            (
+                "json_path",
+                serde_json::json!({"mode": "json_path", "path": "$.foo"}),
+            ),
+            (
+                "json_array_slice",
+                serde_json::json!({
+                    "mode": "json_array_slice",
+                    "path": "$.hits",
+                    "offset": 3,
+                    "len": 50,
+                }),
             ),
         ] {
             assert!(DESCRIPTION.contains(&format!("`{mode}`")));

--- a/core/tests/compose_recovery.rs
+++ b/core/tests/compose_recovery.rs
@@ -198,7 +198,7 @@ async fn compose_with_large_return_curated() {
 async fn compose_sub_invocations_directory_lists_only_persisted_calls() {
     let pool = pool().await;
     let (toolsets, _) =
-        build_toolsets_with_invocations(&pool, StubSet::new("stub", "list_items", 8000)).await;
+        build_toolsets_with_invocations(&pool, StubSet::new("stub", "list_items", 16_000)).await;
 
     let user_id = insert_user(&pool).await;
     let subject = AuthSubject::User(user_id);
@@ -253,7 +253,7 @@ async fn compose_sub_invocations_directory_lists_only_persisted_calls() {
 async fn compose_under_workflow_executor_no_persistence() {
     let pool = pool().await;
     let (toolsets, _) =
-        build_toolsets_with_invocations(&pool, StubSet::new("stub", "list_items", 8000)).await;
+        build_toolsets_with_invocations(&pool, StubSet::new("stub", "list_items", 16_000)).await;
 
     let subject = AuthSubject::workflow_executor(
         ProjectId::new(),
@@ -296,7 +296,7 @@ async fn compose_under_workflow_executor_no_persistence() {
 async fn tool_output_fetch_inside_compose_engine() {
     let pool = pool().await;
     let (toolsets, _) =
-        build_toolsets_with_invocations(&pool, StubSet::new("stub", "list_items", 8000)).await;
+        build_toolsets_with_invocations(&pool, StubSet::new("stub", "list_items", 16_000)).await;
 
     let user_id = insert_user(&pool).await;
     let subject = AuthSubject::User(user_id);


### PR DESCRIPTION
## Summary

Follow-up to #309 surfacing several gaps from production traces. Three categories of change:

### Recovery flow (the main thing)

- **8 KB elision threshold** (was 4 KB). Borderline payloads now passthrough rather than ride a sentinel + recovery round-trip. The asymmetry with the 16 KB no-query recovery cap is now defensible — recovery can still pull bigger results than the elision floor.
- **Floating sentinel byte budget**. Replaces fixed `SENTINEL_BYTE_BUDGET = 2048` with `threshold.min(SENTINEL_HARD_CAP_BYTES=16K).max(SENTINEL_MIN_BYTES=512)`. With 8 KB threshold, sentinels can carry up to 8 KB instead of 2 KB — more head/tail items kept when borderline-elided.
- **Array sentinels carry a `_recover` template** with the exact `tool_output_fetch` args needed to retrieve the missing middle items:
  ```json
  {
    "_elided": true, "kind": "array", "length": 100, "head": [...], "tail": [...],
    "_recover": {
      "tool": "tool_output_fetch",
      "args_template": {
        "invocation_id": "<spliced at persist time>",
        "view": "original",
        "query": { "mode": "json_array_slice", "path": "$.hits", "offset": 3, "len": 94 }
      }
    }
  }
  ```
  Walker emits a `<this-invocation>` placeholder; tool-cache substitutes the real UUID in `persist_and_envelope` and `tool_output_fetch view=summary`.
- **Two new `FetchQuery` modes** operating on `original_structured` rather than `raw_text`:
  - `JsonPath { path }` — resolves a `$.foo.bar[3]` path
  - `JsonArraySlice { path, offset, len }` — resolves to an array, slices items
  Tests cover root, nested keys + indices, missing paths, scalar errors, clamping, and "no structured_content" friendly errors.

### Universal-pipeline plumbing fix

- **`UpstreamToolSet::call` reifies JSON-shaped text into `structured_content`** when the upstream tool didn't populate it. Sampled production tools (`github_list_pull_requests`, `pg_execute_sql`, `github_pull_request_read get_review_comments`, `github_actions_actions_list`, `code_assistant_search_code`) return their result as a JSON string in `content[].text` — without this, the walker treats the whole payload as a `Value::String` and falls back to byte head/tail elision. With it, the walker enters the JSON tree and per-key / array-sentinel logic kicks in.

### New classifier passes

- `NixImageLayerRun` — collapses `dockerTools.streamLayeredImage`'s `Creating layer N from paths: […]` runs. ~7× compression on docker-image rebuild stderr.
- `TerraformInstallRun` — collapses `- Finding latest version of …` / `- Installing hashicorp/X v…` / `- Installed hashicorp/X v…` runs from `tofu init` / `terraform init`.
- `TerraformRefreshRun` — collapses `module.X.Y.Z: Refreshing state...` runs from `tofu plan` / apply.
- `TerraformDataSourceRun` — pairs `data.X: Reading...` / `: Read complete after Ys`.
- `RsyncFileList` — collapses the path-list region of rsync output, preserving `sending incremental file list` header and `sent N bytes received M bytes` / `total size` summary.

## Test plan
- [ ] `cargo check -p drua-core -p drua-tool-classifier -p drua-tool-cache --tests` passes
- [ ] All new unit tests pass (walker `_recover`, floating budget, fetch-query json modes, classifier passes)
- [ ] Manual e2e: `mcp__drua__call_tool pg_execute_sql LIMIT 500` → observe `_recover` template → `mcp__drua__tool_output_fetch json_array_slice` → middle rows return
- [ ] Manual e2e: `nix build .#docker-image --rebuild --no-link -L` → observe `<nix-image-layers count="98">` marker inside `<nix-derivation name="drua.tar.gz">`
- [ ] Manual e2e: a Concourse build log with terraform plan output → observe `<terraform-refresh>` / `<terraform-data-source>` markers and `<terraform-install>` if the build did `tofu init`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the universal tool-result pipeline (classification elision, persistence envelopes, and recovery fetch) and changes how upstream tool responses are parsed into `structured_content`, which could alter payload shapes and recovery behavior.
> 
> **Overview**
> Improves **structured elision recovery** by raising the generic elision threshold to `8192`, adding a floating-size array sentinel budget, and embedding a `_recover` template in array sentinels that points to `tool_output_fetch` with a placeholder invocation id.
> 
> Extends `tool_output_fetch`/tool-cache fetching with `json_path` and `json_array_slice` queries over persisted `original_structured`, plus placeholder substitution so recovery templates contain the real invocation UUID in persisted envelopes and `view: summary`.
> 
> Adds new log-summarizer passes for noisy outputs (`terraform` provider install + refresh/data-source lines, `rsync` file lists, and nix `dockerTools` image layer creation lines) and wires them into the default summarizer chain.
> 
> Fixes upstream tool calling to **reify JSON text outputs** into `structured_content` when the upstream returns JSON only in `content[].text`, enabling the structured walker/elision logic to operate on the JSON tree.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db096fde674940d3842c447da9f35ee1c1868351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->