### PR TITLE
fix(tool-caching): two follow-ups from PR #333 (recovery offsets + envelope test)

### DIFF
--- a/core/crates/tool-caching/src/preprocessors/bash.rs
+++ b/core/crates/tool-caching/src/preprocessors/bash.rs
@@ -8,8 +8,13 @@
 //! highlighting failed steps, summarising exit codes) doesn't need
 //! to re-touch the walker dispatch table.
 
+use super::{identity_mapping, Preprocessed};
+
 pub const TOOL_NAMES: &[&str] = &["bash"];
 
-pub fn run(raw: &str) -> String {
-    raw.to_string()
+pub fn run(raw: &str) -> Preprocessed {
+    Preprocessed {
+        text: raw.to_string(),
+        preprocessed_to_raw: identity_mapping(raw),
+    }
 }

--- a/core/crates/tool-caching/src/preprocessors/concourse.rs
+++ b/core/crates/tool-caching/src/preprocessors/concourse.rs
@@ -4,58 +4,45 @@
 //! / curl style) into one logical line per intermediate state.
 //! Line-aligned with the input so downstream line-aware passes
 //! (string-summarizer chain, byte/line elide) can do their work
-//! against clean text.
+//! against clean text — and emits a `preprocessed_to_raw` mapping
+//! tracking which raw line each output line came from (`\r`-reflow
+//! emits multiple output lines per raw line, so the mapping is no
+//! longer identity).
 
 use std::sync::OnceLock;
 
 use regex::Regex;
+
+use super::Preprocessed;
 
 /// Tool-name suffixes this preprocessor matches. Production concourse
 /// tools use `concourse_get_build_logs`; the bats fake-upstream fixture
 /// uses `concourse-build-log` (catalog naming convention).
 pub const TOOL_NAMES: &[&str] = &["concourse_get_build_logs", "concourse-build-log"];
 
-/// Strip ANSI colour codes, leading `[HH:MM:SS] ` timestamps, and
-/// translate every `\r` into `\n` so downstream line-mode elision (and
-/// the existing line-pattern chain passes — `<git-clone>`, `<nix-copy>`,
-/// etc.) see one progress increment per line instead of a single
-/// multi-KB `\r`-packed mega-line. Idempotent.
-pub fn run(raw: &str) -> String {
+/// Strip ANSI colour codes, leading `[HH:MM:SS] ` timestamps, and split
+/// each `\r`-packed raw line into one output line per intermediate
+/// state. Returns the cleaned text plus the per-output-line index back
+/// to the raw line each output line came from. Idempotent.
+pub fn run(raw: &str) -> Preprocessed {
     let timestamp_re = timestamp_re();
-    let reflowed = reflow_carriage_returns(raw);
-    let mut out = String::with_capacity(reflowed.len());
-    for line in reflowed.lines() {
-        let no_ansi = strip_ansi(line);
-        let body = strip_timestamp(&no_ansi, timestamp_re);
-        out.push_str(body);
-        out.push('\n');
-    }
-    out
-}
-
-/// Translate `\r` runs into `\n`s. `git clone`, `nix copy`, `curl`, …
-/// use bare `\r` to rewrite the same terminal line in-place; what
-/// reaches a captured log is one `\n`-terminated line of
-/// `seg1\rseg2\r…\rfinal` that can run to tens of KB. Splitting each
-/// such mega-line back into one logical line per intermediate state
-/// lets the existing string-summarizer chain match the progress
-/// patterns it already knows about (e.g. `<git-clone>` collapses runs
-/// of `remote: …` lines). `\r\n` is normalised to `\n` first so we
-/// don't double-newline Windows-style endings.
-fn reflow_carriage_returns(raw: &str) -> std::borrow::Cow<'_, str> {
-    if !raw.contains('\r') {
-        return std::borrow::Cow::Borrowed(raw);
-    }
     let mut out = String::with_capacity(raw.len());
-    let normalised = raw.replace("\r\n", "\n");
-    for ch in normalised.chars() {
-        if ch == '\r' {
+    let mut preprocessed_to_raw = Vec::new();
+    for (raw_idx, raw_line) in raw.lines().enumerate() {
+        // `str::lines` already trims a trailing `\r` from the line,
+        // so we only see intermediate `\r`s as content here.
+        for segment in raw_line.split('\r') {
+            let no_ansi = strip_ansi(segment);
+            let body = strip_timestamp(&no_ansi, timestamp_re);
+            out.push_str(body);
             out.push('\n');
-        } else {
-            out.push(ch);
+            preprocessed_to_raw.push(raw_idx as u32);
         }
     }
-    std::borrow::Cow::Owned(out)
+    Preprocessed {
+        text: out,
+        preprocessed_to_raw,
+    }
 }
 
 fn strip_ansi(s: &str) -> std::borrow::Cow<'_, str> {
@@ -84,33 +71,40 @@ mod tests {
     #[test]
     fn strips_ansi_and_timestamps() {
         let raw = "\x1b[32m[12:34:56] hello\x1b[0m\n[12:34:57] world\n";
-        let cleaned = run(raw);
-        assert_eq!(cleaned, "hello\nworld\n");
+        let out = run(raw);
+        assert_eq!(out.text, "hello\nworld\n");
+        assert_eq!(out.preprocessed_to_raw, vec![0, 1]);
     }
 
     #[test]
     fn idempotent_on_clean_text() {
         let raw = "already clean\nno escapes\n";
-        assert_eq!(run(raw), raw);
+        let out = run(raw);
+        assert_eq!(out.text, raw);
+        assert_eq!(out.preprocessed_to_raw, vec![0, 1]);
     }
 
     #[test]
     fn reflows_carriage_return_progress_into_separate_lines() {
         let raw = "[08:53:32] remote: Counting objects:   1% (21/2027)\rremote: Counting objects:  50% (1014/2027)\rremote: Counting objects: 100% (2027/2027), done.\n[08:53:33] next line\n";
-        let cleaned = run(raw);
+        let out = run(raw);
         assert_eq!(
-            cleaned,
+            out.text,
             "remote: Counting objects:   1% (21/2027)\n\
              remote: Counting objects:  50% (1014/2027)\n\
              remote: Counting objects: 100% (2027/2027), done.\n\
              next line\n"
         );
+        // First three output lines come from raw line 0 (the `\r`-packed
+        // progress); fourth output line comes from raw line 1.
+        assert_eq!(out.preprocessed_to_raw, vec![0, 0, 0, 1]);
     }
 
     #[test]
     fn normalises_crlf_without_doubling_newlines() {
         let raw = "[12:00:00] a\r\n[12:00:01] b\r\n";
-        let cleaned = run(raw);
-        assert_eq!(cleaned, "a\nb\n");
+        let out = run(raw);
+        assert_eq!(out.text, "a\nb\n");
+        assert_eq!(out.preprocessed_to_raw, vec![0, 1]);
     }
 }

--- a/core/crates/tool-caching/src/preprocessors/mod.rs
+++ b/core/crates/tool-caching/src/preprocessors/mod.rs
@@ -1,13 +1,27 @@
-//! Tool-name-keyed preprocessors. Each one is a `&str -> String`
-//! transform that runs before the generic chain when the upstream
-//! tool name matches.
+//! Tool-name-keyed preprocessors. Each one transforms the raw upstream
+//! text before the generic chain runs, returning both the transformed
+//! string and a per-output-line index pointing back to the raw line it
+//! came from. The mapping lets the walker translate chain-compacted
+//! line offsets all the way back to raw-text line space — necessary
+//! because `tool_output_fetch(mode: lines)` slices the persisted raw
+//! string, not the preprocessed one.
 
 mod bash;
 mod concourse;
 
-/// Run any registered preprocessor whose tool-name set matches.
-/// Falls through to the input unchanged when nothing matches.
-pub(crate) fn run(tool_name: &str, raw: &str) -> String {
+/// Output of [`run`]: the preprocessed text plus a per-output-line
+/// index pointing back to the raw line each preprocessed line came
+/// from. `preprocessed_to_raw[i]` is the raw line index (0-based by
+/// `\n`) that contributed preprocessed line `i`.
+pub(crate) struct Preprocessed {
+    pub text: String,
+    pub preprocessed_to_raw: Vec<u32>,
+}
+
+/// Run any registered preprocessor whose tool-name set matches. Falls
+/// through to the raw input with an identity line-mapping when nothing
+/// matches.
+pub(crate) fn run(tool_name: &str, raw: &str) -> Preprocessed {
     if bash::TOOL_NAMES.contains(&tool_name) {
         return bash::run(raw);
     }
@@ -19,5 +33,14 @@ pub(crate) fn run(tool_name: &str, raw: &str) -> String {
     if concourse::TOOL_NAMES.iter().any(|n| tool_name.ends_with(n)) {
         return concourse::run(raw);
     }
-    raw.to_string()
+    Preprocessed {
+        text: raw.to_string(),
+        preprocessed_to_raw: identity_mapping(raw),
+    }
+}
+
+/// Per-line identity mapping for preprocessors that preserve line
+/// count. Returns one entry per `raw.lines()` line — `[0, 1, 2, …]`.
+pub(crate) fn identity_mapping(raw: &str) -> Vec<u32> {
+    (0..raw.lines().count() as u32).collect()
 }

--- a/core/crates/tool-caching/src/walker.rs
+++ b/core/crates/tool-caching/src/walker.rs
@@ -453,11 +453,8 @@ fn make_line_elide(
     let n = lines.len();
     let missing_compacted = n - head - tail;
     let raw_offset = compacted_to_raw_line(head as u32, ctx, preprocessed_to_raw);
-    let raw_after = compacted_to_raw_line(
-        (head + missing_compacted) as u32,
-        ctx,
-        preprocessed_to_raw,
-    );
+    let raw_after =
+        compacted_to_raw_line((head + missing_compacted) as u32, ctx, preprocessed_to_raw);
     // If the elided middle falls entirely inside a single raw line
     // (e.g. inner `\r`-progress segments of a packed line), return that
     // raw line as the recovery so the agent gets at least the

--- a/core/crates/tool-caching/src/walker.rs
+++ b/core/crates/tool-caching/src/walker.rs
@@ -195,16 +195,22 @@ impl Walker {
         // runs first so downstream passes see clean text. Only meaningful
         // at the root — for nested strings we use the empty tool_name (no
         // preprocessor matches), since e.g. only the root concourse log
-        // string benefits from ANSI stripping.
+        // string benefits from ANSI stripping. The mapping flows back
+        // from chain-compacted lines all the way to raw text via
+        // `current_to_original_line` (compacted → preprocessed) plus
+        // `preprocessed_to_raw` (preprocessed → raw).
         let preprocessed = if path == "$" {
             preprocessors::run(tool_name, s)
         } else {
-            s.to_string()
+            preprocessors::Preprocessed {
+                text: s.to_string(),
+                preprocessed_to_raw: preprocessors::identity_mapping(s),
+            }
         };
         // Pattern passes (nix-copy, cargo-compile, rsync, …) compact runs
         // of boring lines in place. Operates on a SegmentedText so order
         // and line indices stay accurate across passes.
-        let mut ctx = SegmentedText::from_initial(&preprocessed);
+        let mut ctx = SegmentedText::from_initial(&preprocessed.text);
         let _ = self.chain.run(&mut ctx);
         let prepared = ctx.log().to_string();
         let modified = prepared != *s;
@@ -227,7 +233,9 @@ impl Walker {
             return Value::String(prepared);
         }
         // Try line-mode first if the string has enough lines to split.
-        if let Some(elide) = line_elide_string(&prepared, budget, &ctx) {
+        if let Some(elide) =
+            line_elide_string(&prepared, budget, &ctx, &preprocessed.preprocessed_to_raw)
+        {
             elided_paths.push(ElidedPath {
                 path: path.to_string(),
                 bytes: s.len() as u64,
@@ -371,16 +379,43 @@ fn line_count(s: &str) -> u32 {
 
 /// `raw_offset` / `raw_missing` are line indices into the *persisted*
 /// raw text (what `tool_output_fetch` slices). They're translated from
-/// the post-chain "current" line indices via `SegmentedText`, so chain
-/// passes that compact `nix-copy`/`cargo`/`git-clone` runs into XML
-/// markers don't desync the recovery template from the on-disk bytes.
+/// the post-chain "current" line indices via two composed mappings:
+///
+///   compacted → preprocessed   (`SegmentedText::current_to_original_line`)
+///   preprocessed → raw         (`preprocessors::Preprocessed::preprocessed_to_raw`)
+///
+/// Both legs matter — chain passes compact `nix-copy`/`cargo`/`git-clone`
+/// runs into XML markers, and the concourse preprocessor splits each
+/// `\r`-packed raw line into one preprocessed line per intermediate
+/// state. Skipping either leg desyncs the recovery template from the
+/// on-disk bytes.
 struct LineElide {
     text: String,
     raw_offset: u32,
     raw_missing: u32,
 }
 
-fn line_elide_string(s: &str, budget: usize, ctx: &SegmentedText) -> Option<LineElide> {
+/// Translate a compacted-line index into a raw-line index by composing
+/// the chain mapping and the preprocessor mapping. Out-of-range indices
+/// resolve to the raw line count (i.e. "past the end"), which lets the
+/// caller compute `raw_missing` as the difference between the head end
+/// and the tail start without special-casing the right boundary.
+fn compacted_to_raw_line(compacted: u32, ctx: &SegmentedText, preprocessed_to_raw: &[u32]) -> u32 {
+    let preprocessed = ctx.current_to_original_line(compacted);
+    let raw_total = preprocessed_to_raw.last().map(|&r| r + 1).unwrap_or(0);
+    if (preprocessed as usize) >= preprocessed_to_raw.len() {
+        raw_total
+    } else {
+        preprocessed_to_raw[preprocessed as usize]
+    }
+}
+
+fn line_elide_string(
+    s: &str,
+    budget: usize,
+    ctx: &SegmentedText,
+    preprocessed_to_raw: &[u32],
+) -> Option<LineElide> {
     let lines: Vec<&str> = s.lines().collect();
     let n = lines.len();
     if n < 3 {
@@ -393,14 +428,14 @@ fn line_elide_string(s: &str, budget: usize, ctx: &SegmentedText) -> Option<Line
     } else {
         head = head.saturating_sub(1);
     }
-    let mut elide = make_line_elide(&lines, head, tail, ctx);
+    let mut elide = make_line_elide(&lines, head, tail, ctx, preprocessed_to_raw);
     while elide.text.len() > budget && (head > 0 || tail > 0) {
         if tail > head {
             tail -= 1;
         } else {
             head -= 1;
         }
-        elide = make_line_elide(&lines, head, tail, ctx);
+        elide = make_line_elide(&lines, head, tail, ctx, preprocessed_to_raw);
     }
     if head == 0 && tail == 0 {
         return None;
@@ -408,12 +443,26 @@ fn line_elide_string(s: &str, budget: usize, ctx: &SegmentedText) -> Option<Line
     Some(elide)
 }
 
-fn make_line_elide(lines: &[&str], head: usize, tail: usize, ctx: &SegmentedText) -> LineElide {
+fn make_line_elide(
+    lines: &[&str],
+    head: usize,
+    tail: usize,
+    ctx: &SegmentedText,
+    preprocessed_to_raw: &[u32],
+) -> LineElide {
     let n = lines.len();
     let missing_compacted = n - head - tail;
-    let raw_offset = ctx.current_to_original_line(head as u32);
-    let raw_after = ctx.current_to_original_line((head + missing_compacted) as u32);
-    let raw_missing = raw_after.saturating_sub(raw_offset);
+    let raw_offset = compacted_to_raw_line(head as u32, ctx, preprocessed_to_raw);
+    let raw_after = compacted_to_raw_line(
+        (head + missing_compacted) as u32,
+        ctx,
+        preprocessed_to_raw,
+    );
+    // If the elided middle falls entirely inside a single raw line
+    // (e.g. inner `\r`-progress segments of a packed line), return that
+    // raw line as the recovery so the agent gets at least the
+    // containing content instead of an empty slice.
+    let raw_missing = raw_after.saturating_sub(raw_offset).max(1);
     let mut text = String::new();
     if head > 0 {
         let head_text = lines[..head].join("\n");

--- a/core/crates/tool-caching/tests/envelope.rs
+++ b/core/crates/tool-caching/tests/envelope.rs
@@ -25,8 +25,13 @@ fn envelope_text(result: &CallToolResult) -> String {
 
 #[tokio::test]
 async fn root_string_over_threshold_yields_envelope_with_recovery_section() {
+    // Threshold must leave room above the ~200-byte byte-mode marker
+    // overhead so head/tail blocks have non-empty content — otherwise
+    // `byte_elide_string` correctly omits them and the structural
+    // assertions below (which check the byte-mode envelope shape with
+    // all three regions present) wouldn't fire.
     let config = ToolCachingConfig {
-        generic_threshold_bytes: 64,
+        generic_threshold_bytes: 512,
         ..ToolCachingConfig::default()
     };
     let caching = ToolCaching::new(&pool().await, config);


### PR DESCRIPTION
Follow-up to #333. Two independent fixes.

## 1. Recovery offsets desynced when preprocessor changes line count

Reported by Cursor Bugbot:
https://github.com/GaloyMoney/drua/pull/333#discussion_r3227019695

PR #333 translated chain-compacted line offsets back through
`SegmentedText::current_to_original_line`, but that mapping only covers
chain compaction — its "original" is the **preprocessed** text, not the
**raw** text. The concourse preprocessor's `\r → \n` reflow (added in
the same PR) inflates line count by the per-line `\r`-segment factor, so
for any log with `\r`-packed progress the recovery template's `offset` /
`len` were in preprocessed-line space while `tool_output_fetch(mode:
lines)` slices raw-line space.

Preprocessors now return a `Preprocessed { text, preprocessed_to_raw }`
struct. `preprocessed_to_raw[i]` is the raw-line index that preprocessed
line `i` came from:

- **bash + no-op fallback**: identity mapping.
- **concourse**: walks `raw.lines()` and emits one preprocessed line per
  `\r`-separated segment, tagging each with its source raw-line index.

The walker composes both legs (compacted → preprocessed → raw) in a new
`compacted_to_raw_line` helper used by `make_line_elide`. Both the
`<bulk-elided original-lines>` count *and* the recovery `offset` / `len`
now read in raw-line space, so an agent following the recovery template
gets exactly the bytes that were hidden.

Also added a `.max(1)` safety on `raw_missing` so an elision that falls
entirely inside a single `\r`-packed raw line returns that whole raw
line instead of an empty slice.

## 2. Envelope integration test breaks on empty head/tail

CI failure on main after #333 merged:
https://github.com/GaloyMoney/drua/actions/runs/25739071070/job/75584133036

    assertion failed: text.contains("<head bytes=\"")
    core/crates/tool-caching/tests/envelope.rs:85

PR #333 omitted `<head bytes="0">` / `<tail bytes="0">` wrappers from
byte-mode elision. The integration test was configured with
`generic_threshold_bytes: 64`; the ~200-byte byte-mode marker overhead
saturated the available budget to zero, so both head and tail rounded
to zero bytes and the new code correctly emitted only the
`<bulk-elided>` block.

Bumped the test's threshold to `512` so the byte-mode shrink leaves
~156 bytes for each of head and tail — the full envelope shape the
assertions were designed to cover.

## Test plan

- [ ] `cargo nextest run` (`envelope::root_string_over_threshold_yields_envelope_with_recovery_section` passes)
- [ ] `nix run .#bats` (existing fixtures unchanged — no `\r`-bearing fixture exists yet, so the new mapping reduces to identity for current inputs)
- [ ] manual recovery against a fresh production concourse build log returns the actually-elided middle when the input has `\r`-packed progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts how elided log recovery offsets are computed, which affects what bytes/lines agents can fetch back from persisted tool output; mistakes here could yield incorrect or empty recovery slices. Changes are localized and covered by updated unit/integration tests, reducing risk.
> 
> **Overview**
> Preprocessors now return `Preprocessed { text, preprocessed_to_raw }` instead of just a cleaned string, so line-oriented recovery can map from *compacted* output back into the persisted *raw* log lines.
> 
> `concourse` now splits `\r`-packed progress into multiple output lines while tracking which raw line each came from, and the walker composes this mapping with `SegmentedText`’s compaction mapping to compute correct `tool_output_fetch(mode: lines)` `offset`/`len` (including a `.max(1)` guard to avoid zero-length recoveries).
> 
> The envelope integration test bumps `generic_threshold_bytes` to `512` to ensure byte-mode elision includes non-empty head/tail blocks under marker overhead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 200e0cc8f61d9b9cec3fc999224c0ba129b9d7c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->