### PR TITLE
fix(git-proxy): bearer-auth from sandbox; nil-uuid Agent on JWT validation

### DIFF
--- a/images/sandbox/default.nix
+++ b/images/sandbox/default.nix
@@ -148,20 +148,23 @@ let
   ];
 
   # Credential helper: reads the projected K8s ServiceAccount token at
-  # invocation time and hands it back to git as an HTTP basic-auth
-  # password. Token rotates on disk; helper re-reads each call.
-  # Used for traffic to the drua git-proxy (`drua-internal:.../git/...`),
-  # which then validates the SA token via TokenReview and mints a fresh
-  # GitHub App installation token upstream — the sandbox never sees a
-  # GitHub credential.
+  # invocation time and hands it to git as a Bearer credential (git
+  # 2.46+ authtype/credential protocol — see `gitcredentials(7)`).
+  # Token rotates on disk; helper re-reads each call. Used for traffic
+  # to the drua git-proxy (`$DRUA_GIT_PROXY_URL/git/...`), whose auth
+  # middleware expects `Authorization: Bearer <SA JWT>`. The proxy
+  # validates the JWT via TokenReview and mints a fresh GitHub App
+  # installation token upstream — the sandbox never sees a GitHub
+  # credential.
   gitCredentialHelper = pkgs.writeShellScriptBin "git-credential-drua-sa" ''
     case "$1" in
       get)
         token_path="''${DRUA_SA_TOKEN_PATH:-/var/run/secrets/galoy-agents-git/token}"
         if [ -f "$token_path" ]; then
-          echo "username=x-access-token"
-          echo "password=$(cat "$token_path")"
-          echo ""
+          printf 'capability[]=authtype\n'
+          printf 'authtype=Bearer\n'
+          printf 'credential=%s\n' "$(cat "$token_path")"
+          printf '\n'
         fi
         ;;
       store|erase) ;;
@@ -188,13 +191,21 @@ let
 
     # Compose the agent's gitconfig: static base + dynamic insteadOf
     # block that points GitHub URLs at the drua git-proxy when
-    # DRUA_GIT_PROXY_URL is set. Helper-name must match the wrapper
-    # written into the image (no path — git resolves via PATH).
+    # DRUA_GIT_PROXY_URL is set. The rewritten URL embeds a
+    # `x-access-token@` username so git invokes the credential helper
+    # proactively (no unauthenticated probe / 401 round-trip needed);
+    # the helper then returns `authtype=Bearer credential=<SA JWT>` and
+    # git sends `Authorization: Bearer <SA JWT>` to the proxy.
+    # Helper-name must match the wrapper written into the image (no
+    # path — git resolves via PATH).
     cp /home/agent/.gitconfig.base /home/agent/.gitconfig
     chown 1000:1000 /home/agent/.gitconfig 2>/dev/null || true
     if [ -n "''${DRUA_GIT_PROXY_URL:-}" ]; then
+      proxy_no_scheme="''${DRUA_GIT_PROXY_URL#*://}"
+      proxy_scheme="''${DRUA_GIT_PROXY_URL%%://*}"
+      proxy_with_user="''${proxy_scheme}://x-access-token@''${proxy_no_scheme%/}/"
       cat >> /home/agent/.gitconfig <<EOF
-[url "''${DRUA_GIT_PROXY_URL%/}/"]
+[url "''${proxy_with_user}"]
     insteadOf = https://github.com/
     insteadOf = git@github.com:
 [credential]

--- a/server/src/auth/mod.rs
+++ b/server/src/auth/mod.rs
@@ -142,19 +142,21 @@ async fn resolve_auth_context(
         }
 
         // SA tokens from sandbox pods (projected ServiceAccount tokens).
+        // A valid audience-scoped JWT is sufficient — the git-proxy's
+        // global allow-list is the policy gate, no per-pod identity
+        // lookup. Synthesise the same nil-uuid `AuthSubject::Agent`
+        // shape that the `dev-agent` literal uses; downstream
+        // `is_agent()` returns true and audit rows carry nil
+        // project_id / agent_id (consistent with the design pivot in
+        // PR #290 where the allow-list became global).
         if sa_token::looks_like_jwt(&raw_token) {
             if let Some(ref validator) = state.sa_token_validator {
-                if let Ok(id_str) = validator.validate(&raw_token).await {
-                    let agent_id = domain::primitives::AgentId::from(
-                        id_str.parse::<uuid::Uuid>().expect("validated as UUID"),
+                if validator.validate(&raw_token).await.is_ok() {
+                    return AuthSubject::Agent(
+                        domain::primitives::ProjectId::from(uuid::Uuid::nil()),
+                        domain::primitives::AgentId::from(uuid::Uuid::nil()),
+                        Vec::new(),
                     );
-                    // System-level User subject bypasses authz; runs during token
-                    // resolution, before the per-request AuthSubject is known.
-                    let system_sub =
-                        AuthSubject::User(domain::primitives::UserId::from(uuid::Uuid::nil()));
-                    if let Ok(agent) = state.app.agents().find_by_id(&system_sub, agent_id).await {
-                        return agent.auth_subject();
-                    }
                 }
             }
         }

--- a/server/src/auth/sa_token.rs
+++ b/server/src/auth/sa_token.rs
@@ -1,10 +1,12 @@
 //! Validates Kubernetes projected ServiceAccount tokens via the TokenReview API.
 //!
-//! Sandbox pods authenticate to the MCP gateway using audience-scoped SA tokens
-//! (projected volume, auto-rotated by kubelet). This module validates those tokens
-//! and extracts the agent identity from the bound pod name.
+//! The git-proxy doesn't gate on per-pod identity — a valid
+//! audience-scoped JWT from any sandbox pod is enough to use the proxy
+//! (the global allow-list constrains which repos / refs are reachable).
+//! `validate` therefore returns nothing: it just confirms the JWT
+//! validates for the configured audience, no pod-name parsing.
 
-use k8s_openapi::api::authentication::v1::{TokenReview, TokenReviewSpec, TokenReviewStatus};
+use k8s_openapi::api::authentication::v1::{TokenReview, TokenReviewSpec};
 use kube::api::PostParams;
 use tracing::instrument;
 
@@ -26,9 +28,12 @@ impl SaTokenValidator {
         })
     }
 
-    /// Returns the agent UUID parsed from the bound pod name (`agent-{uuid}`).
+    /// Validates the SA token against the K8s TokenReview API for the
+    /// configured audience. Returns `Ok(())` on success; the bound
+    /// subject's identity isn't propagated — the global git-proxy
+    /// allow-list is the policy gate.
     #[instrument(name = "web.auth.sa_token.validate", skip_all)]
-    pub async fn validate(&self, raw_token: &str) -> Result<String, AuthError> {
+    pub async fn validate(&self, raw_token: &str) -> Result<(), AuthError> {
         let review = TokenReview {
             spec: TokenReviewSpec {
                 token: Some(raw_token.to_string()),
@@ -50,28 +55,8 @@ impl SaTokenValidator {
         if !status.authenticated.unwrap_or(false) {
             return Err(AuthError::InvalidToken);
         }
-
-        let pod_name = extract_pod_name(&status)?;
-        let id_str = pod_name
-            .strip_prefix("agent-")
-            .ok_or(AuthError::InvalidToken)?;
-        // Full UUID required to prevent ambiguous prefix lookups.
-        id_str
-            .parse::<uuid::Uuid>()
-            .map_err(|_| AuthError::InvalidToken)?;
-        Ok(id_str.to_string())
+        Ok(())
     }
-}
-
-/// Kubelet includes `authentication.kubernetes.io/pod-name` in the bound
-/// token's extra fields (nested under `status.user.extra`).
-fn extract_pod_name(status: &TokenReviewStatus) -> Result<String, AuthError> {
-    let user = status.user.as_ref().ok_or(AuthError::InvalidToken)?;
-    let extra = user.extra.as_ref().ok_or(AuthError::InvalidToken)?;
-    let pod_names = extra
-        .get("authentication.kubernetes.io/pod-name")
-        .ok_or(AuthError::InvalidToken)?;
-    pod_names.first().cloned().ok_or(AuthError::InvalidToken)
 }
 
 /// Quick heuristic: SA tokens are JWTs (three dot-separated base64 segments).


### PR DESCRIPTION
## Summary

After PR #290 rolled to prod, sandbox `git clone` calls fail with
`Server returned error: git clone failed: ... git-proxy: unauthorized`.

Honeycomb traces confirmed: `web.auth.middleware` resolved to
`AuthSubject::Anonymous`, no `web.auth.sa_token.validate` child span ever
appeared, and `domain.git_proxy.check_authorization` short-circuited on
`!is_agent()` → 401. Two distinct root causes, each fixed minimally.

### 1. Sandbox sent Basic auth, server only accepts Bearer

The credential helper emitted `username=x-access-token` / `password=<JWT>`,
so git put it in HTTP **Basic** — which `extract_bearer_token` doesn't
parse. The server never saw the token; `looks_like_jwt` was never invoked.

Fix (in `images/sandbox/default.nix`):
- The helper now uses git's `authtype` / `credential` protocol
  (`gitcredentials(7)`, git ≥ 2.46) and emits `authtype=Bearer` +
  `credential=<JWT>`. Git sends `Authorization: Bearer <JWT>` straight
  to the proxy — same path as MCP clients, no Basic-auth shim needed
  server-side.
- The rewritten `insteadOf` URL embeds `x-access-token@` so git invokes
  the helper proactively (skips the unauthenticated probe / 401
  round-trip that was otherwise needed to trigger the helper).

### 2. Server tied SA tokens back to a per-pod agent identity

`SaTokenValidator::validate` parsed `agent-{uuid}` from the bound
token's `authentication.kubernetes.io/pod-name` extra field, then
`resolve_auth_context` did a DB `find_by_id` to hydrate an
`AuthSubject` from the agent row. But PR #290 pivoted to a **global**
allow-list as the policy gate (memo §7.2) — per-pod attribution adds
nothing to the decision and fails-closed when there's no matching agent.

Fix (in `server/src/auth/sa_token.rs` + `server/src/auth/mod.rs`):
A valid audience-scoped JWT yields `AuthSubject::Agent(nil, nil, [])`,
matching the `dev-agent` literal's shape. `is_agent()` is true,
allow-list gates the decision, audit rows carry nil `agent_id` /
`project_id`. `validate` now returns `Result<(), AuthError>` instead
of the pod-name UUID.

## Test plan

- [x] `cargo build -p drua-server` — clean
- [x] `cargo nextest run -p drua-server --lib` — passes
- [x] `cargo clippy -p drua-server --all-targets -- -D warnings` — clean
- [x] `nix flake check` — all checks pass (fmt, clippy, nextest, sdl, default-config)
- [ ] Rolled to a dev env, verified sandbox `git clone` succeeds via the proxy
- [ ] Verified Honeycomb trace shows `web.auth.sa_token.validate` child span and `AuthSubject::Agent` resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes sandbox→git-proxy authentication and server-side agent resolution for Kubernetes ServiceAccount JWTs; mistakes could break sandbox git access or unintentionally widen agent-authenticated requests if validation is misconfigured.
> 
> **Overview**
> Updates the sandbox image’s git credential flow to send Kubernetes ServiceAccount tokens as **Bearer** auth (via git’s `authtype`/`credential` protocol) and rewrites GitHub URLs to include `x-access-token@` so the credential helper is invoked without an initial 401 probe.
> 
> Simplifies server SA-token handling: `SaTokenValidator::validate` now only checks TokenReview authentication/audience (no pod-name parsing), and successful JWT validation yields a synthetic `AuthSubject::Agent` with **nil** `project_id`/`agent_id`, removing the prior DB lookup tied to per-pod identity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49aec9833eec6908cf2fb33e7394dcaa9c127cce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->