### PR TITLE
fix(migrations): restore as-applied text — unblock prod CrashLoopBackOff

### DIFF
--- a/core/migrations/20260508000000_tool_invocations.sql
+++ b/core/migrations/20260508000000_tool_invocations.sql
@@ -1,4 +1,4 @@
--- Persistence layer for tool-output caching. Each row holds
+-- Persistence layer for the tool-output universal pipeline. Each row holds
 -- the raw output of a single tool call that the dispatcher's
 -- `ResultClassifier` deemed worth persisting (i.e. anything but
 -- `Passthrough`).

--- a/core/migrations/20260512000000_tool_invocations_rebuild.sql
+++ b/core/migrations/20260512000000_tool_invocations_rebuild.sql
@@ -1,5 +1,5 @@
 -- Drop the pre-disconnect tool_invocations table and recreate against the
--- simplified tool-caching schema:
+-- simplified universal-pipeline schema:
 --
 --   * single polymorphic `owner_id` (agent_id wins on AgentOnBehalfOfUser).
 --   * `query_structure` jsonb holds the parsed root Value the walker


### PR DESCRIPTION
**Prod is in CrashLoopBackOff** after #333 rolled out:

\`\`\`
Error: migration 20260508000000 was previously applied but has been modified
\`\`\`

The rename commit in #333 (\`a7be9515\` "chore: drop 'universal pipeline' naming") touched the leading comment in two already-applied migrations. sqlx tracks a content hash for every applied migration and refuses to start when the file diverges from what was originally run.

Reverting **only** those two comment lines back to the byte-identical text that was first applied — `bf9184ff` for 20260508 (PR #309) and `63e08cdf` for 20260512 (PR #326). No SQL changed.

\`\`\`
$ diff <(git show bf9184ff:core/migrations/20260508000000_tool_invocations.sql) core/migrations/20260508000000_tool_invocations.sql
20260508 OK
$ diff <(git show 63e08cdf:core/migrations/20260512000000_tool_invocations_rebuild.sql) core/migrations/20260512000000_tool_invocations_rebuild.sql
20260512 OK
\`\`\`

The rename of the term "universal pipeline" everywhere else (descriptions, error messages, comments in non-migration files) is unaffected and stays in main.

## Test plan

- [ ] CI green
- [ ] After merge, prod pod transitions out of CrashLoopBackOff

## Follow-up

Never edit an applied migration file in place. Cosmetic-only comments on a migration should be done via a no-op follow-up migration or skipped. The reverted comments will quietly say "universal pipeline" forever; the right way to fix them, if it matters, is a new migration that's been applied to no environment yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only comment text in two already-applied migration files is reverted to the byte-identical original to satisfy `sqlx` migration hashing; no SQL behavior or schema changes.
> 
> **Overview**
> Reverts the leading comment line in the already-applied `20260508000000_tool_invocations.sql` and `20260512000000_tool_invocations_rebuild.sql` migrations to exactly match the originally-applied bytes, so `sqlx` no longer errors on “previously applied but has been modified”.
> 
> No schema or SQL logic changes—this is a comment-only fix intended to unblock startup/rollout.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03773ec7817106c92ef03947a9a7c4e30c1699b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->