### PR TITLE
fix(llm): max_tokens per chain entry; drop Prompt.max_tokens

### DIFF
--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -1,14 +1,12 @@
 use std::collections::HashMap;
 
-use llm::ModelChain;
+use llm::ModelChain as LlmModelChain;
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::error::AgentError;
 use super::session::CompactionConfig;
 use super::AgentRole;
 
-/// Roles that must be present in `builtin_roles`. New variants must be
-/// added here too — `validate` fails fast at startup if missing.
 const REQUIRED_ROLES: &[AgentRole] = &[
     AgentRole::ProjectLead,
     AgentRole::Agent,
@@ -17,14 +15,13 @@ const REQUIRED_ROLES: &[AgentRole] = &[
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct RoleConfig {
-    /// Per-role override; falls through to `AgentsConfig.default_chain`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub chain: Option<ModelChain>,
+    pub chain: Option<LlmModelChain>,
     #[serde(default)]
     pub compaction: CompactionConfig,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ModelDefaults {
     pub model: String,
     pub max_tokens_per_response: u32,
@@ -41,21 +38,54 @@ impl Default for ModelDefaults {
     }
 }
 
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ModelChain {
+    pub primary: ModelDefaults,
+    #[serde(default)]
+    pub fallbacks: Vec<ModelDefaults>,
+}
+
+impl ModelChain {
+    pub fn iter(&self) -> impl Iterator<Item = &ModelDefaults> {
+        std::iter::once(&self.primary).chain(self.fallbacks.iter())
+    }
+
+    pub(super) fn from_policy(
+        policy: &LlmModelChain,
+        models: &HashMap<String, ModelDefaults>,
+    ) -> Result<Self, AgentError> {
+        let primary = lookup(policy.primary.name.as_str(), models)?;
+        let fallbacks = policy
+            .fallbacks
+            .iter()
+            .map(|spec| lookup(spec.name.as_str(), models))
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { primary, fallbacks })
+    }
+}
+
+fn lookup(
+    name: &str,
+    models: &HashMap<String, ModelDefaults>,
+) -> Result<ModelDefaults, AgentError> {
+    models
+        .get(name)
+        .cloned()
+        .ok_or_else(|| AgentError::ModelNotConfigured(name.to_string()))
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct AgentsConfig {
-    /// Required at startup unless every role sets its own `chain`.
-    /// Workflow / per-step overrides ride on the entity, not here.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[serde(deserialize_with = "deserialize_chain_loose")]
-    pub default_chain: Option<ModelChain>,
+    pub default_chain: Option<LlmModelChain>,
     #[serde(default)]
     pub builtin_roles: HashMap<AgentRole, RoleConfig>,
     #[serde(default)]
     pub models: HashMap<String, ModelDefaults>,
 }
 
-/// Accepts the bare-string shortcut `"x"` as well as the full object.
-fn deserialize_chain_loose<'de, D>(deserializer: D) -> Result<Option<ModelChain>, D::Error>
+fn deserialize_chain_loose<'de, D>(deserializer: D) -> Result<Option<LlmModelChain>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -63,17 +93,16 @@ where
     #[serde(untagged)]
     enum Either {
         Bare(String),
-        Full(ModelChain),
+        Full(LlmModelChain),
     }
     let opt: Option<Either> = Option::deserialize(deserializer)?;
     Ok(opt.map(|e| match e {
-        Either::Bare(name) => ModelChain::new(name),
+        Either::Bare(name) => LlmModelChain::new(name),
         Either::Full(chain) => chain,
     }))
 }
 
 impl AgentsConfig {
-    /// Called from `App::init` to fail loudly at startup.
     pub fn validate(&self) -> Result<(), AgentError> {
         for role in REQUIRED_ROLES {
             let role_cfg = self
@@ -100,11 +129,11 @@ impl AgentsConfig {
     }
 
     /// Precedence: `override_chain` > role `chain` > `default_chain`.
-    pub fn resolve_chain(
+    pub fn resolve_policy(
         &self,
         role: AgentRole,
-        override_chain: Option<ModelChain>,
-    ) -> Result<ModelChain, AgentError> {
+        override_chain: Option<LlmModelChain>,
+    ) -> Result<LlmModelChain, AgentError> {
         if let Some(c) = override_chain {
             return Ok(c);
         }
@@ -119,6 +148,15 @@ impl AgentsConfig {
             .ok_or_else(|| {
                 AgentError::ModelNotConfigured(format!("no chain resolvable for role {role:?}"))
             })
+    }
+
+    pub(crate) fn resolve_chain(
+        &self,
+        role: AgentRole,
+        override_chain: Option<LlmModelChain>,
+    ) -> Result<ModelChain, AgentError> {
+        let policy = self.resolve_policy(role, override_chain)?;
+        ModelChain::from_policy(&policy, &self.models)
     }
 }
 
@@ -137,7 +175,7 @@ mod tests {
     #[test]
     fn validate_passes_with_default_chain_and_role_without_override() {
         let mut cfg = AgentsConfig {
-            default_chain: Some(ModelChain::new("primary").with_fallback("backup")),
+            default_chain: Some(LlmModelChain::new("primary").with_fallback("backup")),
             ..Default::default()
         };
         cfg.models.insert("primary".into(), defaults_for("primary"));
@@ -154,7 +192,7 @@ mod tests {
     #[test]
     fn validate_fails_when_chain_references_unregistered_model() {
         let mut cfg = AgentsConfig {
-            default_chain: Some(ModelChain::new("missing")),
+            default_chain: Some(LlmModelChain::new("missing")),
             ..Default::default()
         };
         cfg.builtin_roles
@@ -168,9 +206,77 @@ mod tests {
     }
 
     #[test]
+    fn resolve_chain_pulls_limits_from_models_map() {
+        let mut cfg = AgentsConfig {
+            default_chain: Some(LlmModelChain::new("primary").with_fallback("backup")),
+            ..Default::default()
+        };
+        cfg.models.insert(
+            "primary".into(),
+            ModelDefaults {
+                model: "primary".into(),
+                max_tokens_per_response: 8192,
+                context_window_tokens: 200_000,
+            },
+        );
+        cfg.models.insert(
+            "backup".into(),
+            ModelDefaults {
+                model: "backup".into(),
+                max_tokens_per_response: 4096,
+                context_window_tokens: 128_000,
+            },
+        );
+        cfg.builtin_roles
+            .insert(AgentRole::Agent, RoleConfig::default());
+        let chain = cfg.resolve_chain(AgentRole::Agent, None).unwrap();
+        assert_eq!(chain.primary.model, "primary");
+        assert_eq!(chain.primary.max_tokens_per_response, 8192);
+        assert_eq!(chain.primary.context_window_tokens, 200_000);
+        assert_eq!(chain.fallbacks.len(), 1);
+        assert_eq!(chain.fallbacks[0].model, "backup");
+        assert_eq!(chain.fallbacks[0].max_tokens_per_response, 4096);
+        assert_eq!(chain.fallbacks[0].context_window_tokens, 128_000);
+    }
+
+    #[test]
+    fn resolve_chain_errors_when_fallback_unconfigured() {
+        let mut cfg = AgentsConfig {
+            default_chain: Some(LlmModelChain::new("primary").with_fallback("ghost")),
+            ..Default::default()
+        };
+        cfg.models.insert("primary".into(), defaults_for("primary"));
+        cfg.builtin_roles
+            .insert(AgentRole::Agent, RoleConfig::default());
+        let err = cfg
+            .resolve_chain(AgentRole::Agent, None)
+            .expect_err("ghost fallback");
+        assert!(format!("{err}").contains("ghost"));
+    }
+
+    #[test]
+    fn explicit_override_beats_role_and_default() {
+        let mut cfg = AgentsConfig {
+            default_chain: Some(LlmModelChain::new("default")),
+            ..Default::default()
+        };
+        cfg.builtin_roles.insert(
+            AgentRole::Agent,
+            RoleConfig {
+                chain: Some(LlmModelChain::new("role")),
+                ..Default::default()
+            },
+        );
+        let resolved = cfg
+            .resolve_policy(AgentRole::Agent, Some(LlmModelChain::new("explicit")))
+            .unwrap();
+        assert_eq!(resolved.primary.name, "explicit");
+    }
+
+    #[test]
     fn role_chain_overrides_default() {
         let mut cfg = AgentsConfig {
-            default_chain: Some(ModelChain::new("default")),
+            default_chain: Some(LlmModelChain::new("default")),
             ..Default::default()
         };
         cfg.models.insert("default".into(), defaults_for("default"));
@@ -178,44 +284,25 @@ mod tests {
         cfg.builtin_roles.insert(
             AgentRole::Agent,
             RoleConfig {
-                chain: Some(ModelChain::new("role")),
+                chain: Some(LlmModelChain::new("role")),
                 ..Default::default()
             },
         );
-        let resolved = cfg.resolve_chain(AgentRole::Agent, None).unwrap();
-        assert_eq!(resolved.primary.name, "role");
-    }
-
-    #[test]
-    fn explicit_override_beats_role_and_default() {
-        let mut cfg = AgentsConfig {
-            default_chain: Some(ModelChain::new("default")),
-            ..Default::default()
-        };
-        cfg.builtin_roles.insert(
-            AgentRole::Agent,
-            RoleConfig {
-                chain: Some(ModelChain::new("role")),
-                ..Default::default()
-            },
-        );
-        let resolved = cfg
-            .resolve_chain(AgentRole::Agent, Some(ModelChain::new("explicit")))
-            .unwrap();
-        assert_eq!(resolved.primary.name, "explicit");
+        let chain = cfg.resolve_chain(AgentRole::Agent, None).unwrap();
+        assert_eq!(chain.primary.model, "role");
     }
 
     #[test]
     fn falls_back_to_default_when_role_has_no_override() {
         let mut cfg = AgentsConfig {
-            default_chain: Some(ModelChain::new("default")),
+            default_chain: Some(LlmModelChain::new("default")),
             ..Default::default()
         };
         cfg.models.insert("default".into(), defaults_for("default"));
         cfg.builtin_roles
             .insert(AgentRole::Agent, RoleConfig::default());
-        let resolved = cfg.resolve_chain(AgentRole::Agent, None).unwrap();
-        assert_eq!(resolved.primary.name, "default");
+        let chain = cfg.resolve_chain(AgentRole::Agent, None).unwrap();
+        assert_eq!(chain.primary.model, "default");
     }
 
     #[test]
@@ -287,9 +374,9 @@ models:
     context_window_tokens: 200000
 "#;
         let cfg: AgentsConfig = serde_yaml::from_str(yaml).unwrap();
-        let lead_chain = cfg.resolve_chain(AgentRole::ProjectLead, None).unwrap();
-        assert_eq!(lead_chain.primary.name, "lead/special");
-        let agent_chain = cfg.resolve_chain(AgentRole::Agent, None).unwrap();
-        assert_eq!(agent_chain.primary.name, "primary/model");
+        let lead = cfg.resolve_chain(AgentRole::ProjectLead, None).unwrap();
+        assert_eq!(lead.primary.model, "lead/special");
+        let agent = cfg.resolve_chain(AgentRole::Agent, None).unwrap();
+        assert_eq!(agent.primary.model, "primary/model");
     }
 }

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -54,24 +54,34 @@ impl ModelChain {
         policy: &LlmModelChain,
         models: &HashMap<String, ModelDefaults>,
     ) -> Result<Self, AgentError> {
-        let primary = lookup(policy.primary.name.as_str(), models)?;
+        let primary = resolve_spec(&policy.primary, models)?;
         let fallbacks = policy
             .fallbacks
             .iter()
-            .map(|spec| lookup(spec.name.as_str(), models))
+            .map(|spec| resolve_spec(spec, models))
             .collect::<Result<Vec<_>, _>>()?;
         Ok(Self { primary, fallbacks })
     }
 }
 
-fn lookup(
-    name: &str,
+/// Pins `.model` to the lookup key (so downstream code can never see the YAML
+/// `model:` field diverge from the registry key), then applies the policy's
+/// `max_tokens` override on top of the registry default.
+fn resolve_spec(
+    spec: &llm::ModelSpec,
     models: &HashMap<String, ModelDefaults>,
 ) -> Result<ModelDefaults, AgentError> {
-    models
-        .get(name)
+    let defaults = models
+        .get(spec.name.as_str())
         .cloned()
-        .ok_or_else(|| AgentError::ModelNotConfigured(name.to_string()))
+        .ok_or_else(|| AgentError::ModelNotConfigured(spec.name.clone()))?;
+    Ok(ModelDefaults {
+        model: spec.name.clone(),
+        max_tokens_per_response: spec
+            .max_tokens
+            .unwrap_or(defaults.max_tokens_per_response),
+        context_window_tokens: defaults.context_window_tokens,
+    })
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -237,6 +247,44 @@ mod tests {
         assert_eq!(chain.fallbacks[0].model, "backup");
         assert_eq!(chain.fallbacks[0].max_tokens_per_response, 4096);
         assert_eq!(chain.fallbacks[0].context_window_tokens, 128_000);
+    }
+
+    #[test]
+    fn policy_max_tokens_overrides_registry_else_registry_wins() {
+        use llm::ModelSpec;
+
+        let mut cfg = AgentsConfig::default();
+        cfg.models.insert(
+            "model-a".into(),
+            ModelDefaults {
+                model: "model-a".into(),
+                max_tokens_per_response: 4096,
+                context_window_tokens: 128_000,
+            },
+        );
+        cfg.models.insert(
+            "model-b".into(),
+            ModelDefaults {
+                model: "model-b".into(),
+                max_tokens_per_response: 8192,
+                context_window_tokens: 200_000,
+            },
+        );
+        cfg.builtin_roles
+            .insert(AgentRole::Agent, RoleConfig::default());
+
+        // Primary specifies an override, fallback omits it.
+        let policy = LlmModelChain::new(ModelSpec::new("model-a").with_max_tokens(2048))
+            .with_fallback(ModelSpec::new("model-b"));
+        let chain = ModelChain::from_policy(&policy, &cfg.models).unwrap();
+
+        assert_eq!(chain.primary.max_tokens_per_response, 2048);
+        assert_eq!(chain.fallbacks[0].max_tokens_per_response, 8192);
+        // Context window is always from the registry; not overridable per-call.
+        assert_eq!(chain.primary.context_window_tokens, 128_000);
+        // `.model` is pinned to the lookup key, never the registry's `model` field.
+        assert_eq!(chain.primary.model, "model-a");
+        assert_eq!(chain.fallbacks[0].model, "model-b");
     }
 
     #[test]

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -240,21 +240,6 @@ mod tests {
     }
 
     #[test]
-    fn resolve_chain_errors_when_fallback_unconfigured() {
-        let mut cfg = AgentsConfig {
-            default_chain: Some(LlmModelChain::new("primary").with_fallback("ghost")),
-            ..Default::default()
-        };
-        cfg.models.insert("primary".into(), defaults_for("primary"));
-        cfg.builtin_roles
-            .insert(AgentRole::Agent, RoleConfig::default());
-        let err = cfg
-            .resolve_chain(AgentRole::Agent, None)
-            .expect_err("ghost fallback");
-        assert!(format!("{err}").contains("ghost"));
-    }
-
-    #[test]
     fn explicit_override_beats_role_and_default() {
         let mut cfg = AgentsConfig {
             default_chain: Some(LlmModelChain::new("default")),

--- a/core/src/agent/entity.rs
+++ b/core/src/agent/entity.rs
@@ -1,7 +1,6 @@
 use std::collections::HashSet;
 
 use derive_builder::Builder;
-use llm::ModelChain;
 use serde::{Deserialize, Serialize};
 
 use crate::primitives::{
@@ -62,10 +61,6 @@ pub enum AgentEvent {
     SandboxDetached {
         sandbox_id: SandboxId,
     },
-    /// `Some` sets / replaces the override; `None` clears it.
-    ModelChainUpdated {
-        chain: Option<ModelChain>,
-    },
 }
 
 #[derive(EsEntity, Builder)]
@@ -89,10 +84,6 @@ pub struct Agent {
     pub workflow_id: Option<WorkflowDefinitionId>,
     #[builder(default)]
     pub workflow_run_id: Option<WorkflowRunId>,
-    /// Per-agent chain override. Highest precedence after a per-call
-    /// `chain_override`; only valid for non-workflow agents.
-    #[builder(default)]
-    pub model_chain_override: Option<ModelChain>,
     /// Set on workflow step agents — the schema the `submit_output`
     /// tool validates the model's args against. `None` for non-workflow
     /// agents.
@@ -182,23 +173,6 @@ impl Agent {
         self.workflow_id.is_some()
     }
 
-    /// Workflow agents reject — their chain comes from the
-    /// `WorkflowDefinition` / step. `None` clears any prior override.
-    pub(super) fn update_model_chain(
-        &mut self,
-        chain: Option<ModelChain>,
-    ) -> Result<Idempotent<()>, super::error::AgentError> {
-        if self.is_workflow_agent() {
-            return Err(super::error::AgentError::WorkflowAgentChainImmutable);
-        }
-        if self.model_chain_override == chain {
-            return Ok(Idempotent::AlreadyApplied);
-        }
-        self.model_chain_override = chain.clone();
-        self.events.push(AgentEvent::ModelChainUpdated { chain });
-        Ok(Idempotent::Executed(()))
-    }
-
     /// Drops both `SandboxUse` and `SandboxRead` for `sandbox_id`.
     /// Idempotent when not attached to that sandbox.
     pub(super) fn sandbox_detached(&mut self, sandbox_id: SandboxId) -> Idempotent<()> {
@@ -285,9 +259,6 @@ impl TryFromEvents<AgentEvent> for Agent {
                     if matches!(attached_sandbox, Some((id, _)) if id == *sandbox_id) {
                         attached_sandbox = None;
                     }
-                }
-                AgentEvent::ModelChainUpdated { chain } => {
-                    builder = builder.model_chain_override(chain.clone());
                 }
             }
         }

--- a/core/src/agent/error.rs
+++ b/core/src/agent/error.rs
@@ -44,4 +44,6 @@ pub enum AgentError {
     LeadCannotAttachSandbox,
     #[error("AgentError - no lead agent found in project {0}")]
     NoLeadAgent(ProjectId),
+    #[error("AgentError - workflow agents inherit their chain from the workflow definition")]
+    WorkflowAgentChainImmutable,
 }

--- a/core/src/agent/error.rs
+++ b/core/src/agent/error.rs
@@ -44,6 +44,4 @@ pub enum AgentError {
     LeadCannotAttachSandbox,
     #[error("AgentError - no lead agent found in project {0}")]
     NoLeadAgent(ProjectId),
-    #[error("AgentError - workflow agents inherit their chain from the workflow definition")]
-    WorkflowAgentChainImmutable,
 }

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -14,7 +14,6 @@ use std::sync::Arc;
 use crate::audit::Audit;
 use crate::library::SpaceMounts;
 use crate::note::Notes;
-use crate::project::repo::ProjectRepo;
 use crate::skill::Skills;
 use crate::toolset::ToolSets;
 
@@ -40,7 +39,7 @@ use crate::primitives::{
     ProjectId, SandboxId, WorkflowDefinitionId, WorkflowRunId,
 };
 use crate::sandbox::{SandboxAgentMode, Sandboxes};
-pub use config::{AgentsConfig, ModelDefaults, RoleConfig};
+pub use config::{AgentsConfig, ModelChain, ModelDefaults, RoleConfig};
 pub use entity::*;
 pub use error::AgentError;
 use repo::AgentRepo;
@@ -87,9 +86,6 @@ pub struct Agents {
     /// `AuthedSpaces` internally — no upward dep on the `Projects`
     /// service, so the previous `OnceLock<Projects>` cycle is gone.
     space_mounts: Arc<SpaceMounts>,
-    /// Direct repo handle so chain resolution can read
-    /// `Project.model_chain_override` without an upward Projects-service dep.
-    project_repo: Arc<ProjectRepo>,
     config: AgentsConfig,
     toolsets: Arc<ToolSets>,
     prompt_requests: llm::PromptRequestChannel,
@@ -112,12 +108,11 @@ impl Agents {
     ) -> Self {
         Self {
             repo: AgentRepo::new(pool),
-            sessions: Sessions::new(pool),
+            sessions: Sessions::new(pool, config.clone()),
             sandboxes,
             skills,
             notes,
             space_mounts,
-            project_repo: Arc::new(ProjectRepo::new(pool)),
             config,
             toolsets,
             prompt_requests,
@@ -403,23 +398,7 @@ impl Agents {
             .ok_or(AgentError::RoleNotConfigured(agent_role))?
             .clone();
 
-        // Per-call override beats project-level; project-level beats role/default.
-        let effective_override = match chain_override {
-            Some(c) => Some(c),
-            None => self
-                .project_repo
-                .find_by_id(project_id)
-                .await
-                .ok()
-                .and_then(|p| p.model_chain_override.clone()),
-        };
-        let chain = self.config.resolve_chain(agent_role, effective_override)?;
-        let primary_model_id = chain.primary.name.clone();
-        let model_defaults = self
-            .config
-            .models
-            .get(&primary_model_id)
-            .ok_or_else(|| AgentError::ModelNotConfigured(primary_model_id.clone()))?;
+        let session_chain = self.config.resolve_chain(agent_role, chain_override)?;
 
         let authz_scopes = default_authz_scopes(agent_role, project_id);
 
@@ -520,16 +499,11 @@ impl Agents {
             });
         }
 
-        let session_model_defaults = ModelDefaults {
-            model: primary_model_id,
-            ..model_defaults.clone()
-        };
-
         self.sessions
             .create_in_op(
                 op,
                 agent.id,
-                session_model_defaults,
+                session_chain,
                 role_config.compaction.clone(),
                 system_blocks,
                 tool_defs,
@@ -578,6 +552,29 @@ impl Agents {
         Audit::record_project_id(agent.project_id);
         Audit::record_agent_id(agent.id);
         Ok(agent)
+    }
+
+    #[instrument(name = "domain.agent.update_session_chain", skip(self, sub))]
+    pub async fn update_session_chain(
+        &self,
+        sub: &AuthSubject,
+        agent_id: AgentId,
+        model_chain: Option<llm::ModelChain>,
+    ) -> Result<session::AgentSession, AgentError> {
+        let agent = self.repo.find_by_id(agent_id).await?;
+        sub.can(
+            AuthVerb::Update,
+            AuthResource::Agent(agent.project_id, Some(agent.id)),
+        )?;
+        Audit::record_action_if_unset("agent.update_session_chain");
+        Audit::record_project_id(agent.project_id);
+        Audit::record_agent_id(agent.id);
+
+        let session = self
+            .sessions
+            .update_chain_for_agent(agent.agent_role, agent.id, model_chain)
+            .await?;
+        Ok(session)
     }
 
     /// Read-only accessor for an agent's persisted `output_schema`.
@@ -717,32 +714,6 @@ impl Agents {
             )
             .await?;
         Ok(result.entities.into_iter().find(|a| a.name == name))
-    }
-
-    /// `Some(chain)` sets / replaces; `None` clears. Rejects workflow
-    /// agents — their chain comes from the workflow definition.
-    #[instrument(name = "domain.agent.update_model_chain", skip(self, sub))]
-    pub async fn update_model_chain(
-        &self,
-        sub: &AuthSubject,
-        id: impl Into<AgentId> + std::fmt::Debug,
-        chain: Option<llm::ModelChain>,
-    ) -> Result<Agent, AgentError> {
-        let id = id.into();
-        let mut agent = self.repo.find_by_id(id).await?;
-        sub.can(
-            AuthVerb::Update,
-            AuthResource::Agent(agent.project_id, Some(agent.id)),
-        )?;
-        Audit::record_action_if_unset("agent.update_model_chain");
-        Audit::record_project_id(agent.project_id);
-        Audit::record_agent_id(id);
-        if agent.update_model_chain(chain)?.did_execute() {
-            let mut op = self.repo.begin_op().await?;
-            self.repo.update_in_op(&mut op, &mut agent).await?;
-            op.commit().await?;
-        }
-        Ok(agent)
     }
 
     #[instrument(name = "domain.agent.delete", skip(self, sub))]
@@ -1174,24 +1145,6 @@ impl Agents {
         Ok(pi_export::export_to_jsonl(&exportable))
     }
 
-    /// Resolves the per-turn chain override for a long-lived agent:
-    /// `Agent.model_chain_override` > `Project.model_chain_override` >
-    /// `None` (use the session's stored chain). Workflow agents always
-    /// return `None`.
-    async fn resolve_runtime_chain(&self, agent: &Agent) -> Option<llm::ModelChain> {
-        if agent.is_workflow_agent() {
-            return None;
-        }
-        if let Some(c) = &agent.model_chain_override {
-            return Some(c.clone());
-        }
-        self.project_repo
-            .find_by_id(agent.project_id)
-            .await
-            .ok()
-            .and_then(|p| p.model_chain_override)
-    }
-
     #[instrument(name = "domain.agent.send_message", skip(self, prompt))]
     pub async fn send_message(
         &self,
@@ -1298,23 +1251,15 @@ impl Agents {
             },
         );
 
-        // Snapshot the per-agent + per-project chain once for the whole
-        // turn-loop. Workflow agents skip both — their chain is baked
-        // into the session at create and is immutable for the run.
-        let runtime_chain_override = self.resolve_runtime_chain(&agent).await;
-
         let mut prompt_state = self
             .sessions
             .next_prompt(id, session::TargetThread::Main)
             .await?;
-        if let Some(c) = runtime_chain_override.clone() {
-            prompt_state.chain = c;
-        }
         if let Some(choice) = tool_choice {
             prompt_state.tool_choice = Some(choice);
         }
 
-        self.drive_session_loop(id, agent_subject, tx, prompt_state, runtime_chain_override)
+        self.drive_session_loop(id, agent_subject, tx, prompt_state)
             .await?;
 
         Ok(rx)
@@ -1362,7 +1307,7 @@ impl Agents {
         };
 
         let (tx, rx) = tokio::sync::mpsc::channel::<ChatOutputEvent>(64);
-        self.drive_session_loop(id, agent_subject, tx, prompt_state, None)
+        self.drive_session_loop(id, agent_subject, tx, prompt_state)
             .await?;
         Ok(Some(rx))
     }
@@ -1370,15 +1315,14 @@ impl Agents {
     /// Send the initial `prompt_state` to the LLM and spawn the response
     /// loop. Shared by [`Self::send_message`] (fresh turn) and
     /// [`Self::resume_message`] (retried turn from a persisted `PromptSent`).
-    /// `runtime_chain_override` is re-applied to every per-turn prompt so the
-    /// agent/project override survives across the spawned loop.
+    /// The chain travels inside `prompt_state` itself — the session
+    /// is the only source of truth for which chain to dispatch with.
     async fn drive_session_loop(
         &self,
         id: AgentId,
         agent_subject: AuthSubject,
         tx: tokio::sync::mpsc::Sender<ChatOutputEvent>,
         prompt_state: llm::Prompt,
-        runtime_chain_override: Option<llm::ModelChain>,
     ) -> Result<(), AgentError> {
         let model_name = prompt_state.chain.primary.name.clone();
         let (request, response_rx) = llm::PromptRequest::new(prompt_state);
@@ -1390,7 +1334,6 @@ impl Agents {
         let sessions = self.sessions.clone();
         let toolsets = self.toolsets.clone();
         let prompt_requests = self.prompt_requests.clone();
-        let runtime_override_for_loop = runtime_chain_override;
         tokio::spawn(async move {
             let mut next = response_rx.await;
             let mut turn: u32 = 0;
@@ -1455,7 +1398,7 @@ impl Agents {
                     forward_response(response, &tx);
                 }
 
-                let mut next_prompt = match session_response {
+                let next_prompt = match session_response {
                     session::AgentSessionResponse::Done => break,
                     session::AgentSessionResponse::ToolUseRequest(tool_uses) => {
                         let tool_calls: Vec<llm::RequestToolUse> = tool_uses
@@ -1520,9 +1463,6 @@ impl Agents {
                     _ => break,
                 };
 
-                if let Some(c) = runtime_override_for_loop.clone() {
-                    next_prompt.chain = c;
-                }
                 current_model = next_prompt.chain.primary.name.clone();
                 let (request, rx_next) = llm::PromptRequest::new(next_prompt);
                 if prompt_requests.send(request).await.is_err() {

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -566,6 +566,9 @@ impl Agents {
             AuthVerb::Update,
             AuthResource::Agent(agent.project_id, Some(agent.id)),
         )?;
+        if agent.is_workflow_agent() {
+            return Err(AgentError::WorkflowAgentChainImmutable);
+        }
         Audit::record_action_if_unset("agent.update_session_chain");
         Audit::record_project_id(agent.project_id);
         Audit::record_agent_id(agent.id);

--- a/core/src/agent/session/compaction/mod.rs
+++ b/core/src/agent/session/compaction/mod.rs
@@ -140,7 +140,7 @@ pub(super) fn maybe_prune(
     let tool_definitions_view = current_prompt_definition.tool_definitions_view().clone();
 
     let prompt_definition = PromptDefinition {
-        chain: model_chain.clone(),
+        model_chain: model_chain.clone(),
         system_view: system_view.clone(),
         tool_definitions_view: tool_definitions_view.clone(),
         messages: transformed_messages.clone(),
@@ -253,7 +253,7 @@ fn build_orphan_result<'a>(
     };
 
     let prompt_definition = PromptDefinition {
-        chain: model_chain.clone(),
+        model_chain: model_chain.clone(),
         system_view: system_view.clone(),
         tool_definitions_view: tool_definitions_view.clone(),
         messages: vec![MessageView::User(user_messages.clone())],

--- a/core/src/agent/session/compaction/mod.rs
+++ b/core/src/agent/session/compaction/mod.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use es_entity::EntityEvents;
 
-use crate::agent::config::ModelDefaults;
+use crate::agent::config::ModelChain;
 
 use super::entity::{AgentSessionEvent, ThreadStartReason};
 use super::message::{CompactionMetadata, SandboxOperation, TargetThread};
@@ -42,7 +42,8 @@ pub(super) fn event_belongs_to_thread(
         | AgentSessionEvent::SystemBlockUpdated { .. }
         | AgentSessionEvent::ThreadStarted { .. }
         | AgentSessionEvent::ToolResultsMasked { .. }
-        | AgentSessionEvent::OutputSubmitted { .. } => false,
+        | AgentSessionEvent::OutputSubmitted { .. }
+        | AgentSessionEvent::ModelChainUpdated { .. } => false,
     }
 }
 
@@ -58,7 +59,7 @@ pub(super) struct CompactionResult {
 pub(super) fn maybe_prune(
     events: &EntityEvents<AgentSessionEvent>,
     config: &CompactionConfig,
-    model_defaults: &ModelDefaults,
+    model_chain: &ModelChain,
     session_id: super::AgentSessionId,
     current_thread_id: SessionThreadId,
     is_main_thread: bool,
@@ -76,7 +77,7 @@ pub(super) fn maybe_prune(
 
     let action = config.determine_action(
         estimated_tokens,
-        model_defaults.context_window_tokens,
+        model_chain.primary.context_window_tokens,
         time_since_last_turn,
     );
 
@@ -88,7 +89,7 @@ pub(super) fn maybe_prune(
                 session_id,
                 current_thread_id,
                 is_main_thread,
-                model_defaults,
+                model_chain,
                 current_prompt_definition,
             );
         }
@@ -139,8 +140,7 @@ pub(super) fn maybe_prune(
     let tool_definitions_view = current_prompt_definition.tool_definitions_view().clone();
 
     let prompt_definition = PromptDefinition {
-        model: model_defaults.model.clone(),
-        max_tokens_per_response: model_defaults.max_tokens_per_response,
+        chain: model_chain.clone(),
         system_view: system_view.clone(),
         tool_definitions_view: tool_definitions_view.clone(),
         messages: transformed_messages.clone(),
@@ -150,7 +150,7 @@ pub(super) fn maybe_prune(
     let new_thread = NewSessionThread::compacted(
         new_thread_id,
         session_id,
-        model_defaults.clone(),
+        model_chain.clone(),
         system_view,
         tool_definitions_view,
         transformed_messages,
@@ -231,7 +231,7 @@ fn build_orphan_result<'a>(
     session_id: super::AgentSessionId,
     current_thread_id: SessionThreadId,
     is_main_thread: bool,
-    model_defaults: &ModelDefaults,
+    model_chain: &ModelChain,
     current_prompt_definition: &PromptDefinition,
 ) -> Option<CompactionResult> {
     let new_thread_id = SessionThreadId::new();
@@ -253,8 +253,7 @@ fn build_orphan_result<'a>(
     };
 
     let prompt_definition = PromptDefinition {
-        model: model_defaults.model.clone(),
-        max_tokens_per_response: model_defaults.max_tokens_per_response,
+        chain: model_chain.clone(),
         system_view: system_view.clone(),
         tool_definitions_view: tool_definitions_view.clone(),
         messages: vec![MessageView::User(user_messages.clone())],
@@ -274,7 +273,7 @@ fn build_orphan_result<'a>(
             new_thread_id,
             session_id,
             current_thread_id,
-            model_defaults.clone(),
+            model_chain.clone(),
             system_view,
             tool_definitions_view,
             user_messages,

--- a/core/src/agent/session/compaction/prune.rs
+++ b/core/src/agent/session/compaction/prune.rs
@@ -327,6 +327,7 @@ impl SandboxTracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::agent::config::ModelChain;
     use crate::agent::session::message::*;
     use crate::agent::session::metadata::*;
     use crate::agent::session::settings::*;
@@ -367,7 +368,7 @@ mod tests {
             })]
         };
         PromptDefinition {
-            chain: crate::agent::config::ModelChain::default(),
+            model_chain: ModelChain::default(),
             system_view: SystemView { indexes: vec![] },
             tool_definitions_view: ToolDefinitionsView { indexes: vec![] },
             messages,

--- a/core/src/agent/session/compaction/prune.rs
+++ b/core/src/agent/session/compaction/prune.rs
@@ -367,8 +367,7 @@ mod tests {
             })]
         };
         PromptDefinition {
-            model: String::new(),
-            max_tokens_per_response: 0,
+            chain: crate::agent::config::ModelChain::default(),
             system_view: SystemView { indexes: vec![] },
             tool_definitions_view: ToolDefinitionsView { indexes: vec![] },
             messages,

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -123,7 +123,6 @@ pub struct AgentSession {
     #[builder(default)]
     current_main_thread: Option<SessionThreadId>,
 
-    #[builder(default)]
     model_chain: ModelChain,
 
     #[builder(default)]
@@ -744,7 +743,7 @@ impl AgentSession {
             .id(thread_id)
             .session_id(self.id)
             .start_reason(ThreadStartReason::InitialThread)
-            .chain(self.model_chain.clone())
+            .model_chain(self.model_chain.clone())
             .system_view(prompt_definition.system_view().clone())
             .tool_definitions_view(prompt_definition.tool_definitions_view().clone())
             .initial_user_messages(prompt_definition.user_messages_view())
@@ -1174,7 +1173,10 @@ mod tests {
         // The rebuilt prompt mirrors the one emitted by `next_prompt`:
         // same model, same messages, same system view.
         assert_eq!(pending.messages.len(), issued.messages.len());
-        assert_eq!(pending.chain.primary.model, issued.chain.primary.model);
+        assert_eq!(
+            pending.model_chain.primary.model,
+            issued.model_chain.primary.model
+        );
     }
 
     #[test]
@@ -1399,7 +1401,7 @@ mod tests {
             .next_prompt(TargetThread::Main)
             .expect("next_prompt should succeed");
 
-        assert_eq!(prompt.chain.primary.model, "test-model");
+        assert_eq!(prompt.model_chain.primary.model, "test-model");
         let expected_cache_key = format!("agent-session:{}", session.id);
         assert_eq!(
             prompt.cache_key.as_deref(),

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -345,7 +345,8 @@ impl AgentSession {
         // the user turn that triggered this prompt; otherwise hydration would
         // set its turn to User and reject the upcoming assistant response.
         let (thread_id, prompt_definition) = if matches!(target, TargetThread::Main)
-            && self.thread_has_stale_system_view(thread_id)
+            && (self.thread_has_stale_system_view(thread_id)
+                || self.thread_has_stale_model_chain(thread_id))
         {
             let (new_id, new_pd) =
                 self.spawn_context_refreshed_thread(thread_id, prompt_definition.messages.clone());
@@ -486,6 +487,14 @@ impl AgentSession {
         view.indexes() != refreshed.indexes()
     }
 
+    /// Stale when session.model_chain has diverged from the thread's snapshot.
+    fn thread_has_stale_model_chain(&self, thread_id: SessionThreadId) -> bool {
+        let Some(thread) = self.threads.get_persisted(&thread_id) else {
+            return false;
+        };
+        thread.prompt_definition().model_chain() != &self.model_chain
+    }
+
     /// Latest-per-kind ordered by `SystemBlockKind::ORDER`; skips unset kinds.
     fn canonical_refreshed_view(&self) -> SystemView {
         let materialized = self.materialize();
@@ -496,10 +505,11 @@ impl AgentSession {
         SystemView::from_indexes(indexes)
     }
 
-    /// Inherits supplied `messages` verbatim and refreshes system blocks.
+    /// Inherits supplied `messages` verbatim and refreshes system blocks + model_chain.
     /// Returns id + prompt definition so caller doesn't re-fetch (new thread
     /// lives in `new_entities`, not visible to `get_persisted`).
-    /// Caller must verify staleness via `thread_has_stale_system_view`.
+    /// Caller must verify staleness via `thread_has_stale_system_view` or
+    /// `thread_has_stale_model_chain`.
     fn spawn_context_refreshed_thread(
         &mut self,
         from_thread: SessionThreadId,

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -4,7 +4,7 @@ use serde::{Deserialize, Serialize};
 use crate::primitives::{AgentId, UserMessageSource};
 use es_entity::*;
 
-use crate::agent::config::ModelDefaults;
+use crate::agent::config::ModelChain;
 
 use super::{
     compaction, error::AgentSessionError, export, history, message::*, metadata::*, settings::*,
@@ -38,7 +38,7 @@ pub enum AgentSessionEvent {
     Initialized {
         id: AgentSessionId,
         agent_id: AgentId,
-        model_defaults: ModelDefaults,
+        model_chain: ModelChain,
         compaction_config: CompactionConfig,
         system_blocks: Vec<SystemBlock>,
         tool_defs: Vec<ToolDefinition>,
@@ -103,6 +103,9 @@ pub enum AgentSessionEvent {
         value: serde_json::Value,
         submitted_at: chrono::DateTime<chrono::Utc>,
     },
+    ModelChainUpdated {
+        model_chain: ModelChain,
+    },
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -121,7 +124,7 @@ pub struct AgentSession {
     current_main_thread: Option<SessionThreadId>,
 
     #[builder(default)]
-    model_defaults: ModelDefaults,
+    model_chain: ModelChain,
 
     #[builder(default)]
     compaction_config: CompactionConfig,
@@ -155,7 +158,11 @@ impl AgentSession {
     }
 
     pub fn model(&self) -> &str {
-        &self.model_defaults.model
+        &self.model_chain.primary.model
+    }
+
+    pub fn chain(&self) -> &ModelChain {
+        &self.model_chain
     }
 
     pub fn exportable_thread(
@@ -171,11 +178,27 @@ impl AgentSession {
 
         Ok(export::build_exportable_thread(
             self.id,
-            &self.model_defaults.model,
+            &self.model_chain.primary.model,
             &self.events,
             thread_id,
             self.current_main_thread,
         ))
+    }
+
+    pub(super) fn update_model_chain(&mut self, new_chain: ModelChain) -> Idempotent<()> {
+        idempotency_guard!(
+            self.events.iter_all().rev(),
+            already_applied:
+                AgentSessionEvent::ModelChainUpdated { model_chain } if *model_chain == new_chain,
+            already_applied:
+                AgentSessionEvent::Initialized { model_chain, .. } if *model_chain == new_chain,
+            resets_on:
+                AgentSessionEvent::ModelChainUpdated { .. } | AgentSessionEvent::Initialized { .. }
+        );
+        self.model_chain = new_chain.clone();
+        self.events
+            .push(AgentSessionEvent::ModelChainUpdated { model_chain: new_chain });
+        Idempotent::Executed(())
     }
 
     pub fn add_user_input(
@@ -495,7 +518,7 @@ impl AgentSession {
         let new_thread = NewSessionThread::refreshed(
             new_thread_id,
             self.id,
-            self.model_defaults.clone(),
+            self.model_chain.clone(),
             new_view.clone(),
             tool_view.clone(),
             messages.clone(),
@@ -509,7 +532,7 @@ impl AgentSession {
         self.current_main_thread = Some(new_thread_id);
 
         let new_pd = PromptDefinition::for_refreshed_thread(
-            self.model_defaults.clone(),
+            self.model_chain.clone(),
             new_view,
             tool_view,
             messages,
@@ -697,7 +720,7 @@ impl AgentSession {
         let result = compaction::maybe_prune(
             &self.events,
             &self.compaction_config,
-            &self.model_defaults,
+            &self.model_chain,
             self.id,
             current_thread_id,
             is_main_thread,
@@ -720,7 +743,7 @@ impl AgentSession {
             .id(thread_id)
             .session_id(self.id)
             .start_reason(ThreadStartReason::InitialThread)
-            .model_defaults(self.model_defaults.clone())
+            .chain(self.model_chain.clone())
             .system_view(prompt_definition.system_view().clone())
             .tool_definitions_view(prompt_definition.tool_definitions_view().clone())
             .initial_user_messages(prompt_definition.user_messages_view())
@@ -746,7 +769,7 @@ impl AgentSession {
     }
 
     fn materialize(&self) -> MaterializedSession<'_> {
-        let mut materialized = MaterializedSession::init(&self.model_defaults);
+        let mut materialized = MaterializedSession::init(&self.model_chain);
         for event in self.events.iter_all() {
             match event {
                 AgentSessionEvent::Initialized {
@@ -754,7 +777,7 @@ impl AgentSession {
                     tool_defs,
                     ..
                 } => {
-                    materialized = MaterializedSession::init(&self.model_defaults);
+                    materialized = MaterializedSession::init(&self.model_chain);
                     materialized.push_system_blocks(system_blocks.iter());
                     materialized.push_tool_defs(tool_defs.iter());
                 }
@@ -852,14 +875,14 @@ impl TryFromEvents<AgentSessionEvent> for AgentSession {
                 AgentSessionEvent::Initialized {
                     id,
                     agent_id,
-                    model_defaults,
+                    model_chain,
                     compaction_config,
                     ..
                 } => {
                     builder = builder
                         .id(*id)
                         .agent_id(*agent_id)
-                        .model_defaults(model_defaults.clone())
+                        .model_chain(model_chain.clone())
                         .compaction_config(compaction_config.clone());
                 }
                 AgentSessionEvent::ThreadStarted { thread_id, .. } => {
@@ -875,6 +898,9 @@ impl TryFromEvents<AgentSessionEvent> for AgentSession {
                 AgentSessionEvent::ToolResultsMasked { .. } => {}
                 AgentSessionEvent::CompactionApplied { .. } => {}
                 AgentSessionEvent::OutputSubmitted { .. } => {}
+                AgentSessionEvent::ModelChainUpdated { model_chain } => {
+                    builder = builder.model_chain(model_chain.clone());
+                }
             }
         }
 
@@ -887,7 +913,7 @@ pub struct NewAgentSession {
     #[builder(setter(into))]
     pub(super) id: AgentSessionId,
     pub(super) agent_id: AgentId,
-    pub(super) model_defaults: ModelDefaults,
+    pub(super) model_chain: ModelChain,
     #[builder(default)]
     pub(super) compaction_config: CompactionConfig,
     pub(super) system_blocks: Vec<SystemBlock>,
@@ -909,7 +935,7 @@ impl IntoEvents<AgentSessionEvent> for NewAgentSession {
             [AgentSessionEvent::Initialized {
                 id: self.id,
                 agent_id: self.agent_id,
-                model_defaults: self.model_defaults,
+                model_chain: self.model_chain,
                 compaction_config: self.compaction_config,
                 system_blocks: self.system_blocks,
                 tool_defs: self.tool_defs,
@@ -920,6 +946,7 @@ impl IntoEvents<AgentSessionEvent> for NewAgentSession {
 
 #[cfg(test)]
 mod tests {
+    use crate::agent::config::ModelDefaults;
     use crate::primitives::UserId;
     use es_entity::{IntoEvents as _, TryFromEvents as _};
 
@@ -928,10 +955,13 @@ mod tests {
     fn new_session() -> AgentSession {
         let new = NewAgentSession::builder()
             .agent_id(AgentId::new())
-            .model_defaults(ModelDefaults {
-                model: "test-model".into(),
-                max_tokens_per_response: 1024,
-                context_window_tokens: 200_000,
+            .model_chain(ModelChain {
+                primary: ModelDefaults {
+                    model: "test-model".into(),
+                    max_tokens_per_response: 1024,
+                    context_window_tokens: 200_000,
+                },
+                fallbacks: Vec::new(),
             })
             .compaction_config(CompactionConfig {
                 enabled: false,
@@ -1143,7 +1173,7 @@ mod tests {
         // The rebuilt prompt mirrors the one emitted by `next_prompt`:
         // same model, same messages, same system view.
         assert_eq!(pending.messages.len(), issued.messages.len());
-        assert_eq!(pending.model, issued.model);
+        assert_eq!(pending.chain.primary.model, issued.chain.primary.model);
     }
 
     #[test]
@@ -1368,7 +1398,7 @@ mod tests {
             .next_prompt(TargetThread::Main)
             .expect("next_prompt should succeed");
 
-        assert_eq!(prompt.model, "test-model");
+        assert_eq!(prompt.chain.primary.model, "test-model");
         let expected_cache_key = format!("agent-session:{}", session.id);
         assert_eq!(
             prompt.cache_key.as_deref(),
@@ -1410,10 +1440,13 @@ mod tests {
     fn new_session_with_compaction(keep_recent: usize) -> AgentSession {
         let new = NewAgentSession::builder()
             .agent_id(AgentId::new())
-            .model_defaults(ModelDefaults {
-                model: "test-model".into(),
-                max_tokens_per_response: 1024,
-                context_window_tokens: 100,
+            .model_chain(ModelChain {
+                primary: ModelDefaults {
+                    model: "test-model".into(),
+                    max_tokens_per_response: 1024,
+                    context_window_tokens: 100,
+                },
+                fallbacks: Vec::new(),
             })
             .compaction_config(CompactionConfig {
                 enabled: true,

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -196,8 +196,9 @@ impl AgentSession {
                 AgentSessionEvent::ModelChainUpdated { .. } | AgentSessionEvent::Initialized { .. }
         );
         self.model_chain = new_chain.clone();
-        self.events
-            .push(AgentSessionEvent::ModelChainUpdated { model_chain: new_chain });
+        self.events.push(AgentSessionEvent::ModelChainUpdated {
+            model_chain: new_chain,
+        });
         Idempotent::Executed(())
     }
 

--- a/core/src/agent/session/error.rs
+++ b/core/src/agent/session/error.rs
@@ -20,4 +20,6 @@ pub enum AgentSessionError {
     NotAssistantTurn,
     #[error("AgentSessionError - received tool results but no tool use is pending")]
     NotToolUseTurn,
+    #[error("AgentSessionError - proposed model chain is invalid: {0}")]
+    ModelChainInvalid(String),
 }

--- a/core/src/agent/session/message.rs
+++ b/core/src/agent/session/message.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::agent::config::ModelChain;
+
 use super::thread::SessionThreadId;
 
 /// Name of the runtime-provided `submit_output` tool. Used by:
@@ -31,8 +33,7 @@ pub struct CompactionMetadata {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Prompt {
     pub target_thread: TargetThread,
-    pub model: String,
-    pub max_tokens_per_response: u32,
+    pub chain: ModelChain,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_key: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -189,9 +190,14 @@ pub enum StopReason {
 
 impl From<Prompt> for llm::Prompt {
     fn from(p: Prompt) -> Self {
+        let max_tokens = Some(p.chain.primary.max_tokens_per_response);
+        let mut chain = llm::ModelChain::new(p.chain.primary.model);
+        for fallback in p.chain.fallbacks {
+            chain = chain.with_fallback(fallback.model);
+        }
         llm::Prompt {
-            chain: llm::ModelChain::new(p.model),
-            max_tokens: Some(p.max_tokens_per_response),
+            chain,
+            max_tokens,
             cache_key: p.cache_key,
             system: p
                 .system

--- a/core/src/agent/session/message.rs
+++ b/core/src/agent/session/message.rs
@@ -33,7 +33,7 @@ pub struct CompactionMetadata {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Prompt {
     pub target_thread: TargetThread,
-    pub chain: ModelChain,
+    pub model_chain: ModelChain,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_key: Option<String>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -190,9 +190,9 @@ pub enum StopReason {
 
 impl From<Prompt> for llm::Prompt {
     fn from(p: Prompt) -> Self {
-        let max_tokens = Some(p.chain.primary.max_tokens_per_response);
-        let mut chain = llm::ModelChain::new(p.chain.primary.model);
-        for fallback in p.chain.fallbacks {
+        let max_tokens = Some(p.model_chain.primary.max_tokens_per_response);
+        let mut chain = llm::ModelChain::new(p.model_chain.primary.model);
+        for fallback in p.model_chain.fallbacks {
             chain = chain.with_fallback(fallback.model);
         }
         llm::Prompt {

--- a/core/src/agent/session/message.rs
+++ b/core/src/agent/session/message.rs
@@ -190,14 +190,17 @@ pub enum StopReason {
 
 impl From<Prompt> for llm::Prompt {
     fn from(p: Prompt) -> Self {
-        let max_tokens = Some(p.model_chain.primary.max_tokens_per_response);
-        let mut chain = llm::ModelChain::new(p.model_chain.primary.model);
+        let primary = llm::ModelSpec::new(p.model_chain.primary.model)
+            .with_max_tokens(p.model_chain.primary.max_tokens_per_response);
+        let mut chain = llm::ModelChain::new(primary);
         for fallback in p.model_chain.fallbacks {
-            chain = chain.with_fallback(fallback.model);
+            chain = chain.with_fallback(
+                llm::ModelSpec::new(fallback.model)
+                    .with_max_tokens(fallback.max_tokens_per_response),
+            );
         }
         llm::Prompt {
             chain,
-            max_tokens,
             cache_key: p.cache_key,
             system: p
                 .system

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -12,8 +12,13 @@ mod view;
 
 use tracing::instrument;
 
-use crate::agent::config::ModelDefaults;
-use crate::primitives::{AgentId, UserMessageSource};
+use crate::{
+    agent::{
+        config::{AgentsConfig, ModelChain},
+        AgentRole,
+    },
+    primitives::{AgentId, UserMessageSource},
+};
 pub use entity::*;
 use error::AgentSessionError;
 pub use message::TargetThread;
@@ -28,13 +33,36 @@ es_entity::entity_id! { AgentSessionId }
 #[derive(Clone)]
 pub struct Sessions {
     repo: AgentSessionRepo,
+    config: AgentsConfig,
 }
 
 impl Sessions {
-    pub fn new(pool: &sqlx::PgPool) -> Self {
+    pub fn new(pool: &sqlx::PgPool, config: AgentsConfig) -> Self {
         Self {
             repo: AgentSessionRepo::new(pool),
+            config,
         }
+    }
+
+    #[instrument(name = "domain.agent_session.update_chain_for_agent", skip(self))]
+    pub async fn update_chain_for_agent(
+        &self,
+        agent_role: AgentRole,
+        agent_id: AgentId,
+        model_chain: Option<llm::ModelChain>,
+    ) -> Result<AgentSession, AgentSessionError> {
+        let new_chain = self
+            .config
+            .resolve_chain(agent_role, model_chain)
+            .map_err(|e| AgentSessionError::ModelChainInvalid(e.to_string()))?;
+
+        let mut op = self.repo.begin_op().await?;
+        let mut session = self.repo.find_by_agent_id_in_op(&mut op, agent_id).await?;
+        if session.update_model_chain(new_chain).did_execute() {
+            self.repo.update_in_op(&mut op, &mut session).await?;
+        }
+        op.commit().await?;
+        Ok(session)
     }
 
     #[instrument(
@@ -45,14 +73,14 @@ impl Sessions {
         &self,
         op: &mut es_entity::DbOp<'_>,
         agent_id: AgentId,
-        model_defaults: ModelDefaults,
+        model_chain: ModelChain,
         compaction_config: CompactionConfig,
         system_blocks: Vec<SystemBlock>,
         tool_defs: Vec<ToolDefinition>,
     ) -> Result<AgentSession, AgentSessionError> {
         let new_session = NewAgentSession::builder()
             .agent_id(agent_id)
-            .model_defaults(model_defaults)
+            .model_chain(model_chain)
             .compaction_config(compaction_config)
             .system_blocks(system_blocks)
             .tool_defs(tool_defs)

--- a/core/src/agent/session/thread.rs
+++ b/core/src/agent/session/thread.rs
@@ -27,7 +27,7 @@ pub enum SessionThreadEvent {
         id: SessionThreadId,
         session_id: AgentSessionId,
         start_reason: ThreadStartReason,
-        chain: ModelChain,
+        model_chain: ModelChain,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         initial_user_messages: UserMessagesView,
@@ -35,7 +35,7 @@ pub enum SessionThreadEvent {
     InitializedFromCompaction {
         id: SessionThreadId,
         session_id: AgentSessionId,
-        chain: ModelChain,
+        model_chain: ModelChain,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         messages: Vec<MessageView>,
@@ -45,7 +45,7 @@ pub enum SessionThreadEvent {
     InitializedFromRefresh {
         id: SessionThreadId,
         session_id: AgentSessionId,
-        chain: ModelChain,
+        model_chain: ModelChain,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         messages: Vec<MessageView>,
@@ -116,7 +116,7 @@ impl SessionThread {
     }
 
     pub fn prompt_definition(&self) -> PromptDefinition {
-        let mut chain = ModelChain::default();
+        let mut model_chain = ModelChain::default();
         let mut system_view = SystemView { indexes: vec![] };
         let mut tool_definitions_view = ToolDefinitionsView { indexes: vec![] };
         let mut messages = Vec::new();
@@ -124,32 +124,32 @@ impl SessionThread {
         for event in self.events.iter_all() {
             match event {
                 SessionThreadEvent::Initialized {
-                    chain: c,
+                    model_chain: c,
                     system_view: sv,
                     tool_definitions_view: tdv,
                     initial_user_messages,
                     ..
                 } => {
-                    chain = c.clone();
+                    model_chain = c.clone();
                     system_view = sv.clone();
                     tool_definitions_view = tdv.clone();
                     messages.push(MessageView::User(initial_user_messages.clone()));
                 }
                 SessionThreadEvent::InitializedFromCompaction {
-                    chain: c,
+                    model_chain: c,
                     system_view: sv,
                     tool_definitions_view: tdv,
                     messages: init_messages,
                     ..
                 }
                 | SessionThreadEvent::InitializedFromRefresh {
-                    chain: c,
+                    model_chain: c,
                     system_view: sv,
                     tool_definitions_view: tdv,
                     messages: init_messages,
                     ..
                 } => {
-                    chain = c.clone();
+                    model_chain = c.clone();
                     system_view = sv.clone();
                     tool_definitions_view = tdv.clone();
                     messages.extend(init_messages.iter().cloned());
@@ -178,7 +178,7 @@ impl SessionThread {
         }
 
         PromptDefinition {
-            chain,
+            model_chain,
             system_view,
             tool_definitions_view,
             messages,
@@ -270,7 +270,7 @@ pub struct NewSessionThread {
     pub(super) id: SessionThreadId,
     pub(super) session_id: AgentSessionId,
     pub(super) start_reason: ThreadStartReason,
-    pub(super) chain: ModelChain,
+    pub(super) model_chain: ModelChain,
     pub(super) system_view: SystemView,
     pub(super) tool_definitions_view: ToolDefinitionsView,
     init: ThreadInitData,
@@ -297,7 +297,7 @@ impl NewSessionThread {
             id: SessionThreadId::new(),
             session_id: None,
             start_reason: None,
-            chain: None,
+            model_chain: None,
             system_view: None,
             tool_definitions_view: None,
             initial_user_messages: None,
@@ -307,7 +307,7 @@ impl NewSessionThread {
     pub fn compacted(
         id: SessionThreadId,
         session_id: AgentSessionId,
-        chain: ModelChain,
+        model_chain: ModelChain,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         messages: Vec<MessageView>,
@@ -319,7 +319,7 @@ impl NewSessionThread {
             start_reason: ThreadStartReason::Compaction {
                 from_thread: follows_from,
             },
-            chain,
+            model_chain,
             system_view,
             tool_definitions_view,
             init: ThreadInitData::Compacted {
@@ -333,7 +333,7 @@ impl NewSessionThread {
     pub fn refreshed(
         id: SessionThreadId,
         session_id: AgentSessionId,
-        chain: ModelChain,
+        model_chain: ModelChain,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         messages: Vec<MessageView>,
@@ -345,7 +345,7 @@ impl NewSessionThread {
             start_reason: ThreadStartReason::ContextRefreshed {
                 from_thread: follows_from,
             },
-            chain,
+            model_chain,
             system_view,
             tool_definitions_view,
             init: ThreadInitData::Refreshed {
@@ -360,7 +360,7 @@ impl NewSessionThread {
         id: SessionThreadId,
         session_id: AgentSessionId,
         from_thread: SessionThreadId,
-        chain: ModelChain,
+        model_chain: ModelChain,
         system_view: super::view::SystemView,
         tool_definitions_view: super::view::ToolDefinitionsView,
         pending_user_messages: super::view::UserMessagesView,
@@ -369,7 +369,7 @@ impl NewSessionThread {
             id,
             session_id,
             start_reason: ThreadStartReason::Orphan { from_thread },
-            chain,
+            model_chain,
             system_view,
             tool_definitions_view,
             init: ThreadInitData::Initial {
@@ -383,7 +383,7 @@ pub struct NewSessionThreadBuilder {
     id: SessionThreadId,
     session_id: Option<AgentSessionId>,
     start_reason: Option<ThreadStartReason>,
-    chain: Option<ModelChain>,
+    model_chain: Option<ModelChain>,
     system_view: Option<SystemView>,
     tool_definitions_view: Option<ToolDefinitionsView>,
     initial_user_messages: Option<UserMessagesView>,
@@ -405,8 +405,8 @@ impl NewSessionThreadBuilder {
         self
     }
 
-    pub fn chain(mut self, chain: ModelChain) -> Self {
-        self.chain = Some(chain);
+    pub fn model_chain(mut self, model_chain: ModelChain) -> Self {
+        self.model_chain = Some(model_chain);
         self
     }
 
@@ -434,8 +434,8 @@ impl NewSessionThreadBuilder {
             start_reason: self.start_reason.ok_or(EntityHydrationError::from(
                 derive_builder::UninitializedFieldError::from("start_reason"),
             ))?,
-            chain: self.chain.ok_or(EntityHydrationError::from(
-                derive_builder::UninitializedFieldError::from("chain"),
+            model_chain: self.model_chain.ok_or(EntityHydrationError::from(
+                derive_builder::UninitializedFieldError::from("model_chain"),
             ))?,
             system_view: self.system_view.ok_or(EntityHydrationError::from(
                 derive_builder::UninitializedFieldError::from("system_view"),
@@ -465,7 +465,7 @@ impl IntoEvents<SessionThreadEvent> for NewSessionThread {
                 id: self.id,
                 session_id: self.session_id,
                 start_reason: self.start_reason,
-                chain: self.chain,
+                model_chain: self.model_chain,
                 system_view: self.system_view,
                 tool_definitions_view: self.tool_definitions_view,
                 initial_user_messages,
@@ -476,7 +476,7 @@ impl IntoEvents<SessionThreadEvent> for NewSessionThread {
             } => SessionThreadEvent::InitializedFromCompaction {
                 id: self.id,
                 session_id: self.session_id,
-                chain: self.chain,
+                model_chain: self.model_chain,
                 system_view: self.system_view,
                 tool_definitions_view: self.tool_definitions_view,
                 messages,
@@ -488,7 +488,7 @@ impl IntoEvents<SessionThreadEvent> for NewSessionThread {
             } => SessionThreadEvent::InitializedFromRefresh {
                 id: self.id,
                 session_id: self.session_id,
-                chain: self.chain,
+                model_chain: self.model_chain,
                 system_view: self.system_view,
                 tool_definitions_view: self.tool_definitions_view,
                 messages,

--- a/core/src/agent/session/thread.rs
+++ b/core/src/agent/session/thread.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 
 use es_entity::*;
 
-use crate::agent::config::ModelDefaults;
+use crate::agent::config::ModelChain;
 
 use super::entity::ThreadStartReason;
 use super::view::*;
@@ -27,7 +27,7 @@ pub enum SessionThreadEvent {
         id: SessionThreadId,
         session_id: AgentSessionId,
         start_reason: ThreadStartReason,
-        model_defaults: ModelDefaults,
+        chain: ModelChain,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         initial_user_messages: UserMessagesView,
@@ -35,7 +35,7 @@ pub enum SessionThreadEvent {
     InitializedFromCompaction {
         id: SessionThreadId,
         session_id: AgentSessionId,
-        model_defaults: ModelDefaults,
+        chain: ModelChain,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         messages: Vec<MessageView>,
@@ -45,7 +45,7 @@ pub enum SessionThreadEvent {
     InitializedFromRefresh {
         id: SessionThreadId,
         session_id: AgentSessionId,
-        model_defaults: ModelDefaults,
+        chain: ModelChain,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         messages: Vec<MessageView>,
@@ -116,8 +116,7 @@ impl SessionThread {
     }
 
     pub fn prompt_definition(&self) -> PromptDefinition {
-        let mut model = String::new();
-        let mut max_tokens_per_response = 0;
+        let mut chain = ModelChain::default();
         let mut system_view = SystemView { indexes: vec![] };
         let mut tool_definitions_view = ToolDefinitionsView { indexes: vec![] };
         let mut messages = Vec::new();
@@ -125,34 +124,32 @@ impl SessionThread {
         for event in self.events.iter_all() {
             match event {
                 SessionThreadEvent::Initialized {
-                    model_defaults,
+                    chain: c,
                     system_view: sv,
                     tool_definitions_view: tdv,
                     initial_user_messages,
                     ..
                 } => {
-                    model = model_defaults.model.clone();
-                    max_tokens_per_response = model_defaults.max_tokens_per_response;
+                    chain = c.clone();
                     system_view = sv.clone();
                     tool_definitions_view = tdv.clone();
                     messages.push(MessageView::User(initial_user_messages.clone()));
                 }
                 SessionThreadEvent::InitializedFromCompaction {
-                    model_defaults,
+                    chain: c,
                     system_view: sv,
                     tool_definitions_view: tdv,
                     messages: init_messages,
                     ..
                 }
                 | SessionThreadEvent::InitializedFromRefresh {
-                    model_defaults,
+                    chain: c,
                     system_view: sv,
                     tool_definitions_view: tdv,
                     messages: init_messages,
                     ..
                 } => {
-                    model = model_defaults.model.clone();
-                    max_tokens_per_response = model_defaults.max_tokens_per_response;
+                    chain = c.clone();
                     system_view = sv.clone();
                     tool_definitions_view = tdv.clone();
                     messages.extend(init_messages.iter().cloned());
@@ -181,8 +178,7 @@ impl SessionThread {
         }
 
         PromptDefinition {
-            model,
-            max_tokens_per_response,
+            chain,
             system_view,
             tool_definitions_view,
             messages,
@@ -274,7 +270,7 @@ pub struct NewSessionThread {
     pub(super) id: SessionThreadId,
     pub(super) session_id: AgentSessionId,
     pub(super) start_reason: ThreadStartReason,
-    pub(super) model_defaults: ModelDefaults,
+    pub(super) chain: ModelChain,
     pub(super) system_view: SystemView,
     pub(super) tool_definitions_view: ToolDefinitionsView,
     init: ThreadInitData,
@@ -301,7 +297,7 @@ impl NewSessionThread {
             id: SessionThreadId::new(),
             session_id: None,
             start_reason: None,
-            model_defaults: None,
+            chain: None,
             system_view: None,
             tool_definitions_view: None,
             initial_user_messages: None,
@@ -311,7 +307,7 @@ impl NewSessionThread {
     pub fn compacted(
         id: SessionThreadId,
         session_id: AgentSessionId,
-        model_defaults: ModelDefaults,
+        chain: ModelChain,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         messages: Vec<MessageView>,
@@ -323,7 +319,7 @@ impl NewSessionThread {
             start_reason: ThreadStartReason::Compaction {
                 from_thread: follows_from,
             },
-            model_defaults,
+            chain,
             system_view,
             tool_definitions_view,
             init: ThreadInitData::Compacted {
@@ -337,7 +333,7 @@ impl NewSessionThread {
     pub fn refreshed(
         id: SessionThreadId,
         session_id: AgentSessionId,
-        model_defaults: ModelDefaults,
+        chain: ModelChain,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         messages: Vec<MessageView>,
@@ -349,7 +345,7 @@ impl NewSessionThread {
             start_reason: ThreadStartReason::ContextRefreshed {
                 from_thread: follows_from,
             },
-            model_defaults,
+            chain,
             system_view,
             tool_definitions_view,
             init: ThreadInitData::Refreshed {
@@ -364,7 +360,7 @@ impl NewSessionThread {
         id: SessionThreadId,
         session_id: AgentSessionId,
         from_thread: SessionThreadId,
-        model_defaults: ModelDefaults,
+        chain: ModelChain,
         system_view: super::view::SystemView,
         tool_definitions_view: super::view::ToolDefinitionsView,
         pending_user_messages: super::view::UserMessagesView,
@@ -373,7 +369,7 @@ impl NewSessionThread {
             id,
             session_id,
             start_reason: ThreadStartReason::Orphan { from_thread },
-            model_defaults,
+            chain,
             system_view,
             tool_definitions_view,
             init: ThreadInitData::Initial {
@@ -387,7 +383,7 @@ pub struct NewSessionThreadBuilder {
     id: SessionThreadId,
     session_id: Option<AgentSessionId>,
     start_reason: Option<ThreadStartReason>,
-    model_defaults: Option<ModelDefaults>,
+    chain: Option<ModelChain>,
     system_view: Option<SystemView>,
     tool_definitions_view: Option<ToolDefinitionsView>,
     initial_user_messages: Option<UserMessagesView>,
@@ -409,8 +405,8 @@ impl NewSessionThreadBuilder {
         self
     }
 
-    pub fn model_defaults(mut self, model_defaults: ModelDefaults) -> Self {
-        self.model_defaults = Some(model_defaults);
+    pub fn chain(mut self, chain: ModelChain) -> Self {
+        self.chain = Some(chain);
         self
     }
 
@@ -438,8 +434,8 @@ impl NewSessionThreadBuilder {
             start_reason: self.start_reason.ok_or(EntityHydrationError::from(
                 derive_builder::UninitializedFieldError::from("start_reason"),
             ))?,
-            model_defaults: self.model_defaults.ok_or(EntityHydrationError::from(
-                derive_builder::UninitializedFieldError::from("model_defaults"),
+            chain: self.chain.ok_or(EntityHydrationError::from(
+                derive_builder::UninitializedFieldError::from("chain"),
             ))?,
             system_view: self.system_view.ok_or(EntityHydrationError::from(
                 derive_builder::UninitializedFieldError::from("system_view"),
@@ -469,7 +465,7 @@ impl IntoEvents<SessionThreadEvent> for NewSessionThread {
                 id: self.id,
                 session_id: self.session_id,
                 start_reason: self.start_reason,
-                model_defaults: self.model_defaults,
+                chain: self.chain,
                 system_view: self.system_view,
                 tool_definitions_view: self.tool_definitions_view,
                 initial_user_messages,
@@ -480,7 +476,7 @@ impl IntoEvents<SessionThreadEvent> for NewSessionThread {
             } => SessionThreadEvent::InitializedFromCompaction {
                 id: self.id,
                 session_id: self.session_id,
-                model_defaults: self.model_defaults,
+                chain: self.chain,
                 system_view: self.system_view,
                 tool_definitions_view: self.tool_definitions_view,
                 messages,
@@ -492,7 +488,7 @@ impl IntoEvents<SessionThreadEvent> for NewSessionThread {
             } => SessionThreadEvent::InitializedFromRefresh {
                 id: self.id,
                 session_id: self.session_id,
-                model_defaults: self.model_defaults,
+                chain: self.chain,
                 system_view: self.system_view,
                 tool_definitions_view: self.tool_definitions_view,
                 messages,

--- a/core/src/agent/session/view.rs
+++ b/core/src/agent/session/view.rs
@@ -69,7 +69,7 @@ pub struct ToolResultsView {
 
 #[derive(Debug)]
 pub(super) struct MaterializedSession<'a> {
-    chain: &'a ModelChain,
+    model_chain: &'a ModelChain,
     system_blocks: Vec<&'a SystemBlock>,
     system_breakpoints: Vec<SystemBlockIndex>,
     /// Per kind, the index of its most-recent block. Resolves latest-for-kind
@@ -84,9 +84,9 @@ pub(super) struct MaterializedSession<'a> {
 }
 
 impl<'a> MaterializedSession<'a> {
-    pub fn init(chain: &'a ModelChain) -> Self {
+    pub fn init(model_chain: &'a ModelChain) -> Self {
         Self {
-            chain,
+            model_chain,
             system_blocks: Vec::new(),
             system_breakpoints: Vec::new(),
             latest_idx_by_kind: std::collections::HashMap::new(),
@@ -209,7 +209,7 @@ impl<'a> MaterializedSession<'a> {
         let tool_definitions_view = self.tools_since_last_breakpoint();
         let initial_user_messages = self.all_user_messages();
         PromptDefinition {
-            chain: self.chain.clone(),
+            model_chain: self.model_chain.clone(),
             system_view,
             tool_definitions_view,
             messages: vec![MessageView::User(initial_user_messages)],
@@ -234,7 +234,7 @@ pub enum MessageView {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PromptDefinition {
-    pub(super) chain: ModelChain,
+    pub(super) model_chain: ModelChain,
     pub(super) system_view: SystemView,
     pub(super) tool_definitions_view: ToolDefinitionsView,
     pub(super) messages: Vec<MessageView>,
@@ -244,13 +244,13 @@ pub struct PromptDefinition {
 
 impl PromptDefinition {
     pub(super) fn for_refreshed_thread(
-        chain: ModelChain,
+        model_chain: ModelChain,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         inherited_messages: Vec<MessageView>,
     ) -> Self {
         Self {
-            chain,
+            model_chain,
             system_view,
             tool_definitions_view,
             messages: inherited_messages,
@@ -417,7 +417,7 @@ impl PromptDefinition {
 
         Ok(Prompt {
             target_thread,
-            chain: self.chain,
+            model_chain: self.model_chain,
             cache_key: None,
             system,
             tools,

--- a/core/src/agent/session/view.rs
+++ b/core/src/agent/session/view.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use es_entity::EntityEvents;
 
-use crate::agent::config::ModelDefaults;
+use crate::agent::config::ModelChain;
 
 use super::{entity::AgentSessionEvent, error::AgentSessionError, message::*};
 
@@ -69,7 +69,7 @@ pub struct ToolResultsView {
 
 #[derive(Debug)]
 pub(super) struct MaterializedSession<'a> {
-    model_defaults: &'a ModelDefaults,
+    chain: &'a ModelChain,
     system_blocks: Vec<&'a SystemBlock>,
     system_breakpoints: Vec<SystemBlockIndex>,
     /// Per kind, the index of its most-recent block. Resolves latest-for-kind
@@ -84,9 +84,9 @@ pub(super) struct MaterializedSession<'a> {
 }
 
 impl<'a> MaterializedSession<'a> {
-    pub fn init(model_defaults: &'a ModelDefaults) -> Self {
+    pub fn init(chain: &'a ModelChain) -> Self {
         Self {
-            model_defaults,
+            chain,
             system_blocks: Vec::new(),
             system_breakpoints: Vec::new(),
             latest_idx_by_kind: std::collections::HashMap::new(),
@@ -209,8 +209,7 @@ impl<'a> MaterializedSession<'a> {
         let tool_definitions_view = self.tools_since_last_breakpoint();
         let initial_user_messages = self.all_user_messages();
         PromptDefinition {
-            model: self.model_defaults.model.clone(),
-            max_tokens_per_response: self.model_defaults.max_tokens_per_response,
+            chain: self.chain.clone(),
             system_view,
             tool_definitions_view,
             messages: vec![MessageView::User(initial_user_messages)],
@@ -235,8 +234,7 @@ pub enum MessageView {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PromptDefinition {
-    pub(super) model: String,
-    pub(super) max_tokens_per_response: u32,
+    pub(super) chain: ModelChain,
     pub(super) system_view: SystemView,
     pub(super) tool_definitions_view: ToolDefinitionsView,
     pub(super) messages: Vec<MessageView>,
@@ -246,14 +244,13 @@ pub struct PromptDefinition {
 
 impl PromptDefinition {
     pub(super) fn for_refreshed_thread(
-        model_defaults: ModelDefaults,
+        chain: ModelChain,
         system_view: SystemView,
         tool_definitions_view: ToolDefinitionsView,
         inherited_messages: Vec<MessageView>,
     ) -> Self {
         Self {
-            model: model_defaults.model,
-            max_tokens_per_response: model_defaults.max_tokens_per_response,
+            chain,
             system_view,
             tool_definitions_view,
             messages: inherited_messages,
@@ -420,8 +417,7 @@ impl PromptDefinition {
 
         Ok(Prompt {
             target_thread,
-            model: self.model,
-            max_tokens_per_response: self.max_tokens_per_response,
+            chain: self.chain,
             cache_key: None,
             system,
             tools,
@@ -450,11 +446,14 @@ mod tests {
         }
     }
 
-    fn test_model_defaults() -> ModelDefaults {
-        ModelDefaults {
-            model: "test-model".into(),
-            max_tokens_per_response: 8192,
-            context_window_tokens: 200_000,
+    fn test_chain() -> ModelChain {
+        ModelChain {
+            primary: crate::agent::config::ModelDefaults {
+                model: "test-model".into(),
+                max_tokens_per_response: 8192,
+                context_window_tokens: 200_000,
+            },
+            fallbacks: Vec::new(),
         }
     }
 
@@ -465,7 +464,7 @@ mod tests {
         let tool_c = tool_def("tool_c");
         let tool_d = tool_def("tool_d");
 
-        let defaults = test_model_defaults();
+        let defaults = test_chain();
         let mut m = MaterializedSession::init(&defaults);
         m.push_tool_defs([&tool_a, &tool_b].into_iter());
         m.push_tool_defs([&tool_c, &tool_d].into_iter());
@@ -480,7 +479,7 @@ mod tests {
         let block_b = system_block("Be concise.");
         let block_c = system_block("Use examples.");
 
-        let defaults = test_model_defaults();
+        let defaults = test_chain();
         let mut m = MaterializedSession::init(&defaults);
         m.push_system_blocks([&block_a].into_iter());
         m.push_system_blocks([&block_b, &block_c].into_iter());

--- a/core/src/agent/session/view.rs
+++ b/core/src/agent/session/view.rs
@@ -258,6 +258,10 @@ impl PromptDefinition {
         }
     }
 
+    pub fn model_chain(&self) -> &ModelChain {
+        &self.model_chain
+    }
+
     pub fn system_view(&self) -> &SystemView {
         &self.system_view
     }

--- a/core/src/project/entity.rs
+++ b/core/src/project/entity.rs
@@ -1,6 +1,5 @@
 use chrono::{DateTime, Utc};
 use derive_builder::Builder;
-use llm::ModelChain;
 use serde::{Deserialize, Serialize};
 
 use es_entity::*;
@@ -30,10 +29,6 @@ pub enum ProjectEvent {
     SpaceUnmounted {
         space_id: SpaceId,
     },
-    /// `Some` sets / replaces the override; `None` clears it.
-    ModelChainUpdated {
-        chain: Option<ModelChain>,
-    },
 }
 
 #[derive(EsEntity, Builder)]
@@ -48,9 +43,6 @@ pub struct Project {
     pub archived_at: Option<DateTime<Utc>>,
     #[builder(default)]
     pub mounted_spaces: Vec<SpaceId>,
-    /// Per-project chain. Beats role/default, loses to per-agent override.
-    #[builder(default)]
-    pub model_chain_override: Option<ModelChain>,
     events: EntityEvents<ProjectEvent>,
 }
 
@@ -104,15 +96,6 @@ impl Project {
         self.events.push(ProjectEvent::SpaceUnmounted { space_id });
         Idempotent::Executed(())
     }
-
-    pub(super) fn update_model_chain(&mut self, chain: Option<ModelChain>) -> Idempotent<()> {
-        if self.model_chain_override == chain {
-            return Idempotent::AlreadyApplied;
-        }
-        self.model_chain_override = chain.clone();
-        self.events.push(ProjectEvent::ModelChainUpdated { chain });
-        Idempotent::Executed(())
-    }
 }
 
 impl core::fmt::Display for Project {
@@ -157,9 +140,6 @@ impl TryFromEvents<ProjectEvent> for Project {
                 }
                 ProjectEvent::SpaceUnmounted { space_id } => {
                     mounted_spaces.retain(|id| id != space_id);
-                }
-                ProjectEvent::ModelChainUpdated { chain } => {
-                    builder = builder.model_chain_override(chain.clone());
                 }
             }
         }

--- a/core/src/project/mod.rs
+++ b/core/src/project/mod.rs
@@ -251,26 +251,6 @@ impl Projects {
         Ok(project)
     }
 
-    #[instrument(name = "domain.project.update_model_chain", skip(self, sub))]
-    pub async fn update_model_chain(
-        &self,
-        sub: &AuthSubject,
-        id: impl Into<ProjectId> + std::fmt::Debug,
-        chain: Option<llm::ModelChain>,
-    ) -> Result<Project, ProjectError> {
-        let id = id.into();
-        sub.can(AuthVerb::Update, AuthResource::Project(Some(id)))?;
-        Audit::record_action_if_unset("project.update_model_chain");
-        Audit::record_project_id(id);
-        let mut op = self.repo.begin_op().await?;
-        let mut project = self.repo.find_by_id_in_op(&mut op, id).await?;
-        if project.update_model_chain(chain).did_execute() {
-            self.repo.update_in_op(&mut op, &mut project).await?;
-        }
-        op.commit().await?;
-        Ok(project)
-    }
-
     #[instrument(name = "domain.project.delete", skip(self, sub))]
     pub async fn delete(
         &self,

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -257,8 +257,10 @@ impl ExecutorState {
         for spec in prompt.chain.iter() {
             match self.find(&spec.name) {
                 Some(model) => entries.push(ChainEntry {
-                    model_id: spec.name.clone(),
-                    max_tokens: spec.max_tokens.or(model.default_max_tokens),
+                    spec: llm::ModelSpec {
+                        name: spec.name.clone(),
+                        max_tokens: spec.max_tokens.or(model.default_max_tokens),
+                    },
                     provider: model.client.clone(),
                 }),
                 None => {

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -231,10 +231,6 @@ enum ProjectCommand {
     /// Create a new project (also seeds a ProjectLead agent named 'lead').
     Create,
     List,
-    /// Set / replace / clear the project-level chain.
-    /// `clear_model_chain: true` clears; otherwise `model_chain` sets.
-    /// Inherited by every non-workflow agent in the project.
-    UpdateModelChain,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -242,13 +238,6 @@ struct ProjectParams {
     command: ProjectCommand,
     name: Option<String>,
     description: Option<String>,
-    /// Project ID (required for `update_model_chain`).
-    #[schemars(with = "Option<uuid::Uuid>")]
-    project_id: Option<ProjectId>,
-    #[serde(default)]
-    model_chain: Option<llm::ModelChain>,
-    #[serde(default)]
-    clear_model_chain: bool,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -684,10 +673,7 @@ static TOOLS: &[ToolDef] = &[
     ToolDef {
         name: "project",
         description: "Manage projects. Commands: `create` (requires `name`, optional \
-                       `description`; also seeds a ProjectLead agent), `list`, \
-                       `update_model_chain` (requires `project_id`; set `model_chain` \
-                       to pin a chain inherited by every non-workflow agent in the \
-                       project, or `clear_model_chain: true` to clear).",
+                       `description`; also seeds a ProjectLead agent), `list`.",
         schema: &PROJECT_SCHEMA,
     },
     ToolDef {
@@ -974,19 +960,24 @@ impl AdminToolSet {
                 })?;
                 let chain =
                     resolve_model_chain_update(params.model_chain, params.clear_model_chain)?;
-                let agent = self
-                    .agents
-                    .update_model_chain(subject, agent_id, chain)
+                self.agents
+                    .update_session_chain(subject, agent_id, chain)
                     .await
                     .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
+                let session = self
+                    .agents
+                    .find_session(subject, agent_id)
+                    .await
+                    .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
+                let chain_str = session
+                    .chain()
+                    .iter()
+                    .map(|m| m.model.clone())
+                    .collect::<Vec<_>>()
+                    .join(" -> ");
                 Ok(CallToolResult::success(vec![Content::text(format!(
-                    "Agent {} model_chain_override = {}",
-                    agent.id,
-                    agent
-                        .model_chain_override
-                        .as_ref()
-                        .map(|c| serde_yaml::to_string(c).unwrap_or_default())
-                        .unwrap_or_else(|| "<none>".to_string())
+                    "Agent {} session chain = {}",
+                    agent_id, chain_str
                 ))]))
             }
         }
@@ -1113,29 +1104,6 @@ impl AdminToolSet {
                 Ok(CallToolResult::success(vec![Content::text(
                     format_projects(&all),
                 )]))
-            }
-
-            ProjectCommand::UpdateModelChain => {
-                let project_id = params.project_id.ok_or_else(|| {
-                    ToolSetsError::MissingArgument(
-                        "project_id is required for update_model_chain".to_string(),
-                    )
-                })?;
-                let chain =
-                    resolve_model_chain_update(params.model_chain, params.clear_model_chain)?;
-                let project = self
-                    .projects
-                    .update_model_chain(subject, project_id, chain)
-                    .await?;
-                Ok(CallToolResult::success(vec![Content::text(format!(
-                    "Project {} model_chain_override = {}",
-                    project.id,
-                    project
-                        .model_chain_override
-                        .as_ref()
-                        .map(|c| serde_yaml::to_string(c).unwrap_or_default())
-                        .unwrap_or_else(|| "<none>".to_string())
-                ))]))
             }
         }
     }

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -960,13 +960,9 @@ impl AdminToolSet {
                 })?;
                 let chain =
                     resolve_model_chain_update(params.model_chain, params.clear_model_chain)?;
-                self.agents
-                    .update_session_chain(subject, agent_id, chain)
-                    .await
-                    .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
                 let session = self
                     .agents
-                    .find_session(subject, agent_id)
+                    .update_session_chain(subject, agent_id, chain)
                     .await
                     .map_err(|e| ToolSetsError::Agent(e.to_string()))?;
                 let chain_str = session

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -875,3 +875,34 @@ async fn detach_conflicting_writer_is_noop_when_unattached() {
     op.commit().await.expect("commit");
     assert!(detached.is_empty());
 }
+
+#[tokio::test]
+async fn update_session_chain_rejects_workflow_agents() {
+    let pool = pool().await;
+    let (agents, _sandboxes) = build_agents(&pool).await;
+    let project_id = insert_project(&pool).await;
+    let (workflow_id, run_id) = seed_workflow_run(&pool, project_id).await;
+
+    let mut op = agents.begin_op().await.expect("begin op");
+    let agent = agents
+        .create_for_workflow_run_in_op(
+            &mut op,
+            project_id,
+            workflow_id,
+            run_id,
+            "wf-step",
+            None,
+            None,
+            drua_core::workflow::default_output_schema(),
+        )
+        .await
+        .expect("create workflow agent");
+    op.commit().await.expect("commit");
+
+    let sub = AuthSubject::User(UserId::new());
+    let result = agents.update_session_chain(&sub, agent.id, None).await;
+    assert!(matches!(
+        result,
+        Err(drua_core::agent::AgentError::WorkflowAgentChainImmutable)
+    ));
+}

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -879,8 +879,8 @@ async fn detach_conflicting_writer_is_noop_when_unattached() {
 #[tokio::test]
 async fn update_session_chain_rejects_workflow_agents() {
     let pool = pool().await;
-    let (agents, _sandboxes) = build_agents(&pool).await;
-    let project_id = insert_project(&pool).await;
+    let (agents, _sandboxes, _sandbox_id, project_id) =
+        fixture_for_detach_test(&pool, "sb-update-chain-wf").await;
     let (workflow_id, run_id) = seed_workflow_run(&pool, project_id).await;
 
     let mut op = agents.begin_op().await.expect("begin op");

--- a/lib/anthropic-client/src/convert.rs
+++ b/lib/anthropic-client/src/convert.rs
@@ -35,7 +35,10 @@ impl AnthropicCacheTtl {
     }
 }
 
-pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> AnthropicRequest {
+pub(crate) fn prompt_to_request(
+    prompt: &llm::Prompt,
+    spec: &llm::ModelSpec,
+) -> AnthropicRequest {
     let messages: Vec<AnthropicMessage> = prompt.messages.iter().map(convert_message).collect();
 
     let system = if prompt.system.is_empty() {
@@ -53,10 +56,10 @@ pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> AnthropicRequest {
     let tool_choice = prompt.tool_choice.as_ref().map(convert_tool_choice);
 
     let mut request = AnthropicRequest {
-        model: prompt.chain.primary.name.clone(),
+        model: spec.name.clone(),
         messages,
         system,
-        max_tokens: prompt.max_tokens.unwrap_or(8192),
+        max_tokens: spec.max_tokens.unwrap_or(8192),
         temperature: None,
         tools,
         tool_choice,
@@ -390,7 +393,7 @@ impl AnthropicDeltaConverter {
 mod tests {
     use super::*;
     use llm::prompt::{Message, Prompt, SystemBlock, UserBlock};
-    use llm::ModelChain;
+    use llm::{ModelChain, ModelSpec};
 
     fn base_prompt() -> Prompt {
         Prompt {
@@ -401,14 +404,17 @@ mod tests {
             }],
             tools: vec![],
             tool_choice: None,
-            max_tokens: Some(1024),
             cache_key: None,
         }
     }
 
+    fn base_spec() -> ModelSpec {
+        ModelSpec::new("claude-sonnet-4").with_max_tokens(1024)
+    }
+
     #[test]
     fn cache_marker_lands_on_last_user_block() {
-        let req = prompt_to_request(&base_prompt());
+        let req = prompt_to_request(&base_prompt(), &base_spec());
         let last = req.messages.last().unwrap();
         match &last.content[0] {
             AnthropicContent::Text { cache_control, .. } => {
@@ -425,14 +431,14 @@ mod tests {
     fn cache_marker_falls_through_to_system_when_no_messages() {
         let mut p = base_prompt();
         p.messages.clear();
-        let req = prompt_to_request(&p);
+        let req = prompt_to_request(&p, &base_spec());
         let sys = req.system.as_ref().unwrap().last().unwrap();
         assert!(sys.cache_control.is_some());
     }
 
     #[test]
     fn primary_model_id_is_used() {
-        let req = prompt_to_request(&base_prompt());
+        let req = prompt_to_request(&base_prompt(), &base_spec());
         assert_eq!(req.model, "claude-sonnet-4");
     }
 }

--- a/lib/anthropic-client/src/lib.rs
+++ b/lib/anthropic-client/src/lib.rs
@@ -11,9 +11,8 @@ use thiserror::Error;
 use tracing::instrument;
 
 use llm::provider::LlmProvider;
-use llm::{Prompt, PromptError, PromptResponse};
-
 use llm::stream::StreamDelta;
+use llm::{ModelSpec, Prompt, PromptError, PromptResponse};
 
 use crate::convert::{accumulated_to_response, prompt_to_request, AnthropicDeltaConverter};
 use crate::sse::{parse_sse_stream, SseError};
@@ -70,8 +69,12 @@ impl AnthropicClient {
 
     /// Streams the Messages API and returns the fully-accumulated reply.
     #[instrument(name = "anthropic_client.send_prompt", skip_all)]
-    pub async fn send_prompt(&self, prompt: &Prompt) -> Result<PromptResponse, AnthropicError> {
-        let request_body = prompt_to_request(prompt);
+    pub async fn send_prompt(
+        &self,
+        prompt: &Prompt,
+        spec: &ModelSpec,
+    ) -> Result<PromptResponse, AnthropicError> {
+        let request_body = prompt_to_request(prompt, spec);
 
         let resp = self
             .http
@@ -126,9 +129,10 @@ impl AnthropicClient {
     pub async fn send_prompt_streaming(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, AnthropicError>>, AnthropicError>
     {
-        let request_body = prompt_to_request(prompt);
+        let request_body = prompt_to_request(prompt, spec);
 
         let resp = self
             .http
@@ -208,8 +212,9 @@ impl LlmProvider for AnthropicClient {
     async fn send_prompt_streaming(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
-        let rx = AnthropicClient::send_prompt_streaming(self, prompt)
+        let rx = AnthropicClient::send_prompt_streaming(self, prompt, spec)
             .await
             .map_err(classify)?;
 

--- a/lib/llm/src/prompt.rs
+++ b/lib/llm/src/prompt.rs
@@ -13,8 +13,6 @@ pub struct Prompt {
     pub tools: Vec<Tool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_tokens: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_key: Option<String>,
 }
@@ -27,7 +25,6 @@ impl Default for Prompt {
             system: Vec::new(),
             tools: Vec::new(),
             tool_choice: None,
-            max_tokens: None,
             cache_key: None,
         }
     }
@@ -136,19 +133,19 @@ impl Prompt {
         #[derive(Serialize)]
         struct Hashable<'a> {
             primary_model: &'a str,
+            primary_max_tokens: Option<u32>,
             messages: &'a [Message],
             system: &'a [SystemBlock],
             tools: &'a [Tool],
             tool_choice: Option<&'a ToolChoice>,
-            max_tokens: Option<u32>,
         }
         let hashable = Hashable {
             primary_model: &self.chain.primary.name,
+            primary_max_tokens: self.chain.primary.max_tokens,
             messages: &self.messages,
             system: &self.system,
             tools: &self.tools,
             tool_choice: self.tool_choice.as_ref(),
-            max_tokens: self.max_tokens,
         };
         let value = serde_json::to_value(&hashable).expect("hashable is always serializable");
         let canonical = canonicalize(&value);
@@ -233,7 +230,9 @@ mod tests {
 
     fn sample_prompt(msg_text: &str) -> Prompt {
         Prompt {
-            chain: ModelChain::new(ModelSpec::new("claude-sonnet-4-20250514")),
+            chain: ModelChain::new(
+                ModelSpec::new("claude-sonnet-4-20250514").with_max_tokens(1024),
+            ),
             system: vec![SystemBlock::Text {
                 text: "You are a helpful assistant.".to_string(),
             }],
@@ -255,7 +254,6 @@ mod tests {
                 strict: false,
             }],
             tool_choice: None,
-            max_tokens: Some(1024),
             cache_key: None,
         }
     }
@@ -298,7 +296,6 @@ mod tests {
             }],
             tools: vec![],
             tool_choice: None,
-            max_tokens: None,
             cache_key: None,
         };
 

--- a/lib/llm/src/provider.rs
+++ b/lib/llm/src/provider.rs
@@ -5,18 +5,24 @@ use async_trait::async_trait;
 use tokio::sync::mpsc;
 
 use crate::stream::StreamDelta;
-use crate::{Prompt, PromptError};
+use crate::{ModelSpec, Prompt, PromptError};
 
 #[async_trait]
 pub trait LlmProvider: Send + Sync {
     /// e.g. `"anthropic"`, `"openai"`.
     fn name(&self) -> &str;
 
+    /// `spec` identifies the chain entry being attempted — providers MUST
+    /// read the wire-level model id from `spec.name` and the output cap
+    /// from `spec.max_tokens`. `prompt.chain.primary` is metadata about
+    /// the originally-requested model and may differ on fallback attempts.
+    ///
     /// Typical event order: content deltas, then `Usage` (additive, may
     /// arrive at any point), then `Done`. Providers emit only the events
     /// natural to their wire format.
     async fn send_prompt_streaming(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError>;
 }

--- a/lib/llm/src/router.rs
+++ b/lib/llm/src/router.rs
@@ -7,21 +7,18 @@ use std::sync::Arc;
 use crate::provider::LlmProvider;
 use crate::request::PromptError;
 use crate::response::Usage;
-use crate::{Prompt, StreamHandle};
+use crate::{ModelSpec, Prompt, StreamHandle};
 
 #[derive(Clone)]
 pub struct ChainEntry {
-    pub model_id: String,
-    /// Today only `max_tokens` is plumbed through per-attempt.
-    pub max_tokens: Option<u32>,
+    pub spec: ModelSpec,
     pub provider: Arc<dyn LlmProvider>,
 }
 
 impl std::fmt::Debug for ChainEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ChainEntry")
-            .field("model_id", &self.model_id)
-            .field("max_tokens", &self.max_tokens)
+            .field("spec", &self.spec)
             .field("provider", &self.provider.name())
             .finish()
     }
@@ -78,40 +75,35 @@ pub async fn walk(chain: &[ChainEntry], base: &Prompt) -> Result<WalkOutcome, Pr
     let mut last_err: Option<PromptError> = None;
 
     for entry in chain {
-        let mut prompt = base.clone();
-        if let Some(mt) = entry.max_tokens {
-            prompt.max_tokens = Some(mt);
-        }
-
-        match entry.provider.send_prompt_streaming(&prompt).await {
+        match entry.provider.send_prompt_streaming(base, &entry.spec).await {
             Ok(rx) => {
                 attempts.push(AttemptRecord {
-                    model_id: entry.model_id.clone(),
+                    model_id: entry.spec.name.clone(),
                     provider_name: entry.provider.name().to_string(),
                     outcome: AttemptOutcome::Succeeded,
                     usage: None,
                 });
                 tracing::info!(
-                    model = %entry.model_id,
+                    model = %entry.spec.name,
                     provider = entry.provider.name(),
                     attempts = attempts.len(),
                     "router.walk: stream opened",
                 );
                 return Ok(WalkOutcome {
                     stream: StreamHandle { rx },
-                    model_used: entry.model_id.clone(),
+                    model_used: entry.spec.name.clone(),
                     attempts,
                 });
             }
             Err(e) if e.is_terminal() => {
                 attempts.push(AttemptRecord {
-                    model_id: entry.model_id.clone(),
+                    model_id: entry.spec.name.clone(),
                     provider_name: entry.provider.name().to_string(),
                     outcome: AttemptOutcome::Terminal(e.to_string()),
                     usage: None,
                 });
                 tracing::error!(
-                    model = %entry.model_id,
+                    model = %entry.spec.name,
                     provider = entry.provider.name(),
                     error = %e,
                     "router.walk: terminal error, aborting chain",
@@ -120,13 +112,13 @@ pub async fn walk(chain: &[ChainEntry], base: &Prompt) -> Result<WalkOutcome, Pr
             }
             Err(e) => {
                 tracing::warn!(
-                    model = %entry.model_id,
+                    model = %entry.spec.name,
                     provider = entry.provider.name(),
                     error = %e,
                     "router.walk: transient error, trying next",
                 );
                 attempts.push(AttemptRecord {
-                    model_id: entry.model_id.clone(),
+                    model_id: entry.spec.name.clone(),
                     provider_name: entry.provider.name().to_string(),
                     outcome: AttemptOutcome::Transient(e.to_string()),
                     usage: None,
@@ -160,6 +152,7 @@ mod tests {
         async fn send_prompt_streaming(
             &self,
             _prompt: &Prompt,
+            _spec: &ModelSpec,
         ) -> Result<mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
             let (_tx, rx) = mpsc::channel(1);
             Ok(rx)
@@ -188,6 +181,7 @@ mod tests {
         async fn send_prompt_streaming(
             &self,
             _prompt: &Prompt,
+            _spec: &ModelSpec,
         ) -> Result<mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             Err(self.err.clone())
@@ -196,8 +190,7 @@ mod tests {
 
     fn entry(model_id: &str, provider: Arc<dyn LlmProvider>) -> ChainEntry {
         ChainEntry {
-            model_id: model_id.to_string(),
-            max_tokens: None,
+            spec: ModelSpec::new(model_id),
             provider,
         }
     }

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -18,7 +18,10 @@ use crate::types::{
 /// these as a passthrough field.
 const ANTHROPIC_MODEL_PREFIX: &str = "anthropic/";
 
-pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> OpenAiRequest {
+pub(crate) fn prompt_to_request(
+    prompt: &llm::Prompt,
+    spec: &llm::ModelSpec,
+) -> OpenAiRequest {
     let mut messages: Vec<OpenAiMessage> = Vec::new();
 
     for block in &prompt.system {
@@ -47,10 +50,10 @@ pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> OpenAiRequest {
     let tool_choice = prompt.tool_choice.as_ref().map(convert_tool_choice);
 
     let mut request = OpenAiRequest {
-        model: prompt.chain.primary.name.clone(),
+        model: spec.name.clone(),
         messages,
         prompt_cache_key: prompt.cache_key.clone(),
-        max_completion_tokens: prompt.max_tokens,
+        max_completion_tokens: spec.max_tokens,
         temperature: None,
         tools,
         tool_choice,
@@ -444,15 +447,18 @@ mod tests {
                 strict: false,
             }],
             tool_choice: None,
-            max_tokens: Some(1024),
             cache_key: None,
         }
+    }
+
+    fn sample_spec() -> llm::ModelSpec {
+        llm::ModelSpec::new("gpt-4o").with_max_tokens(1024)
     }
 
     #[test]
     fn prompt_to_request_basic() {
         let prompt = sample_prompt();
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, &sample_spec());
 
         assert_eq!(req.model, "gpt-4o");
         assert!(req.stream);
@@ -471,7 +477,7 @@ mod tests {
         let mut prompt = sample_prompt();
         prompt.cache_key = Some("agent-session:test".to_string());
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, &sample_spec());
         assert_eq!(req.prompt_cache_key.as_deref(), Some("agent-session:test"));
     }
 
@@ -500,11 +506,10 @@ mod tests {
             ],
             tools: vec![],
             tool_choice: None,
-            max_tokens: None,
             cache_key: None,
         };
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, &sample_spec());
         assert_eq!(req.messages.len(), 2);
         assert_eq!(req.messages[0].role, "assistant");
         assert!(req.messages[0].tool_calls.is_some());
@@ -531,11 +536,10 @@ mod tests {
             }],
             tools: vec![],
             tool_choice: None,
-            max_tokens: None,
             cache_key: None,
         };
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, &sample_spec());
         assert_eq!(req.messages.len(), 1);
         assert_eq!(
             content_text(&req.messages[0]),
@@ -855,14 +859,20 @@ mod tests {
                 strict: false,
             }],
             tool_choice: None,
-            max_tokens: Some(1024),
             cache_key: None,
         }
     }
 
+    fn anthropic_via_openrouter_spec() -> llm::ModelSpec {
+        llm::ModelSpec::new("anthropic/claude-sonnet-4.6").with_max_tokens(1024)
+    }
+
     #[test]
     fn anthropic_via_openrouter_marks_last_user_text_block() {
-        let req = prompt_to_request(&anthropic_via_openrouter_prompt());
+        let req = prompt_to_request(
+            &anthropic_via_openrouter_prompt(),
+            &anthropic_via_openrouter_spec(),
+        );
 
         let last = req.messages.last().expect("messages present");
         assert_eq!(last.role, "user");
@@ -893,10 +903,10 @@ mod tests {
 
     #[test]
     fn non_anthropic_model_emits_plain_string_content() {
-        let mut prompt = anthropic_via_openrouter_prompt();
-        prompt.chain = llm::ModelChain::new("openai/gpt-5-mini");
+        let prompt = anthropic_via_openrouter_prompt();
+        let spec = llm::ModelSpec::new("openai/gpt-5-mini").with_max_tokens(1024);
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, &spec);
 
         for msg in &req.messages {
             assert!(
@@ -924,7 +934,7 @@ mod tests {
         prompt.messages.clear();
         prompt.system.clear();
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, &anthropic_via_openrouter_spec());
 
         let tool = req
             .tools
@@ -937,7 +947,10 @@ mod tests {
 
     #[test]
     fn anthropic_serialised_request_has_cache_control_inside_content_block() {
-        let req = prompt_to_request(&anthropic_via_openrouter_prompt());
+        let req = prompt_to_request(
+            &anthropic_via_openrouter_prompt(),
+            &anthropic_via_openrouter_spec(),
+        );
         let json = serde_json::to_value(&req).unwrap();
 
         // Wire-format check: the marker is nested inside a content block on

--- a/lib/openai-client/src/lib.rs
+++ b/lib/openai-client/src/lib.rs
@@ -14,7 +14,7 @@ use tracing::{instrument, Instrument};
 
 use llm::provider::LlmProvider;
 use llm::stream::StreamDelta;
-use llm::{Prompt, PromptError, PromptResponse};
+use llm::{ModelSpec, Prompt, PromptError, PromptResponse};
 
 use crate::convert::{prompt_to_request, DeltaSynthesizer, EMPTY_COMPLETION_ERR};
 use crate::sse::{parse_sse_stream, SseError};
@@ -87,8 +87,9 @@ impl OpenAiClient {
     pub async fn send_prompt(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<PromptResponse, OpenAiChatCompletionsError> {
-        let rx = self.send_prompt_streaming_internal(prompt).await?;
+        let rx = self.send_prompt_streaming_internal(prompt, spec).await?;
         let mut rx = rx;
 
         let mut accumulator = llm::stream::StreamAccumulator::new();
@@ -174,11 +175,12 @@ impl OpenAiClient {
     async fn send_prompt_streaming_internal(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<
         tokio::sync::mpsc::Receiver<Result<StreamDelta, OpenAiChatCompletionsError>>,
         OpenAiChatCompletionsError,
     > {
-        let request_body = prompt_to_request(prompt);
+        let request_body = prompt_to_request(prompt, spec);
         let body_bytes = Arc::new(
             serde_json::to_vec(&request_body)
                 .map_err(|e| OpenAiChatCompletionsError::Stream(format!("body serialize: {e}")))?,
@@ -392,9 +394,10 @@ impl LlmProvider for OpenAiClient {
     async fn send_prompt_streaming(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
         let rx = self
-            .send_prompt_streaming_internal(prompt)
+            .send_prompt_streaming_internal(prompt, spec)
             .await
             .map_err(classify)?;
 

--- a/lib/openai-client/src/responses.rs
+++ b/lib/openai-client/src/responses.rs
@@ -7,7 +7,7 @@ use llm::prompt::{
 };
 use llm::provider::LlmProvider;
 use llm::stream::StreamDelta;
-use llm::{Prompt, PromptError};
+use llm::{ModelSpec, Prompt, PromptError};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
@@ -99,11 +99,12 @@ impl OpenAiResponsesClient {
     async fn send_prompt_streaming_internal(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<
         tokio::sync::mpsc::Receiver<Result<StreamDelta, OpenAiResponsesError>>,
         OpenAiResponsesError,
     > {
-        let request_body = prompt_to_responses_request(prompt, &self.auth);
+        let request_body = prompt_to_responses_request(prompt, spec, &self.auth);
         let mut request = self
             .http
             .post(&self.api_url)
@@ -231,9 +232,10 @@ impl LlmProvider for OpenAiResponsesClient {
     async fn send_prompt_streaming(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
         let rx = self
-            .send_prompt_streaming_internal(prompt)
+            .send_prompt_streaming_internal(prompt, spec)
             .await
             .map_err(classify)?;
 
@@ -320,7 +322,11 @@ struct ResponsesReasoningConfig {
     summary: &'static str,
 }
 
-fn prompt_to_responses_request(prompt: &Prompt, auth: &OpenAiResponsesAuth) -> ResponsesRequest {
+fn prompt_to_responses_request(
+    prompt: &Prompt,
+    spec: &ModelSpec,
+    auth: &OpenAiResponsesAuth,
+) -> ResponsesRequest {
     let mut input = Vec::new();
 
     for message in &prompt.messages {
@@ -343,13 +349,13 @@ fn prompt_to_responses_request(prompt: &Prompt, auth: &OpenAiResponsesAuth) -> R
         .join("\n");
 
     ResponsesRequest {
-        model: prompt.chain.primary.name.clone(),
+        model: spec.name.clone(),
         input,
         instructions: (!instructions.is_empty()).then_some(instructions),
         prompt_cache_key: prompt.cache_key.clone(),
         max_output_tokens: match auth {
             OpenAiResponsesAuth::ApiKey { .. } => {
-                prompt.max_tokens.or(Some(DEFAULT_MAX_OUTPUT_TOKENS))
+                spec.max_tokens.or(Some(DEFAULT_MAX_OUTPUT_TOKENS))
             }
             OpenAiResponsesAuth::Subscription => None,
         },
@@ -1058,9 +1064,12 @@ mod tests {
             system: Vec::new(),
             tools: Vec::new(),
             tool_choice: None,
-            max_tokens: Some(1234),
             cache_key: None,
         }
+    }
+
+    fn sample_spec() -> ModelSpec {
+        ModelSpec::new("gpt-5.4-mini").with_max_tokens(1234)
     }
 
     fn build_test_jwt(account_id: &str) -> String {
@@ -1155,6 +1164,7 @@ mod tests {
     fn api_key_requests_include_max_output_tokens() {
         let request = prompt_to_responses_request(
             &sample_prompt(),
+            &sample_spec(),
             &OpenAiResponsesAuth::ApiKey {
                 api_key: "sk-test".to_string(),
             },
@@ -1166,8 +1176,11 @@ mod tests {
 
     #[test]
     fn subscription_requests_omit_max_output_tokens() {
-        let request =
-            prompt_to_responses_request(&sample_prompt(), &OpenAiResponsesAuth::Subscription);
+        let request = prompt_to_responses_request(
+            &sample_prompt(),
+            &sample_spec(),
+            &OpenAiResponsesAuth::Subscription,
+        );
 
         let value = serde_json::to_value(request).expect("request serializes");
         assert!(
@@ -1183,6 +1196,7 @@ mod tests {
 
         let request = prompt_to_responses_request(
             &prompt,
+            &sample_spec(),
             &OpenAiResponsesAuth::ApiKey {
                 api_key: "sk-test".to_string(),
             },

--- a/server/src/graphql/agent.rs
+++ b/server/src/graphql/agent.rs
@@ -59,6 +59,25 @@ impl From<ModelChain> for DomainModelChain {
     }
 }
 
+impl From<drua_core::agent::ModelChain> for ModelChain {
+    fn from(c: drua_core::agent::ModelChain) -> Self {
+        Self {
+            primary: ModelSpec {
+                name: c.primary.model,
+                max_tokens: None,
+            },
+            fallbacks: c
+                .fallbacks
+                .into_iter()
+                .map(|m| ModelSpec {
+                    name: m.model,
+                    max_tokens: None,
+                })
+                .collect(),
+        }
+    }
+}
+
 #[derive(SimpleObject, Clone)]
 #[graphql(complex)]
 pub struct Agent {
@@ -73,12 +92,6 @@ pub struct Agent {
 
 #[ComplexObject]
 impl Agent {
-    /// `None` ⇒ use the project / role / config-default chain.
-    /// Always `None` for workflow-spawned agents.
-    async fn model_chain_override(&self) -> Option<ModelChain> {
-        self.entity.model_chain_override.clone().map(Into::into)
-    }
-
     async fn attached_sandbox(
         &self,
         ctx: &Context<'_>,
@@ -180,14 +193,14 @@ pub struct AgentCreateInput {
 mutation_payload! { AgentCreatePayload, agent: Agent }
 
 #[derive(InputObject)]
-pub struct AgentUpdateModelChainInput {
+pub struct AgentUpdateSessionChainInput {
     pub agent_id: AgentId,
-    /// `None` clears the override (revert to project / role / default).
+    /// `None` reverts the session chain to the role / `agents.default_chain`.
     /// Rejects workflow-spawned agents.
     pub chain: Option<ModelChain>,
 }
 
-mutation_payload! { AgentUpdateModelChainPayload, agent: Agent }
+mutation_payload! { AgentUpdateSessionChainPayload, session: super::session::AgentSession }
 
 #[derive(InputObject)]
 pub struct AgentAttachSandboxInput {

--- a/server/src/graphql/agent.rs
+++ b/server/src/graphql/agent.rs
@@ -13,6 +13,8 @@ use drua_core::{ModelChain as DomainModelChain, ModelSpec as DomainModelSpec};
 #[graphql(input_name = "ModelSpecInput")]
 pub struct ModelSpec {
     pub name: String,
+    /// Input: optional override of the registry's `max_tokens_per_response`.
+    /// Output: the effective max_tokens currently in force (registry value or override).
     pub max_tokens: Option<i32>,
 }
 

--- a/server/src/graphql/agent.rs
+++ b/server/src/graphql/agent.rs
@@ -16,15 +16,6 @@ pub struct ModelSpec {
     pub max_tokens: Option<i32>,
 }
 
-impl From<DomainModelSpec> for ModelSpec {
-    fn from(s: DomainModelSpec) -> Self {
-        Self {
-            name: s.name,
-            max_tokens: s.max_tokens.map(|n| n as i32),
-        }
-    }
-}
-
 impl From<ModelSpec> for DomainModelSpec {
     fn from(s: ModelSpec) -> Self {
         DomainModelSpec {
@@ -41,15 +32,6 @@ pub struct ModelChain {
     pub fallbacks: Vec<ModelSpec>,
 }
 
-impl From<DomainModelChain> for ModelChain {
-    fn from(c: DomainModelChain) -> Self {
-        Self {
-            primary: c.primary.into(),
-            fallbacks: c.fallbacks.into_iter().map(Into::into).collect(),
-        }
-    }
-}
-
 impl From<ModelChain> for DomainModelChain {
     fn from(c: ModelChain) -> Self {
         DomainModelChain {
@@ -64,14 +46,14 @@ impl From<drua_core::agent::ModelChain> for ModelChain {
         Self {
             primary: ModelSpec {
                 name: c.primary.model,
-                max_tokens: None,
+                max_tokens: Some(c.primary.max_tokens_per_response as i32),
             },
             fallbacks: c
                 .fallbacks
                 .into_iter()
                 .map(|m| ModelSpec {
                     name: m.model,
-                    max_tokens: None,
+                    max_tokens: Some(m.max_tokens_per_response as i32),
                 })
                 .collect(),
         }

--- a/server/src/graphql/mutation.rs
+++ b/server/src/graphql/mutation.rs
@@ -69,19 +69,6 @@ impl Mutation {
         })
     }
 
-    async fn project_update_model_chain(
-        &self,
-        ctx: &Context<'_>,
-        input: ProjectUpdateModelChainInput,
-    ) -> async_graphql::Result<ProjectUpdateModelChainPayload> {
-        let (app, sub) = app_and_sub_from_ctx!(ctx);
-        let project = app
-            .projects()
-            .update_model_chain(sub, input.id, input.chain.map(Into::into))
-            .await?;
-        Ok(ProjectUpdateModelChainPayload::from(Project::from(project)))
-    }
-
     async fn agent_create(
         &self,
         ctx: &Context<'_>,
@@ -105,17 +92,19 @@ impl Mutation {
         Ok(AgentCreatePayload::from(Agent::from(agent)))
     }
 
-    async fn agent_update_model_chain(
+    async fn agent_update_session_chain(
         &self,
         ctx: &Context<'_>,
-        input: AgentUpdateModelChainInput,
-    ) -> async_graphql::Result<AgentUpdateModelChainPayload> {
+        input: AgentUpdateSessionChainInput,
+    ) -> async_graphql::Result<AgentUpdateSessionChainPayload> {
         let (app, sub) = app_and_sub_from_ctx!(ctx);
-        let agent = app
+        let session = app
             .agents()
-            .update_model_chain(sub, input.agent_id, input.chain.map(Into::into))
+            .update_session_chain(sub, input.agent_id, input.chain.map(Into::into))
             .await?;
-        Ok(AgentUpdateModelChainPayload::from(Agent::from(agent)))
+        Ok(AgentUpdateSessionChainPayload::from(
+            super::session::AgentSession::from(session),
+        ))
     }
 
     async fn agent_attach_sandbox(

--- a/server/src/graphql/project.rs
+++ b/server/src/graphql/project.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use async_graphql::{ComplexObject, Context, InputObject, SimpleObject};
 
-use super::agent::{Agent, ModelChain};
+use super::agent::Agent;
 use super::mcp_creds::McpCreds;
 use super::primitives::*;
 use super::project_secret::ProjectSecret;
@@ -26,12 +26,6 @@ pub struct Project {
 impl Project {
     async fn created_at(&self) -> Timestamp {
         self.entity.created_at().into()
-    }
-
-    /// Per-project chain. Inherited by every non-workflow agent in
-    /// the project unless the agent has its own override.
-    async fn model_chain_override(&self) -> Option<ModelChain> {
-        self.entity.model_chain_override.clone().map(Into::into)
     }
 
     async fn lead(&self, ctx: &Context<'_>) -> async_graphql::Result<Agent> {
@@ -120,15 +114,6 @@ pub struct ProjectDeleteInput {
 }
 
 mutation_payload! { ProjectDeletePayload, project: Project }
-
-#[derive(InputObject)]
-pub struct ProjectUpdateModelChainInput {
-    pub id: ProjectId,
-    /// `None` clears the override.
-    pub chain: Option<ModelChain>,
-}
-
-mutation_payload! { ProjectUpdateModelChainPayload, project: Project }
 
 #[derive(SimpleObject)]
 pub struct BootstrapPersonalProjectPayload {

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -271,11 +271,19 @@ input ModelChainInput {
 }
 
 type ModelSpec {
+	"""
+	Input: optional override of the registry's `max_tokens_per_response`.
+	Output: the effective max_tokens currently in force (registry value or override).
+	"""
 	maxTokens: Int
 	name: String!
 }
 
 input ModelSpecInput {
+	"""
+	Input: optional override of the registry's `max_tokens_per_response`.
+	Output: the effective max_tokens currently in force (registry value or override).
+	"""
 	maxTokens: Int
 	name: String!
 }

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -293,8 +293,8 @@ type Mutation {
 	agentCreate(input: AgentCreateInput!): AgentCreatePayload!
 	agentDelete(input: AgentDeleteInput!): AgentDeletePayload!
 	agentDetachSandbox(input: AgentDetachSandboxInput!): AgentDetachSandboxPayload!
-	bootstrapPersonalProject: BootstrapPersonalProjectPayload!
 	agentUpdateSessionChain(input: AgentUpdateSessionChainInput!): AgentUpdateSessionChainPayload!
+	bootstrapPersonalProject: BootstrapPersonalProjectPayload!
 	mcpCredentialsCreate(input: McpCredentialsCreateInput!): McpCredentialsCreatePayload!
 	mcpCredentialsRevoke(input: McpCredentialsRevokeInput!): McpCredentialsRevokePayload!
 	noteDelete(input: NoteDeleteInput!): NoteDeletePayload!

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -1,11 +1,6 @@
 type Agent {
 	attachedSandbox: SandboxAttachment
 	id: AgentId!
-	"""
-	`None` ⇒ use the project / role / config-default chain.
-	Always `None` for workflow-spawned agents.
-	"""
-	modelChainOverride: ModelChain
 	name: String!
 	projectId: ProjectId!
 	role: AgentRole!
@@ -65,12 +60,17 @@ enum AgentRole {
 
 type AgentSession {
 	"""
+	Full chain (primary + fallbacks) currently persisted on the session.
+	Read-shape mirror of `AgentUpdateSessionChainInput.chain`.
+	"""
+	chain: ModelChain!
+	"""
 	Flat chat history: recent user messages and assistant responses.
 	Returns the last `last` messages in chronological order.
 	"""
 	chatHistory(last: Int! = 20): [ChatMessage!]!
 	"""
-	Model used by the LLM for this session's prompts.
+	Primary model name — what the chat header shows.
 	"""
 	model: String!
 	"""
@@ -87,17 +87,17 @@ type AgentSession {
 	threads: [SessionThread!]!
 }
 
-input AgentUpdateModelChainInput {
+input AgentUpdateSessionChainInput {
 	agentId: AgentId!
 	"""
-	`None` clears the override (revert to project / role / default).
+	`None` reverts the session chain to the role / `agents.default_chain`.
 	Rejects workflow-spawned agents.
 	"""
 	chain: ModelChainInput
 }
 
-type AgentUpdateModelChainPayload {
-	agent: Agent!
+type AgentUpdateSessionChainPayload {
+	session: AgentSession!
 }
 
 type AssistantDoneEvent {
@@ -285,8 +285,8 @@ type Mutation {
 	agentCreate(input: AgentCreateInput!): AgentCreatePayload!
 	agentDelete(input: AgentDeleteInput!): AgentDeletePayload!
 	agentDetachSandbox(input: AgentDetachSandboxInput!): AgentDetachSandboxPayload!
-	agentUpdateModelChain(input: AgentUpdateModelChainInput!): AgentUpdateModelChainPayload!
 	bootstrapPersonalProject: BootstrapPersonalProjectPayload!
+	agentUpdateSessionChain(input: AgentUpdateSessionChainInput!): AgentUpdateSessionChainPayload!
 	mcpCredentialsCreate(input: McpCredentialsCreateInput!): McpCredentialsCreatePayload!
 	mcpCredentialsRevoke(input: McpCredentialsRevokeInput!): McpCredentialsRevokePayload!
 	noteDelete(input: NoteDeleteInput!): NoteDeletePayload!
@@ -296,7 +296,6 @@ type Mutation {
 	projectSecretCreate(input: ProjectSecretCreateInput!): ProjectSecretCreatePayload!
 	projectSecretDelete(input: ProjectSecretDeleteInput!): ProjectSecretDeletePayload!
 	projectUpdate(input: ProjectUpdateInput!): ProjectUpdatePayload!
-	projectUpdateModelChain(input: ProjectUpdateModelChainInput!): ProjectUpdateModelChainPayload!
 	sandboxCreate(input: SandboxCreateInput!): SandboxCreatePayload!
 	sandboxRestart(input: SandboxRestartInput!): SandboxRestartPayload!
 	sandboxSuspend(input: SandboxSuspendInput!): SandboxSuspendPayload!
@@ -346,11 +345,6 @@ type Project {
 	id: ProjectId!
 	lead: Agent!
 	mcpCredentials: [McpCreds!]!
-	"""
-	Per-project chain. Inherited by every non-workflow agent in
-	the project unless the agent has its own override.
-	"""
-	modelChainOverride: ModelChain
 	name: String!
 	sandboxes: [Sandbox!]!
 	"""
@@ -440,18 +434,6 @@ scalar ProjectSecretId
 input ProjectUpdateInput {
 	description: String
 	id: ProjectId!
-}
-
-input ProjectUpdateModelChainInput {
-	"""
-	`None` clears the override.
-	"""
-	chain: ModelChainInput
-	id: ProjectId!
-}
-
-type ProjectUpdateModelChainPayload {
-	project: Project!
 }
 
 type ProjectUpdatePayload {

--- a/server/src/graphql/session.rs
+++ b/server/src/graphql/session.rs
@@ -193,9 +193,15 @@ pub struct AgentSession {
 
 #[Object]
 impl AgentSession {
-    /// Model used by the LLM for this session's prompts.
+    /// Primary model name — what the chat header shows.
     async fn model(&self) -> &str {
         self.entity.model()
+    }
+
+    /// Full chain (primary + fallbacks) currently persisted on the session.
+    /// Read-shape mirror of `AgentUpdateSessionChainInput.chain`.
+    async fn chain(&self) -> super::agent::ModelChain {
+        self.entity.chain().clone().into()
     }
 
     /// Flat chat history: recent user messages and assistant responses.

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -654,14 +654,7 @@ fn project_to_view(project: &domain::project::Project) -> ProjectView {
             .created_at()
             .format("%Y-%m-%d %H:%M UTC")
             .to_string(),
-        model_chain_override_yaml: project.model_chain_override.as_ref().map(render_chain_yaml),
     }
-}
-
-/// Read-only YAML rendering for the override block on the project /
-/// agent detail templates. The form posts directly to GraphQL.
-fn render_chain_yaml(chain: &drua_core::ModelChain) -> String {
-    serde_yaml::to_string(chain).unwrap_or_default()
 }
 
 #[instrument(name = "web.projects_page", skip_all)]
@@ -1382,7 +1375,6 @@ async fn project_agent_detail(
             is_lead: matches!(agent.agent_role, domain::agent::AgentRole::ProjectLead),
             is_workflow_agent: agent.is_workflow_agent(),
             attached_sandbox: attached_view,
-            model_chain_override_yaml: agent.model_chain_override.as_ref().map(render_chain_yaml),
         },
         sandbox_options,
         error: query.error,
@@ -1512,7 +1504,6 @@ async fn project_agent_history(
             is_lead: matches!(agent.agent_role, domain::agent::AgentRole::ProjectLead),
             is_workflow_agent: agent.is_workflow_agent(),
             attached_sandbox: attached_view,
-            model_chain_override_yaml: agent.model_chain_override.as_ref().map(render_chain_yaml),
         },
         messages,
         workflow_run,

--- a/server/src/templates.rs
+++ b/server/src/templates.rs
@@ -150,8 +150,6 @@ pub struct ProjectView {
     pub name: String,
     pub description: String,
     pub created_at: String,
-    /// `None` when no project-level override is set.
-    pub model_chain_override_yaml: Option<String>,
 }
 
 #[derive(Template, WebTemplate)]
@@ -424,8 +422,6 @@ pub struct AgentDetailView {
     pub is_lead: bool,
     pub is_workflow_agent: bool,
     pub attached_sandbox: Option<AttachedSandboxView>,
-    /// Single-line YAML/JSON of the override; `None` when unset.
-    pub model_chain_override_yaml: Option<String>,
 }
 
 #[derive(Template, WebTemplate)]

--- a/server/templates/project_agent_detail.html
+++ b/server/templates/project_agent_detail.html
@@ -141,20 +141,11 @@
 <p><small>Workflow-spawned agents inherit their chain from the workflow definition / step.</small></p>
 {% else %}
 <p><small>
-  Override this agent's chain for every prompt it sends. Empty primary ⇒
-  inherit from the project / role / config default. Fallbacks are
+  Set this agent's session chain. Empty primary ⇒ revert to the
+  role's chain / <code>agents.default_chain</code>. Fallbacks are
   comma-separated model ids tried in order on transient errors.
 </small></p>
-{% match agent.model_chain_override_yaml %}
-  {% when Some(y) %}
-<details>
-  <summary><small>Current override (YAML)</small></summary>
-  <pre style="font-size: 0.8rem; padding: 0.5rem;">{{ y }}</pre>
-</details>
-  {% when None %}
-<p><small><em>No override set — inheriting upstream.</em></small></p>
-{% endmatch %}
-<form data-gql-mutation="mutation($input: AgentUpdateModelChainInput!) { agentUpdateModelChain(input: $input) { agent { id } } }"
+<form data-gql-mutation="mutation($input: AgentUpdateSessionChainInput!) { agentUpdateSessionChain(input: $input) { session { chain { primary { name } fallbacks { name } } } } }"
       data-gql-build="buildAgentChain"
       data-gql-reload="true">
   <label>
@@ -167,7 +158,7 @@
   </label>
   <div style="display: flex; gap: 0.5rem;">
     <button type="submit">Save chain</button>
-    <button type="button" id="agent-chain-clear" class="secondary outline">Clear override</button>
+    <button type="button" id="agent-chain-clear" class="secondary outline">Reset to default</button>
   </div>
 </form>
 <script>
@@ -184,9 +175,9 @@
     };
   }
   document.getElementById('agent-chain-clear')?.addEventListener('click', async () => {
-    if (!confirm('Clear the agent-level model chain override?')) return;
+    if (!confirm("Reset this agent's session chain to the role default?")) return;
     const result = await gqlMutate(
-      `mutation($input: AgentUpdateModelChainInput!) { agentUpdateModelChain(input: $input) { agent { id } } }`,
+      `mutation($input: AgentUpdateSessionChainInput!) { agentUpdateSessionChain(input: $input) { session { chain { primary { name } } } } }`,
       { input: { agentId: "{{ agent.id }}", chain: null } }
     );
     if (result.errors) { alert(result.errors.map(e => e.message).join('\n')); return; }

--- a/server/templates/project_detail.html
+++ b/server/templates/project_detail.html
@@ -128,63 +128,6 @@
 
 <hr>
 
-<h3>Model chain</h3>
-<p><small>
-  Project-wide chain override. Inherited by every non-workflow agent in
-  this project unless the agent has its own override. Empty primary ⇒
-  inherit from <code>agents.default_chain</code>.
-</small></p>
-{% match project.model_chain_override_yaml %}
-  {% when Some(y) %}
-<details>
-  <summary><small>Current override (YAML)</small></summary>
-  <pre style="font-size: 0.8rem; padding: 0.5rem;">{{ y }}</pre>
-</details>
-  {% when None %}
-<p><small><em>No override set — inheriting from <code>agents.default_chain</code>.</em></small></p>
-{% endmatch %}
-<form data-gql-mutation="mutation($input: ProjectUpdateModelChainInput!) { projectUpdateModelChain(input: $input) { project { id } } }"
-      data-gql-build="buildProjectChain"
-      data-gql-reload="true">
-  <label>
-    Primary model
-    <input name="primary_name" type="text" placeholder="anthropic/claude-sonnet-4-6">
-  </label>
-  <label>
-    Fallbacks <small>(comma-separated, in priority order)</small>
-    <input name="fallbacks" type="text" placeholder="openai/gpt-4o, anthropic/claude-haiku-4-5">
-  </label>
-  <div style="display: flex; gap: 0.5rem;">
-    <button type="submit">Save chain</button>
-    <button type="button" id="project-chain-clear" class="secondary outline">Clear override</button>
-  </div>
-</form>
-<script>
-  function buildProjectChain(fd) {
-    const primary = fd.get('primary_name').trim();
-    if (!primary) {
-      return { id: "{{ project.id }}", chain: null };
-    }
-    const fbRaw = fd.get('fallbacks') || '';
-    const fallbacks = fbRaw.split(',').map(s => s.trim()).filter(Boolean).map(name => ({ name }));
-    return {
-      id: "{{ project.id }}",
-      chain: { primary: { name: primary }, fallbacks }
-    };
-  }
-  document.getElementById('project-chain-clear')?.addEventListener('click', async () => {
-    if (!confirm('Clear the project-level model chain override?')) return;
-    const result = await gqlMutate(
-      `mutation($input: ProjectUpdateModelChainInput!) { projectUpdateModelChain(input: $input) { project { id } } }`,
-      { input: { id: "{{ project.id }}", chain: null } }
-    );
-    if (result.errors) { alert(result.errors.map(e => e.message).join('\n')); return; }
-    window.location.reload();
-  });
-</script>
-
-<hr>
-
 <h3>Secrets</h3>
 <p><small>Secrets are injected into the agent sandbox as environment variables or files. Values are never displayed after creation.</small></p>
 


### PR DESCRIPTION
## Summary

Stacked on #338. Moves `max_tokens` onto each per-attempt `ModelSpec` so fallback models get their own caps, and removes `llm::Prompt.max_tokens` entirely — the chain is now the sole source of truth for per-attempt output caps.

## Three coupled fixes

### 1. Honour policy `max_tokens` override (was silently dropped)

`config::from_policy` previously did `lookup(spec.name, models)` and discarded `spec.max_tokens`. YAML overrides like `primary: { name: openai/gpt-5-mini, max_tokens: 16384 }` and GraphQL `ModelSpecInput.maxTokens` were cosmetic.

**Fix:** new `resolve_spec` applies `spec.max_tokens` over the registry's `max_tokens_per_response` when present. It also pins `ModelDefaults.model` to the lookup key so the registry key and `.model` field can't diverge downstream (defensive against future loader changes).

### 2. Per-entry caps survive into `llm::ModelChain`

`From<Prompt> for llm::Prompt` was passing only the `.model` string into `llm::ModelChain::new` / `with_fallback`, which dropped each entry's `max_tokens_per_response` via the implicit `String → ModelSpec` conversion. The standalone `Prompt.max_tokens` was set to the **primary's** cap, then the router stamped it onto every fallback attempt — primary's cap leaked everywhere.

**Fix:** build each `llm::ModelSpec` with `.with_max_tokens(...)` so per-entry caps reach the chain.

### 3. Drop `Prompt.max_tokens`; trait carries the spec being attempted

`llm::Prompt.max_tokens` is deleted. `LlmProvider::send_prompt_streaming` now takes `(&Prompt, &ModelSpec)`; providers read the wire-level model id from `spec.name` and the cap from `spec.max_tokens`. `router::ChainEntry` holds a `ModelSpec` instead of separate `model_id` + `max_tokens` fields; the walker no longer clones the prompt to stamp `max_tokens` per attempt.

**Net effect:** primary's cap can never leak; per-attempt model id is whatever the chain says (no more reading `prompt.chain.primary.name` inside fallback HTTP bodies).

## Touched

- `core/src/agent/config.rs` — `lookup` → `resolve_spec`; honours policy override + pins `.model` to key. New test pins both override-wins and registry-fallback.
- `core/src/agent/session/message.rs` — `From<Prompt>` builds per-entry `ModelSpec` with cap; drops global `max_tokens` field.
- `core/src/prompt_executor.rs` — `ChainEntry` carries `ModelSpec`.
- `lib/llm/src/prompt.rs` — delete `max_tokens` field; hash now incorporates `chain.primary.max_tokens` instead.
- `lib/llm/src/provider.rs` — trait sig: `send_prompt_streaming(&self, prompt, spec)`.
- `lib/llm/src/router.rs` — `ChainEntry { spec, provider }`; walker stops mutating prompt.
- `lib/openai-client/{lib,convert,responses}.rs` — trait impls + `prompt_to_request` / `prompt_to_responses_request` take `&ModelSpec`; read `spec.name` for model id and `spec.max_tokens` for cap.
- `lib/anthropic-client/{lib,convert}.rs` — same.

## Test plan

- [x] `cargo check --workspace` clean.
- [x] `cargo test --workspace --lib` — all tests pass (no failures).
- [x] New test `policy_max_tokens_overrides_registry_else_registry_wins` pins both the override-wins and registry-fallback cases.
- [ ] Smoke: configure a chain whose fallback has a smaller `max_tokens_per_response` than the primary; force-fail the primary and confirm the fallback HTTP body sends its own cap (would previously have errored or used primary's cap).

## Notes

- `Prompt::hash()` content changed (now includes `chain.primary.max_tokens` instead of the deleted top-level field). Any persisted cache keyed by this hash will see a one-time invalidation on deploy.
- OpenAI Responses' subscription-auth path still omits `max_output_tokens` entirely — conditional preserved, just reads from `spec` now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)