### PR TITLE
docs(toolset): remove stale tool_output_fetch references

### DIFF
--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -403,8 +403,7 @@ impl TopLevelTool for CallCatalogTool {
     fn description(&self) -> &str {
         "Execute an upstream tool by its prefixed name with the provided \
          arguments. Use describe_tool first to understand the parameters. \
-         Oversize results are auto-classified and persisted; recover full \
-         bytes via tool_output_fetch(invocation_id, query)."
+         The upstream result is returned verbatim."
     }
     fn input_schema(&self) -> &serde_json::Value {
         &CALL_SCHEMA

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -52,15 +52,14 @@ static COMPOSE_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<
 
 #[derive(serde::Serialize, schemars::JsonSchema)]
 struct ComposeOutput {
-    /// The JS script's return value. Curated when oversize; recoverable via `tool_output_fetch` using `result_invocation_id`.
+    /// The JS script's return value, returned verbatim.
     #[schemars(schema_with = "crate::toolset::any_json_schema")]
     result: serde_json::Value,
-    /// Set when `result` was curated; pass to `tool_output_fetch` to recover the full JS return.
+    /// Reserved for future curated-output recovery; currently always `None`.
     #[serde(skip_serializing_if = "Option::is_none")]
     result_invocation_id: Option<uuid::Uuid>,
-    /// Recoverable sub-tool calls; excludes passthrough, errored, and bypass-marked calls.
+    /// Reserved for future curated-output recovery; currently always empty.
     sub_invocations: Vec<SubInvocation>,
-    fetch_hint: String,
     console: Vec<String>,
     tool_calls: usize,
     execution_time_ms: u64,
@@ -166,7 +165,6 @@ impl TopLevelTool for ComposeTool {
             result: result.value.clone(),
             result_invocation_id: None,
             sub_invocations: Vec::new(),
-            fetch_hint: COMPOSE_FETCH_HINT.to_string(),
             console: result.console_output.clone(),
             tool_calls: result.tool_calls_made,
             execution_time_ms: result.execution_time.as_millis() as u64,
@@ -201,12 +199,9 @@ impl TopLevelTool for ComposeTool {
             sections.push(format!("=== Sub Invocations ===\n{}", lines.join("\n"),));
         }
         sections.push(format!(
-            "=== Metadata ===\ntool_calls: {}\nexecution_time: {:?}\n{}",
+            "=== Metadata ===\ntool_calls: {}\nexecution_time: {:?}\nresult: verbatim",
             out.tool_calls,
             std::time::Duration::from_millis(out.execution_time_ms),
-            out.result_invocation_id
-                .map(|id| format!("result_invocation_id: {id}"))
-                .unwrap_or_else(|| "result: verbatim (small enough)".to_string()),
         ));
 
         let text = sections.join("\n\n");
@@ -217,10 +212,6 @@ impl TopLevelTool for ComposeTool {
     }
 }
 
-const COMPOSE_FETCH_HINT: &str = "invocation_id is either `result_invocation_id` (full JS return) \
-     or any `sub_invocations[].invocation_id` (specific sub-call's \
-     persisted output) — see `tool_output_fetch` for the full call shape.";
-
 /// Recovery metadata for one sub-tool dispatch inside a compose script.
 #[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
 pub struct SubInvocation {
@@ -229,7 +220,7 @@ pub struct SubInvocation {
     pub tool_name: String,
     /// `tool(key=value, ...)` truncated to 80 chars.
     pub args_digest: String,
-    /// `tool_invocations.id` — pass to `tool_output_fetch`.
+    /// Reserved for future curated-output recovery.
     pub invocation_id: uuid::Uuid,
     /// Summary kind discriminator (e.g. `concourse`, `structured_elision`, `generic`).
     pub kind: String,


### PR DESCRIPTION
## Summary

Follow-up to **#325** (merged). Cursor Bugbot review flagged that the
disconnect PR left several user-visible references to `tool_output_fetch`
(deleted in the same PR) and to the `invocation_id`/recovery mechanism
that no longer exists. An agent reading those would waste a round trip
calling a non-existent tool.

> [#325 review](https://github.com/GaloyMoney/drua/pull/325#pullrequestreview-4262702124):
> \"\`CallCatalogTool::description()\` tells MCP clients 'Oversize results
> are auto-classified and persisted; recover full bytes via
> tool_output_fetch(invocation_id, query)' — but this commit removes
> \`tool_output_fetch\` entirely and disables the
> classification/persistence pipeline. … Similarly, \`COMPOSE_FETCH_HINT\`
> in \`compose.rs\` is returned in every compose response and references
> \`tool_output_fetch\`.\"

## Fix

- `core/src/toolset/top_level/catalog.rs` — rewrite `CallCatalogTool::description()`
  to say the upstream result is returned verbatim.
- `core/src/toolset/top_level/compose.rs`:
  - Drop the `fetch_hint` field from `ComposeOutput` (always-misleading
    static string) and stop emitting it in the `=== Metadata ===` text
    section. Replaced the conditional `result_invocation_id`/`verbatim`
    metadata line with a constant `result: verbatim`.
  - Delete the `COMPOSE_FETCH_HINT` constant.
  - Rewrite docstrings on `ComposeOutput.result`,
    `ComposeOutput.result_invocation_id`,
    `ComposeOutput.sub_invocations`, and `SubInvocation.invocation_id`
    to acknowledge the disconnect — fields are kept (always `None`/empty)
    so re-enabling the cache later remains a pure code change, matching
    #325's stated reversal path.

No behavior change beyond doc/text: the result was already always
verbatim, sub-invocations always empty, etc. The structured schema loses
only `fetch_hint`.

## Test plan

- [x] `nix flake check` — all 7 checks pass (fmt, clippy `-D warnings`,
      nextest, schema, default-config, write-sdl, graphql-schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Low functional risk, but it changes the `compose` structured output schema by removing `fetch_hint`, which could break any clients expecting that field.
> 
> **Overview**
> Updates user-visible metadata to match the disconnected tool-output caching path: `call_tool` now documents that upstream results are returned *verbatim*, and `compose` stops advertising recovery via `tool_output_fetch`.
> 
> In `compose`, the always-misleading `fetch_hint` field/constant is removed, the metadata text is simplified to a constant `result: verbatim`, and several output fields/docstrings are marked as *reserved for future curated-output recovery* (currently `None`/empty).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca5527a5379dca4e57d248cedd8bd8ac716206c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->