### PR TITLE
fix(bats): regen fixtures missed in PR #337 merge — byte-count unification

### DIFF
--- a/bats/summarized-tool-responses/concourse-build-log.txt
+++ b/bats/summarized-tool-responses/concourse-build-log.txt
@@ -1,4 +1,4 @@
-<summary path="$" total-bytes="32994" shown-bytes="8443" total-lines="320" shown-lines="164">
+<summary path="$" total-bytes="32474" shown-bytes="8137" total-lines="320" shown-lines="164">
 <head lines="82">
 INFO: found existing resource cache
 

--- a/bats/summarized-tool-responses/nix-copy-output.txt
+++ b/bats/summarized-tool-responses/nix-copy-output.txt
@@ -1,4 +1,4 @@
-<summary path="$" total-bytes="1851" shown-bytes="209" total-lines="28" shown-lines="6">
+<summary path="$" total-bytes="1821" shown-bytes="197" total-lines="28" shown-lines="6">
 preparing to build
 building '/nix/store/aaa-foo.drv'
 <nix-copy original-lines="3-27" original-bytes="1700">

--- a/bats/summarized-tool-responses/str-large-table.txt
+++ b/bats/summarized-tool-responses/str-large-table.txt
@@ -1,4 +1,4 @@
-<summary path="$" total-bytes="13093" shown-bytes="7909" total-lines="41" shown-lines="25">
+<summary path="$" total-bytes="13051" shown-bytes="7870" total-lines="41" shown-lines="25">
 <head lines="12">
 NAMESPACE     APIVERSION   KIND   NAME                                                             READY   STATUS    RESTARTS   AGE    IP             NODE                                                  NOMINATED NODE   READINESS GATES   LABELS
 kube-system   v1           Pod    calico-node-kxw8s                                                1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2


### PR DESCRIPTION
## Summary

PR #337 merged at PR head \`dea1ba13\` (the \`byte_size()\` code fix), but the follow-up commit \`b626edda\` which regenerated the bats snapshot fixtures with the new byte counts was pushed ~1 minute after the merge — so the merge picked up the code change without the fixture update.

Result: on main, \`<summary total-bytes>\` reports the new raw \`s.len()\`-based count (e.g. 13051) while the checked-in fixture still has the old \`json_size\`-based count (13093). Concourse bats job test-bats/builds/622 caught this.

This PR cherry-picks just the fixture regen.

## Test plan
- [ ] CI bats job passes — snapshot diff matches generated output
- [ ] Concourse downstream rebuild green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: updates only Bats snapshot fixtures to match new `total-bytes`/`shown-bytes` calculations, with no runtime logic changes.
> 
> **Overview**
> Regenerates Bats summarized-tool-response snapshot fixtures to reflect the updated byte-counting behavior, updating `total-bytes`/`shown-bytes` values in `concourse-build-log.txt`, `nix-copy-output.txt`, and `str-large-table.txt` so CI snapshot comparisons pass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4046d7faa3d2b2fef55f4d3ccfa59e84df2e790a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->