### PR TITLE
chore: Remove Lingo MCP upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ A complete `.env.example` is provided at the repo root.
 | `CONCOURSE_USERNAME` | No | — | Concourse CI basic-auth username (when concourse toolset is enabled). |
 | `CONCOURSE_PASSWORD` | No | — | Concourse CI basic-auth password. |
 | `ZENDUTY_API_TOKEN` | No | — | Zenduty API token (sent as `Authorization: Token <token>`). Required when the zenduty toolset is enabled. |
-| `{UPSTREAM}_AUTH_HEADER` | No | — | Auth header for each MCP upstream. Name is uppercased from the config, e.g. `HONEYCOMB_AUTH_HEADER`, `GITHUB_AUTH_HEADER`, `LINGO_AUTH_HEADER`. |
+| `{UPSTREAM}_AUTH_HEADER` | No | — | Auth header for each MCP upstream. Name is uppercased from the config, e.g. `HONEYCOMB_AUTH_HEADER`, `GITHUB_AUTH_HEADER`. |
 | `GITHUB_APP_PRIVATE_KEY_PATH` | No | — | Filesystem path to the GitHub App PEM private key (for sandbox token auto-provisioning). Requires `github_app` section in config. |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | No | `http://localhost:4317` | OpenTelemetry OTLP gRPC endpoint. |
 | `OTEL_SDK_DISABLED` | No | `false` | Set to `true` to disable OpenTelemetry tracing entirely. |
@@ -207,4 +207,3 @@ charts/         Helm chart for Kubernetes deployment
 | `make build-sandbox` | Build only the sandbox tool server |
 | `make sqlx-prepare` | Regenerate SQLx offline query data |
 | `make start` | Full reset: `reset-deps` then server with dev login |
-

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -177,11 +177,6 @@ galoyAgents:
     #     - actions_list
     #     - actions_get
     #     - get_job_logs
-    # - name: lingo
-    #   url: https://mcp.lingo.dev/account
-    #   authHeaderName: x-api-key
-    #   category: localization
-    #   categoryDescription: "AI-powered localization engine management and translation"
     ## GitHub App configuration for token auto-provisioning.
     ## When enabled, sandbox agents receive a `github-token` file secret.
     ## The PEM private key is read from the main drua secret (key: github-app-private-key).

--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -19,9 +19,6 @@ variable "honeycomb_api_key" {
 variable "github_pat" {
   default = ""
 }
-variable "lingo_api_key" {
-  default = ""
-}
 variable "anthropic_api_key" {
   default = ""
 }
@@ -111,7 +108,6 @@ resource "kubernetes_secret" "galoy_agents" {
     "github-auth-header"                  = var.github_pat != "" ? "Bearer ${var.github_pat}" : ""
     "github_actions-auth-header"          = var.github_pat != "" ? "Bearer ${var.github_pat}" : ""
     "github_pull_requests-auth-header"    = var.github_pat != "" ? "Bearer ${var.github_pat}" : ""
-    "lingo-auth-header"          = var.lingo_api_key
     "anthropic-api-key"          = var.anthropic_api_key
     "openai-api-key"             = var.openrouter_api_key
     "zenduty-api-token"          = var.zenduty_api_token

--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -99,19 +99,19 @@ resource "kubernetes_secret" "galoy_agents" {
     # Read-only DSN for the postgres-mcp sidecar. `?sslmode=require` is
     # required — Cloud SQL's pg_hba.conf rejects unencrypted connections
     # and dbhub crash-loops without it.
-    "pg-mcp-uri"                 = "postgres://${module.postgresql.creds["galoy-agents"].readonly_users["mcp"].user}:${module.postgresql.creds["galoy-agents"].readonly_users["mcp"].password}@${module.postgresql.creds["galoy-agents"].host}:5432/galoy-agents?sslmode=require"
-    "github-client-secret"       = var.github_client_secret
-    "gcs-creds"                  = file("${path.module}/gcs-creds.json")
-    "concourse-username"         = var.concourse_username
-    "concourse-password"         = var.concourse_password
-    "honeycomb-auth-header"               = var.honeycomb_api_key != "" ? "Bearer ${var.honeycomb_api_key}" : ""
-    "github-auth-header"                  = var.github_pat != "" ? "Bearer ${var.github_pat}" : ""
-    "github_actions-auth-header"          = var.github_pat != "" ? "Bearer ${var.github_pat}" : ""
-    "github_pull_requests-auth-header"    = var.github_pat != "" ? "Bearer ${var.github_pat}" : ""
-    "anthropic-api-key"          = var.anthropic_api_key
-    "openai-api-key"             = var.openrouter_api_key
-    "zenduty-api-token"          = var.zenduty_api_token
-    "github-app-private-key"     = local.github_app_private_key
+    "pg-mcp-uri"                       = "postgres://${module.postgresql.creds["galoy-agents"].readonly_users["mcp"].user}:${module.postgresql.creds["galoy-agents"].readonly_users["mcp"].password}@${module.postgresql.creds["galoy-agents"].host}:5432/galoy-agents?sslmode=require"
+    "github-client-secret"             = var.github_client_secret
+    "gcs-creds"                        = file("${path.module}/gcs-creds.json")
+    "concourse-username"               = var.concourse_username
+    "concourse-password"               = var.concourse_password
+    "honeycomb-auth-header"            = var.honeycomb_api_key != "" ? "Bearer ${var.honeycomb_api_key}" : ""
+    "github-auth-header"               = var.github_pat != "" ? "Bearer ${var.github_pat}" : ""
+    "github_actions-auth-header"       = var.github_pat != "" ? "Bearer ${var.github_pat}" : ""
+    "github_pull_requests-auth-header" = var.github_pat != "" ? "Bearer ${var.github_pat}" : ""
+    "anthropic-api-key"                = var.anthropic_api_key
+    "openai-api-key"                   = var.openrouter_api_key
+    "zenduty-api-token"                = var.zenduty_api_token
+    "github-app-private-key"           = local.github_app_private_key
   }
 
   depends_on = [kubernetes_namespace.galoy_agents]

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -110,11 +110,6 @@ galoyAgents:
         internalOnly: true
         allowedTools:
           - create_pull_request
-      - name: lingo
-        url: https://mcp.lingo.dev/account
-        authHeaderName: x-api-key
-        category: localization
-        categoryDescription: "AI-powered localization engine management and translation"
   postgresMcp:
     enabled: true
     databaseUrlSecret:

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -159,7 +159,6 @@ jobs:
         LANA_BANK_CACHIX_PUBLIC_KEY: #@ data.values.deploy_lana_bank_cachix_public_key
         HONEYCOMB_API_KEY: #@ data.values.honeycomb_api_key
         GITHUB_PAT: #@ data.values.github_pat
-        LINGO_API_KEY: #@ data.values.lingo_api_key
         ZENDUTY_API_TOKEN: #@ data.values.zenduty_api_token
         ANTHROPIC_API_KEY: #@ data.values.deploy_anthropic_api_key
         OPENROUTER_API_KEY: #@ data.values.deploy_openrouter_api_key
@@ -215,7 +214,6 @@ jobs:
             lana_bank_cachix_public_key = "${LANA_BANK_CACHIX_PUBLIC_KEY}"
             honeycomb_api_key = "${HONEYCOMB_API_KEY}"
             github_pat = "${GITHUB_PAT}"
-            lingo_api_key = "${LINGO_API_KEY}"
             zenduty_api_token = "${ZENDUTY_API_TOKEN}"
             anthropic_api_key = "${ANTHROPIC_API_KEY}"
             openrouter_api_key = "${OPENROUTER_API_KEY}"

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -31,7 +31,6 @@ deploy_lana_bank_cachix_auth_token: ((lana-bank-cachix-token.token))
 deploy_lana_bank_cachix_public_key: ""
 honeycomb_api_key: ((mcp-upstream.honeycomb_api_key))
 github_pat: ((mcp-upstream.github_pat))
-lingo_api_key: ((mcp-upstream.lingo_dev_api_key))
 zenduty_api_token: ((zenduty.api_key))
 deploy_anthropic_api_key: ((anthropic-api-key.key))
 deploy_openrouter_api_key: ((openrouter-api-key.key))

--- a/drua.yml
+++ b/drua.yml
@@ -132,8 +132,3 @@ toolsets:
       # and we don't want any agent flow ever discovering it.
       allowed_tools:
         - create_pull_request
-    - name: lingo
-      url: https://mcp.lingo.dev/account
-      auth_header_name: x-api-key
-      category: localization
-      category_description: "AI-powered localization engine management and translation"


### PR DESCRIPTION
## Summary
- remove Lingo from the default and prod MCP upstream lists
- remove Lingo API key plumbing from Concourse/Terraform deployment config
- update the README upstream auth-header example
- format the deploy Terraform with OpenTofu

## Validation
- rg "lingo|Lingo|LINGO" .
- ytt -f ci/values.yml -f ci/pipeline.yml -f ci/fragments.lib.yml
- helm template drua charts/drua --set global.security.allowInsecureImages=true
- tofu fmt -check -diff
- tofu init -backend=false
- tofu validate attempted, but this local checkout lacks deploy-time files read by Terraform: gcs-creds.json, chart/vendor/agent-sandbox/manifest.yaml, and chart/vendor/agent-sandbox/extensions.yaml
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes an unused MCP upstream and associated deployment secrets/variables; primary impact is that Lingo tools will no longer be available in dev/prod configs if anyone relied on them.
> 
> **Overview**
> Removes the Lingo MCP upstream from the default/dev `drua.yml`, the Helm chart example upstream list, and the production values template.
> 
> Cleans up deployment plumbing by dropping the `LINGO_API_KEY`/`lingo_api_key` variables from Concourse pipeline/values and Terraform secret wiring, and updates the README auth-header example accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da70de05121ab64d7207971a0ff1531e14c249f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->