### PR TITLE
fix(tool-caching): six production-found bugs from end-to-end MCP testing

### DIFF
--- a/bats/fake_mcp_upstream.bats
+++ b/bats/fake_mcp_upstream.bats
@@ -258,7 +258,7 @@ assert_summarized_text_matches() {
 
 @test "fake-upstream: str-large-table summarized into <summary>+<recovery> envelope" {
   # ~13KB kubectl-table-style output (real k8s_list_pods shape); exceeds the
-  # 8KiB threshold so the universal pipeline elides head/tail and renders a
+  # 8KiB threshold so tool-caching elides head/tail and renders a
   # range-mode tool_output_fetch recovery template. Snapshot lives at
   # bats/summarized-tool-responses/str-large-table.txt — open the file to
   # see exactly what the agent receives. Re-run with UPDATE_FIXTURES=1 to

--- a/bats/summarized-tool-responses/concourse-build-log.txt
+++ b/bats/summarized-tool-responses/concourse-build-log.txt
@@ -173,6 +173,6 @@ INFO: found existing resource cache
 </summary>
 <recovery>
   <elided path="$" bytes="32474" lines="320">
-    tool_output_fetch(invocation_id="<uuid>", path="$", query={"len":80,"mode":"lines","offset":82})
+    tool_output_fetch(invocation_id="<uuid>", path="$", query={"len":80,"mode":"lines","offset":120})
   </elided>
 </recovery>

--- a/core/crates/tool-caching/src/config.rs
+++ b/core/crates/tool-caching/src/config.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 const DEFAULT_GENERIC_THRESHOLD_BYTES: usize = 8192;
 const DEFAULT_SENTINEL_HARD_CAP_BYTES: usize = 16 * 1024;
 const DEFAULT_SENTINEL_MIN_BYTES: usize = 512;
+const DEFAULT_MAX_FETCH_RESPONSE_BYTES: usize = 16 * 1024;
 
 /// Knobs the walker actually reads. Per-string head/tail counts are
 /// derived adaptively from `generic_threshold_bytes` at walk time;
@@ -19,6 +20,12 @@ pub struct ToolCachingConfig {
     /// Upper bound for the array-sentinel size-shrink loop budget.
     #[serde(default = "default_sentinel_hard_cap_bytes")]
     pub sentinel_hard_cap_bytes: usize,
+    /// Ceiling on a single `tool_output_fetch` response. Recovery
+    /// templates the walker emits stay under this by construction; ad
+    /// hoc fetches with a bigger `len` or no `query` get rejected with
+    /// `FetchResponseTooLarge`.
+    #[serde(default = "default_max_fetch_response_bytes")]
+    pub max_fetch_response_bytes: usize,
 }
 
 impl Default for ToolCachingConfig {
@@ -27,6 +34,7 @@ impl Default for ToolCachingConfig {
             generic_threshold_bytes: DEFAULT_GENERIC_THRESHOLD_BYTES,
             sentinel_min_bytes: DEFAULT_SENTINEL_MIN_BYTES,
             sentinel_hard_cap_bytes: DEFAULT_SENTINEL_HARD_CAP_BYTES,
+            max_fetch_response_bytes: DEFAULT_MAX_FETCH_RESPONSE_BYTES,
         }
     }
 }
@@ -39,4 +47,7 @@ fn default_sentinel_hard_cap_bytes() -> usize {
 }
 fn default_sentinel_min_bytes() -> usize {
     DEFAULT_SENTINEL_MIN_BYTES
+}
+fn default_max_fetch_response_bytes() -> usize {
+    DEFAULT_MAX_FETCH_RESPONSE_BYTES
 }

--- a/core/crates/tool-caching/src/error.rs
+++ b/core/crates/tool-caching/src/error.rs
@@ -8,4 +8,9 @@ pub enum ToolCachingError {
     InvocationNotFound,
     #[error("invalid fetch path: {0}")]
     InvalidPath(String),
+    #[error(
+        "fetch response too large: {size} bytes (max {max}); narrow the query \
+         with a smaller `len`, a deeper `path`, or by switching mode"
+    )]
+    FetchResponseTooLarge { size: usize, max: usize },
 }

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -1,5 +1,5 @@
-//! Recovery side of the universal pipeline: given a stored invocation,
-//! navigate a json-path and optionally slice the resolved value.
+//! Recovery side of tool-caching: given a stored invocation, navigate
+//! a json-path and optionally slice the resolved value.
 
 use rmcp::model::{CallToolResult, Content};
 use serde::{Deserialize, Serialize};

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -78,7 +78,7 @@ pub struct FetchResult {
 impl StoredInvocation {
     /// Resolve `path` against the stored root and slice with `query`.
     /// Wraps the result back at `path` so the response shape mirrors
-    /// the caller's request (`$.foo[2]` → `{"foo": [null, null, X]}`).
+    /// the caller's request (`$.foo[2]` → `{"foo": [X]}`).
     pub fn query(
         &self,
         path: &str,
@@ -118,9 +118,11 @@ impl StoredInvocation {
 
     /// Rebuild the structure implied by `path` around `value`. For
     /// `path == "$"` returns `value` directly. Object-key segments nest
-    /// into `{key: …}`; array-index segments produce a sparse array
-    /// padded with `null` so the position is preserved (`$[3]` →
-    /// `[null, null, null, value]`).
+    /// into `{key: …}`; array-index segments wrap into a single-element
+    /// array (`$[3]` → `[value]`) — callers can read `result[0]` and
+    /// recover the original index from the recovery template's `path`
+    /// field. Leading `null` padding scales linearly with the index and
+    /// would burn tokens at every higher position without adding info.
     fn wrap_at_path(path: &str, value: Value) -> Result<Value, ToolCachingError> {
         let segments = Self::parse_path(path)?;
         let mut acc = value;
@@ -131,11 +133,7 @@ impl StoredInvocation {
                     obj.insert(k, acc);
                     Value::Object(obj)
                 }
-                PathSegment::Index(i) => {
-                    let mut arr = vec![Value::Null; i];
-                    arr.push(acc);
-                    Value::Array(arr)
-                }
+                PathSegment::Index(_) => Value::Array(vec![acc]),
             };
         }
         Ok(acc)
@@ -233,9 +231,9 @@ mod tests {
     }
 
     #[test]
-    fn wrap_at_path_array_root_pads_with_nulls() {
+    fn wrap_at_path_array_root_uses_single_element() {
         let wrapped = StoredInvocation::wrap_at_path("$[2]", Value::String("hi".into())).unwrap();
-        assert_eq!(wrapped, serde_json::json!([null, null, "hi"]));
+        assert_eq!(wrapped, serde_json::json!(["hi"]));
     }
 
     #[test]
@@ -244,7 +242,7 @@ mod tests {
             StoredInvocation::wrap_at_path("$.items[1].name", Value::String("hi".into())).unwrap();
         assert_eq!(
             wrapped,
-            serde_json::json!({"items": [null, {"name": "hi"}]}),
+            serde_json::json!({"items": [{"name": "hi"}]}),
         );
     }
 

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -78,11 +78,13 @@ pub struct FetchResult {
 impl StoredInvocation {
     /// Resolve `path` against the stored root and slice with `query`.
     /// Wraps the result back at `path` so the response shape mirrors
-    /// the caller's request (`$.foo[2]` → `{"foo": [X]}`).
+    /// the caller's request (`$.foo[2]` → `{"foo": [X]}`). Responses
+    /// over `max_bytes` (text channel size) are rejected.
     pub fn query(
         &self,
         path: &str,
         query: Option<&FetchQuery>,
+        max_bytes: usize,
     ) -> Result<FetchResult, ToolCachingError> {
         let resolved = self.navigate(path)?.clone();
         let sliced = match query {
@@ -94,6 +96,12 @@ impl StoredInvocation {
             Value::String(s) => s.clone(),
             other => serde_json::to_string(other).unwrap_or_default(),
         };
+        if text.len() > max_bytes {
+            return Err(ToolCachingError::FetchResponseTooLarge {
+                size: text.len(),
+                max: max_bytes,
+            });
+        }
         Ok(FetchResult {
             result: CallToolResult::success(vec![Content::text(text)]),
             structured: wrapped,

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -248,10 +248,7 @@ mod tests {
     fn wrap_at_path_mixed_keys_and_indices() {
         let wrapped =
             StoredInvocation::wrap_at_path("$.items[1].name", Value::String("hi".into())).unwrap();
-        assert_eq!(
-            wrapped,
-            serde_json::json!({"items": [{"name": "hi"}]}),
-        );
+        assert_eq!(wrapped, serde_json::json!({"items": [{"name": "hi"}]}),);
     }
 
     #[test]

--- a/core/crates/tool-caching/src/lib.rs
+++ b/core/crates/tool-caching/src/lib.rs
@@ -27,7 +27,6 @@ use rmcp::model::{CallToolResult, RawContent};
 pub struct ToolCaching {
     #[allow(dead_code)]
     pool: sqlx::PgPool,
-    #[allow(dead_code)]
     config: ToolCachingConfig,
     repo: ToolCacheRepo,
     walker: Walker,
@@ -121,7 +120,9 @@ impl ToolCaching {
     /// Resolve a path on a previously-persisted invocation and slice
     /// the resolved value with `query`. Owner-scoped — non-owners get
     /// `InvocationNotFound`. Wraps the result back at `path` so the
-    /// response mirrors the caller's request shape.
+    /// response mirrors the caller's request shape. Responses larger
+    /// than `config.max_fetch_response_bytes` are rejected with
+    /// `FetchResponseTooLarge`.
     pub async fn fetch(
         &self,
         owner_id: ToolCallOwnerId,
@@ -130,7 +131,7 @@ impl ToolCaching {
         query: Option<&FetchQuery>,
     ) -> Result<FetchResult, ToolCachingError> {
         let stored = self.repo.find_by_id(id, owner_id).await?;
-        stored.query(path, query)
+        stored.query(path, query, self.config.max_fetch_response_bytes)
     }
 }
 

--- a/core/crates/tool-caching/src/preprocessors/concourse.rs
+++ b/core/crates/tool-caching/src/preprocessors/concourse.rs
@@ -1,6 +1,8 @@
-//! Concourse build-log preprocessor: strips ANSI escapes and the
+//! Concourse build-log preprocessor: strips ANSI escapes, the
 //! `[HH:MM:SS] ` timestamp prefix that the upstream emits on every
-//! line. Line-aligned with the input so downstream line-aware passes
+//! line, and re-flows `\r`-overwriting progress (git clone / nix copy
+//! / curl style) into one logical line per intermediate state.
+//! Line-aligned with the input so downstream line-aware passes
 //! (string-summarizer chain, byte/line elide) can do their work
 //! against clean text.
 
@@ -13,18 +15,47 @@ use regex::Regex;
 /// uses `concourse-build-log` (catalog naming convention).
 pub const TOOL_NAMES: &[&str] = &["concourse_get_build_logs", "concourse-build-log"];
 
-/// Strip ANSI colour codes and leading `[HH:MM:SS] ` timestamps from
-/// every line in `raw`. Idempotent.
+/// Strip ANSI colour codes, leading `[HH:MM:SS] ` timestamps, and
+/// translate every `\r` into `\n` so downstream line-mode elision (and
+/// the existing line-pattern chain passes — `<git-clone>`, `<nix-copy>`,
+/// etc.) see one progress increment per line instead of a single
+/// multi-KB `\r`-packed mega-line. Idempotent.
 pub fn run(raw: &str) -> String {
     let timestamp_re = timestamp_re();
-    let mut out = String::with_capacity(raw.len());
-    for line in raw.lines() {
+    let reflowed = reflow_carriage_returns(raw);
+    let mut out = String::with_capacity(reflowed.len());
+    for line in reflowed.lines() {
         let no_ansi = strip_ansi(line);
         let body = strip_timestamp(&no_ansi, timestamp_re);
         out.push_str(body);
         out.push('\n');
     }
     out
+}
+
+/// Translate `\r` runs into `\n`s. `git clone`, `nix copy`, `curl`, …
+/// use bare `\r` to rewrite the same terminal line in-place; what
+/// reaches a captured log is one `\n`-terminated line of
+/// `seg1\rseg2\r…\rfinal` that can run to tens of KB. Splitting each
+/// such mega-line back into one logical line per intermediate state
+/// lets the existing string-summarizer chain match the progress
+/// patterns it already knows about (e.g. `<git-clone>` collapses runs
+/// of `remote: …` lines). `\r\n` is normalised to `\n` first so we
+/// don't double-newline Windows-style endings.
+fn reflow_carriage_returns(raw: &str) -> std::borrow::Cow<'_, str> {
+    if !raw.contains('\r') {
+        return std::borrow::Cow::Borrowed(raw);
+    }
+    let mut out = String::with_capacity(raw.len());
+    let normalised = raw.replace("\r\n", "\n");
+    for ch in normalised.chars() {
+        if ch == '\r' {
+            out.push('\n');
+        } else {
+            out.push(ch);
+        }
+    }
+    std::borrow::Cow::Owned(out)
 }
 
 fn strip_ansi(s: &str) -> std::borrow::Cow<'_, str> {
@@ -61,5 +92,25 @@ mod tests {
     fn idempotent_on_clean_text() {
         let raw = "already clean\nno escapes\n";
         assert_eq!(run(raw), raw);
+    }
+
+    #[test]
+    fn reflows_carriage_return_progress_into_separate_lines() {
+        let raw = "[08:53:32] remote: Counting objects:   1% (21/2027)\rremote: Counting objects:  50% (1014/2027)\rremote: Counting objects: 100% (2027/2027), done.\n[08:53:33] next line\n";
+        let cleaned = run(raw);
+        assert_eq!(
+            cleaned,
+            "remote: Counting objects:   1% (21/2027)\n\
+             remote: Counting objects:  50% (1014/2027)\n\
+             remote: Counting objects: 100% (2027/2027), done.\n\
+             next line\n"
+        );
+    }
+
+    #[test]
+    fn normalises_crlf_without_doubling_newlines() {
+        let raw = "[12:00:00] a\r\n[12:00:01] b\r\n";
+        let cleaned = run(raw);
+        assert_eq!(cleaned, "a\nb\n");
     }
 }

--- a/core/crates/tool-caching/src/walker.rs
+++ b/core/crates/tool-caching/src/walker.rs
@@ -206,7 +206,7 @@ impl Walker {
         // and line indices stay accurate across passes.
         let mut ctx = SegmentedText::from_initial(&preprocessed);
         let _ = self.chain.run(&mut ctx);
-        let prepared = ctx.into_log();
+        let prepared = ctx.log().to_string();
         let modified = prepared != *s;
         // If the chain didn't change anything and we're already under
         // budget, passthrough verbatim.
@@ -227,7 +227,7 @@ impl Walker {
             return Value::String(prepared);
         }
         // Try line-mode first if the string has enough lines to split.
-        if let Some(elide) = line_elide_string(&prepared, budget) {
+        if let Some(elide) = line_elide_string(&prepared, budget, &ctx) {
             elided_paths.push(ElidedPath {
                 path: path.to_string(),
                 bytes: s.len() as u64,
@@ -236,13 +236,27 @@ impl Walker {
                 recover: make_lines_recover(
                     invocation_id,
                     path,
-                    elide.head_lines as usize,
-                    elide.missing_lines as usize,
+                    elide.raw_offset as usize,
+                    elide.raw_missing as usize,
                 ),
             });
             return Value::String(elide.text);
         }
         // Fall back to byte-mode for single-line / few-line strings.
+        // When preprocess / chain modified the string, the recovery
+        // template can't carry byte offsets (they wouldn't map back to
+        // the persisted raw bytes), so emit a full-value recover and
+        // let the fetch cap gate response size.
+        if modified {
+            elided_paths.push(ElidedPath {
+                path: path.to_string(),
+                bytes: s.len() as u64,
+                lines: None,
+                length: None,
+                recover: make_full_recover(invocation_id, path),
+            });
+            return Value::String(prepared);
+        }
         if let Some(elide) = byte_elide_string(&prepared, budget) {
             elided_paths.push(ElidedPath {
                 path: path.to_string(),
@@ -355,21 +369,23 @@ fn line_count(s: &str) -> u32 {
 
 // ── String elision: line-mode (preferred for line-oriented content) ──
 
+/// `raw_offset` / `raw_missing` are line indices into the *persisted*
+/// raw text (what `tool_output_fetch` slices). They're translated from
+/// the post-chain "current" line indices via `SegmentedText`, so chain
+/// passes that compact `nix-copy`/`cargo`/`git-clone` runs into XML
+/// markers don't desync the recovery template from the on-disk bytes.
 struct LineElide {
     text: String,
-    head_lines: u32,
-    missing_lines: u32,
+    raw_offset: u32,
+    raw_missing: u32,
 }
 
-fn line_elide_string(s: &str, budget: usize) -> Option<LineElide> {
+fn line_elide_string(s: &str, budget: usize, ctx: &SegmentedText) -> Option<LineElide> {
     let lines: Vec<&str> = s.lines().collect();
     let n = lines.len();
     if n < 3 {
-        // Need head + tail + missing >= 3 lines to even attempt.
         return None;
     }
-    // Start as wide as possible (symmetric, at least one missing line),
-    // shrink alternately from the bigger side until rendered text fits.
     let mut head = n / 2;
     let mut tail = n - head;
     if tail > 0 {
@@ -377,14 +393,14 @@ fn line_elide_string(s: &str, budget: usize) -> Option<LineElide> {
     } else {
         head = head.saturating_sub(1);
     }
-    let mut elide = make_line_elide(&lines, head, tail);
+    let mut elide = make_line_elide(&lines, head, tail, ctx);
     while elide.text.len() > budget && (head > 0 || tail > 0) {
         if tail > head {
             tail -= 1;
         } else {
             head -= 1;
         }
-        elide = make_line_elide(&lines, head, tail);
+        elide = make_line_elide(&lines, head, tail, ctx);
     }
     if head == 0 && tail == 0 {
         return None;
@@ -392,17 +408,20 @@ fn line_elide_string(s: &str, budget: usize) -> Option<LineElide> {
     Some(elide)
 }
 
-fn make_line_elide(lines: &[&str], head: usize, tail: usize) -> LineElide {
+fn make_line_elide(lines: &[&str], head: usize, tail: usize, ctx: &SegmentedText) -> LineElide {
     let n = lines.len();
-    let missing = n - head - tail;
+    let missing_compacted = n - head - tail;
+    let raw_offset = ctx.current_to_original_line(head as u32);
+    let raw_after = ctx.current_to_original_line((head + missing_compacted) as u32);
+    let raw_missing = raw_after.saturating_sub(raw_offset);
     let mut text = String::new();
     if head > 0 {
         let head_text = lines[..head].join("\n");
         text.push_str(&format!("<head lines=\"{head}\">\n{head_text}\n</head>\n"));
     }
     text.push_str(&format!(
-        "<bulk-elided original-lines=\"{missing}\">\n\
-         {missing} lines elided\n\
+        "<bulk-elided original-lines=\"{raw_missing}\">\n\
+         {raw_missing} lines elided\n\
          </bulk-elided>\n"
     ));
     if tail > 0 {
@@ -413,8 +432,8 @@ fn make_line_elide(lines: &[&str], head: usize, tail: usize) -> LineElide {
     }
     LineElide {
         text,
-        head_lines: head as u32,
-        missing_lines: missing as u32,
+        raw_offset,
+        raw_missing,
     }
 }
 

--- a/core/crates/tool-caching/src/walker.rs
+++ b/core/crates/tool-caching/src/walker.rs
@@ -394,16 +394,23 @@ fn line_elide_string(s: &str, budget: usize) -> Option<LineElide> {
 
 fn make_line_elide(lines: &[&str], head: usize, tail: usize) -> LineElide {
     let n = lines.len();
-    let head_text = lines[..head].join("\n");
-    let tail_text = lines[n - tail..].join("\n");
     let missing = n - head - tail;
-    let text = format!(
-        "<head lines=\"{head}\">\n{head_text}\n</head>\n\
-         <bulk-elided original-lines=\"{missing}\">\n\
+    let mut text = String::new();
+    if head > 0 {
+        let head_text = lines[..head].join("\n");
+        text.push_str(&format!("<head lines=\"{head}\">\n{head_text}\n</head>\n"));
+    }
+    text.push_str(&format!(
+        "<bulk-elided original-lines=\"{missing}\">\n\
          {missing} lines elided\n\
-         </bulk-elided>\n\
-         <tail lines=\"{tail}\">\n{tail_text}\n</tail>"
-    );
+         </bulk-elided>\n"
+    ));
+    if tail > 0 {
+        let tail_text = lines[n - tail..].join("\n");
+        text.push_str(&format!("<tail lines=\"{tail}\">\n{tail_text}\n</tail>"));
+    } else {
+        text.truncate(text.trim_end_matches('\n').len());
+    }
     LineElide {
         text,
         head_lines: head as u32,
@@ -433,15 +440,26 @@ fn byte_elide_string(s: &str, budget: usize) -> Option<ByteElide> {
     }
     let missing_len = tail_start - head_end;
     let tail_bytes = s.len() - tail_start;
-    let text = format!(
-        "<head bytes=\"{head_end}\">\n{}\n</head>\n\
-         <bulk-elided original-bytes=\"{missing_len}\">\n\
+    let mut text = String::new();
+    if head_end > 0 {
+        text.push_str(&format!(
+            "<head bytes=\"{head_end}\">\n{}\n</head>\n",
+            &s[..head_end],
+        ));
+    }
+    text.push_str(&format!(
+        "<bulk-elided original-bytes=\"{missing_len}\">\n\
          {missing_len} bytes elided\n\
-         </bulk-elided>\n\
-         <tail bytes=\"{tail_bytes}\">\n{}\n</tail>",
-        &s[..head_end],
-        &s[tail_start..],
-    );
+         </bulk-elided>\n"
+    ));
+    if tail_bytes > 0 {
+        text.push_str(&format!(
+            "<tail bytes=\"{tail_bytes}\">\n{}\n</tail>",
+            &s[tail_start..],
+        ));
+    } else {
+        text.truncate(text.trim_end_matches('\n').len());
+    }
     Some(ByteElide {
         text,
         head_end,

--- a/core/migrations/20260508000000_tool_invocations.sql
+++ b/core/migrations/20260508000000_tool_invocations.sql
@@ -1,4 +1,4 @@
--- Persistence layer for the tool-output universal pipeline. Each row holds
+-- Persistence layer for tool-output caching. Each row holds
 -- the raw output of a single tool call that the dispatcher's
 -- `ResultClassifier` deemed worth persisting (i.e. anything but
 -- `Passthrough`).

--- a/core/migrations/20260512000000_tool_invocations_rebuild.sql
+++ b/core/migrations/20260512000000_tool_invocations_rebuild.sql
@@ -1,5 +1,5 @@
 -- Drop the pre-disconnect tool_invocations table and recreate against the
--- simplified universal-pipeline schema:
+-- simplified tool-caching schema:
 --
 --   * single polymorphic `owner_id` (agent_id wins on AgentOnBehalfOfUser).
 --   * `query_structure` jsonb holds the parsed root Value the walker

--- a/core/src/toolset/searchable/concourse.rs
+++ b/core/src/toolset/searchable/concourse.rs
@@ -378,7 +378,7 @@ impl ConcourseToolSet {
             ),
             tool_entry(
                 "get_build_logs",
-                "Get build output/logs for a Concourse build by its numeric build ID. Returns log output as plain text. For in-flight builds, returns partial output — use get_build_status first to check if the build has finished. Oversize logs are auto-classified by the universal pipeline (typed Concourse summary + persisted full bytes); recover specific slices via tool_output_fetch(invocation_id, query={mode:'tail'|'head'|'range'|'grep', ...}).",
+                "Get build output/logs for a Concourse build by its numeric build ID. Returns log output as plain text. For in-flight builds, returns partial output — use get_build_status first to check if the build has finished. Oversize logs are summarised by the universal pipeline and the full bytes are persisted; recover specific slices via tool_output_fetch(invocation_id, path, query={mode:'range'|'lines'|'json_array_slice', offset, len}).",
                 (*BUILD_ID_SCHEMA).clone(),
                 (*OUT_BUILD_LOGS).clone(),
             ),

--- a/core/src/toolset/searchable/concourse.rs
+++ b/core/src/toolset/searchable/concourse.rs
@@ -378,7 +378,7 @@ impl ConcourseToolSet {
             ),
             tool_entry(
                 "get_build_logs",
-                "Get build output/logs for a Concourse build by its numeric build ID. Returns log output as plain text. For in-flight builds, returns partial output — use get_build_status first to check if the build has finished. Oversize logs are summarised by the universal pipeline and the full bytes are persisted; recover specific slices via tool_output_fetch(invocation_id, path, query={mode:'range'|'lines'|'json_array_slice', offset, len}).",
+                "Get build output/logs for a Concourse build by its numeric build ID. Returns log output as plain text. For in-flight builds, returns partial output — use get_build_status first to check if the build has finished. Oversize logs are summarised on the way back and the full bytes are persisted; recover specific slices via tool_output_fetch(invocation_id, path, query={mode:'range'|'lines'|'json_array_slice', offset, len}).",
                 (*BUILD_ID_SCHEMA).clone(),
                 (*OUT_BUILD_LOGS).clone(),
             ),

--- a/core/src/toolset/top_level/tool_output_fetch.rs
+++ b/core/src/toolset/top_level/tool_output_fetch.rs
@@ -1,4 +1,4 @@
-//! Recovery handle for the universal-pipeline envelope. Given an
+//! Recovery handle for the tool-caching envelope. Given an
 //! `invocation_id` (advertised verbatim in `<recovery>`), navigate a
 //! JSON-path on the persisted upstream payload and optionally slice
 //! the resolved value.

--- a/lib/js-engine/src/error.rs
+++ b/lib/js-engine/src/error.rs
@@ -22,7 +22,7 @@ pub enum JsEngineError {
          script's sub-tool calls already produced what you need, look \
          up sub_invocations[].invocation_id from a prior successful \
          compose run and call tool_output_fetch(invocation_id, \
-         query={{mode:'grep'|'tail'|'head'|'range', ...}}) instead of \
+         path, query={{mode:'range'|'lines'|'json_array_slice', offset, len}}) instead of \
          re-running the whole compose script."
     )]
     ReturnTooLarge { size: usize, max: usize },

--- a/lib/js-engine/src/error.rs
+++ b/lib/js-engine/src/error.rs
@@ -14,7 +14,7 @@ pub enum JsEngineError {
     MemoryLimit,
     #[error("JsEngineError - ToolCallLimit: script exceeded {max} tool calls")]
     ToolCallLimit { max: usize },
-    #[error("JsEngineError - ToolResultTooLarge: {size} bytes (max {max}). The tool returned more data than compose can hold in a single result. Try a more specific upstream query (limit/filter parameters), or recover the persisted bytes via tool_output_fetch(invocation_id, query) — the universal pipeline already stored the full result.")]
+    #[error("JsEngineError - ToolResultTooLarge: {size} bytes (max {max}). The tool returned more data than compose can hold in a single result. Try a more specific upstream query (limit/filter parameters), or recover the persisted bytes via tool_output_fetch(invocation_id, query) — the tool-caching layer already stored the full result.")]
     ToolResultTooLarge { size: usize, max: usize },
     #[error(
         "JsEngineError - ReturnTooLarge: {size} bytes (max {max}). \

--- a/lib/js-engine/src/lib.rs
+++ b/lib/js-engine/src/lib.rs
@@ -42,7 +42,7 @@ pub struct JsEngine {
     /// payloads and filter them before returning.
     max_tool_result_bytes: usize,
     // Anti-runaway hard ceiling only — must stay well above the walker's
-    // threshold or it pre-empts the universal pipeline.
+    // threshold or it pre-empts tool-caching.
     max_return_bytes: usize,
     /// Cap on the console buffer in bytes. Drops oldest entries (tail
     /// truncation) when exceeded. Console is a debug sidecar, not primary


### PR DESCRIPTION
## Summary

End-to-end testing of the merged universal pipeline (PR #326) across
the live drua MCP catalog turned up six independent bugs. Each is
fixed in its own commit so this can be cherry-picked / reverted
piecewise if a snapshot regeneration takes time.

## Bugs fixed (most → least impactful)

1. **Chain-compacted vs raw-line offset mismatch** — `line_elide_string`
   was producing recovery templates whose `offset` / `len` were in
   *compacted-line space*, but `tool_output_fetch(mode: lines)` slices
   raw text. Real concourse logs hit this hard: a template saying
   ``offset: 53, len: 54`` returned the *start* of the nix-fetch-list
   instead of the actually-elided middle. Walker now translates head/
   tail boundaries via `SegmentedText::current_to_original_line` when
   writing the recovery template and the `<bulk-elided original-lines>`
   marker. Byte-mode emits a full-value recover when the string was
   modified by preprocess / chain (no clean byte-level mapping; the
   16 KB fetch cap protects the response size).

2. **`\r`-progress collapsed into one mega-line** — `git clone`, `nix
   copy`, `curl` use bare `\r` to rewrite the terminal line in-place.
   The captured log has one `\n`-terminated line of `seg1\rseg2\r…` up
   to tens of KB. Line-mode elide treated each as one unit, so a
   "5 line" slice could return 25 KB. The concourse preprocessor now
   normalises `\r\n` → `\n` and then translates remaining `\r` → `\n`,
   so progress increments land on separate lines and the existing
   `<git-clone>` summarizer pattern collapses them natively.

3. **No fetch response cap** — `max_fetch_response_bytes` (16 KB) was
   missing from the config struct, and `StoredInvocation::query`
   accepted any `len`. A fetch with no query or a deliberately huge
   `len` could pull the full persisted blob into the agent's context.
   Restored the field, plumbed it through `ToolCaching::fetch`, and
   added `ToolCachingError::FetchResponseTooLarge { size, max }`.

4. **Sparse-null padding on recovered arrays** — `wrap_at_path` padded
   `$[3]` → `[null, null, null, value]`. At `$[45]` that's ~270 chars
   of useless `null,`. The recovery template's `path` field already
   says which index the value came from, so we wrap as a
   single-element array (`$[3]` → `[value]`) and let the caller read
   `result[0]`. Test for the old behaviour was renamed to assert the
   new shape.

5. **Zero-byte head/tail markers on fully elided strings** — `<head
   bytes="0">\n\n</head>` and `<tail bytes="0">\n\n</tail>` were
   wrapped around `<bulk-elided>` whenever a body fell entirely into
   the per-item budget. Pure padding. Both `make_line_elide` and
   `byte_elide_string` now skip the head / tail block when empty.

6. **Stale fetch-mode references in tool descriptions** —
   `concourse_get_build_logs` description and
   `JsEngineError::ReturnTooLarge` hint still advertised the old
   `tail` / `head` / `grep` modes that no longer exist. Replaced with
   the actual `range` / `lines` / `json_array_slice` + `offset` / `len`
   shape.

## Why these slipped past the bats suite

End-to-end report on which bugs the existing tests *should* have
caught and why they didn't:

- #1 — round-trip tests exist for `str-large-table` and the compose
  result, but **neither input triggers the chain** (clean kubectl
  table + synthetic compose string). The `concourse-build-log` and
  `nix-copy-output` tests assert the envelope only, no recovery
  round-trip. A round-trip on either would have failed.
- #2 — the `concourse-build-log.txt` fixture happens to have **zero
  `\r` characters**. Realistic concourse output (git clone, nix
  progress) is full of them.
- #3 — no test calls `tool_output_fetch` with a `len` that should
  overflow the cap.
- #4 — fixtures only round-trip `$[0]` paths or `json_array_slice`;
  no `$[N]` for `N > 0`.
- #5 — no fixture has bodies that fall entirely into the per-item
  budget (`arr-large-fat-items` uses partial-elide bodies).
- #6 — no test calls `describe_tool`.

A future PR can close these by adding a concourse round-trip, a
`\r`-rich fixture variant, a `$[N>0]` round-trip on
`arr-large-passthrough-items`, and a fetch-cap assertion.

## Fixture regeneration

Commit 6 changes how `<bulk-elided original-lines>` is rendered for
strings that *did* go through chain compaction. Two snapshots will
need `UPDATE_FIXTURES=1` after a green local run:

- `bats/summarized-tool-responses/concourse-build-log.txt`
- `bats/summarized-tool-responses/nix-copy-output.txt`

The `str-large-table.txt` snapshot is chain-passthrough so its values
are unchanged.

## Test plan

- [ ] `cargo build --workspace`
- [ ] `cargo nextest run --workspace`
- [ ] `nix flake check`
- [ ] `nix run .#bats` (after fixture regen with `UPDATE_FIXTURES=1`)
- [ ] manual recovery against the production concourse build log
      (`019e1c5c-…`) returns the actually-elided middle, not the
      early nix-fetch-list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core tool-output summarization/recovery logic and changes recovery slice math and response shaping, which could affect clients relying on prior fetch semantics. Guardrails were added (fetch-size cap), but regressions could surface in edge-case recovery templates and large log handling.
> 
> **Overview**
> Fixes several `tool-caching` recovery correctness issues: line-based elision recovery now translates compacted line indices back to raw persisted line offsets, and byte-mode elision avoids emitting unusable range templates when preprocess/chain modified the text (falls back to full-value recovery).
> 
> Hardens `tool_output_fetch` by adding `max_fetch_response_bytes` (default 16KiB) and returning a new `FetchResponseTooLarge` error when requests would exceed the cap, and reduces token bloat by wrapping array index recoveries as single-element arrays instead of sparse `null`-padded arrays.
> 
> Improves concourse log preprocessing by reflowing `\r` progress updates into separate lines (and normalizing CRLF), updates tool/help text to reflect current fetch modes, and refreshes affected Bats snapshots/fixtures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7be9515ef3c3d9b249145bf1ca7670576443bc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->