### PR TITLE
fix(toolset): don't wrap return-channel structured_content for non-records

### DIFF
--- a/core/crates/tool-cache/src/lib.rs
+++ b/core/crates/tool-cache/src/lib.rs
@@ -15,22 +15,8 @@ use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 use tracing::instrument;
 
-use drua_tool_classifier::{
-    unwrap_at_owned, wrap_non_record, Classification, ToolResultSummary,
-    RECOVERY_INVOCATION_PLACEHOLDER,
-};
+use drua_tool_classifier::{Classification, ToolResultSummary, RECOVERY_INVOCATION_PLACEHOLDER};
 use repo::ToolInvocationRepo;
-
-/// Reapply the transport-level record wrapping over an unwrapped value
-/// stored at `root_path`. Object roots pass through unchanged; array,
-/// string, and scalar roots get re-enveloped via `wrap_non_record`.
-pub fn wrap_for_transport(value: serde_json::Value, root_path: &str) -> serde_json::Value {
-    if root_path == "$" {
-        value
-    } else {
-        wrap_non_record(value)
-    }
-}
 
 #[derive(Debug, Clone, Deserialize, Serialize, schemars::JsonSchema)]
 #[serde(tag = "mode", rename_all = "snake_case")]
@@ -192,11 +178,6 @@ impl ToolInvocations {
             root_path,
         } = classification;
         let raw_size_bytes = canonical_text.len() as i64;
-        // Storage holds the upstream's *unwrapped* value, not the transport
-        // envelope. The wrapping at `root_path` is reapplied at fetch time
-        // via `wrap_for_transport`. Records pass through; arrays / scalars
-        // are unwrapped here.
-        let original_structured = original_structured.map(|v| unwrap_at_owned(&root_path, v));
 
         let summary_value = match serde_json::to_value(&summary) {
             Ok(v) => v,

--- a/core/crates/tool-cache/src/lib.rs
+++ b/core/crates/tool-cache/src/lib.rs
@@ -245,13 +245,20 @@ impl ToolInvocations {
         duration_ms: u64,
         started_at: chrono::DateTime<chrono::Utc>,
     ) -> Option<(CallToolResult, ToolInvocationId)> {
+        // Storage holds the upstream's canonical value, regardless of which
+        // channel the upstream used. `raw.structured_content` is `None` for
+        // non-record upstreams (the response keeps the text channel clean
+        // for the agent), but we still want `original_structured` populated
+        // for arrays / scalars so json_path / json_array_slice `_recover`
+        // templates the walker emits for those shapes round-trip cleanly.
+        let original_structured = drua_tool_classifier::canonicalize(raw);
         let persisted = self
             .persist_classification(
                 owner,
                 tool_name,
                 args,
                 classification,
-                raw.structured_content.clone(),
+                original_structured,
                 duration_ms,
                 started_at,
             )

--- a/core/crates/tool-classifier/src/lib.rs
+++ b/core/crates/tool-classifier/src/lib.rs
@@ -15,10 +15,7 @@ mod terraform_install;
 mod terraform_state;
 mod walker;
 
-pub use reify::{
-    ensure_structured_content, root_path_of_unwrapped, root_path_of_wrapped, unwrap_at,
-    unwrap_at_owned, wrap_non_record,
-};
+pub use reify::{canonicalize, ensure_structured_content, root_path_of_unwrapped};
 
 pub use bash::BashClassifier;
 pub use cargo::{CargoCheckRun, CargoCompileRun, CargoDownloadRun};
@@ -325,16 +322,17 @@ impl ResultClassifier for GenericFallback {
     }
 
     fn classify(&self, ctx: &ClassifierContext<'_>) -> Result<Classification, ClassifierError> {
-        let wrapped = canonical_value(ctx.raw);
-        // The walker, canonical-text rendering, and emitted `_recover`
-        // templates all operate on the upstream's *unwrapped* shape. The
-        // wrapping in `structured_content` exists only to satisfy the MCP
-        // transport's record-only contract.
-        let root_path = reify::root_path_of_wrapped(&wrapped);
-        let unwrapped = reify::unwrap_at(root_path, &wrapped);
-        let canonical_text = canonical_text_for(unwrapped);
+        // Walker, canonical-text rendering, and emitted `_recover` templates
+        // all operate on the upstream's *unwrapped* shape. `canonicalize`
+        // pulls the parsed value from whichever channel the upstream used
+        // (or `Value::String(text)` as a last-ditch fallback when the
+        // upstream emitted plain non-JSON text).
+        let value = reify::canonicalize(ctx.raw)
+            .unwrap_or_else(|| serde_json::Value::String(extract_text(ctx.raw)));
+        let root_path = reify::root_path_of_unwrapped(&value);
+        let canonical_text = canonical_text_for(&value);
         let chain = self.summarizer_chain.as_deref();
-        let summary = match walker::classify_value(unwrapped, self.threshold_bytes, chain) {
+        let summary = match walker::classify_value(&value, self.threshold_bytes, chain) {
             walker::WalkOutcome::Passthrough(v) => ToolResultSummary::Passthrough { value: v },
             walker::WalkOutcome::Elided {
                 kept,
@@ -365,13 +363,6 @@ pub fn canonical_text_for(value: &serde_json::Value) -> String {
         },
         _ => serde_json::to_string_pretty(value).unwrap_or_default(),
     }
-}
-
-fn canonical_value(result: &CallToolResult) -> serde_json::Value {
-    if let Some(sc) = result.structured_content.as_ref() {
-        return sc.clone();
-    }
-    serde_json::Value::String(extract_text(result))
 }
 
 fn extract_text(result: &CallToolResult) -> String {

--- a/core/crates/tool-classifier/src/reify.rs
+++ b/core/crates/tool-classifier/src/reify.rs
@@ -1,108 +1,65 @@
-//! Always-populate `structured_content` at the classifier boundary.
-//!
-//! Every dispatch path (regular MCP, compose, catalog) calls this once before
-//! classification, so the universal pipeline always sees the same shape:
-//! `result.structured_content` is `Some(record)` on return, never `None` and
-//! never a raw string / array / scalar.
+//! Classify the upstream value at the dispatch boundary so storage,
+//! rendering, and recovery all key off the upstream's actual shape — without
+//! injecting a transport envelope into the response the agent reads.
 //!
 //! Resolution order:
-//! 1. If `structured_content` is already attached and is already a record →
-//!    leave it alone, root_path is `$`. If it's a non-record, idempotently
-//!    wrap it (so a buggy upstream that pre-populated with `Value::Array`
-//!    can't escape the transport contract).
-//! 2. Combine `content[].text` parts.
-//! 3. Try to parse the combined text as JSON.
-//!    - Object → attach as-is, root_path `$`.
-//!    - Array  → attach `{ "items": [...], "_shape": "array" }`, root_path `$.items`.
-//!    - String → attach `{ "value": "...", "_shape": "string" }`, root_path `$.value`.
-//!    - Number → attach `{ "value": N, "_shape": "number" }`, root_path `$.value`.
-//!    - Bool   → attach `{ "value": B, "_shape": "boolean" }`, root_path `$.value`.
-//!    - Null   → attach `{ "value": null, "_shape": "null" }`, root_path `$.value`.
-//! 4. Parse failure → attach `{ "value": <raw_text>, "_shape": "string" }`,
-//!    root_path `$.value`.
+//! 1. If `structured_content` is already attached and is a record → leave it,
+//!    root_path `$`. If it's a non-record, the upstream tool misused the
+//!    channel — clear it so the agent reads the text content instead. The
+//!    parsed shape still informs root_path metadata for storage.
+//! 2. Otherwise, parse the combined `content[].text` body as JSON:
+//!    - Object → attach as `structured_content`, root_path `$`.
+//!    - Array → leave `structured_content` as `None`, root_path `$.items`.
+//!    - String / Number / Bool / Null → leave `None`, root_path `$.value`.
+//!    - Parse failure / non-JSON text → leave `None`, root_path `$.value`.
 //!
-//! `root_path` rides alongside the wrapped value through the rest of the
-//! pipeline so consumers (walker, canonical-text rendering, `tool_output_fetch`,
-//! compose JS engine) can address the unwrapped upstream value directly. The
-//! envelope only exists to satisfy the MCP transport's record-only
-//! `structuredContent` validation.
+//! Non-record upstreams (kubectl tables, code-assistant markdown, top-level
+//! JSON arrays) flow to the agent through the text channel verbatim; no
+//! `{value|items, _shape}` envelope leaks into the response. `root_path` is
+//! recorded as invocation metadata so the persistence layer, walker, and
+//! `tool_output_fetch` can reconstruct the upstream's shape on demand.
 
 use rmcp::model::CallToolResult;
-use serde_json::{json, Value};
+use serde_json::Value;
 
-/// Mutates `result` so `structured_content` is `Some(record)` on return.
-/// Returns the root_path: where the *unwrapped* upstream value lives within
-/// the wrapped envelope (`$` for records, `$.items` for arrays, `$.value`
-/// for strings / scalars / non-JSON text).
+/// Inspect `result` and return the root_path of the upstream's value:
+/// `$` for records, `$.items` for arrays, `$.value` for strings / scalars
+/// / non-JSON text.
+///
+/// `structured_content` is *only* populated when the parse yields a JSON
+/// object. Non-record values stay in the text content channel — the MCP
+/// transport accepts a missing `structured_content`, and agents reading the
+/// response see the upstream's verbatim text rather than a record envelope.
+/// A pre-populated non-record `structured_content` is treated as upstream
+/// misuse and cleared.
 pub fn ensure_structured_content(result: &mut CallToolResult) -> &'static str {
     if let Some(existing) = result.structured_content.take() {
-        let path = root_path_of_unwrapped(&existing);
-        let wrapped = wrap_non_record(existing);
-        result.structured_content = Some(wrapped);
-        return path;
+        if matches!(existing, Value::Object(_)) {
+            result.structured_content = Some(existing);
+            return "$";
+        }
+        // Non-record pre-set: clear it. root_path reflects the underlying
+        // shape so storage / fetch can reconstruct.
+        return root_path_of_unwrapped(&existing);
     }
     let combined = combined_text(result);
-    let v = reify(combined);
-    let path = root_path_of_wrapped(&v);
-    result.structured_content = Some(v);
-    path
-}
-
-/// Wrap an arbitrary tool-output text into a record-shaped JSON value.
-///
-/// Pure function over a `String` so it can be unit-tested without an
-/// `rmcp::CallToolResult`.
-pub fn reify(text: String) -> Value {
-    if text.trim().is_empty() {
-        return wrap_string(text);
-    }
-    match serde_json::from_str::<Value>(text.trim()) {
-        Ok(v) => wrap_non_record(v),
-        Err(_) => wrap_string(text),
-    }
-}
-
-/// Wrap a `Value` so the result is always a JSON object.
-///
-/// Mirror of [`reify`] for the case where the caller already has a
-/// parsed `Value` (e.g. `tool_output_fetch` slice/json-mode outputs).
-/// Objects pass through unchanged so the function is idempotent.
-pub fn wrap_non_record(v: Value) -> Value {
-    match v {
-        Value::Object(_) => v,
-        Value::Array(items) => json!({ "items": items, "_shape": "array" }),
-        Value::String(s) => json!({ "value": s, "_shape": "string" }),
-        Value::Number(n) => json!({ "value": n, "_shape": "number" }),
-        Value::Bool(b) => json!({ "value": b, "_shape": "boolean" }),
-        Value::Null => json!({ "value": null, "_shape": "null" }),
-    }
-}
-
-fn wrap_string(s: String) -> Value {
-    json!({ "value": s, "_shape": "string" })
-}
-
-/// Where the unwrapped value lives within a wrapped envelope. Pure shape
-/// inspection — used at `ensure_structured_content` time to record the
-/// root_path metadata that the rest of the pipeline keys off.
-pub fn root_path_of_wrapped(v: &Value) -> &'static str {
-    if let Value::Object(map) = v {
-        if map.len() == 2 {
-            if let Some(Value::String(shape)) = map.get("_shape") {
-                match shape.as_str() {
-                    "array" if map.contains_key("items") => return "$.items",
-                    "string" | "number" | "boolean" | "null" if map.contains_key("value") => {
-                        return "$.value"
-                    }
-                    _ => {}
-                }
-            }
+    let parsed = if combined.trim().is_empty() {
+        None
+    } else {
+        serde_json::from_str::<Value>(combined.trim()).ok()
+    };
+    match parsed {
+        Some(Value::Object(map)) => {
+            result.structured_content = Some(Value::Object(map));
+            "$"
         }
+        Some(Value::Array(_)) => "$.items",
+        Some(_) => "$.value",
+        None => "$.value",
     }
-    "$"
 }
 
-/// Inverse of `root_path_of_wrapped`: where would we wrap an unwrapped value?
+/// Where would we record root_path for this *unwrapped* upstream value?
 pub fn root_path_of_unwrapped(v: &Value) -> &'static str {
     match v {
         Value::Object(_) => "$",
@@ -111,31 +68,20 @@ pub fn root_path_of_unwrapped(v: &Value) -> &'static str {
     }
 }
 
-/// Look through a wrapped envelope at `root_path` to the unwrapped upstream
-/// value. Returns the input unchanged for `$` (records).
-pub fn unwrap_at<'a>(root_path: &str, v: &'a Value) -> &'a Value {
-    match root_path {
-        "$" => v,
-        "$.items" => v.get("items").unwrap_or(v),
-        "$.value" => v.get("value").unwrap_or(v),
-        _ => v,
+/// Resolve the upstream value to store / classify, regardless of which
+/// channel the upstream used to deliver it. Returns `None` only when the
+/// upstream emitted no usable shape (empty content, non-JSON text). Used by
+/// the persistence layer to populate `original_structured` and by the
+/// classifier to decide what to walk.
+pub fn canonicalize(result: &CallToolResult) -> Option<Value> {
+    if let Some(sc) = result.structured_content.as_ref() {
+        return Some(sc.clone());
     }
-}
-
-/// Owning version of `unwrap_at`.
-pub fn unwrap_at_owned(root_path: &str, v: Value) -> Value {
-    match root_path {
-        "$" => v,
-        "$.items" => match v {
-            Value::Object(mut map) => map.remove("items").unwrap_or(Value::Object(map)),
-            other => other,
-        },
-        "$.value" => match v {
-            Value::Object(mut map) => map.remove("value").unwrap_or(Value::Object(map)),
-            other => other,
-        },
-        _ => v,
+    let combined = combined_text(result);
+    if combined.trim().is_empty() {
+        return None;
     }
+    serde_json::from_str::<Value>(combined.trim()).ok()
 }
 
 fn combined_text(result: &CallToolResult) -> String {
@@ -155,31 +101,74 @@ fn combined_text(result: &CallToolResult) -> String {
 mod tests {
     use super::*;
     use rmcp::model::Content;
+    use serde_json::json;
 
     #[test]
-    fn object_passes_through_unchanged() {
+    fn object_text_sets_structured_content() {
         let mut r = CallToolResult::success(vec![Content::text(
             r#"{"total":2,"items":[{"id":1},{"id":2}]}"#.to_string(),
         )]);
         let path = ensure_structured_content(&mut r);
         assert_eq!(path, "$");
-        let sc = r.structured_content.expect("structured_content set");
+        let sc = r.structured_content.expect("set for record upstream");
         assert_eq!(sc.get("total"), Some(&json!(2)));
         assert!(sc.get("items").unwrap().is_array());
-        assert!(sc.get("_shape").is_none(), "objects must not be re-wrapped");
     }
 
     #[test]
-    fn array_wraps_into_items_envelope() {
+    fn array_text_leaves_structured_content_none_with_items_root_path() {
         let mut r = CallToolResult::success(vec![Content::text(
             r#"[{"a":1},{"a":2},{"a":3}]"#.to_string(),
         )]);
         let path = ensure_structured_content(&mut r);
         assert_eq!(path, "$.items");
-        let sc = r.structured_content.expect("set");
-        assert!(sc.is_object(), "array must be wrapped as an object");
-        assert_eq!(sc.get("_shape"), Some(&json!("array")));
-        assert_eq!(sc.get("items").unwrap().as_array().unwrap().len(), 3);
+        assert!(
+            r.structured_content.is_none(),
+            "non-record upstreams must NOT set structured_content — agent reads content text",
+        );
+    }
+
+    #[test]
+    fn string_text_leaves_structured_content_none_with_value_root_path() {
+        let raw = "NAMESPACE  KIND  NAME\nkube-system  Pod  calico\n".to_string();
+        let mut r = CallToolResult::success(vec![Content::text(raw.clone())]);
+        let path = ensure_structured_content(&mut r);
+        assert_eq!(path, "$.value");
+        assert!(r.structured_content.is_none());
+        // Original text content is preserved.
+        assert_eq!(combined_text(&r), raw);
+    }
+
+    #[test]
+    fn json_scalar_text_leaves_none_with_value_root_path() {
+        for (text, expected_path) in [
+            ("42", "$.value"),
+            ("true", "$.value"),
+            ("null", "$.value"),
+            (r#""quoted""#, "$.value"),
+        ] {
+            let mut r = CallToolResult::success(vec![Content::text(text.to_string())]);
+            let path = ensure_structured_content(&mut r);
+            assert_eq!(path, expected_path, "scalar {text}");
+            assert!(r.structured_content.is_none(), "scalar {text}");
+        }
+    }
+
+    #[test]
+    fn invalid_json_leaves_none_with_value_root_path() {
+        let raw = r#"{"a": 1, "b":"#.to_string();
+        let mut r = CallToolResult::success(vec![Content::text(raw)]);
+        let path = ensure_structured_content(&mut r);
+        assert_eq!(path, "$.value");
+        assert!(r.structured_content.is_none());
+    }
+
+    #[test]
+    fn empty_content_yields_value_root_path_with_none_structured() {
+        let mut r = CallToolResult::success(vec![]);
+        let path = ensure_structured_content(&mut r);
+        assert_eq!(path, "$.value");
+        assert!(r.structured_content.is_none());
     }
 
     #[test]
@@ -192,219 +181,62 @@ mod tests {
     }
 
     #[test]
-    fn preset_array_idempotently_wraps() {
-        // Defends the transport contract against an upstream that bypasses
-        // text content and stuffs `Value::Array(_)` into `structured_content`
-        // directly.
-        let mut r = CallToolResult::success(vec![]);
+    fn preset_non_record_is_cleared() {
+        // Defends the transport contract: an upstream that misuses the
+        // channel by stuffing a `Value::Array` directly into
+        // `structured_content` would crash the wrapper validation. We clear
+        // it; root_path still reflects the original shape so storage knows
+        // the upstream was array-typed.
+        let mut r = CallToolResult::success(vec![Content::text("[1,2,3]".to_string())]);
         r.structured_content = Some(json!([1, 2, 3]));
         let path = ensure_structured_content(&mut r);
         assert_eq!(path, "$.items");
-        assert_eq!(
-            r.structured_content,
-            Some(json!({"items":[1,2,3],"_shape":"array"})),
-        );
-    }
+        assert!(r.structured_content.is_none());
 
-    #[test]
-    fn preset_string_idempotently_wraps() {
-        let mut r = CallToolResult::success(vec![]);
+        let mut r = CallToolResult::success(vec![Content::text("\"hi\"".to_string())]);
         r.structured_content = Some(json!("hi"));
         let path = ensure_structured_content(&mut r);
         assert_eq!(path, "$.value");
-        assert_eq!(
-            r.structured_content,
-            Some(json!({"value":"hi","_shape":"string"})),
-        );
+        assert!(r.structured_content.is_none());
     }
 
     #[test]
-    fn non_json_text_wraps_as_string_envelope() {
-        let raw = "NAME    READY   STATUS\nfoo     1/1     Running\n".to_string();
-        let mut r = CallToolResult::success(vec![Content::text(raw.clone())]);
-        let path = ensure_structured_content(&mut r);
-        assert_eq!(path, "$.value");
-        let sc = r.structured_content.expect("set");
-        assert_eq!(sc.get("_shape"), Some(&json!("string")));
-        assert_eq!(sc.get("value"), Some(&Value::String(raw)));
+    fn root_path_of_unwrapped_per_shape() {
+        assert_eq!(root_path_of_unwrapped(&json!({"k":1})), "$");
+        assert_eq!(root_path_of_unwrapped(&json!([1, 2])), "$.items");
+        assert_eq!(root_path_of_unwrapped(&json!("hi")), "$.value");
+        assert_eq!(root_path_of_unwrapped(&json!(42)), "$.value");
+        assert_eq!(root_path_of_unwrapped(&json!(true)), "$.value");
+        assert_eq!(root_path_of_unwrapped(&Value::Null), "$.value");
     }
 
     #[test]
-    fn json_string_scalar_wraps_unquoted() {
-        let mut r = CallToolResult::success(vec![Content::text(r#""just a string""#.to_string())]);
-        ensure_structured_content(&mut r);
-        let sc = r.structured_content.expect("set");
-        assert_eq!(sc.get("_shape"), Some(&json!("string")));
-        assert_eq!(sc.get("value"), Some(&json!("just a string")));
+    fn canonicalize_prefers_pre_set_structured_content() {
+        let mut r = CallToolResult::success(vec![Content::text("ignored".to_string())]);
+        r.structured_content = Some(json!({"k": 1}));
+        assert_eq!(canonicalize(&r), Some(json!({"k": 1})));
     }
 
     #[test]
-    fn json_number_wraps_as_number_envelope() {
-        let mut r = CallToolResult::success(vec![Content::text("42".to_string())]);
-        ensure_structured_content(&mut r);
-        let sc = r.structured_content.expect("set");
-        assert_eq!(sc.get("_shape"), Some(&json!("number")));
-        assert_eq!(sc.get("value"), Some(&json!(42)));
+    fn canonicalize_parses_text_when_no_structured_content() {
+        let r = CallToolResult::success(vec![Content::text(r#"[{"a":1},{"a":2}]"#.to_string())]);
+        assert_eq!(canonicalize(&r), Some(json!([{"a":1},{"a":2}])));
+
+        let r = CallToolResult::success(vec![Content::text("42".to_string())]);
+        assert_eq!(canonicalize(&r), Some(json!(42)));
     }
 
     #[test]
-    fn json_bool_wraps_as_boolean_envelope() {
-        let mut r = CallToolResult::success(vec![Content::text("true".to_string())]);
-        ensure_structured_content(&mut r);
-        let sc = r.structured_content.expect("set");
-        assert_eq!(sc.get("_shape"), Some(&json!("boolean")));
-        assert_eq!(sc.get("value"), Some(&json!(true)));
-    }
+    fn canonicalize_returns_none_for_non_json_or_empty() {
+        let r = CallToolResult::success(vec![Content::text(
+            "NAME    READY   STATUS\nfoo  1/1  Running\n".to_string(),
+        )]);
+        assert_eq!(canonicalize(&r), None);
 
-    #[test]
-    fn json_null_wraps_as_null_envelope() {
-        let mut r = CallToolResult::success(vec![Content::text("null".to_string())]);
-        ensure_structured_content(&mut r);
-        let sc = r.structured_content.expect("set");
-        assert_eq!(sc.get("_shape"), Some(&json!("null")));
-        assert_eq!(sc.get("value"), Some(&Value::Null));
-    }
+        let r = CallToolResult::success(vec![]);
+        assert_eq!(canonicalize(&r), None);
 
-    #[test]
-    fn truncated_or_invalid_json_falls_back_to_raw_string() {
-        let raw = r#"{"a": 1, "b":"#.to_string();
-        let mut r = CallToolResult::success(vec![Content::text(raw.clone())]);
-        ensure_structured_content(&mut r);
-        let sc = r.structured_content.expect("set");
-        assert_eq!(sc.get("_shape"), Some(&json!("string")));
-        assert_eq!(sc.get("value"), Some(&Value::String(raw)));
-    }
-
-    #[test]
-    fn parses_with_leading_whitespace() {
-        let mut r = CallToolResult::success(vec![Content::text("  \n\t  [1,2,3]\n".to_string())]);
-        ensure_structured_content(&mut r);
-        let sc = r.structured_content.expect("set");
-        assert_eq!(sc.get("_shape"), Some(&json!("array")));
-        assert_eq!(sc.get("items").unwrap().as_array().unwrap().len(), 3);
-    }
-
-    #[test]
-    fn empty_content_wraps_empty_string() {
-        let mut r = CallToolResult::success(vec![]);
-        ensure_structured_content(&mut r);
-        let sc = r.structured_content.expect("set");
-        assert_eq!(sc.get("_shape"), Some(&json!("string")));
-        assert_eq!(sc.get("value"), Some(&json!("")));
-    }
-
-    #[test]
-    fn wrap_non_record_object_passes_through() {
-        let v = json!({"k": 1});
-        assert_eq!(wrap_non_record(v.clone()), v);
-    }
-
-    #[test]
-    fn wrap_non_record_array_string_number_bool_null() {
-        assert_eq!(
-            wrap_non_record(json!([1, 2, 3])),
-            json!({"items":[1,2,3],"_shape":"array"})
-        );
-        assert_eq!(
-            wrap_non_record(json!("hello")),
-            json!({"value":"hello","_shape":"string"})
-        );
-        assert_eq!(
-            wrap_non_record(json!(7)),
-            json!({"value":7,"_shape":"number"})
-        );
-        assert_eq!(
-            wrap_non_record(json!(false)),
-            json!({"value":false,"_shape":"boolean"})
-        );
-        assert_eq!(
-            wrap_non_record(json!(null)),
-            json!({"value":null,"_shape":"null"})
-        );
-    }
-
-    #[test]
-    fn wrap_non_record_is_idempotent_on_envelopes() {
-        let env = json!({"value":"x","_shape":"string"});
-        assert_eq!(wrap_non_record(env.clone()), env);
-        let arr_env = json!({"items":[1,2],"_shape":"array"});
-        assert_eq!(wrap_non_record(arr_env.clone()), arr_env);
-    }
-
-    #[test]
-    fn root_path_of_wrapped_recognises_each_envelope() {
-        assert_eq!(root_path_of_wrapped(&json!({"a":1})), "$");
-        assert_eq!(
-            root_path_of_wrapped(&json!({"items":[1],"_shape":"array"})),
-            "$.items"
-        );
-        assert_eq!(
-            root_path_of_wrapped(&json!({"value":"x","_shape":"string"})),
-            "$.value"
-        );
-        assert_eq!(
-            root_path_of_wrapped(&json!({"value":7,"_shape":"number"})),
-            "$.value"
-        );
-        // Object that happens to have keys named like the envelope but a
-        // different `_shape` value should NOT be recognised.
-        assert_eq!(
-            root_path_of_wrapped(&json!({"value":"x","_shape":"custom"})),
-            "$"
-        );
-        // Three keys ≠ envelope.
-        assert_eq!(
-            root_path_of_wrapped(&json!({"value":"x","_shape":"string","extra":1})),
-            "$"
-        );
-    }
-
-    #[test]
-    fn unwrap_at_returns_inner_for_each_root_path() {
-        let env = json!({"items":[1,2,3],"_shape":"array"});
-        assert_eq!(unwrap_at("$.items", &env), &json!([1, 2, 3]));
-        let env = json!({"value":"x","_shape":"string"});
-        assert_eq!(unwrap_at("$.value", &env), &json!("x"));
-        let plain = json!({"k":1});
-        assert_eq!(unwrap_at("$", &plain), &plain);
-    }
-
-    #[test]
-    fn unwrap_at_owned_consumes() {
-        let env = json!({"items":[1,2,3],"_shape":"array"});
-        assert_eq!(unwrap_at_owned("$.items", env), json!([1, 2, 3]));
-        let env = json!({"value":"x","_shape":"string"});
-        assert_eq!(unwrap_at_owned("$.value", env), json!("x"));
-        let plain = json!({"k":1});
-        assert_eq!(unwrap_at_owned("$", plain.clone()), plain);
-    }
-
-    #[test]
-    fn reify_helper_directly_records() {
-        assert_eq!(reify(r#"{"k":1}"#.to_string()), json!({"k":1}));
-        assert_eq!(
-            reify("[1,2]".to_string()),
-            json!({"items":[1,2],"_shape":"array"})
-        );
-        assert_eq!(
-            reify("42".to_string()),
-            json!({"value":42,"_shape":"number"})
-        );
-        assert_eq!(
-            reify("true".to_string()),
-            json!({"value":true,"_shape":"boolean"})
-        );
-        assert_eq!(
-            reify("null".to_string()),
-            json!({"value":null,"_shape":"null"})
-        );
-        assert_eq!(
-            reify(r#""hi""#.to_string()),
-            json!({"value":"hi","_shape":"string"}),
-        );
-        assert_eq!(
-            reify("kubectl table".to_string()),
-            json!({"value":"kubectl table","_shape":"string"}),
-        );
+        let r = CallToolResult::success(vec![Content::text("   \n\t  ".to_string())]);
+        assert_eq!(canonicalize(&r), None);
     }
 }

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -292,15 +292,17 @@ impl TopLevelTool for ComposeTool {
 
 /// Build the synthetic `CallToolResult` the classifier walks for compose's
 /// top-level return value. Mirrors what `ensure_structured_content` produces
-/// on the regular dispatch path: non-record values are wrapped into the
-/// transport envelope so the classifier's `root_path_of_wrapped` detection
-/// returns the correct path (`$.items` for arrays, `$.value` for strings /
-/// scalars / non-JSON text), not `$`.
+/// Synthetic `CallToolResult` the classifier walks for compose's top-level
+/// return value. The classifier's `canonicalize` helper reads
+/// `structured_content` first — only set when the JS return is a record so
+/// non-record returns flow through the text channel and the classifier
+/// derives root_path from the parsed shape directly.
 fn build_walker_input(value: &serde_json::Value) -> CallToolResult {
     let text = serde_json::to_string(value).unwrap_or_default();
-    let wrapped = drua_tool_classifier::wrap_non_record(value.clone());
     let mut ctr = CallToolResult::success(vec![Content::text(text)]);
-    ctr.structured_content = Some(wrapped);
+    if let serde_json::Value::Object(_) = value {
+        ctr.structured_content = Some(value.clone());
+    }
     ctr
 }
 
@@ -634,9 +636,9 @@ async fn run_searchable_call(
         .call(subject, tool_name, inner_args)
         .await
         .map_err(|e| e.to_string())?;
-    let root_path = super::super::classifier::ensure_structured_content(&mut result);
+    let _ = super::super::classifier::ensure_structured_content(&mut result);
 
-    let value = result_to_value(&result, root_path);
+    let value = result_to_value(&result);
     Ok((result, value))
 }
 
@@ -665,26 +667,22 @@ async fn run_top_level_call(
         .call(subject, inner_args)
         .await
         .map_err(|e| e.to_string())?;
-    let root_path = if bypass {
-        // top-level tools that opt out of the universal pipeline already
-        // emit a record-shaped `structured_content` (or none). Treat them
-        // as `$` from JS's perspective.
-        "$"
-    } else {
-        super::super::classifier::ensure_structured_content(&mut result)
-    };
+    if !bypass {
+        let _ = super::super::classifier::ensure_structured_content(&mut result);
+    }
 
-    let value = result_to_value(&result, root_path);
+    let value = result_to_value(&result);
     Ok((result, value))
 }
 
-/// JS-engine view of a sub-call's result. Always returns the upstream's
-/// **unwrapped** shape so compose scripts see the same value they would get
-/// by parsing the upstream's text directly — no `_shape` / `value` /
-/// `items` envelope leakage.
-fn result_to_value(result: &CallToolResult, root_path: &str) -> serde_json::Value {
+/// JS-engine view of a sub-call's result. Returns the upstream's actual
+/// shape: a record from `structured_content` when set, otherwise the
+/// upstream's text content parsed as JSON (or as a bare `Value::String` if
+/// the text isn't JSON). No `{value|items, _shape}` envelope ever leaks
+/// into JS.
+fn result_to_value(result: &CallToolResult) -> serde_json::Value {
     if let Some(structured) = &result.structured_content {
-        return drua_tool_classifier::unwrap_at(root_path, structured).clone();
+        return structured.clone();
     }
     let text = extract_text(result);
     match serde_json::from_str::<serde_json::Value>(&text) {

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -552,13 +552,18 @@ impl CatalogDispatcherShared {
             super::super::record_pipeline_metrics(raw_bytes, kept_bytes, &classifier_kind, false);
             return;
         };
+        // Same canonicalize step `persist_and_envelope` uses on the regular
+        // dispatch path: pull the upstream value from whichever channel was
+        // used so json_path / json_array_slice `_recover` templates round-trip
+        // for non-record sub-tools.
+        let original_structured = drua_tool_classifier::canonicalize(raw);
         let Some(persisted): Option<PersistedClassification> = invocations
             .persist_classification(
                 owner,
                 tool_name,
                 args,
                 classification,
-                raw.structured_content.clone(),
+                original_structured,
                 duration_ms,
                 started_at,
             )

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -290,13 +290,11 @@ impl TopLevelTool for ComposeTool {
     }
 }
 
-/// Build the synthetic `CallToolResult` the classifier walks for compose's
-/// top-level return value. Mirrors what `ensure_structured_content` produces
 /// Synthetic `CallToolResult` the classifier walks for compose's top-level
-/// return value. The classifier's `canonicalize` helper reads
-/// `structured_content` first — only set when the JS return is a record so
-/// non-record returns flow through the text channel and the classifier
-/// derives root_path from the parsed shape directly.
+/// return value. Only sets `structured_content` when the JS return is a
+/// record; non-record returns flow through the text channel so the
+/// classifier's `canonicalize` helper derives root_path from the parsed
+/// shape directly (matches the regular dispatch path's behaviour).
 fn build_walker_input(value: &serde_json::Value) -> CallToolResult {
     let text = serde_json::to_string(value).unwrap_or_default();
     let mut ctr = CallToolResult::success(vec![Content::text(text)]);

--- a/core/src/toolset/top_level/tool_output_fetch.rs
+++ b/core/src/toolset/top_level/tool_output_fetch.rs
@@ -184,30 +184,30 @@ impl TopLevelTool for ToolOutputFetch {
             }
         };
 
-        // Any `query` (text or json) overrides structured_content with the
-        // slice. JSON modes carry a real Value override; text modes (tail/
-        // head/range/grep) become Value::String of the sliced text. The
-        // wrap step (`wrap_non_record`) lifts non-object slice results into
-        // the same `{value|items, _shape}` envelope reify uses on the input
-        // side, so the MCP transport's record-only `structuredContent`
-        // contract holds for every recovery template the gateway emits.
-        // Objects pass through unchanged.
+        // `structured_content` is set ONLY when the result is a JSON object
+        // (record). Non-record results — text-mode slices, array roots,
+        // string roots, scalars — flow through the text channel verbatim.
+        // The MCP transport accepts a missing `structured_content`, so the
+        // agent reads clean upstream-shaped text (kubectl tables stay tabular,
+        // markdown stays markdown, JSON arrays stay JSON arrays — no
+        // `{value|items, _shape}` envelope leaks into the response).
         //
         // Without `query`:
         // - `view: "summary"` returns the typed summary (always a record).
-        // - `view: "original"` returns the *unwrapped* upstream value as
-        //   stored. Reapply the transport envelope so the response shape
-        //   honours the wrapper contract — for record roots this is a no-op,
-        //   for array / string / scalar roots it produces `{items|value,
-        //   _shape}`.
+        // - `view: "original"` returns the persisted `original_structured`
+        //   only when it's a record; otherwise leaves it None and the agent
+        //   reads the raw text content.
         let final_structured = match (&query_outcome, input.view) {
-            (Some(r), _) => Some(drua_tool_classifier::wrap_non_record(
-                r.structured
-                    .clone()
-                    .unwrap_or_else(|| serde_json::Value::String(r.content.clone())),
-            )),
-            (None, FetchView::Original) => view_structured
-                .map(|v| drua_tool_cache::wrap_for_transport(v, &invocation.root_path)),
+            (Some(r), _) => match &r.structured {
+                Some(serde_json::Value::Object(map)) => {
+                    Some(serde_json::Value::Object(map.clone()))
+                }
+                _ => None,
+            },
+            (None, FetchView::Original) => match view_structured {
+                Some(serde_json::Value::Object(map)) => Some(serde_json::Value::Object(map)),
+                _ => None,
+            },
             (None, FetchView::Summary) => view_structured,
         };
 

--- a/core/tests/compose_recovery.rs
+++ b/core/tests/compose_recovery.rs
@@ -299,10 +299,15 @@ async fn compose_under_workflow_executor_no_persistence() {
 struct ArrayRootStub {
     name: String,
     tools: Vec<ToolSetEntry>,
+    array_size: usize,
 }
 
 impl ArrayRootStub {
     fn new() -> Self {
+        Self::with_size(3)
+    }
+
+    fn with_size(array_size: usize) -> Self {
         let mut tool = Tool::default();
         tool.name = "list_things".to_string().into();
         tool.description = Some("returns a top-level JSON array".to_string().into());
@@ -313,6 +318,7 @@ impl ArrayRootStub {
                 name: "list_things".to_string(),
                 description: tool,
             }],
+            array_size,
         }
     }
 }
@@ -337,13 +343,14 @@ impl SearchableToolSet for ArrayRootStub {
         _tool_name: &str,
         _arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
-        let arr = json!([{"id":1,"name":"a"},{"id":2,"name":"b"},{"id":3,"name":"c"}]);
-        let text = serde_json::to_string(&arr).unwrap();
+        let arr: Vec<_> = (0..self.array_size)
+            .map(|i| json!({ "id": i, "blob": "x".repeat(200) }))
+            .collect();
+        let text = serde_json::to_string(&serde_json::Value::Array(arr)).unwrap();
         // Deliberately do NOT pre-populate structured_content — the
         // dispatcher's `ensure_structured_content` is responsible for
-        // wrapping the text into the transport envelope, and root_path
-        // metadata is what tells `result_to_value` to unwrap before
-        // exposing to JS.
+        // shape detection. Non-record upstreams flow through the text
+        // channel; storage canonicalises so json modes still work.
         Ok(CallToolResult::success(vec![Content::text(text)]))
     }
 }
@@ -398,6 +405,127 @@ async fn compose_top_level_array_persists_with_items_root_path() {
 }
 
 #[tokio::test]
+async fn array_root_persists_canonicalized_for_recovery_round_trip() {
+    // Regression pin for the Bugbot finding (PR #323): when a non-record
+    // upstream is dispatched and elided, `persist_and_envelope` /
+    // `maybe_persist_sub_invocation` used to store
+    // `raw.structured_content.clone()` — which is `None` for arrays after
+    // the unwrap-return-channel change. The walker still emits
+    // `json_array_slice` `_recover` templates for array elision, so the
+    // agent following those templates would hit "json_array_slice
+    // requested but invocation has no structured_content".
+    //
+    // This test goes through the real dispatch path (no manual seeding),
+    // pulls the elided `_recover.args_template.query` out of the summary
+    // the agent receives, then runs that exact query through
+    // `tool_output_fetch` and asserts it actually returns the requested
+    // slice instead of an error.
+    let pool = pool().await;
+    let audit = Arc::new(Audit::new(&pool));
+    let invocations = Arc::new(ToolInvocations::new(&pool));
+    let toolsets = ToolSets::init(
+        ToolSetsConfig::default(),
+        Some(Arc::clone(&audit)),
+        None,
+        Some(Arc::clone(&invocations)),
+    )
+    .await
+    .expect("init toolsets");
+    // 50 items * ~200B blob each → ~10KB+ raw, comfortably above the
+    // walker's elision threshold so a `_recover` template gets emitted.
+    toolsets.register_searchable(ArrayRootStub::with_size(50));
+
+    let user_id = insert_user(&pool).await;
+    let subject = AuthSubject::User(user_id);
+
+    // 1. Dispatch the array-root stub via compose so it gets persisted.
+    let dispatch = toolsets
+        .call_top_level_tool(
+            &subject,
+            "compose",
+            compose_args("return await tools.stub.list_things({});"),
+        )
+        .await
+        .expect("compose dispatch");
+
+    // 2. Locate the persisted sub-invocation.
+    let env = extract_structured(&dispatch);
+    let subs = env
+        .get("sub_invocations")
+        .and_then(|v| v.as_array())
+        .expect("sub_invocations");
+    assert_eq!(subs.len(), 1, "exactly one elided sub-call");
+    let sub_id = subs[0]
+        .get("invocation_id")
+        .and_then(|v| v.as_str())
+        .expect("sub-invocation invocation_id");
+
+    // 3. Read back the persisted summary so we have the *real*
+    //    `_recover.args_template.query` the agent would see.
+    let inv_uuid: uuid::Uuid = sub_id.parse().unwrap();
+    let persisted = invocations
+        .find_by_id(inv_uuid.into())
+        .await
+        .expect("persisted row");
+    assert_eq!(
+        persisted.root_path, "$.items",
+        "array-rooted upstream must persist root_path '$.items'"
+    );
+    assert!(
+        persisted.original_structured.is_some(),
+        "Bugbot regression: original_structured must be Some for array roots, \
+         else `_recover` templates with json modes can't resolve"
+    );
+    assert!(
+        persisted.original_structured.as_ref().unwrap().is_array(),
+        "original_structured holds the unwrapped array, not an envelope"
+    );
+
+    let recover_query = persisted
+        .summary
+        .get("elided_paths")
+        .and_then(|v| v.get(0))
+        .and_then(|p| p.get("_recover"))
+        .and_then(|r| r.get("args_template"))
+        .and_then(|t| t.get("query"))
+        .cloned()
+        .expect("array elision must emit a _recover template with a query");
+
+    // 4. Run the literal recover template and assert it actually returns
+    //    the requested slice (no "no structured_content" error).
+    let mut fetch_args = JsonObject::new();
+    fetch_args.insert("invocation_id".to_string(), json!(sub_id));
+    fetch_args.insert("query".to_string(), recover_query);
+    fetch_args.insert("view".to_string(), json!("original"));
+    let fetched = toolsets
+        .call_top_level_tool(&subject, "tool_output_fetch", Some(fetch_args))
+        .await
+        .expect("recover template dispatch");
+
+    assert!(
+        !fetched.is_error.unwrap_or(false),
+        "the gateway-emitted _recover template must round-trip without error"
+    );
+    // Slice result is a non-record (array) → goes in content channel.
+    assert!(
+        fetched.structured_content.is_none(),
+        "array slice does NOT set structured_content (no envelope leak)"
+    );
+    let text: String = fetched
+        .content
+        .iter()
+        .filter_map(|c| match &c.raw {
+            rmcp::model::RawContent::Text(t) => Some(t.text.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        text.contains("\"id\""),
+        "recovered slice text should contain the array's items"
+    );
+}
+
+#[tokio::test]
 async fn compose_inner_array_root_is_unwrapped_for_js() {
     let pool = pool().await;
     let audit = Arc::new(Audit::new(&pool));
@@ -439,7 +567,7 @@ async fn compose_inner_array_root_is_unwrapped_for_js() {
     );
     assert_eq!(
         env.get("result").and_then(|v| v.get("first_id")),
-        Some(&json!(1))
+        Some(&json!(0))
     );
 }
 

--- a/core/tests/tool_output_fetch_slice_emission.rs
+++ b/core/tests/tool_output_fetch_slice_emission.rs
@@ -1,10 +1,12 @@
 //! Integration tests for `tool_output_fetch` slice/json-mode emission.
 //!
-//! Locks in the contract that every `tool_output_fetch` query result lands in
-//! `structured_content` as a JSON object — never a raw string, array, number,
-//! bool, or null. Without this the MCP transport's record-only
-//! `structuredContent` validation rejects the response and the
-//! gateway-emitted `_recover` templates round-trip-fail.
+//! Locks in the contract that `tool_output_fetch` only sets
+//! `structured_content` when the result is a JSON **object** (record).
+//! Non-record results — text-mode slices, array slices, scalar `json_path`
+//! results, string roots — flow through the `content[].text` channel
+//! verbatim with `structured_content` left as `None`. The MCP transport
+//! accepts a missing `structured_content`, and the agent reads the
+//! upstream's actual shape rather than a `{value|items, _shape}` envelope.
 
 use std::sync::Arc;
 
@@ -50,9 +52,37 @@ async fn insert_user(pool: &sqlx::PgPool) -> UserId {
     id
 }
 
-/// Seed a string-root invocation (root_path `$.value`, `original_structured`
-/// holding a bare `Value::String`). Mirrors what reify produces when the
-/// upstream emits non-JSON text like a kubectl table.
+/// Seed a record-root invocation. `original_structured` holds the parsed
+/// `{items:[…], logs:"…"}` object; root_path is `$`.
+async fn seed_wide(invocations: &ToolInvocations, owner: InvocationOwner) -> ToolInvocationId {
+    let items: Vec<_> = (0..200).map(|i| json!({ "id": i, "tag": "x" })).collect();
+    let logs = (0..200)
+        .map(|i| format!("[line-{i:04}] kube-proxy event"))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let payload = json!({ "items": items, "logs": logs });
+    let raw_text = serde_json::to_string(&payload).unwrap();
+    let raw_size_bytes = raw_text.len() as i64;
+    let new = NewToolInvocation {
+        owner,
+        tool_name: "stub_wide".to_string(),
+        args: json!({}),
+        args_hash: vec![1, 2, 3, 4],
+        classifier: "passthrough".to_string(),
+        summary: json!({"kind": "passthrough", "value": payload.clone()}),
+        raw_text,
+        raw_size_bytes,
+        original_structured: Some(payload),
+        exit_code: None,
+        duration_ms: 1,
+        started_at: chrono::Utc::now(),
+        root_path: "$".to_string(),
+    };
+    invocations.persist(new).await.expect("seed").id
+}
+
+/// Seed a string-root invocation: `original_structured` is `None`,
+/// `raw_text` holds the verbatim upstream text, root_path is `$.value`.
 async fn seed_string_root(
     invocations: &ToolInvocations,
     owner: InvocationOwner,
@@ -66,9 +96,9 @@ async fn seed_string_root(
         args_hash: vec![9, 9, 9, 9],
         classifier: "passthrough".to_string(),
         summary: json!({"kind":"passthrough","value":raw_text.clone()}),
-        raw_text: raw_text.clone(),
+        raw_text,
         raw_size_bytes,
-        original_structured: Some(json!(raw_text)),
+        original_structured: None,
         exit_code: None,
         duration_ms: 1,
         started_at: chrono::Utc::now(),
@@ -77,10 +107,8 @@ async fn seed_string_root(
     invocations.persist(new).await.expect("seed").id
 }
 
-/// Seed an array-root invocation (root_path `$.items`,
-/// `original_structured` holding a bare `Value::Array`). Mirrors what reify
-/// produces when the upstream emits a top-level JSON array (github
-/// list-style endpoints, lingo's listers).
+/// Seed an array-root invocation: `original_structured` holds the parsed
+/// `Value::Array`, raw_text is the JSON encoding, root_path is `$.items`.
 async fn seed_array_root(
     invocations: &ToolInvocations,
     owner: InvocationOwner,
@@ -106,39 +134,6 @@ async fn seed_array_root(
     invocations.persist(new).await.expect("seed").id
 }
 
-/// Seed an invocation directly via the persistence layer so the test focuses
-/// on `tool_output_fetch` emission, not on full upstream dispatch. Payload is
-/// `{items:[...], logs:"..."}` — wide enough to exercise array, object,
-/// string field, and raw-text grep paths.
-async fn seed_wide(invocations: &ToolInvocations, owner: InvocationOwner) -> ToolInvocationId {
-    let items: Vec<_> = (0..200).map(|i| json!({ "id": i, "tag": "x" })).collect();
-    let logs = (0..200)
-        .map(|i| format!("[line-{i:04}] kube-proxy event"))
-        .collect::<Vec<_>>()
-        .join("\n");
-    let payload = json!({ "items": items, "logs": logs });
-    let raw_text = serde_json::to_string(&payload).unwrap();
-    let raw_size_bytes = raw_text.len() as i64;
-
-    let new = NewToolInvocation {
-        owner,
-        tool_name: "stub_wide".to_string(),
-        args: json!({}),
-        args_hash: vec![1, 2, 3, 4],
-        classifier: "passthrough".to_string(),
-        summary: json!({"kind": "passthrough", "value": payload.clone()}),
-        raw_text,
-        raw_size_bytes,
-        original_structured: Some(payload),
-        exit_code: None,
-        duration_ms: 1,
-        started_at: chrono::Utc::now(),
-        root_path: "$".to_string(),
-    };
-    let persisted = invocations.persist(new).await.expect("seed persist");
-    persisted.id
-}
-
 fn fetch_args(invocation_id: ToolInvocationId, query: serde_json::Value) -> Option<JsonObject> {
     let mut args = JsonObject::new();
     args.insert(
@@ -149,15 +144,20 @@ fn fetch_args(invocation_id: ToolInvocationId, query: serde_json::Value) -> Opti
     Some(args)
 }
 
-fn structured(result: &CallToolResult) -> &serde_json::Value {
+fn text_content(result: &CallToolResult) -> String {
     result
-        .structured_content
-        .as_ref()
-        .expect("tool_output_fetch always emits structured_content")
+        .content
+        .iter()
+        .filter_map(|c| match &c.raw {
+            rmcp::model::RawContent::Text(t) => Some(t.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[tokio::test]
-async fn json_array_slice_wraps_array_in_items_envelope() {
+async fn json_array_slice_returns_array_in_text_channel_no_envelope() {
     let pool = pool().await;
     let (toolsets, invocations) = build(&pool).await;
     let user_id = insert_user(&pool).await;
@@ -176,17 +176,17 @@ async fn json_array_slice_wraps_array_in_items_envelope() {
         .await
         .expect("dispatch");
 
-    let sc = structured(&result);
-    assert!(sc.is_object(), "json_array_slice must wrap into an object");
-    assert_eq!(sc.get("_shape"), Some(&json!("array")));
-    let items = sc.get("items").and_then(|v| v.as_array()).expect("items");
-    assert_eq!(items.len(), 2);
-    assert_eq!(items[0].get("id"), Some(&json!(1)));
-    assert_eq!(items[1].get("id"), Some(&json!(2)));
+    assert!(
+        result.structured_content.is_none(),
+        "array slice must NOT set structured_content (no envelope leaks to agent)",
+    );
+    let text = text_content(&result);
+    assert!(text.contains("\"id\": 1") || text.contains("\"id\":1"));
+    assert!(text.contains("\"id\": 2") || text.contains("\"id\":2"));
 }
 
 #[tokio::test]
-async fn json_path_to_array_wraps_in_items_envelope() {
+async fn json_path_to_array_returns_array_in_text_channel_no_envelope() {
     let pool = pool().await;
     let (toolsets, invocations) = build(&pool).await;
     let user_id = insert_user(&pool).await;
@@ -202,17 +202,13 @@ async fn json_path_to_array_wraps_in_items_envelope() {
         .await
         .expect("dispatch");
 
-    let sc = structured(&result);
-    assert!(sc.is_object(), "json_path → array must wrap into an object");
-    assert_eq!(sc.get("_shape"), Some(&json!("array")));
-    assert_eq!(
-        sc.get("items").and_then(|v| v.as_array()).map(Vec::len),
-        Some(200)
-    );
+    assert!(result.structured_content.is_none());
+    let text = text_content(&result);
+    assert!(text.contains("\"id\""));
 }
 
 #[tokio::test]
-async fn json_path_to_string_wraps_in_value_envelope() {
+async fn json_path_to_string_returns_string_in_text_channel_no_envelope() {
     let pool = pool().await;
     let (toolsets, invocations) = build(&pool).await;
     let user_id = insert_user(&pool).await;
@@ -228,17 +224,12 @@ async fn json_path_to_string_wraps_in_value_envelope() {
         .await
         .expect("dispatch");
 
-    let sc = structured(&result);
-    assert!(
-        sc.is_object(),
-        "json_path → string must wrap into an object"
-    );
-    assert_eq!(sc.get("_shape"), Some(&json!("string")));
-    assert_eq!(sc.get("value"), Some(&json!("x")));
+    assert!(result.structured_content.is_none());
+    assert!(text_content(&result).contains('x'));
 }
 
 #[tokio::test]
-async fn json_path_to_object_passes_through_unchanged() {
+async fn json_path_to_object_sets_structured_content() {
     let pool = pool().await;
     let (toolsets, invocations) = build(&pool).await;
     let user_id = insert_user(&pool).await;
@@ -254,18 +245,20 @@ async fn json_path_to_object_passes_through_unchanged() {
         .await
         .expect("dispatch");
 
-    let sc = structured(&result);
-    assert!(sc.is_object(), "json_path → object must remain an object");
+    let sc = result
+        .structured_content
+        .expect("object slice must set structured_content");
+    assert!(sc.is_object());
     assert_eq!(sc.get("id"), Some(&json!(0)));
     assert_eq!(sc.get("tag"), Some(&json!("x")));
     assert!(
         sc.get("_shape").is_none(),
-        "object passthrough must not be re-wrapped",
+        "no `_shape` envelope on records"
     );
 }
 
 #[tokio::test]
-async fn grep_text_slice_wraps_in_value_envelope() {
+async fn grep_text_slice_returns_lines_in_text_channel_no_envelope() {
     let pool = pool().await;
     let (toolsets, invocations) = build(&pool).await;
     let user_id = insert_user(&pool).await;
@@ -284,22 +277,36 @@ async fn grep_text_slice_wraps_in_value_envelope() {
         .await
         .expect("dispatch");
 
-    let sc = structured(&result);
-    assert!(sc.is_object(), "grep slice must wrap into an object");
-    assert_eq!(sc.get("_shape"), Some(&json!("string")));
-    let v = sc
-        .get("value")
-        .and_then(|v| v.as_str())
-        .expect("value is a string");
-    assert!(v.contains("line-0001"));
+    assert!(result.structured_content.is_none());
+    assert!(text_content(&result).contains("line-0001"));
 }
 
 #[tokio::test]
-async fn view_original_wraps_string_root_for_transport() {
-    // Persisted state: original_structured is a bare `Value::String`,
-    // root_path is `$.value`. The fetch's view:original must reapply the
-    // envelope so the response satisfies MCP's record-only structuredContent
-    // contract.
+async fn head_text_slice_returns_lines_in_text_channel_no_envelope() {
+    let pool = pool().await;
+    let (toolsets, invocations) = build(&pool).await;
+    let user_id = insert_user(&pool).await;
+    let subject = AuthSubject::User(user_id);
+    let id = seed_wide(&invocations, InvocationOwner::user(user_id)).await;
+
+    let result = toolsets
+        .call_top_level_tool(
+            &subject,
+            "tool_output_fetch",
+            fetch_args(id, json!({"mode":"head","lines":3,"path":"$.logs"})),
+        )
+        .await
+        .expect("dispatch");
+
+    assert!(result.structured_content.is_none());
+    assert!(text_content(&result).contains("line-0000"));
+}
+
+#[tokio::test]
+async fn view_original_on_string_root_returns_raw_text_no_envelope() {
+    // String-root persisted: original_structured is None, raw_text holds the
+    // verbatim upstream text. view:original returns the raw text in the
+    // content channel and leaves structured_content None.
     let pool = pool().await;
     let (toolsets, invocations) = build(&pool).await;
     let user_id = insert_user(&pool).await;
@@ -316,15 +323,14 @@ async fn view_original_wraps_string_root_for_transport() {
         .await
         .expect("dispatch");
 
-    let sc = structured(&result);
-    assert!(sc.is_object(), "view:original on string root must wrap");
-    assert_eq!(sc.get("_shape"), Some(&json!("string")));
-    let v = sc.get("value").and_then(|v| v.as_str()).expect("value");
-    assert!(v.contains("kube-system"));
+    assert!(result.structured_content.is_none());
+    let text = text_content(&result);
+    assert!(text.contains("kube-system"));
+    assert!(text.contains("calico"));
 }
 
 #[tokio::test]
-async fn view_original_wraps_array_root_for_transport() {
+async fn view_original_on_array_root_returns_array_text_no_envelope() {
     let pool = pool().await;
     let (toolsets, invocations) = build(&pool).await;
     let user_id = insert_user(&pool).await;
@@ -341,20 +347,45 @@ async fn view_original_wraps_array_root_for_transport() {
         .await
         .expect("dispatch");
 
-    let sc = structured(&result);
-    assert!(sc.is_object(), "view:original on array root must wrap");
-    assert_eq!(sc.get("_shape"), Some(&json!("array")));
-    assert_eq!(
-        sc.get("items").and_then(|v| v.as_array()).map(Vec::len),
-        Some(3)
-    );
+    assert!(result.structured_content.is_none());
+    let text = text_content(&result);
+    assert!(text.starts_with('['));
+    assert!(text.contains("\"id\""));
 }
 
 #[tokio::test]
-async fn json_path_dollar_on_array_root_returns_wrapped_array() {
+async fn view_original_on_record_root_sets_structured_content() {
+    let pool = pool().await;
+    let (toolsets, invocations) = build(&pool).await;
+    let user_id = insert_user(&pool).await;
+    let subject = AuthSubject::User(user_id);
+    // seed_wide creates a record-rooted invocation (root_path "$").
+    let id = seed_wide(&invocations, InvocationOwner::user(user_id)).await;
+
+    let mut args = JsonObject::new();
+    args.insert(
+        "invocation_id".to_string(),
+        json!(uuid::Uuid::from(id).to_string()),
+    );
+    args.insert("query".to_string(), json!({"mode":"json_path","path":"$"}));
+    let result = toolsets
+        .call_top_level_tool(&subject, "tool_output_fetch", Some(args))
+        .await
+        .expect("dispatch");
+
+    let sc = result
+        .structured_content
+        .expect("record root must set structured_content");
+    assert!(sc.get("items").is_some());
+    assert!(sc.get("logs").is_some());
+}
+
+#[tokio::test]
+async fn json_path_dollar_on_array_root_returns_text_no_envelope() {
     // `_recover` templates emitted by the walker for an array-root
-    // invocation use `path: "$"` (unwrapped space). The query must resolve
-    // against the unwrapped storage and reapply the envelope.
+    // invocation use `path: "$"` (unwrapped space). The query resolves
+    // against the unwrapped storage; the agent reads the array text
+    // without any `{items, _shape}` envelope wrapping.
     let pool = pool().await;
     let (toolsets, invocations) = build(&pool).await;
     let user_id = insert_user(&pool).await;
@@ -370,37 +401,7 @@ async fn json_path_dollar_on_array_root_returns_wrapped_array() {
         .await
         .expect("dispatch");
 
-    let sc = structured(&result);
-    assert_eq!(sc.get("_shape"), Some(&json!("array")));
-    assert_eq!(
-        sc.get("items").and_then(|v| v.as_array()).map(Vec::len),
-        Some(3)
-    );
-}
-
-#[tokio::test]
-async fn head_text_slice_wraps_in_value_envelope() {
-    let pool = pool().await;
-    let (toolsets, invocations) = build(&pool).await;
-    let user_id = insert_user(&pool).await;
-    let subject = AuthSubject::User(user_id);
-    let id = seed_wide(&invocations, InvocationOwner::user(user_id)).await;
-
-    let result = toolsets
-        .call_top_level_tool(
-            &subject,
-            "tool_output_fetch",
-            fetch_args(id, json!({"mode":"head","lines":3,"path":"$.logs"})),
-        )
-        .await
-        .expect("dispatch");
-
-    let sc = structured(&result);
-    assert!(sc.is_object(), "head slice must wrap into an object");
-    assert_eq!(sc.get("_shape"), Some(&json!("string")));
-    let v = sc
-        .get("value")
-        .and_then(|v| v.as_str())
-        .expect("value is a string");
-    assert!(v.contains("line-0000"));
+    assert!(result.structured_content.is_none());
+    let text = text_content(&result);
+    assert!(text.starts_with('['));
 }


### PR DESCRIPTION
## Summary
Stop leaking the `{_shape, value|items}` envelope into the agent's read view. For non-record upstreams (code-assistant markdown, kubectl tables, top-level JSON arrays, scalars), `structured_content` is now left `None` and the agent reads the upstream's verbatim text from the content channel. Records are unchanged.

## Why
Post-#322 the agent still saw `{_shape:\"string\", value:\"…markdown…\"}` instead of the raw markdown for code-assistant, and `{_shape:\"array\", items:[…]}` instead of the JSON array text for github lists. MCP clients that prefer `structured_content` over `content` hid the upstream's actual text behind the transport envelope — the wrap was a hammer that solved the original wrapper-validation crash but trampled the agent's view.

The wrapper validation only fires for *non-record* `structured_content` values, not absent ones. Leaving `structured_content` as `None` for non-records satisfies the transport (no validation runs) and lets the content text channel carry the upstream's actual bytes.

## Design
1. `ensure_structured_content` only sets `structured_content` when the parse yields a JSON object. Non-records return root_path metadata (`$.items` / `$.value`) without populating the envelope. Pre-set non-record `structured_content` is cleared — upstream misuse can't escape the contract.
2. The classifier resolves the upstream value via `canonicalize(result)` (parses text when `structured_content` is absent), so the walker / `canonical_text` / `_recover` template generation still see the upstream's actual shape — record / array / string / scalar — and emit paths in upstream space.
3. `tool_output_fetch` populates response `structured_content` only when the slice / view result is itself a JSON object. Text slices, array slices, scalar `json_path` results, and view:original on non-record roots all land in the content channel verbatim.
4. Compose's `result_to_value` no longer unwraps via root_path (no envelope to unwrap from); falls back to parsing content text when `structured_content` is `None`.
5. Storage / walker / `_recover` paths from #322 unchanged — `root_path` metadata still recorded per-invocation, walker still walks the upstream's actual shape.

## Net effect on the agent's view
| upstream | pre-#322 | post-#322 (current prod) | post this PR |
|---|---|---|---|
| `code_assistant_search_code` (markdown) | wrapper crash | `{_shape:\"string\", value:\"<markdown>\"}` | content channel: raw markdown, `structured_content`: None |
| `galoy_staging_kubernetes_pods_list` (kubectl table) | wrapper crash | `{_shape:\"string\", value:\"<table>\"}` | content channel: raw table, `structured_content`: None |
| `github_list_pull_requests` (top-level array) | wrapper crash | `{_shape:\"array\", items:[…]}` | content channel: raw JSON array text, `structured_content`: None |
| object-rooted upstream (`pg_execute_sql`, `concourse_list_pipelines`) | record | record | record (unchanged) |

## Diff
- `core/crates/tool-classifier/src/reify.rs` — `ensure_structured_content` only sets `structured_content` for records; new `canonicalize` helper. Removed `wrap_non_record`, `unwrap_at`, `unwrap_at_owned`, `root_path_of_wrapped`, `reify(text)` — no callers anymore.
- `core/crates/tool-classifier/src/lib.rs` — re-exports trimmed; classifier walks the canonicalized value directly.
- `core/crates/tool-cache/src/lib.rs` — drop `wrap_for_transport` (no callers); `persist_classification` stores `original_structured` as-passed.
- `core/src/toolset/top_level/tool_output_fetch.rs` — `final_structured` is set only when the result is a record. Removed all `wrap_non_record` / `wrap_for_transport` calls.
- `core/src/toolset/top_level/compose.rs` — `result_to_value` simpler: returns `structured_content` if set, else parses content text. `build_walker_input` only sets `structured_content` for records.
- Tests rewritten:
  - `reify.rs` test module — 10 tests pinning the new contract: non-records leave `structured_content` None, pre-set non-records are cleared.
  - `core/tests/tool_output_fetch_slice_emission.rs` — 10 tests pinning that slice / json_path / view results land in the content channel for non-records and only set `structured_content` for records. Test names reflect the new contract (`*_returns_*_in_text_channel_no_envelope`, `*_sets_structured_content` for records).

## Test plan
- [x] `cargo test --workspace --lib` — all green (94 tool-classifier + others).
- [x] `cargo test -p drua-core --tests -- --test-threads=1` — full integration suite green.
- [x] `cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, `nix flake check --no-build`.
- [ ] After merge + prod rollout: re-verify against drua prod that code-assistant returns raw markdown to the agent (no `_shape` keys), kubectl tables stay tabular, github list responses are clean JSON array text. The walker / `_recover` round-trip behaviour from #322 should be unchanged.

## Out of scope
- No DB schema changes. `tool_invocations.root_path` column from #322 is still used for metadata; no migration needed.
- No `tool_invocations` wipe needed: existing rows remain queryable, and the new return-channel logic doesn't change how persisted `original_structured` is read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the contract for when `structured_content` is set across dispatch, compose, persistence, and `tool_output_fetch`, which can affect downstream MCP clients and recovery behavior for existing invocations.
> 
> **Overview**
> Stops wrapping non-record tool outputs (arrays/scalars/plain text) into a `{value|items,_shape}` record envelope, leaving `structured_content` as `None` so agents see the upstream’s verbatim `content[].text`.
> 
> Adds `canonicalize()` and updates classification and persistence paths (including compose sub-invocation persistence) to still store the upstream’s parsed value in `original_structured` for recovery (`json_path`/`json_array_slice`) even when the response omits `structured_content`.
> 
> Updates compose’s JS view (`result_to_value`) and `tool_output_fetch` emission to only populate `structured_content` for JSON objects; expands/rewrites tests to lock in the new no-envelope behavior and verify `_recover` round-trips for array-rooted outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02cd02bcc59638feecaf59bbdc4be8fee9a0cac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->