### PR TITLE
fix: MCP typed output schema mismatch

### DIFF
--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -536,8 +536,7 @@ impl ToolSets {
                 "arguments": args_value,
             }));
 
-            let bypass_pipeline =
-                tool.bypass_universal_pipeline() || invocation_owner(subject).is_none();
+            let bypass_pipeline = should_bypass_universal_pipeline(tool.as_ref(), subject);
             let start = std::time::Instant::now();
             let raw_result = tool.call(subject, arguments).await.map(|mut raw| {
                 if !bypass_pipeline {
@@ -641,6 +640,12 @@ pub fn estimate_tokens(result: &CallToolResult) -> u64 {
         })
         .sum();
     (total_chars / 4).max(1) as u64
+}
+
+fn should_bypass_universal_pipeline(tool: &dyn TopLevelTool, subject: &AuthSubject) -> bool {
+    tool.bypass_universal_pipeline()
+        || tool.output_schema().is_some()
+        || invocation_owner(subject).is_none()
 }
 
 pub(crate) fn estimate_text_bytes(result: &CallToolResult) -> u64 {
@@ -1055,6 +1060,38 @@ mod tests {
         ) -> Result<CallToolResult, ToolSetsError> {
             unreachable!("stub tool not invoked in find_for_workflow tests")
         }
+    }
+
+    #[test]
+    fn typed_output_tools_bypass_universal_pipeline() {
+        let tool = StubTopLevelTool::new("typed", true, true);
+        let subject = AuthSubject::User(crate::primitives::UserId::new());
+
+        assert!(
+            should_bypass_universal_pipeline(&tool, &subject),
+            "tools that advertise an MCP output_schema must preserve their structured_content shape"
+        );
+    }
+
+    #[test]
+    fn untyped_user_tools_still_use_universal_pipeline() {
+        let tool = StubTopLevelTool::new("untyped", true, false);
+        let subject = AuthSubject::User(crate::primitives::UserId::new());
+
+        assert!(
+            !should_bypass_universal_pipeline(&tool, &subject),
+            "untyped tools with an invocation owner should still get classify/persist/envelope handling"
+        );
+    }
+
+    #[test]
+    fn unattributed_tools_bypass_universal_pipeline() {
+        let tool = StubTopLevelTool::new("untyped", true, false);
+
+        assert!(
+            should_bypass_universal_pipeline(&tool, &AuthSubject::Anonymous),
+            "subjects without an invocation owner cannot use persisted-output recovery"
+        );
     }
 
     #[test]

--- a/core/src/toolset/traits.rs
+++ b/core/src/toolset/traits.rs
@@ -25,6 +25,11 @@ pub trait TopLevelTool: Send + Sync {
     fn input_schema(&self) -> &serde_json::Value;
 
     /// When present, the tool MUST return `structured_content` in its `CallToolResult`.
+    ///
+    /// Typed-output tools are exempt from the universal classify/persist/envelope
+    /// stage in `ToolSets::call_top_level_tool`: replacing their
+    /// `structured_content` with a recovery envelope would violate the advertised
+    /// MCP `outputSchema` and cause clients/servers to reject the result.
     fn output_schema(&self) -> Option<&serde_json::Value> {
         None
     }

--- a/core/tests/tool_invocations.rs
+++ b/core/tests/tool_invocations.rs
@@ -166,6 +166,7 @@ struct StubTool {
     name: &'static str,
     body: String,
     bypass: bool,
+    has_output_schema: bool,
 }
 
 #[async_trait::async_trait]
@@ -182,6 +183,21 @@ impl TopLevelTool for StubTool {
             serde_json::json!({"type": "object", "properties": {}, "additionalProperties": false})
         })
     }
+    fn output_schema(&self) -> Option<&serde_json::Value> {
+        static OUTPUT: std::sync::OnceLock<serde_json::Value> = std::sync::OnceLock::new();
+        self.has_output_schema.then(|| {
+            OUTPUT.get_or_init(|| {
+                serde_json::json!({
+                    "type": "object",
+                    "properties": {
+                        "value": { "type": "string" }
+                    },
+                    "required": ["value"],
+                    "additionalProperties": false
+                })
+            })
+        })
+    }
     fn bypass_universal_pipeline(&self) -> bool {
         self.bypass
     }
@@ -190,9 +206,11 @@ impl TopLevelTool for StubTool {
         _subject: &AuthSubject,
         _arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
-        Ok(CallToolResult::success(vec![Content::text(
-            self.body.clone(),
-        )]))
+        let mut result = CallToolResult::success(vec![Content::text(self.body.clone())]);
+        if self.has_output_schema {
+            result.structured_content = Some(serde_json::json!({ "value": self.body }));
+        }
+        Ok(result)
     }
 }
 
@@ -219,11 +237,13 @@ async fn bypass_universal_pipeline_skips_classifier_and_persistence() {
         name: "stub-bypass",
         body: body.clone(),
         bypass: true,
+        has_output_schema: false,
     });
     toolsets.register_top_level(StubTool {
         name: "stub-no-bypass",
         body: body.clone(),
         bypass: false,
+        has_output_schema: false,
     });
 
     let agent_subject = AuthSubject::Agent(project_id, agent_id, Vec::new());
@@ -322,6 +342,7 @@ async fn workflow_executor_subject_skips_envelope_to_preserve_structured_output(
         name: "stub-workflow-tool",
         body: body.clone(),
         bypass: false,
+        has_output_schema: false,
     });
 
     let subject = AuthSubject::workflow_executor(
@@ -377,6 +398,7 @@ async fn user_subject_gets_pipeline_wrapping_via_mcp_gateway_path() {
         name: "stub-user-call",
         body: body.clone(),
         bypass: false,
+        has_output_schema: false,
     });
 
     let user_subject = AuthSubject::User(user_id);
@@ -405,6 +427,53 @@ async fn user_subject_gets_pipeline_wrapping_via_mcp_gateway_path() {
         persisted.owner,
         InvocationOwner::user(user_id),
         "user-rooted call must persist with the User owner shape",
+    );
+}
+
+// MCP outputSchema contract: typed tools must preserve their declared
+// structured_content shape even for oversized outputs. They must not be
+// replaced by the persisted-output recovery envelope, because that envelope
+// would not validate against the tool's advertised outputSchema.
+#[tokio::test]
+async fn typed_output_tool_preserves_structured_content_for_oversized_user_call() {
+    let pool = pool().await;
+    let user_id = insert_user(&pool).await;
+
+    let tool_invocations = Arc::new(ToolInvocations::new(&pool));
+    let toolsets = ToolSets::init(
+        ToolSetsConfig::default(),
+        None,
+        None,
+        Some(Arc::clone(&tool_invocations)),
+    )
+    .await
+    .expect("ToolSets::init");
+
+    let body = "typed".repeat(12_000);
+    toolsets.register_top_level(StubTool {
+        name: "stub-typed-user-call",
+        body: body.clone(),
+        bypass: false,
+        has_output_schema: true,
+    });
+
+    let result = toolsets
+        .call_top_level_tool(
+            &AuthSubject::User(user_id),
+            "stub-typed-user-call",
+            None,
+        )
+        .await
+        .expect("typed user-scoped dispatch");
+
+    let structured = result
+        .structured_content
+        .as_ref()
+        .expect("typed tool must return structured_content");
+    assert_eq!(structured, &serde_json::json!({ "value": body }));
+    assert!(
+        structured.get("invocation_id").is_none(),
+        "typed output must not be replaced by a persisted-output recovery envelope"
     );
 }
 


### PR DESCRIPTION
## Summary
- Bypass Drua's tool-result post-processing pipeline for top-level tools that advertise an MCP `outputSchema`.
- Document why typed-output tools must preserve their `structured_content` shape.
- Add unit and integration/e2e coverage for the bypass decision and oversized typed-output behavior.

## Root cause
MCP tools can advertise an `outputSchema`. When they do, the `structuredContent` in the tool response must validate against that schema.

Drua has a generic tool-result post-processing path (called the universal pipeline in code) that is useful for large outputs: it classifies the raw result, may persist the full bytes, and can return a smaller recovery envelope with an invocation id so callers can fetch slices later via `tool_output_fetch`.

That behavior is correct for untyped/free-form outputs, but it breaks tools that have an MCP `outputSchema`. For example:

- `search_tools` advertises output shaped like `{ tools, total }`
- `compose_types` advertises output shaped like `{ declarations, tool_count, not_found }`

For large responses, the post-processing pipeline could replace the tool's original `structured_content` with a recovery/envelope object. That envelope is still structured JSON, but it is a different shape than the advertised MCP schema. MCP clients/servers then reject the call during output validation with errors like:

```text
Structured content does not match the tool's output schema:
data must have required property 'tools'
data must have required property 'total'
```

So the failure mode is not that structured output became plain text; it is that the structured output was replaced by a different structured shape after the tool had already produced a schema-compliant result.

## Fix
Treat `tool.output_schema().is_some()` as an automatic bypass for the post-processing/envelope pipeline:

```rust
fn should_bypass_universal_pipeline(tool: &dyn TopLevelTool, subject: &AuthSubject) -> bool {
    tool.bypass_universal_pipeline()
        || tool.output_schema().is_some()
        || invocation_owner(subject).is_none()
}
```

This preserves the exact `structured_content` returned by typed tools, keeping the MCP response consistent with the advertised `outputSchema`.

## Before / after
Before:

1. `compose_types({ tool_names: ["*"] })` produces `{ declarations, tool_count, not_found }`.
2. Large result enters the generic post-processing pipeline.
3. Pipeline may replace `structured_content` with a recovery envelope.
4. MCP validates the envelope against the original `compose_types` schema.
5. Validation fails because the envelope has the wrong shape.

After:

1. `compose_types({ tool_names: ["*"] })` produces `{ declarations, tool_count, not_found }`.
2. Because the tool declares an output schema, Drua skips the post-processing/envelope pipeline.
3. MCP receives the original schema-compliant `structured_content`.
4. Validation succeeds.

## Tests
Added unit tests for the bypass predicate:

- typed-output tools bypass the universal pipeline
- untyped user-owned tools still use the universal pipeline
- unattributed calls still bypass because there is no invocation owner for persisted recovery

Added an integration/e2e-style regression test in `core/tests/tool_invocations.rs`:

- registers a stub top-level tool with an `output_schema`
- calls it through `ToolSets::call_top_level_tool` as a user-rooted/MCP-gateway-style subject
- uses an oversized output that would normally be eligible for persisted-output wrapping
- asserts the original schema-compliant `structured_content` is preserved and no `invocation_id` recovery envelope is returned

## Tradeoff
Typed-output tools with very large responses will not get the automatic persisted-output recovery envelope. That is intentional: once a tool advertises an MCP `outputSchema`, preserving schema correctness is required for clients to accept the response.

For tools that need the large-output recovery behavior, they should either:

- avoid advertising a strict `outputSchema`, or
- include recovery metadata in their declared schema explicitly.

## Test commands
- `direnv exec . cargo check -p drua-core -p drua-mcp-gateway`
- `direnv exec . cargo test -p drua-core typed_output_tool_preserves_structured_content_for_oversized_user_call -- --nocapture`
