### PR TITLE
fix(bats): retry audit-row queries to absorb fire-and-forget race

### DIFF
--- a/bats/git-proxy.bats
+++ b/bats/git-proxy.bats
@@ -98,7 +98,7 @@ SVC_PULL="?service=git-upload-pack"
   # + `# service=git-upload-pack` literal somewhere in the first frame.
   grep -aq 'service=git-upload-pack' "$BATS_TEST_TMPDIR/body"
 
-  count="$(psql "$PG_CON" -tAc "SELECT count(*) FROM audit_entries WHERE action = 'git_proxy.git-upload-pack' AND outcome = 'success' AND metadata->>'owner' = 'GaloyMoney' AND metadata->>'repo' = 'drua'")"
+  count="$(wait_for_audit_count "action = 'git_proxy.git-upload-pack' AND outcome = 'success' AND metadata->>'owner' = 'GaloyMoney' AND metadata->>'repo' = 'drua'")"
   [ "$count" -ge 1 ]
 }
 
@@ -109,7 +109,7 @@ SVC_PULL="?service=git-upload-pack"
   [ "$status" = "403" ]
   grep -q 'repo_not_allowed' "$BATS_TEST_TMPDIR/body"
 
-  count="$(psql "$PG_CON" -tAc "SELECT count(*) FROM audit_entries WHERE action = 'git_proxy.git-upload-pack' AND outcome = 'error' AND error_message = 'repo_not_allowed' AND metadata->>'owner' = 'attacker' AND metadata->>'repo' = 'exfil'")"
+  count="$(wait_for_audit_count "action = 'git_proxy.git-upload-pack' AND outcome = 'error' AND error_message = 'repo_not_allowed' AND metadata->>'owner' = 'attacker' AND metadata->>'repo' = 'exfil'")"
   [ "$count" -ge 1 ]
 }
 
@@ -199,6 +199,6 @@ SVC_PULL="?service=git-upload-pack"
   echo "$output" | grep -E "HTTP 403|error: 22" >/dev/null
 
   # Audit row should record push_ref_denied for the receive-pack POST.
-  count="$(psql "$PG_CON" -tAc "SELECT count(*) FROM audit_entries WHERE action = 'git_proxy.git-receive-pack' AND outcome = 'error' AND error_message = 'push_ref_denied' AND metadata->>'owner' = 'GaloyMoney' AND metadata->>'repo' = 'drua'")"
+  count="$(wait_for_audit_count "action = 'git_proxy.git-receive-pack' AND outcome = 'error' AND error_message = 'push_ref_denied' AND metadata->>'owner' = 'GaloyMoney' AND metadata->>'repo' = 'drua'")"
   [ "$count" -ge 1 ]
 }

--- a/bats/helpers.bash
+++ b/bats/helpers.bash
@@ -228,6 +228,23 @@ mcp_call_no_auth() {
     -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"$method\",\"params\":$params}"
 }
 
+# Poll `audit_entries` until a row matching the given WHERE clause appears.
+# Echoes the final count on stdout. Audit persistence is fire-and-forget
+# (`tokio::spawn`) so the row may arrive a few ms after the HTTP response —
+# wait up to ~3s to absorb CI scheduler jitter.
+wait_for_audit_count() {
+  local where="$1"
+  local count=0
+  for _i in $(seq 1 30); do
+    count="$(psql "$PG_CON" -tAc "SELECT count(*) FROM audit_entries WHERE $where")"
+    if [ "$count" -ge 1 ]; then
+      break
+    fi
+    sleep 0.1
+  done
+  echo "$count"
+}
+
 graphql_query() {
   local query="$1"
   local token="${2:-}"


### PR DESCRIPTION
## Summary

bats build 614 (`test-bats`) failed on `git-proxy: git push to refs/heads/release rejected by ref-pattern` with `[ \"\$count\" -ge 1 ]' failed` at `bats/git-proxy.bats:203`.

Root cause: `audit_middleware` persists rows via `tokio::spawn` — the HTTP response returns to the client before the INSERT lands. The three audit assertions in `git-proxy.bats` (lines 101, 112, 202) query `audit_entries` immediately after the HTTP response and assume the row is already there. The two pull/GET assertions win the race because the handler returns essentially instantly with no body. The receive-pack push assertion has a packfile body + extra processing, and in CI build 614 the spawned INSERT just hadn't completed before `psql` queried.

Confirmed via:
- Honeycomb traces of `web.audit.middleware` showed no failure on the receive-pack request itself.
- Local repro (docker compose backed) — all 92 tests pass.
- Code inspection of `core/src/audit/mod.rs::record_from_context` — `tokio::spawn(async move { audit.record(&ctx_data).await })`, no await on the persistence task.

## Fix

Add a `wait_for_audit_count` helper in `bats/helpers.bash` that polls up to ~3s (30 × 0.1s) for the row, and switch all three audit assertions in `bats/git-proxy.bats` over to it. The other two pull-side assertions get the same treatment defensively so a future CI scheduler hiccup can't flake them too.

## Test plan

- [x] `nix flake check` — passes (fmt, clippy, nextest --lib, sdl, default-config)
- [x] `nix run .#bats -- bats/git-proxy.bats` (docker compose) — 92/92 pass, including test 40
- [ ] CI bats job (`test-bats`) — should turn green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only test helper and Bats assertions change to add a short polling wait for asynchronously-written audit rows, without affecting production code paths.
> 
> **Overview**
> Fixes flaky `git-proxy` Bats tests by replacing immediate `psql` audit assertions with a new `wait_for_audit_count` helper that polls `audit_entries` (up to ~3s) until the expected row appears.
> 
> This makes the three audit-related assertions resilient to the audit middleware’s fire-and-forget persistence timing, reducing CI race failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 577994242430a601bc0a57f7551a07b1d0806f3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->