### PR TITLE
fix(toolset): wrap non-object structured_content in reify (P0)

### DIFF
--- a/core/crates/tool-classifier/src/reify.rs
+++ b/core/crates/tool-classifier/src/reify.rs
@@ -2,30 +2,60 @@
 //!
 //! Every dispatch path (regular MCP, compose, catalog) calls this once before
 //! classification, so the universal pipeline always sees the same shape:
-//! `result.structured_content` is `Some(_)`, never `None`.
+//! `result.structured_content` is `Some(_)`, never `None`, and always a
+//! JSON **object** (record) — never a raw string, array, number, bool, or null.
 //!
 //! Resolution order:
 //! 1. If `structured_content` is already attached → leave it alone.
 //! 2. Combine `content[].text` parts.
-//! 3. If the combined text parses as a JSON object or array → attach the
-//!    parsed value.
-//! 4. Otherwise → attach `Value::String(combined_text)` so the walker, query
-//!    layer, and downstream consumers always have a structured handle.
+//! 3. Try to parse the combined text as JSON.
+//!    - Object → attach as-is.
+//!    - Array  → attach `{ "items": [...], "_shape": "array" }`.
+//!    - String → attach `{ "value": "...", "_shape": "string" }`.
+//!    - Number → attach `{ "value": N, "_shape": "number" }`.
+//!    - Bool   → attach `{ "value": B, "_shape": "boolean" }`.
+//!    - Null   → attach `{ "value": null, "_shape": "null" }`.
+//! 4. Parse failure → attach `{ "value": <raw_text>, "_shape": "string" }`.
 //!
-//! Net: agents and JS consumers (compose) never have to branch on "did the
-//! tool populate structured_content?" — the answer is always yes.
+//! Why a record envelope: the MCP transport requires `structured_content` to
+//! be a JSON object. Wrapping non-object values here means every downstream
+//! consumer (walker, classifier, query layer, recovery template generator,
+//! gateway emission) sees a record uniformly — and `tool_output_fetch` slice
+//! results round-trip through the same path without breaking the wrapper.
 
 use rmcp::model::CallToolResult;
-use serde_json::Value;
+use serde_json::{json, Value};
 
-/// Mutates `result` so `structured_content` is `Some(_)` on return.
+/// Mutates `result` so `structured_content` is `Some(record)` on return.
 pub fn ensure_structured_content(result: &mut CallToolResult) {
     if result.structured_content.is_some() {
         return;
     }
     let combined = combined_text(result);
-    let parsed = parse_json_object_or_array(&combined);
-    result.structured_content = Some(parsed.unwrap_or(Value::String(combined)));
+    result.structured_content = Some(reify(combined));
+}
+
+/// Wrap an arbitrary tool-output text into a record-shaped JSON value.
+///
+/// Pure function over a `String` so it can be unit-tested without an
+/// `rmcp::CallToolResult`.
+pub fn reify(text: String) -> Value {
+    if text.trim().is_empty() {
+        return wrap_string(text);
+    }
+    match serde_json::from_str::<Value>(text.trim()) {
+        Ok(Value::Object(obj)) => Value::Object(obj),
+        Ok(Value::Array(items)) => json!({ "items": items, "_shape": "array" }),
+        Ok(Value::String(s)) => json!({ "value": s, "_shape": "string" }),
+        Ok(Value::Number(n)) => json!({ "value": n, "_shape": "number" }),
+        Ok(Value::Bool(b)) => json!({ "value": b, "_shape": "boolean" }),
+        Ok(Value::Null) => json!({ "value": null, "_shape": "null" }),
+        Err(_) => wrap_string(text),
+    }
+}
+
+fn wrap_string(s: String) -> Value {
+    json!({ "value": s, "_shape": "string" })
 }
 
 fn combined_text(result: &CallToolResult) -> String {
@@ -41,105 +71,143 @@ fn combined_text(result: &CallToolResult) -> String {
     combined
 }
 
-fn parse_json_object_or_array(text: &str) -> Option<Value> {
-    let trimmed = text.trim_start();
-    if !(trimmed.starts_with('{') || trimmed.starts_with('[')) {
-        return None;
-    }
-    match serde_json::from_str::<Value>(trimmed) {
-        Ok(v @ (Value::Object(_) | Value::Array(_))) => Some(v),
-        _ => None,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use rmcp::model::Content;
 
     #[test]
-    fn ensure_object_text_into_structured_content() {
+    fn object_passes_through_unchanged() {
         let mut r = CallToolResult::success(vec![Content::text(
             r#"{"total":2,"items":[{"id":1},{"id":2}]}"#.to_string(),
         )]);
         ensure_structured_content(&mut r);
         let sc = r.structured_content.expect("structured_content set");
-        assert_eq!(sc.get("total"), Some(&serde_json::json!(2)));
+        assert_eq!(sc.get("total"), Some(&json!(2)));
         assert!(sc.get("items").unwrap().is_array());
+        assert!(sc.get("_shape").is_none(), "objects must not be re-wrapped");
     }
 
     #[test]
-    fn ensure_array_text_into_structured_content() {
+    fn array_wraps_into_items_envelope() {
         let mut r = CallToolResult::success(vec![Content::text(
             r#"[{"a":1},{"a":2},{"a":3}]"#.to_string(),
         )]);
         ensure_structured_content(&mut r);
-        let sc = r.structured_content.expect("structured_content set");
-        assert!(sc.is_array());
-        assert_eq!(sc.as_array().unwrap().len(), 3);
+        let sc = r.structured_content.expect("set");
+        assert!(sc.is_object(), "array must be wrapped as an object");
+        assert_eq!(sc.get("_shape"), Some(&json!("array")));
+        assert_eq!(sc.get("items").unwrap().as_array().unwrap().len(), 3);
     }
 
     #[test]
-    fn ensure_skips_when_already_set() {
+    fn skips_when_already_set() {
         let mut r = CallToolResult::success(vec![Content::text(r#"{"a":1}"#.to_string())]);
-        r.structured_content = Some(serde_json::json!({"existing": true}));
+        r.structured_content = Some(json!({"existing": true}));
         ensure_structured_content(&mut r);
-        assert_eq!(
-            r.structured_content,
-            Some(serde_json::json!({"existing": true}))
-        );
+        assert_eq!(r.structured_content, Some(json!({"existing": true})));
     }
 
     #[test]
-    fn ensure_falls_back_to_value_string_for_non_json_text() {
-        let mut r = CallToolResult::success(vec![Content::text(
-            "NAME    READY   STATUS\nfoo     1/1     Running\n".to_string(),
-        )]);
+    fn non_json_text_wraps_as_string_envelope() {
+        let raw = "NAME    READY   STATUS\nfoo     1/1     Running\n".to_string();
+        let mut r = CallToolResult::success(vec![Content::text(raw.clone())]);
         ensure_structured_content(&mut r);
         let sc = r.structured_content.expect("set");
-        assert_eq!(
-            sc,
-            Value::String("NAME    READY   STATUS\nfoo     1/1     Running\n".to_string())
-        );
+        assert_eq!(sc.get("_shape"), Some(&json!("string")));
+        assert_eq!(sc.get("value"), Some(&Value::String(raw)));
     }
 
     #[test]
-    fn ensure_falls_back_to_value_string_for_scalar_json() {
-        // JSON scalars like `42` or `"foo"` are valid JSON but not "structured" —
-        // wrap them as Value::String so the walker has a uniform input.
-        let mut r = CallToolResult::success(vec![Content::text("42".to_string())]);
-        ensure_structured_content(&mut r);
-        assert_eq!(r.structured_content, Some(Value::String("42".to_string())));
-
+    fn json_string_scalar_wraps_unquoted() {
         let mut r = CallToolResult::success(vec![Content::text(r#""just a string""#.to_string())]);
         ensure_structured_content(&mut r);
-        assert_eq!(
-            r.structured_content,
-            Some(Value::String(r#""just a string""#.to_string()))
-        );
+        let sc = r.structured_content.expect("set");
+        assert_eq!(sc.get("_shape"), Some(&json!("string")));
+        assert_eq!(sc.get("value"), Some(&json!("just a string")));
     }
 
     #[test]
-    fn ensure_falls_back_for_truncated_or_invalid_json() {
-        let mut r = CallToolResult::success(vec![Content::text(r#"{"a": 1, "b":"#.to_string())]);
+    fn json_number_wraps_as_number_envelope() {
+        let mut r = CallToolResult::success(vec![Content::text("42".to_string())]);
         ensure_structured_content(&mut r);
-        assert_eq!(
-            r.structured_content,
-            Some(Value::String(r#"{"a": 1, "b":"#.to_string()))
-        );
+        let sc = r.structured_content.expect("set");
+        assert_eq!(sc.get("_shape"), Some(&json!("number")));
+        assert_eq!(sc.get("value"), Some(&json!(42)));
     }
 
     #[test]
-    fn ensure_parses_with_leading_whitespace() {
+    fn json_bool_wraps_as_boolean_envelope() {
+        let mut r = CallToolResult::success(vec![Content::text("true".to_string())]);
+        ensure_structured_content(&mut r);
+        let sc = r.structured_content.expect("set");
+        assert_eq!(sc.get("_shape"), Some(&json!("boolean")));
+        assert_eq!(sc.get("value"), Some(&json!(true)));
+    }
+
+    #[test]
+    fn json_null_wraps_as_null_envelope() {
+        let mut r = CallToolResult::success(vec![Content::text("null".to_string())]);
+        ensure_structured_content(&mut r);
+        let sc = r.structured_content.expect("set");
+        assert_eq!(sc.get("_shape"), Some(&json!("null")));
+        assert_eq!(sc.get("value"), Some(&Value::Null));
+    }
+
+    #[test]
+    fn truncated_or_invalid_json_falls_back_to_raw_string() {
+        let raw = r#"{"a": 1, "b":"#.to_string();
+        let mut r = CallToolResult::success(vec![Content::text(raw.clone())]);
+        ensure_structured_content(&mut r);
+        let sc = r.structured_content.expect("set");
+        assert_eq!(sc.get("_shape"), Some(&json!("string")));
+        assert_eq!(sc.get("value"), Some(&Value::String(raw)));
+    }
+
+    #[test]
+    fn parses_with_leading_whitespace() {
         let mut r = CallToolResult::success(vec![Content::text("  \n\t  [1,2,3]\n".to_string())]);
         ensure_structured_content(&mut r);
-        assert!(r.structured_content.unwrap().is_array());
+        let sc = r.structured_content.expect("set");
+        assert_eq!(sc.get("_shape"), Some(&json!("array")));
+        assert_eq!(sc.get("items").unwrap().as_array().unwrap().len(), 3);
     }
 
     #[test]
-    fn ensure_falls_back_to_empty_string_when_no_text() {
+    fn empty_content_wraps_empty_string() {
         let mut r = CallToolResult::success(vec![]);
         ensure_structured_content(&mut r);
-        assert_eq!(r.structured_content, Some(Value::String(String::new())));
+        let sc = r.structured_content.expect("set");
+        assert_eq!(sc.get("_shape"), Some(&json!("string")));
+        assert_eq!(sc.get("value"), Some(&json!("")));
+    }
+
+    #[test]
+    fn reify_helper_directly_records() {
+        assert_eq!(reify(r#"{"k":1}"#.to_string()), json!({"k":1}));
+        assert_eq!(
+            reify("[1,2]".to_string()),
+            json!({"items":[1,2],"_shape":"array"})
+        );
+        assert_eq!(
+            reify("42".to_string()),
+            json!({"value":42,"_shape":"number"})
+        );
+        assert_eq!(
+            reify("true".to_string()),
+            json!({"value":true,"_shape":"boolean"})
+        );
+        assert_eq!(
+            reify("null".to_string()),
+            json!({"value":null,"_shape":"null"})
+        );
+        assert_eq!(
+            reify(r#""hi""#.to_string()),
+            json!({"value":"hi","_shape":"string"}),
+        );
+        assert_eq!(
+            reify("kubectl table".to_string()),
+            json!({"value":"kubectl table","_shape":"string"}),
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Wrap non-object JSON parses (string / array / number / bool / null / non-JSON text) into a record envelope inside `reify` — the chokepoint where every dispatch path stores `structured_content`.
- Records pass through untouched; pre-set `structured_content` is left alone.
- Restores the MCP wrapper's record invariant for the cache, all `_recover` templates, and every upstream that returns a non-object body.

## Why P0
Empirical testing against prod drua MCP (memory `019e1142` + extension `019e1147`) showed `structuredContent`-must-be-a-record validation rejecting:
- `code_assistant_search_code`, `honeycomb_*`, `github_get_file_contents`, `k8s_*`, `galoy_staging_kubernetes_*`, `lingo_organizations_listEngines`, `pg_*search_objects` error returns, small `github_list_branches` / `github_list_pull_requests` — every upstream that returns a string / array / scalar at the top level.
- All `tool_output_fetch` text-body slice modes (`tail`, `head`, `range`, `grep`) — slice output is always a string.
- `tool_output_fetch json_path` to any non-object value, `tool_output_fetch json_array_slice` always.
- The `_recover` templates the gateway itself emits — every string-elision recover (`range` on `$X.body`) and every array-elision recover (`json_array_slice`) lands in the wrapper-rejected shapes.

## Envelope shape
```
array  -> {items: [...], _shape: "array"}
string -> {value: "...", _shape: "string"}
number -> {value: N,    _shape: "number"}
bool   -> {value: B,    _shape: "boolean"}
null   -> {value: null, _shape: "null"}
object -> unchanged
```

## Why fix in `reify`, not at the gateway boundary
- Single source of truth: every downstream consumer (walker, classifier, query layer, recovery template generator, gateway emission) sees a record uniformly. No second wrapping logic anywhere.
- Cache stays consistent: persisted `structured_content` is always a record, no migration needed.
- `_recover` templates round-trip cleanly: queries that resolve to non-objects pass through reify on the way out, get the same envelope, satisfy the wrapper.

## Out of scope (deferred)
The larger consistency rework — downstream consumers using `_shape` as a typed witness — is intentionally deferred to a follow-up PR. This commit is reify-only.

## Test plan
- [x] Unit tests inline in `reify.rs` — every shape (object passthrough, array, string, number, bool, null, non-JSON, truncated JSON, leading whitespace, empty, already-set passthrough) and a direct `reify()` helper test. 12 tests, all green.
- [x] `cargo test -p drua-tool-classifier` (94 tests, all green) — walker / concourse / string_summarizer all consume the new envelope without breakage.
- [x] `cargo test --workspace --lib` (all green).
- [x] `cargo test --workspace` (all green when serialized; the only failures observed were pre-existing concurrency races on a shared `/tmp/.../library-52598/repo/` git path, repro'd identically without this change and resolved by `--test-threads=1`).
- [x] `cargo fmt --check`.
- [x] `cargo clippy --workspace --all-targets -- -D warnings`.
- [x] `nix flake check --no-build`.
- [ ] After merge + prod rollout: re-run the empirical matrix against drua prod and confirm wrapper-record errors are gone for the affected upstreams (k8s string outputs, lingo arrays, code_assistant, honeycomb, github file contents, all `tool_output_fetch` slice modes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the runtime shape of `structured_content` for any tool output that isn’t a JSON object, which may affect downstream consumers that previously expected arrays/strings/scalars at the top level. Mitigated by explicit `_shape` tagging and comprehensive unit tests covering all wrapped cases.
> 
> **Overview**
> Makes `tool-classifier` always emit record-shaped `structured_content` by introducing `reify()` and wrapping arrays/scalars/non-JSON text into `{value|items, _shape}` envelopes while leaving JSON objects and pre-set `structured_content` unchanged.
> 
> Updates and expands unit tests to validate pass-through for objects and correct wrapping behavior for arrays, strings, numbers, booleans, null, invalid/truncated JSON, whitespace, and empty outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d03423fcbe6e76da6c74c20e09990c076805749. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->