### PR TITLE
fix(ci): add diffutils to apps.bats PATH

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -299,11 +299,15 @@
               # handlers — bats/sandbox.bats spawns sandbox-tool-server
               # via this PATH so `rg` has to be present here too (the
               # production sandbox image bakes it in separately).
+              # `diffutils` provides `diff`, used by
+              # bats/fake_mcp_upstream.bats to compare snapshot fixtures
+              # under bats/summarized-tool-responses/.
               export PATH="${pkgs.lib.makeBinPath [
                 bats-runner
                 drua
                 podmanPkgs.podman-compose-runner
                 pkgs.bats
+                pkgs.diffutils
                 pkgs.jq
                 pkgs.curl
                 pkgs.coreutils


### PR DESCRIPTION
## Summary
- `bats/fake_mcp_upstream.bats` calls `diff -u` to compare summarized-response snapshots under `bats/summarized-tool-responses/`.
- `apps.bats` in `flake.nix` builds a hermetic PATH for the bats runner from an explicit list — which omits `diffutils`. Locally `nix develop` pulls it in via other deps so the gap was invisible; CI doesn't.
- Concourse failure: [test-bats #612](https://ci.galoy.io/teams/galoy-agents/pipelines/galoy-agents-bin/jobs/test-bats/builds/612) — every summarized-snapshot test failed with `bats/fake_mcp_upstream.bats: line N: diff: command not found`.

## Fix
Add `pkgs.diffutils` to the PATH list for `apps.bats`.

## Test plan
- [ ] Concourse `test-bats` job passes on the new build triggered by this PR
- [ ] No change to the `apps.sandbox-bats` path (unaffected — that test file doesn't use diff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts the Nix-provided PATH for the Bats runner by adding `diffutils`, with no runtime or business-logic changes.
> 
> **Overview**
> Ensures the hermetic `apps.bats` runner environment includes `pkgs.diffutils`, making `diff` available for snapshot comparisons in `bats/fake_mcp_upstream.bats`.
> 
> This aligns CI with local dev environments and prevents Bats failures due to `diff: command not found`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e22e80c77747baa5c1872317572f84a7e25a7eca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->