### PR TITLE
fix(toolset): wrap non-object slice results in tool_output_fetch (P0 follow-up)

### DIFF
--- a/core/crates/tool-classifier/src/lib.rs
+++ b/core/crates/tool-classifier/src/lib.rs
@@ -15,7 +15,7 @@ mod terraform_install;
 mod terraform_state;
 mod walker;
 
-pub use reify::ensure_structured_content;
+pub use reify::{ensure_structured_content, wrap_non_record};
 
 pub use bash::BashClassifier;
 pub use cargo::{CargoCheckRun, CargoCompileRun, CargoDownloadRun};

--- a/core/crates/tool-classifier/src/reify.rs
+++ b/core/crates/tool-classifier/src/reify.rs
@@ -44,13 +44,24 @@ pub fn reify(text: String) -> Value {
         return wrap_string(text);
     }
     match serde_json::from_str::<Value>(text.trim()) {
-        Ok(Value::Object(obj)) => Value::Object(obj),
-        Ok(Value::Array(items)) => json!({ "items": items, "_shape": "array" }),
-        Ok(Value::String(s)) => json!({ "value": s, "_shape": "string" }),
-        Ok(Value::Number(n)) => json!({ "value": n, "_shape": "number" }),
-        Ok(Value::Bool(b)) => json!({ "value": b, "_shape": "boolean" }),
-        Ok(Value::Null) => json!({ "value": null, "_shape": "null" }),
+        Ok(v) => wrap_non_record(v),
         Err(_) => wrap_string(text),
+    }
+}
+
+/// Wrap a `Value` so the result is always a JSON object.
+///
+/// Mirror of [`reify`] for the case where the caller already has a
+/// parsed `Value` (e.g. `tool_output_fetch` slice/json-mode outputs).
+/// Objects pass through unchanged so the function is idempotent.
+pub fn wrap_non_record(v: Value) -> Value {
+    match v {
+        Value::Object(_) => v,
+        Value::Array(items) => json!({ "items": items, "_shape": "array" }),
+        Value::String(s) => json!({ "value": s, "_shape": "string" }),
+        Value::Number(n) => json!({ "value": n, "_shape": "number" }),
+        Value::Bool(b) => json!({ "value": b, "_shape": "boolean" }),
+        Value::Null => json!({ "value": null, "_shape": "null" }),
     }
 }
 
@@ -180,6 +191,44 @@ mod tests {
         let sc = r.structured_content.expect("set");
         assert_eq!(sc.get("_shape"), Some(&json!("string")));
         assert_eq!(sc.get("value"), Some(&json!("")));
+    }
+
+    #[test]
+    fn wrap_non_record_object_passes_through() {
+        let v = json!({"k": 1});
+        assert_eq!(wrap_non_record(v.clone()), v);
+    }
+
+    #[test]
+    fn wrap_non_record_array_string_number_bool_null() {
+        assert_eq!(
+            wrap_non_record(json!([1, 2, 3])),
+            json!({"items":[1,2,3],"_shape":"array"})
+        );
+        assert_eq!(
+            wrap_non_record(json!("hello")),
+            json!({"value":"hello","_shape":"string"})
+        );
+        assert_eq!(
+            wrap_non_record(json!(7)),
+            json!({"value":7,"_shape":"number"})
+        );
+        assert_eq!(
+            wrap_non_record(json!(false)),
+            json!({"value":false,"_shape":"boolean"})
+        );
+        assert_eq!(
+            wrap_non_record(json!(null)),
+            json!({"value":null,"_shape":"null"})
+        );
+    }
+
+    #[test]
+    fn wrap_non_record_is_idempotent_on_envelopes() {
+        let env = json!({"value":"x","_shape":"string"});
+        assert_eq!(wrap_non_record(env.clone()), env);
+        let arr_env = json!({"items":[1,2],"_shape":"array"});
+        assert_eq!(wrap_non_record(arr_env.clone()), arr_env);
     }
 
     #[test]

--- a/core/src/toolset/top_level/tool_output_fetch.rs
+++ b/core/src/toolset/top_level/tool_output_fetch.rs
@@ -186,19 +186,21 @@ impl TopLevelTool for ToolOutputFetch {
 
         // Any `query` (text or json) overrides structured_content with the
         // slice. JSON modes carry a real Value override; text modes (tail/
-        // head/range/grep) become Value::String of the sliced text. This
-        // closes the compose-vs-direct gap: compose's `result_to_value`
-        // reads structured first, so without this generalization text-mode
-        // slices were invisible to JS.
+        // head/range/grep) become Value::String of the sliced text. The
+        // wrap step (`wrap_non_record`) lifts non-object slice results into
+        // the same `{value|items, _shape}` envelope reify uses on the input
+        // side, so the MCP transport's record-only `structuredContent`
+        // contract holds for every recovery template the gateway emits.
+        // Objects pass through unchanged.
         //
         // Without `query`, structured_content reflects the requested view
-        // (full original / typed summary).
+        // (full original / typed summary) — already a record post-reify.
         let final_structured = match &query_outcome {
-            Some(r) => Some(
+            Some(r) => Some(drua_tool_classifier::wrap_non_record(
                 r.structured
                     .clone()
                     .unwrap_or_else(|| serde_json::Value::String(r.content.clone())),
-            ),
+            )),
             None => view_structured,
         };
 

--- a/core/tests/tool_output_fetch_slice_emission.rs
+++ b/core/tests/tool_output_fetch_slice_emission.rs
@@ -1,0 +1,265 @@
+//! Integration tests for `tool_output_fetch` slice/json-mode emission.
+//!
+//! Locks in the contract that every `tool_output_fetch` query result lands in
+//! `structured_content` as a JSON object — never a raw string, array, number,
+//! bool, or null. Without this the MCP transport's record-only
+//! `structuredContent` validation rejects the response and the
+//! gateway-emitted `_recover` templates round-trip-fail.
+
+use std::sync::Arc;
+
+use rmcp::model::{CallToolResult, JsonObject};
+use serde_json::json;
+
+use drua_core::audit::Audit;
+use drua_core::auth::AuthSubject;
+use drua_core::primitives::UserId;
+use drua_core::toolset::{ToolInvocations, ToolSets, ToolSetsConfig};
+use drua_tool_cache::{InvocationOwner, NewToolInvocation, ToolInvocationId};
+
+const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
+
+async fn pool() -> sqlx::PgPool {
+    let url = std::env::var("DATABASE_URL").unwrap_or_else(|_| PG_CON.to_string());
+    sqlx::PgPool::connect(&url).await.expect("connect to pg")
+}
+
+async fn build(pool: &sqlx::PgPool) -> (ToolSets, Arc<ToolInvocations>) {
+    let audit = Arc::new(Audit::new(pool));
+    let invocations = Arc::new(ToolInvocations::new(pool));
+    let toolsets = ToolSets::init(
+        ToolSetsConfig::default(),
+        Some(Arc::clone(&audit)),
+        None,
+        Some(Arc::clone(&invocations)),
+    )
+    .await
+    .expect("init toolsets");
+    (toolsets, invocations)
+}
+
+async fn insert_user(pool: &sqlx::PgPool) -> UserId {
+    let id = UserId::new();
+    let github_id = format!("slice-emit-{}", uuid::Uuid::from(id));
+    sqlx::query("INSERT INTO users (id, github_id, created_at) VALUES ($1, $2, NOW())")
+        .bind(id)
+        .bind(&github_id)
+        .execute(pool)
+        .await
+        .expect("insert user");
+    id
+}
+
+/// Seed an invocation directly via the persistence layer so the test focuses
+/// on `tool_output_fetch` emission, not on full upstream dispatch. Payload is
+/// `{items:[...], logs:"..."}` — wide enough to exercise array, object,
+/// string field, and raw-text grep paths.
+async fn seed_wide(invocations: &ToolInvocations, owner: InvocationOwner) -> ToolInvocationId {
+    let items: Vec<_> = (0..200).map(|i| json!({ "id": i, "tag": "x" })).collect();
+    let logs = (0..200)
+        .map(|i| format!("[line-{i:04}] kube-proxy event"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let payload = json!({ "items": items, "logs": logs });
+    let raw_text = serde_json::to_string(&payload).unwrap();
+    let raw_size_bytes = raw_text.len() as i64;
+
+    let new = NewToolInvocation {
+        owner,
+        tool_name: "stub_wide".to_string(),
+        args: json!({}),
+        args_hash: vec![1, 2, 3, 4],
+        classifier: "passthrough".to_string(),
+        summary: json!({"kind": "passthrough", "value": payload.clone()}),
+        raw_text,
+        raw_size_bytes,
+        original_structured: Some(payload),
+        exit_code: None,
+        duration_ms: 1,
+        started_at: chrono::Utc::now(),
+    };
+    let persisted = invocations.persist(new).await.expect("seed persist");
+    persisted.id
+}
+
+fn fetch_args(invocation_id: ToolInvocationId, query: serde_json::Value) -> Option<JsonObject> {
+    let mut args = JsonObject::new();
+    args.insert(
+        "invocation_id".to_string(),
+        json!(uuid::Uuid::from(invocation_id).to_string()),
+    );
+    args.insert("query".to_string(), query);
+    Some(args)
+}
+
+fn structured(result: &CallToolResult) -> &serde_json::Value {
+    result
+        .structured_content
+        .as_ref()
+        .expect("tool_output_fetch always emits structured_content")
+}
+
+#[tokio::test]
+async fn json_array_slice_wraps_array_in_items_envelope() {
+    let pool = pool().await;
+    let (toolsets, invocations) = build(&pool).await;
+    let user_id = insert_user(&pool).await;
+    let subject = AuthSubject::User(user_id);
+    let id = seed_wide(&invocations, InvocationOwner::user(user_id)).await;
+
+    let result = toolsets
+        .call_top_level_tool(
+            &subject,
+            "tool_output_fetch",
+            fetch_args(
+                id,
+                json!({"mode":"json_array_slice","path":"$.items","offset":1,"len":2}),
+            ),
+        )
+        .await
+        .expect("dispatch");
+
+    let sc = structured(&result);
+    assert!(sc.is_object(), "json_array_slice must wrap into an object");
+    assert_eq!(sc.get("_shape"), Some(&json!("array")));
+    let items = sc.get("items").and_then(|v| v.as_array()).expect("items");
+    assert_eq!(items.len(), 2);
+    assert_eq!(items[0].get("id"), Some(&json!(1)));
+    assert_eq!(items[1].get("id"), Some(&json!(2)));
+}
+
+#[tokio::test]
+async fn json_path_to_array_wraps_in_items_envelope() {
+    let pool = pool().await;
+    let (toolsets, invocations) = build(&pool).await;
+    let user_id = insert_user(&pool).await;
+    let subject = AuthSubject::User(user_id);
+    let id = seed_wide(&invocations, InvocationOwner::user(user_id)).await;
+
+    let result = toolsets
+        .call_top_level_tool(
+            &subject,
+            "tool_output_fetch",
+            fetch_args(id, json!({"mode":"json_path","path":"$.items"})),
+        )
+        .await
+        .expect("dispatch");
+
+    let sc = structured(&result);
+    assert!(sc.is_object(), "json_path → array must wrap into an object");
+    assert_eq!(sc.get("_shape"), Some(&json!("array")));
+    assert_eq!(
+        sc.get("items").and_then(|v| v.as_array()).map(Vec::len),
+        Some(200)
+    );
+}
+
+#[tokio::test]
+async fn json_path_to_string_wraps_in_value_envelope() {
+    let pool = pool().await;
+    let (toolsets, invocations) = build(&pool).await;
+    let user_id = insert_user(&pool).await;
+    let subject = AuthSubject::User(user_id);
+    let id = seed_wide(&invocations, InvocationOwner::user(user_id)).await;
+
+    let result = toolsets
+        .call_top_level_tool(
+            &subject,
+            "tool_output_fetch",
+            fetch_args(id, json!({"mode":"json_path","path":"$.items[0].tag"})),
+        )
+        .await
+        .expect("dispatch");
+
+    let sc = structured(&result);
+    assert!(
+        sc.is_object(),
+        "json_path → string must wrap into an object"
+    );
+    assert_eq!(sc.get("_shape"), Some(&json!("string")));
+    assert_eq!(sc.get("value"), Some(&json!("x")));
+}
+
+#[tokio::test]
+async fn json_path_to_object_passes_through_unchanged() {
+    let pool = pool().await;
+    let (toolsets, invocations) = build(&pool).await;
+    let user_id = insert_user(&pool).await;
+    let subject = AuthSubject::User(user_id);
+    let id = seed_wide(&invocations, InvocationOwner::user(user_id)).await;
+
+    let result = toolsets
+        .call_top_level_tool(
+            &subject,
+            "tool_output_fetch",
+            fetch_args(id, json!({"mode":"json_path","path":"$.items[0]"})),
+        )
+        .await
+        .expect("dispatch");
+
+    let sc = structured(&result);
+    assert!(sc.is_object(), "json_path → object must remain an object");
+    assert_eq!(sc.get("id"), Some(&json!(0)));
+    assert_eq!(sc.get("tag"), Some(&json!("x")));
+    assert!(
+        sc.get("_shape").is_none(),
+        "object passthrough must not be re-wrapped",
+    );
+}
+
+#[tokio::test]
+async fn grep_text_slice_wraps_in_value_envelope() {
+    let pool = pool().await;
+    let (toolsets, invocations) = build(&pool).await;
+    let user_id = insert_user(&pool).await;
+    let subject = AuthSubject::User(user_id);
+    let id = seed_wide(&invocations, InvocationOwner::user(user_id)).await;
+
+    let result = toolsets
+        .call_top_level_tool(
+            &subject,
+            "tool_output_fetch",
+            fetch_args(
+                id,
+                json!({"mode":"grep","pattern":"line-0001","-n":true,"path":"$.logs"}),
+            ),
+        )
+        .await
+        .expect("dispatch");
+
+    let sc = structured(&result);
+    assert!(sc.is_object(), "grep slice must wrap into an object");
+    assert_eq!(sc.get("_shape"), Some(&json!("string")));
+    let v = sc
+        .get("value")
+        .and_then(|v| v.as_str())
+        .expect("value is a string");
+    assert!(v.contains("line-0001"));
+}
+
+#[tokio::test]
+async fn head_text_slice_wraps_in_value_envelope() {
+    let pool = pool().await;
+    let (toolsets, invocations) = build(&pool).await;
+    let user_id = insert_user(&pool).await;
+    let subject = AuthSubject::User(user_id);
+    let id = seed_wide(&invocations, InvocationOwner::user(user_id)).await;
+
+    let result = toolsets
+        .call_top_level_tool(
+            &subject,
+            "tool_output_fetch",
+            fetch_args(id, json!({"mode":"head","lines":3,"path":"$.logs"})),
+        )
+        .await
+        .expect("dispatch");
+
+    let sc = structured(&result);
+    assert!(sc.is_object(), "head slice must wrap into an object");
+    assert_eq!(sc.get("_shape"), Some(&json!("string")));
+    let v = sc
+        .get("value")
+        .and_then(|v| v.as_str())
+        .expect("value is a string");
+    assert!(v.contains("line-0000"));
+}


### PR DESCRIPTION
## Summary
- Companion to #316. That PR closed the cache side of the wrapper-record contract; this one closes the recovery side.
- `tool_output_fetch` slice/json-mode emission previously bypassed reify, so text-mode slices, `json_path` to non-objects, and `json_array_slice` all crashed the MCP transport's record-only `structuredContent` validation.
- New `wrap_non_record(Value) -> Value` helper in the classifier crate, applied at the single emission point in `tool_output_fetch::call`. Object passthrough is idempotent.

## Why now
Empirical re-verification after #316 rolled out (memory `019e1177`) showed every previously-failing regular `call_tool` upstream now passes the wrapper, but every `tool_output_fetch` query mode (head / tail / range / grep / `json_path` to a non-object / `json_array_slice`) **still** failed:
```
[{"expected":"record","code":"invalid_type","path":["structuredContent"],"message":"Invalid input: expected record, received string|array"}]
```
That matters because the literal `_recover.args_template.query` the gateway emits in every `elided_paths[]` entry uses one of those very modes — running the gateway-suggested recovery still produced a wrapper crash.

## Envelope (same as #316)
```
array  -> {items: [...], _shape: "array"}
string -> {value: "...", _shape: "string"}
number -> {value: N,    _shape: "number"}
bool   -> {value: B,    _shape: "boolean"}
null   -> {value: null, _shape: "null"}
object -> unchanged
```

`wrap_non_record` is idempotent on objects, so cached values that already came through reify (i.e. anything written post-#316) round-trip without double-wrapping.

## Diff
- `core/crates/tool-classifier/src/reify.rs` — extract the `Value` arm of `reify()` into a public `wrap_non_record(Value) -> Value`; `reify(text)` now calls it after parsing. Three new unit tests (object passthrough, every scalar/array shape, idempotence on envelopes).
- `core/crates/tool-classifier/src/lib.rs` — re-export `wrap_non_record`.
- `core/src/toolset/top_level/tool_output_fetch.rs` — apply `wrap_non_record` to the merged slice value before placing into `structured_content`. Eight-line change in `call()`; comment explains the contract.
- `core/tests/tool_output_fetch_slice_emission.rs` — new integration suite (6 `tokio::test`s) seeded directly via `ToolInvocations::persist`, exercising `json_array_slice`, `json_path` to array/string/object, `grep`, and `head`. Each asserts the response's `structured_content` is an object with the right `_shape` (or no `_shape` for object passthrough).

## Test plan
- [x] `cargo test -p drua-tool-classifier` (97 tests, all green) — covers the new `wrap_non_record` cases and re-runs the existing reify suite.
- [x] `cargo test -p drua-core --test tool_output_fetch_slice_emission -- --test-threads=1` (6 tests, all green).
- [x] `cargo test --workspace --lib` (all green).
- [x] `cargo test -p drua-core --tests -- --test-threads=1` (all green; pre-existing graphql tests are flaky in parallel only — not touched here).
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `nix flake check --no-build`.
- [ ] After merge + prod rollout: re-run the empirical matrix from `019e1177`'s "tool_output_fetch — partial fix only" table and confirm every row flips to ✅, including the literal `_recover.args_template.query` from a fresh elided invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)