### PR TITLE
feat(workflow): trigger-level condition: gates run creation

### DIFF
--- a/bats/workflow.bats
+++ b/bats/workflow.bats
@@ -254,3 +254,100 @@ extract_id_field() {
   [[ "$output" == *".tags[0]"* ]]
   [[ "$output" == *"trigger.payload.pipeline"* ]]
 }
+
+# Memo 019e20a2: trigger-level `condition:` gates run creation
+# BEFORE the WorkflowRun row is written. Three scenarios pinned
+# end-to-end:
+#  1. condition true → run created, terminates cleanly.
+#  2. condition false → no run created; admin `trigger` returns the
+#     "no run created" text; `list_runs` reports empty.
+#  3. malformed condition rejected at workflow create time.
+@test "workflow: trigger condition gates run creation end-to-end" {
+  local suffix
+  suffix="$(uuidgen | tr '[:upper:]' '[:lower:]' | cut -c1-8)"
+  local proj_name="proj-trigger-cond-$suffix"
+
+  run graphql_query "mutation { projectCreate(input: { name: \"$proj_name\" }) { project { id } } }" "$AGENT_TOKEN"
+  local project_id
+  project_id="$(echo "$output" | jq -r '.data.projectCreate.project.id')"
+  [ -n "$project_id" ] && [ "$project_id" != "null" ]
+
+  # 1. Create with a trigger condition matching only env="staging".
+  run admin_call "workflow" "$(jq -nc --arg pid "$project_id" '{
+    command: "create",
+    project_id: $pid,
+    name: "trigger-cond-flow",
+    manual: true,
+    steps: [
+      { type: "tool_step", name: "identify", tool: "whoami", params: {} }
+    ]
+  }')"
+  echo "$output"
+  local def_id
+  def_id="$(extract_id_field "$output")"
+  [ -n "$def_id" ] || { echo "could not extract definition id"; return 1; }
+
+  # Update to attach a condition gating on `trigger.payload.env`.
+  run admin_call "workflow" "$(jq -nc --arg did "$def_id" '{
+    command: "update",
+    definition_id: $did,
+    update_trigger: true,
+    manual: true,
+    trigger_condition: "trigger.payload.env == \"staging\""
+  }')"
+  echo "$output"
+
+  # 2. Trigger with payload that PASSES the condition.
+  run admin_call "workflow" "$(jq -nc --arg did "$def_id" '{
+    command: "trigger",
+    definition_id: $did,
+    payload: { env: "staging" }
+  }')"
+  echo "$output"
+  local run_id
+  run_id="$(extract_id_field "$output")"
+  [ -n "$run_id" ] || { echo "expected run to be created when condition true"; return 1; }
+
+  run admin_call "workflow" "$(jq -nc --arg rid "$run_id" '{
+    command: "await_run", run_id: $rid, timeout_seconds: 60
+  }')"
+  echo "$output"
+  [[ "$output" == *"state: succeeded"* ]]
+
+  # 3. Trigger with payload that FAILS the condition. No run id.
+  run admin_call "workflow" "$(jq -nc --arg did "$def_id" '{
+    command: "trigger",
+    definition_id: $did,
+    payload: { env: "prod" }
+  }')"
+  echo "$output"
+  [[ "$output" == *"Trigger condition evaluated to false"* ]]
+  [[ "$output" != *"id: "* ]] || {
+    # Belt-and-braces — make sure no `id: <uuid>` line snuck in.
+    ! echo "$output" | grep -qE 'id: [0-9a-f-]{36}'
+  }
+
+  # 4. Update with malformed CEL must be rejected. The admin tool
+  #    surfaces the WorkflowError as an MCP error response.
+  run admin_call "workflow" "$(jq -nc --arg did "$def_id" '{
+    command: "update",
+    definition_id: $did,
+    update_trigger: true,
+    manual: true,
+    trigger_condition: "trigger.payload.x =="
+  }')"
+  echo "$output"
+  [[ "$output" == *"InvalidCondition"* ]] || [[ "$output" == *"failed to compile"* ]]
+
+  # 5. Update with a condition referencing `steps` must be rejected
+  #    (steps aren't in scope at trigger time).
+  run admin_call "workflow" "$(jq -nc --arg did "$def_id" '{
+    command: "update",
+    definition_id: $did,
+    update_trigger: true,
+    manual: true,
+    trigger_condition: "steps.identify.outputs.x == 1"
+  }')"
+  echo "$output"
+  [[ "$output" == *"InvalidCondition"* ]] || [[ "$output" == *"steps"* ]]
+}

--- a/bats/workflow.bats
+++ b/bats/workflow.bats
@@ -43,6 +43,32 @@ extract_id_field() {
     | awk '{print $2}'
 }
 
+# Query the audit log via the `drua_admin_log` MCP tool. Same shape
+# as `_audit_log` in compose.bats; duplicated here so workflow.bats
+# doesn't take a cross-file source dependency.
+_audit_log() {
+  local args_json="$1"
+  local response
+  response="$(mcp_call "$AGENT_TOKEN" "tools/call" \
+    "$(jq -nc --argjson args "$args_json" \
+      '{name:"call_tool", arguments:{tool_name:"drua_admin_log", arguments:$args}}')")"
+  echo "$response" | jq -r '.result.content[0].text // ""'
+}
+
+_wait_for_audit_log() {
+  local args_json="$1"
+  for _i in $(seq 1 40); do
+    local out
+    out="$(_audit_log "$args_json")"
+    if [[ "$out" != "No audit entries found."* ]] && [ -n "$out" ]; then
+      echo "$out"
+      return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
+
 @test "workflow: tool_step dispatches whoami and surfaces workflow_executor identity" {
   # Unique-per-run names so re-runs against a persisted PG (developer
   # iteration with SKIP_COMPOSE=1) don't collide.
@@ -326,6 +352,18 @@ extract_id_field() {
     # Belt-and-braces — make sure no `id: <uuid>` line snuck in.
     ! echo "$output" | grep -qE 'id: [0-9a-f-]{36}'
   }
+
+  # 3a. Audit row regression (PR #341 review): the MCP trigger
+  # dispatcher pre-sets `action = "workflow.trigger"` before invoking
+  # the gate. The gate must OVERWRITE that to
+  # `"workflow.trigger_filtered"` so suppressed events are visible
+  # in the audit log. Cursor Bugbot caught this when the helpers
+  # used `record_action_if_unset` (a no-op when set).
+  local audit_row
+  audit_row="$(_wait_for_audit_log '{"action":"workflow.trigger_filtered","limit":1}')" \
+    || { echo "no workflow.trigger_filtered audit row appeared"; return 1; }
+  echo "audit_row=$audit_row"
+  [[ "$audit_row" == *"workflow.trigger_filtered"* ]]
 
   # 4. Update with malformed CEL must be rejected. The admin tool
   #    surfaces the WorkflowError as an MCP error response.

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -536,6 +536,12 @@ struct WorkflowParams {
     /// `create`: opt out of webhooks (Manual trigger).
     #[serde(default)]
     manual: bool,
+    /// Bare CEL boolean expression evaluated against `trigger`
+    /// (only — `steps` is rejected) before a run is created.
+    /// Omit to leave the trigger ungated. Applies on `create` and
+    /// when `update_trigger=true` on `update`. Memo `019e20a2`.
+    #[serde(default)]
+    trigger_condition: Option<String>,
 
     /// `create` / `update`: full step list. Required for create.
     #[serde(default)]
@@ -1301,11 +1307,14 @@ impl AdminToolSet {
                 Audit::record_action("workflow.create");
                 let project = self.projects.find_by_id(subject, project_id).await?;
                 let trigger = if params.manual {
-                    WorkflowTrigger::Manual
+                    WorkflowTrigger::Manual {
+                        condition: params.trigger_condition.clone(),
+                    }
                 } else {
                     WorkflowTrigger::Webhook {
                         provider: params.provider.clone(),
                         secret: String::new(),
+                        condition: params.trigger_condition.clone(),
                     }
                 };
                 let steps = params
@@ -1382,11 +1391,14 @@ impl AdminToolSet {
                 };
                 let trigger = if params.update_trigger {
                     Some(if params.manual {
-                        WorkflowTrigger::Manual
+                        WorkflowTrigger::Manual {
+                            condition: params.trigger_condition.clone(),
+                        }
                     } else {
                         WorkflowTrigger::Webhook {
                             provider: params.provider.clone(),
                             secret: String::new(),
+                            condition: params.trigger_condition.clone(),
                         }
                     })
                 } else {
@@ -1448,14 +1460,16 @@ impl AdminToolSet {
                 let payload = params
                     .payload
                     .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
-                let run = self
+                let maybe_run = self
                     .workflows
                     .trigger_run(subject, definition_id, payload)
                     .await
                     .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
-                Ok(CallToolResult::success(vec![Content::text(format_run(
-                    &run,
-                ))]))
+                let body = match maybe_run {
+                    Some(run) => format_run(&run),
+                    None => "Trigger condition evaluated to false; no run created.".to_string(),
+                };
+                Ok(CallToolResult::success(vec![Content::text(body)]))
             }
 
             WorkflowCommand::AwaitRun => {
@@ -2044,12 +2058,14 @@ fn format_workflow(d: &WorkflowDefinition, created: bool) -> String {
         "Workflow:"
     };
     let trigger = match &d.trigger {
-        WorkflowTrigger::Manual => "manual".to_string(),
+        WorkflowTrigger::Manual { .. } => "manual".to_string(),
         WorkflowTrigger::Webhook { provider, .. } => match provider {
             Some(p) => format!("webhook ({p})"),
             None => "webhook".to_string(),
         },
-        WorkflowTrigger::Cron { schedule, timezone } => match timezone {
+        WorkflowTrigger::Cron {
+            schedule, timezone, ..
+        } => match timezone {
             Some(tz) => format!("cron ({schedule} {tz})"),
             None => format!("cron ({schedule})"),
         },
@@ -2116,7 +2132,7 @@ fn format_workflows(defs: &[WorkflowDefinition]) -> String {
     lines.push("-".repeat(110));
     for d in defs {
         let trigger = match &d.trigger {
-            WorkflowTrigger::Manual => "manual".to_string(),
+            WorkflowTrigger::Manual { .. } => "manual".to_string(),
             WorkflowTrigger::Webhook { provider, .. } => match provider {
                 Some(p) => format!("webhook:{p}"),
                 None => "webhook".to_string(),

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -2694,6 +2694,45 @@ mod tests {
     }
 
     #[test]
+    fn workflow_update_parses_trigger_condition() {
+        let definition_id = uuid::Uuid::new_v4();
+        let p: WorkflowParams = parse_params(args(serde_json::json!({
+            "command": "update",
+            "definition_id": definition_id,
+            "update_trigger": true,
+            "manual": true,
+            "trigger_condition": "trigger.payload.env == \"staging\"",
+        })))
+        .expect("parse");
+        assert_eq!(
+            p.trigger_condition.as_deref(),
+            Some("trigger.payload.env == \"staging\"")
+        );
+        assert!(p.update_trigger);
+        assert!(p.manual);
+    }
+
+    #[test]
+    fn workflow_create_parses_trigger_condition() {
+        let project_id = uuid::Uuid::new_v4();
+        let p: WorkflowParams = parse_params(args(serde_json::json!({
+            "command": "create",
+            "project_id": project_id,
+            "name": "with-cond",
+            "manual": true,
+            "trigger_condition": "trigger.payload.action == 'opened'",
+            "steps": [
+                { "type": "agent_step", "name": "investigate", "skill": "auditor" }
+            ],
+        })))
+        .expect("parse");
+        assert_eq!(
+            p.trigger_condition.as_deref(),
+            Some("trigger.payload.action == 'opened'")
+        );
+    }
+
+    #[test]
     fn workflow_schema_includes_command_enum() {
         let s = serde_json::to_string(&*WORKFLOW_SCHEMA).unwrap();
         for v in ["create", "list", "get", "update"] {

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -28,6 +28,10 @@ enum WorkflowParams {
         provider: Option<String>,
         #[serde(default)]
         manual: bool,
+        /// Bare CEL boolean evaluated against `trigger` before a run
+        /// is created. Memo 019e20a2.
+        #[serde(default)]
+        trigger_condition: Option<String>,
         /// Multi-step form. When non-empty this takes precedence over
         /// the single-step shorthand (`skill`/`sandbox`/`sandbox_mode`/
         /// `timeout_seconds`).
@@ -102,6 +106,11 @@ enum WorkflowParams {
         provider: Option<String>,
         #[serde(default)]
         manual: bool,
+        /// Bare CEL boolean evaluated against `trigger` before a run
+        /// is created. Applies when `update_trigger=true`. Memo
+        /// 019e20a2.
+        #[serde(default)]
+        trigger_condition: Option<String>,
         /// Replace the workflow-wide chain. `clear_model_chain: true`
         /// clears it to `None`; otherwise omitting leaves untouched.
         #[serde(default)]
@@ -649,6 +658,7 @@ impl TopLevelTool for WorkflowTool {
                 description,
                 provider,
                 manual,
+                trigger_condition,
                 steps,
                 skill,
                 sandbox,
@@ -658,12 +668,15 @@ impl TopLevelTool for WorkflowTool {
                 model_chain,
             } => {
                 let trigger = if manual {
-                    WorkflowTrigger::Manual
+                    WorkflowTrigger::Manual {
+                        condition: trigger_condition.clone(),
+                    }
                 } else {
                     // Empty secret → Workflows::create generates one.
                     WorkflowTrigger::Webhook {
                         provider: provider.clone(),
                         secret: String::new(),
+                        condition: trigger_condition.clone(),
                     }
                 };
 
@@ -770,15 +783,21 @@ impl TopLevelTool for WorkflowTool {
                 .await?;
                 let payload =
                     payload.unwrap_or_else(|| serde_json::Value::Object(Default::default()));
-                let run = self
+                let maybe_run = self
                     .workflows
                     .trigger_run(subject, resolved_id, payload)
                     .await
                     .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
-                let text = format_run_text(&run);
+                let (text, run_out) = match &maybe_run {
+                    Some(run) => (format_run_text(run), Some(run_to_output(run))),
+                    None => (
+                        "Trigger condition evaluated to false; no run created.".to_string(),
+                        None,
+                    ),
+                };
                 let out = WorkflowOutput {
                     command: "trigger".to_string(),
-                    run: Some(run_to_output(&run)),
+                    run: run_out,
                     ..Default::default()
                 };
                 (text, out)
@@ -845,6 +864,7 @@ impl TopLevelTool for WorkflowTool {
                 update_trigger,
                 provider,
                 manual,
+                trigger_condition,
                 model_chain,
                 clear_model_chain,
             } => {
@@ -855,11 +875,14 @@ impl TopLevelTool for WorkflowTool {
                 };
                 let trigger = if update_trigger {
                     Some(if manual {
-                        WorkflowTrigger::Manual
+                        WorkflowTrigger::Manual {
+                            condition: trigger_condition.clone(),
+                        }
                     } else {
                         WorkflowTrigger::Webhook {
                             provider,
                             secret: String::new(),
+                            condition: trigger_condition.clone(),
                         }
                     })
                 } else {
@@ -919,9 +942,11 @@ fn definition_to_output(d: &WorkflowDefinition) -> WorkflowDefinitionOutput {
     let mut cron_timezone = None;
     let mut next_run_at = None;
     let (trigger_type, trigger_provider) = match &d.trigger {
-        WorkflowTrigger::Manual => ("manual".to_string(), None),
+        WorkflowTrigger::Manual { .. } => ("manual".to_string(), None),
         WorkflowTrigger::Webhook { provider, .. } => ("webhook".to_string(), provider.clone()),
-        WorkflowTrigger::Cron { schedule, timezone } => {
+        WorkflowTrigger::Cron {
+            schedule, timezone, ..
+        } => {
             cron_schedule = Some(schedule.clone());
             cron_timezone = timezone.clone();
             next_run_at = crate::workflow::next_cron_fire_at(
@@ -1056,7 +1081,7 @@ fn run_state_str(state: WorkflowRunState) -> &'static str {
 impl WorkflowTool {
     fn webhook_url_and_secret(&self, def: &WorkflowDefinition) -> (Option<String>, Option<String>) {
         match &def.trigger {
-            WorkflowTrigger::Manual | WorkflowTrigger::Cron { .. } => (None, None),
+            WorkflowTrigger::Manual { .. } | WorkflowTrigger::Cron { .. } => (None, None),
             WorkflowTrigger::Webhook { secret, .. } => {
                 let url = match &self.public_host {
                     Some(host) => format!("{host}/webhooks/{}", def.id),
@@ -1074,12 +1099,14 @@ impl WorkflowTool {
         webhook_secret: &Option<String>,
     ) -> String {
         let trigger_label = match &def.trigger {
-            WorkflowTrigger::Manual => "manual".to_string(),
+            WorkflowTrigger::Manual { .. } => "manual".to_string(),
             WorkflowTrigger::Webhook { provider, .. } => match provider {
                 Some(p) => format!("webhook ({p})"),
                 None => "webhook".to_string(),
             },
-            WorkflowTrigger::Cron { schedule, timezone } => match timezone {
+            WorkflowTrigger::Cron {
+                schedule, timezone, ..
+            } => match timezone {
                 Some(tz) => format!("cron ({schedule} {tz})"),
                 None => format!("cron ({schedule})"),
             },
@@ -1128,7 +1155,7 @@ fn format_list_text(defs: &[WorkflowDefinition]) -> String {
 
     for d in defs {
         let trigger = match &d.trigger {
-            WorkflowTrigger::Manual => "manual".to_string(),
+            WorkflowTrigger::Manual { .. } => "manual".to_string(),
             WorkflowTrigger::Webhook { provider, .. } => match provider {
                 Some(p) => format!("webhook:{p}"),
                 None => "webhook".to_string(),
@@ -1148,15 +1175,19 @@ fn format_list_text(defs: &[WorkflowDefinition]) -> String {
 
 fn format_get_text(d: &WorkflowDefinition) -> String {
     let trigger = match &d.trigger {
-        WorkflowTrigger::Manual => "manual".to_string(),
-        WorkflowTrigger::Webhook { provider, secret } => {
+        WorkflowTrigger::Manual { .. } => "manual".to_string(),
+        WorkflowTrigger::Webhook {
+            provider, secret, ..
+        } => {
             let label = match provider {
                 Some(p) => format!("webhook ({p})"),
                 None => "webhook".to_string(),
             };
             format!("{label}\n  webhook_secret: {secret}")
         }
-        WorkflowTrigger::Cron { schedule, timezone } => {
+        WorkflowTrigger::Cron {
+            schedule, timezone, ..
+        } => {
             let mut s = format!("cron\n  schedule:    {schedule}");
             let tz_label = timezone.as_deref().unwrap_or("UTC");
             s.push_str(&format!("\n  timezone:    {tz_label}"));

--- a/core/src/workflow/cron_job.rs
+++ b/core/src/workflow/cron_job.rs
@@ -109,7 +109,9 @@ impl JobRunner for TriggerCronRunner {
         };
 
         let (schedule, timezone) = match &definition.trigger {
-            WorkflowTrigger::Cron { schedule, timezone } => (schedule.clone(), timezone.clone()),
+            WorkflowTrigger::Cron {
+                schedule, timezone, ..
+            } => (schedule.clone(), timezone.clone()),
             _ => {
                 tracing::info!("trigger no longer cron; schedule terminating");
                 return Ok(JobCompletion::Complete);
@@ -133,8 +135,13 @@ impl JobRunner for TriggerCronRunner {
         )
         .await
         {
-            Ok(run) => {
+            Ok(Some(run)) => {
                 tracing::info!(run_id = %run.id, "cron-triggered workflow run spawned");
+            }
+            Ok(None) => {
+                tracing::info!(
+                    "cron-triggered run suppressed by trigger condition; schedule continues"
+                );
             }
             Err(e) => {
                 tracing::warn!(error = %e, "cron-triggered run spawn failed; continuing schedule");

--- a/core/src/workflow/definition.rs
+++ b/core/src/workflow/definition.rs
@@ -60,12 +60,29 @@ impl<'de> Deserialize<'de> for OutputSchema {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum WorkflowTrigger {
-    Manual,
+    Manual {
+        /// Bare CEL boolean evaluated against `trigger` before a run
+        /// is created. `None` → fire as today. See `Webhook::condition`
+        /// for full semantics.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        condition: Option<String>,
+    },
     Webhook {
         /// `Some("honeycomb")` selects the `X-Honeycomb-Webhook-Token`
         /// header; `None` falls back to `Authorization: Bearer`.
         provider: Option<String>,
         secret: String,
+        /// Bare CEL boolean evaluated against `trigger` (only —
+        /// `steps` is rejected at parse time, no steps have run yet)
+        /// before a run is created. `None` → always fire (back-compat).
+        /// `Some(expr)` and `expr` evaluates to `false` → no run is
+        /// created and a `workflow.trigger_filtered` audit row is
+        /// written. Errors → no run + `workflow.trigger_condition_errored`
+        /// audit row. Compiled and validated at workflow create/update
+        /// time so authors learn syntax issues then, not on the first
+        /// webhook.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        condition: Option<String>,
     },
     /// Time-based scheduled execution. `schedule` is a 6- or 7-field
     /// cron expression as accepted by the `cron` crate (sec min hr dom
@@ -74,7 +91,27 @@ pub enum WorkflowTrigger {
         schedule: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timezone: Option<String>,
+        /// See `Webhook::condition`. Degenerate today — the cron
+        /// trigger context is empty, so any reference to
+        /// `trigger.payload.X` resolves to null. Useful once a
+        /// `trigger.now` binding lands; permitted in the grammar
+        /// today for uniformity.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        condition: Option<String>,
     },
+}
+
+impl WorkflowTrigger {
+    /// Bare CEL boolean expression gating run creation. `None` →
+    /// always fire (back-compat with definitions that predate the
+    /// field).
+    pub fn condition(&self) -> Option<&str> {
+        match self {
+            Self::Manual { condition }
+            | Self::Webhook { condition, .. }
+            | Self::Cron { condition, .. } => condition.as_deref(),
+        }
+    }
 }
 
 /// IANA name parses through `chrono_tz`; `None` → `UTC`. Surfaces a
@@ -510,6 +547,7 @@ mod tests {
         let trigger = WorkflowTrigger::Cron {
             schedule: "0 */6 * * * *".to_string(),
             timezone: Some("UTC".to_string()),
+            condition: None,
         };
         let s = serde_yaml::to_string(&trigger).unwrap();
         assert!(s.contains("type: cron"));
@@ -518,9 +556,14 @@ mod tests {
 
         let back: WorkflowTrigger = serde_yaml::from_str(&s).unwrap();
         match back {
-            WorkflowTrigger::Cron { schedule, timezone } => {
+            WorkflowTrigger::Cron {
+                schedule,
+                timezone,
+                condition,
+            } => {
                 assert_eq!(schedule, "0 */6 * * * *");
                 assert_eq!(timezone.as_deref(), Some("UTC"));
+                assert!(condition.is_none());
             }
             _ => panic!("expected Cron variant"),
         }
@@ -531,8 +574,43 @@ mod tests {
         let trigger = WorkflowTrigger::Cron {
             schedule: "0 */6 * * * *".to_string(),
             timezone: None,
+            condition: None,
         };
         let s = serde_yaml::to_string(&trigger).unwrap();
         assert!(!s.contains("timezone"));
+    }
+
+    #[test]
+    fn manual_trigger_with_condition_round_trips() {
+        let trigger = WorkflowTrigger::Manual {
+            condition: Some("trigger.payload.env == 'staging'".to_string()),
+        };
+        let s = serde_yaml::to_string(&trigger).unwrap();
+        let back: WorkflowTrigger = serde_yaml::from_str(&s).unwrap();
+        assert_eq!(back.condition(), Some("trigger.payload.env == 'staging'"));
+    }
+
+    #[test]
+    fn manual_trigger_omits_absent_condition() {
+        let trigger = WorkflowTrigger::Manual { condition: None };
+        let s = serde_yaml::to_string(&trigger).unwrap();
+        assert!(!s.contains("condition"));
+    }
+
+    /// Old serialized triggers without the `condition` field must
+    /// hydrate cleanly (replay-safety on `WorkflowDefinitionEvent::Initialized`).
+    #[test]
+    fn legacy_trigger_without_condition_deserializes_to_none() {
+        let yaml = "type: webhook\nprovider: github_app\nsecret: whsec_x\n";
+        let trigger: WorkflowTrigger = serde_yaml::from_str(yaml).unwrap();
+        assert!(trigger.condition().is_none());
+
+        let yaml = "type: manual\n";
+        let trigger: WorkflowTrigger = serde_yaml::from_str(yaml).unwrap();
+        assert!(trigger.condition().is_none());
+
+        let yaml = "type: cron\nschedule: '0 0 * * * *'\n";
+        let trigger: WorkflowTrigger = serde_yaml::from_str(yaml).unwrap();
+        assert!(trigger.condition().is_none());
     }
 }

--- a/core/src/workflow/entity.rs
+++ b/core/src/workflow/entity.rs
@@ -529,6 +529,78 @@ mod tests {
         }
     }
 
+    /// Regression for the bats failure in PR #341 CI: after `update_content`
+    /// attaches a trigger with a CEL `condition:`, hydrating fresh from the
+    /// event log must reproduce the condition. Previously slipped through
+    /// `try_from_events` cleanly in isolation but failed end-to-end —
+    /// pinning the round-trip here narrows the search space if it breaks
+    /// again.
+    #[test]
+    fn update_content_preserves_trigger_condition_through_hydration() {
+        let mut def = build();
+        let res = def.update_content(
+            None,
+            None,
+            Some(WorkflowTrigger::Manual {
+                condition: Some("trigger.payload.env == 'staging'".to_string()),
+            }),
+            None,
+            None,
+            None,
+        );
+        assert!(matches!(res, Idempotent::Executed(())));
+        assert_eq!(
+            def.trigger.condition(),
+            Some("trigger.payload.env == 'staging'"),
+            "in-memory trigger should reflect the update"
+        );
+
+        let events = def.events.clone();
+        let hydrated = WorkflowDefinition::try_from_events(events).unwrap();
+        assert_eq!(
+            hydrated.trigger.condition(),
+            Some("trigger.payload.env == 'staging'"),
+            "hydrated trigger should carry the condition from the Updated event"
+        );
+    }
+
+    /// Serialize a definition's events to JSON and back, then hydrate.
+    /// Catches any event-shape regression where the new `condition` field
+    /// is dropped during persistence (the actual repo serializes events
+    /// via serde_json into a JSONB column).
+    #[test]
+    fn update_content_preserves_trigger_condition_through_json_roundtrip() {
+        let mut def = build();
+        let _ = def.update_content(
+            None,
+            None,
+            Some(WorkflowTrigger::Manual {
+                condition: Some("trigger.payload.env == 'staging'".to_string()),
+            }),
+            None,
+            None,
+            None,
+        );
+        let raw_events: Vec<serde_json::Value> = def
+            .events
+            .iter_all()
+            .map(|e| serde_json::to_value(e).unwrap())
+            .collect();
+        let updated = raw_events
+            .iter()
+            .find(|v| v.get("type").and_then(|t| t.as_str()) == Some("updated"))
+            .expect("updated event present");
+        let trigger = updated
+            .get("trigger")
+            .expect("updated event carries trigger field");
+        assert_eq!(trigger.get("type").and_then(|t| t.as_str()), Some("manual"));
+        assert_eq!(
+            trigger.get("condition").and_then(|c| c.as_str()),
+            Some("trigger.payload.env == 'staging'"),
+            "condition must round-trip through JSON"
+        );
+    }
+
     #[test]
     fn workflow_definition_hydrates_preexisting_sandbox_decl() {
         let new = NewWorkflowDefinition::builder()

--- a/core/src/workflow/entity.rs
+++ b/core/src/workflow/entity.rs
@@ -135,11 +135,16 @@ impl WorkflowDefinition {
             .as_ref()
             .map(|incoming| match (incoming, &self.trigger) {
                 (
-                    WorkflowTrigger::Webhook { provider, .. },
+                    WorkflowTrigger::Webhook {
+                        provider,
+                        condition,
+                        ..
+                    },
                     WorkflowTrigger::Webhook { secret, .. },
                 ) => WorkflowTrigger::Webhook {
                     provider: provider.clone(),
                     secret: secret.clone(),
+                    condition: condition.clone(),
                 },
                 _ => incoming.clone(),
             });
@@ -199,11 +204,16 @@ impl WorkflowDefinition {
             .as_ref()
             .map(|incoming| match (incoming, &self.trigger) {
                 (
-                    WorkflowTrigger::Webhook { provider, .. },
+                    WorkflowTrigger::Webhook {
+                        provider,
+                        condition,
+                        ..
+                    },
                     WorkflowTrigger::Webhook { secret, .. },
                 ) => WorkflowTrigger::Webhook {
                     provider: provider.clone(),
                     secret: secret.clone(),
+                    condition: condition.clone(),
                 },
                 _ => incoming.clone(),
             });
@@ -437,6 +447,7 @@ mod tests {
             .trigger(WorkflowTrigger::Webhook {
                 provider: Some("honeycomb".into()),
                 secret: "whsec_xxx".into(),
+                condition: None,
             })
             .steps(vec![sample_step()])
             .build()
@@ -501,13 +512,16 @@ mod tests {
             .trigger(WorkflowTrigger::Cron {
                 schedule: "0 */6 * * * *".to_string(),
                 timezone: Some("UTC".to_string()),
+                condition: None,
             })
             .steps(vec![sample_step()])
             .build()
             .unwrap();
         let def = WorkflowDefinition::try_from_events(new.into_events()).unwrap();
         match &def.trigger {
-            WorkflowTrigger::Cron { schedule, timezone } => {
+            WorkflowTrigger::Cron {
+                schedule, timezone, ..
+            } => {
                 assert_eq!(schedule, "0 */6 * * * *");
                 assert_eq!(timezone.as_deref(), Some("UTC"));
             }
@@ -520,7 +534,7 @@ mod tests {
         let new = NewWorkflowDefinition::builder()
             .project_id(ProjectId::new())
             .name("uses-existing")
-            .trigger(WorkflowTrigger::Manual)
+            .trigger(WorkflowTrigger::Manual { condition: None })
             .steps(vec![sample_step()])
             .sandboxes(vec![WorkflowSandboxDecl::Preexisting {
                 name: "investigation".to_string(),

--- a/core/src/workflow/error.rs
+++ b/core/src/workflow/error.rs
@@ -47,6 +47,13 @@ pub enum WorkflowError {
         body: String,
         value: String,
     },
+    /// Trigger-level `condition:` failed at runtime — CEL compile,
+    /// runtime, or non-boolean result. No run was created; an
+    /// audit row was written.
+    #[error(
+        "WorkflowError - TriggerConditionErrored: trigger condition `{body}` failed: {reason}"
+    )]
+    TriggerConditionErrored { body: String, reason: String },
     #[error("WorkflowError - ToolNotFound: {0}")]
     ToolNotFound(String),
     #[error("WorkflowError - ToolDispatch: {0}")]

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -776,6 +776,12 @@ impl Workflows {
         definition: WorkflowDefinition,
         trigger_context: serde_json::Value,
     ) -> Result<Option<WorkflowRun>, WorkflowError> {
+        tracing::warn!(
+            definition_id = %definition.id,
+            condition = ?definition.trigger.condition(),
+            trigger_kind = trigger_kind_label(&definition.trigger),
+            "spawn_run_static gate inspection"
+        );
         if let Some(body) = definition.trigger.condition() {
             match template::evaluate_trigger_condition(body, &trigger_context) {
                 Ok(template::ConditionOutcome::True) => {}

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -776,12 +776,6 @@ impl Workflows {
         definition: WorkflowDefinition,
         trigger_context: serde_json::Value,
     ) -> Result<Option<WorkflowRun>, WorkflowError> {
-        tracing::warn!(
-            definition_id = %definition.id,
-            condition = ?definition.trigger.condition(),
-            trigger_kind = trigger_kind_label(&definition.trigger),
-            "spawn_run_static gate inspection"
-        );
         if let Some(body) = definition.trigger.condition() {
             match template::evaluate_trigger_condition(body, &trigger_context) {
                 Ok(template::ConditionOutcome::True) => {}

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -64,7 +64,11 @@ fn record_trigger_filtered_audit(
     condition_body: &str,
     trigger_context: &serde_json::Value,
 ) {
-    Audit::record_action_if_unset(AUDIT_ACTION_TRIGGER_FILTERED);
+    // Overwrite (not `_if_unset`): MCP trigger paths pre-set
+    // `action = "workflow.trigger"` before invoking the gate; the
+    // gate's outcome must replace it so the audit row records the
+    // actual disposition, not the verb.
+    Audit::record_action(AUDIT_ACTION_TRIGGER_FILTERED);
     Audit::record_workflow_id(definition.id);
     Audit::record_metadata(serde_json::json!({
         "definition_id": definition.id.to_string(),
@@ -86,7 +90,8 @@ fn record_trigger_condition_errored_audit(
     trigger_context: &serde_json::Value,
     reason: &str,
 ) {
-    Audit::record_action_if_unset(AUDIT_ACTION_TRIGGER_CONDITION_ERRORED);
+    // See `record_trigger_filtered_audit` — same overwrite rationale.
+    Audit::record_action(AUDIT_ACTION_TRIGGER_CONDITION_ERRORED);
     Audit::record_workflow_id(definition.id);
     Audit::record_metadata(serde_json::json!({
         "definition_id": definition.id.to_string(),

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -18,6 +18,7 @@ use rand::RngCore;
 use tracing::instrument;
 
 use crate::agent::Agents;
+use crate::audit::{Audit, InteractionOutcome};
 use crate::primitives::*;
 use crate::sandbox::Sandboxes;
 use crate::skill::Skills;
@@ -39,6 +40,77 @@ use job::{ExecuteRunConfig, ExecuteRunJobInitializer};
 use repo::WorkflowDefinitionRepo;
 use run::entity::NewWorkflowRun;
 use template::TemplateRef;
+
+/// Audit action recorded when a `trigger.condition:` evaluates to
+/// `false` and the run is deliberately suppressed.
+const AUDIT_ACTION_TRIGGER_FILTERED: &str = "workflow.trigger_filtered";
+/// Audit action recorded when a `trigger.condition:` errors at
+/// runtime (compile, runtime, non-boolean result).
+const AUDIT_ACTION_TRIGGER_CONDITION_ERRORED: &str = "workflow.trigger_condition_errored";
+
+/// SHA-256 hex digest of the JSON-encoded trigger context. Stored
+/// in audit metadata so operators can correlate filtered events
+/// to specific deliveries without persisting the full payload
+/// (memo 019e20a2 §7).
+fn payload_digest(trigger_context: &serde_json::Value) -> String {
+    use sha2::{Digest, Sha256};
+    let bytes = serde_json::to_vec(trigger_context).unwrap_or_default();
+    let digest = Sha256::digest(&bytes);
+    hex::encode(digest)
+}
+
+fn record_trigger_filtered_audit(
+    definition: &WorkflowDefinition,
+    condition_body: &str,
+    trigger_context: &serde_json::Value,
+) {
+    Audit::record_action_if_unset(AUDIT_ACTION_TRIGGER_FILTERED);
+    Audit::record_workflow_id(definition.id);
+    Audit::record_metadata(serde_json::json!({
+        "definition_id": definition.id.to_string(),
+        "trigger_kind": trigger_kind_label(&definition.trigger),
+        "condition_body": condition_body,
+        "payload_digest": payload_digest(trigger_context),
+    }));
+    Audit::record_outcome_if_unset(InteractionOutcome::Success);
+    tracing::info!(
+        definition_id = %definition.id,
+        condition_body,
+        "workflow run suppressed by trigger condition"
+    );
+}
+
+fn record_trigger_condition_errored_audit(
+    definition: &WorkflowDefinition,
+    condition_body: &str,
+    trigger_context: &serde_json::Value,
+    reason: &str,
+) {
+    Audit::record_action_if_unset(AUDIT_ACTION_TRIGGER_CONDITION_ERRORED);
+    Audit::record_workflow_id(definition.id);
+    Audit::record_metadata(serde_json::json!({
+        "definition_id": definition.id.to_string(),
+        "trigger_kind": trigger_kind_label(&definition.trigger),
+        "condition_body": condition_body,
+        "payload_digest": payload_digest(trigger_context),
+        "error": reason,
+    }));
+    Audit::record_error(reason.to_string());
+    tracing::warn!(
+        definition_id = %definition.id,
+        condition_body,
+        error = reason,
+        "trigger condition errored; run not created"
+    );
+}
+
+fn trigger_kind_label(trigger: &WorkflowTrigger) -> &'static str {
+    match trigger {
+        WorkflowTrigger::Manual { .. } => "manual",
+        WorkflowTrigger::Webhook { .. } => "webhook",
+        WorkflowTrigger::Cron { .. } => "cron",
+    }
+}
 
 /// CEL identifier shape — `[A-Za-z_][A-Za-z0-9_]*`. Step names
 /// must conform so `${{ steps.<name>.outputs.… }}` parses as a
@@ -191,12 +263,15 @@ impl Workflows {
         }
 
         let trigger = match trigger {
-            WorkflowTrigger::Webhook { provider, secret } if secret.is_empty() => {
-                WorkflowTrigger::Webhook {
-                    provider,
-                    secret: Self::generate_webhook_secret(),
-                }
-            }
+            WorkflowTrigger::Webhook {
+                provider,
+                secret,
+                condition,
+            } if secret.is_empty() => WorkflowTrigger::Webhook {
+                provider,
+                secret: Self::generate_webhook_secret(),
+                condition,
+            },
             other => other,
         };
 
@@ -232,9 +307,16 @@ impl Workflows {
     /// Reject cron triggers whose schedule or timezone won't parse so
     /// the failure surfaces at create-time, not on the first fire.
     fn validate_trigger(trigger: &WorkflowTrigger) -> Result<(), WorkflowError> {
-        if let WorkflowTrigger::Cron { schedule, timezone } = trigger {
+        if let WorkflowTrigger::Cron {
+            schedule, timezone, ..
+        } = trigger
+        {
             parse_cron_schedule(schedule).map_err(WorkflowError::InvalidCronExpression)?;
             parse_timezone(timezone.as_deref()).map_err(WorkflowError::InvalidTimezone)?;
+        }
+        if let Some(body) = trigger.condition() {
+            template::parse_trigger_condition(body)
+                .map_err(|e| WorkflowError::InvalidCondition(format!("trigger: {e}")))?;
         }
         Ok(())
     }
@@ -449,12 +531,15 @@ impl Workflows {
             .await?;
 
         let trigger = match trigger {
-            WorkflowTrigger::Webhook { provider, secret } if secret.is_empty() => {
-                WorkflowTrigger::Webhook {
-                    provider,
-                    secret: Self::generate_webhook_secret(),
-                }
-            }
+            WorkflowTrigger::Webhook {
+                provider,
+                secret,
+                condition,
+            } if secret.is_empty() => WorkflowTrigger::Webhook {
+                provider,
+                secret: Self::generate_webhook_secret(),
+                condition,
+            },
             other => other,
         };
 
@@ -554,7 +639,10 @@ impl Workflows {
         op: &mut OP,
         workflow: &WorkflowDefinition,
     ) -> Result<(), WorkflowError> {
-        let WorkflowTrigger::Cron { schedule, timezone } = &workflow.trigger else {
+        let WorkflowTrigger::Cron {
+            schedule, timezone, ..
+        } = &workflow.trigger
+        else {
             return Ok(());
         };
         let next_at = match next_cron_fire_at(schedule, timezone.as_deref(), chrono::Utc::now())
@@ -632,13 +720,16 @@ impl Workflows {
     }
 
     /// Spawns the executor as a job and returns the run synchronously.
+    /// `Ok(None)` means the trigger's `condition:` evaluated to false
+    /// and the run was deliberately suppressed (an audit row was
+    /// written).
     #[instrument(name = "core.workflow.trigger_run", skip_all)]
     pub async fn trigger_run(
         &self,
         sub: &AuthSubject,
         definition_id: WorkflowDefinitionId,
         trigger_context: serde_json::Value,
-    ) -> Result<WorkflowRun, WorkflowError> {
+    ) -> Result<Option<WorkflowRun>, WorkflowError> {
         let definition = self.repo.find_by_id(definition_id).await?;
         sub.can(
             AuthVerb::Use,
@@ -649,12 +740,14 @@ impl Workflows {
 
     /// No auth check — pairs with [`Self::find_by_id_unchecked`] so
     /// the webhook handler doesn't double-load the definition.
+    /// `Ok(None)` carries the same "filtered by trigger condition"
+    /// meaning as [`Self::trigger_run`].
     #[instrument(name = "core.workflow.trigger_run_for_definition", skip_all)]
     pub async fn trigger_run_for_definition(
         &self,
         definition: WorkflowDefinition,
         trigger_context: serde_json::Value,
-    ) -> Result<WorkflowRun, WorkflowError> {
+    ) -> Result<Option<WorkflowRun>, WorkflowError> {
         self.spawn_run(definition, trigger_context).await
     }
 
@@ -662,7 +755,7 @@ impl Workflows {
         &self,
         definition: WorkflowDefinition,
         trigger_context: serde_json::Value,
-    ) -> Result<WorkflowRun, WorkflowError> {
+    ) -> Result<Option<WorkflowRun>, WorkflowError> {
         Self::spawn_run_static(
             &self.run_repo,
             &self.execute_run_spawner,
@@ -677,7 +770,43 @@ impl Workflows {
         execute_run_spawner: &::job::JobSpawner<ExecuteRunConfig>,
         definition: WorkflowDefinition,
         trigger_context: serde_json::Value,
-    ) -> Result<WorkflowRun, WorkflowError> {
+    ) -> Result<Option<WorkflowRun>, WorkflowError> {
+        if let Some(body) = definition.trigger.condition() {
+            match template::evaluate_trigger_condition(body, &trigger_context) {
+                Ok(template::ConditionOutcome::True) => {}
+                Ok(template::ConditionOutcome::False) => {
+                    record_trigger_filtered_audit(&definition, body, &trigger_context);
+                    return Ok(None);
+                }
+                Ok(template::ConditionOutcome::NotBoolean(rendered)) => {
+                    let reason = format!("condition evaluated to non-boolean: {rendered}");
+                    record_trigger_condition_errored_audit(
+                        &definition,
+                        body,
+                        &trigger_context,
+                        &reason,
+                    );
+                    return Err(WorkflowError::TriggerConditionErrored {
+                        body: body.to_string(),
+                        reason,
+                    });
+                }
+                Err(e) => {
+                    let reason = e.to_string();
+                    record_trigger_condition_errored_audit(
+                        &definition,
+                        body,
+                        &trigger_context,
+                        &reason,
+                    );
+                    return Err(WorkflowError::TriggerConditionErrored {
+                        body: body.to_string(),
+                        reason,
+                    });
+                }
+            }
+        }
+
         let new = NewWorkflowRun::builder()
             .definition_id(definition.id)
             .project_id(definition.project_id)
@@ -694,7 +823,7 @@ impl Workflows {
             .await
             .map_err(|e| WorkflowError::Job(e.to_string()))?;
 
-        Ok(run)
+        Ok(Some(run))
     }
 
     #[instrument(name = "core.workflow.list_runs", skip_all)]
@@ -789,10 +918,11 @@ mod tests {
 
     #[test]
     fn validate_trigger_accepts_manual_and_webhook() {
-        Workflows::validate_trigger(&WorkflowTrigger::Manual).unwrap();
+        Workflows::validate_trigger(&WorkflowTrigger::Manual { condition: None }).unwrap();
         Workflows::validate_trigger(&WorkflowTrigger::Webhook {
             provider: Some("honeycomb".into()),
             secret: "whsec".into(),
+            condition: None,
         })
         .unwrap();
     }
@@ -802,6 +932,7 @@ mod tests {
         Workflows::validate_trigger(&WorkflowTrigger::Cron {
             schedule: "0 */6 * * * *".into(),
             timezone: Some("UTC".into()),
+            condition: None,
         })
         .unwrap();
     }
@@ -811,6 +942,7 @@ mod tests {
         let err = Workflows::validate_trigger(&WorkflowTrigger::Cron {
             schedule: "not a cron".into(),
             timezone: None,
+            condition: None,
         })
         .unwrap_err();
         assert!(matches!(err, WorkflowError::InvalidCronExpression(_)));
@@ -821,9 +953,42 @@ mod tests {
         let err = Workflows::validate_trigger(&WorkflowTrigger::Cron {
             schedule: "0 */6 * * * *".into(),
             timezone: Some("Mars/Olympus_Mons".into()),
+            condition: None,
         })
         .unwrap_err();
         assert!(matches!(err, WorkflowError::InvalidTimezone(_)));
+    }
+
+    #[test]
+    fn validate_trigger_rejects_malformed_cel_condition() {
+        let err = Workflows::validate_trigger(&WorkflowTrigger::Webhook {
+            provider: None,
+            secret: "whsec".into(),
+            condition: Some("trigger.payload.x ==".into()),
+        })
+        .unwrap_err();
+        assert!(matches!(err, WorkflowError::InvalidCondition(_)));
+    }
+
+    #[test]
+    fn validate_trigger_rejects_condition_referencing_steps() {
+        let err = Workflows::validate_trigger(&WorkflowTrigger::Webhook {
+            provider: None,
+            secret: "whsec".into(),
+            condition: Some("steps.x.outputs.y == 1".into()),
+        })
+        .unwrap_err();
+        assert!(matches!(err, WorkflowError::InvalidCondition(_)));
+    }
+
+    #[test]
+    fn validate_trigger_accepts_well_formed_condition() {
+        Workflows::validate_trigger(&WorkflowTrigger::Webhook {
+            provider: Some("github_app".into()),
+            secret: "whsec".into(),
+            condition: Some("trigger.payload.action == 'opened'".into()),
+        })
+        .unwrap();
     }
 
     #[test]

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -64,6 +64,8 @@ pub enum TemplateError {
     Resolve(String, String),
     #[error("template ref `{0}`: result could not be converted to JSON: {1}")]
     JsonConvert(String, String),
+    #[error("trigger condition `{0}`: references `steps` but no step has run yet at trigger-evaluation time; only `trigger` is in scope")]
+    StepsNotInScopeAtTrigger(String),
 }
 
 /// Resolution context borrowed for one substitution pass. The two
@@ -247,6 +249,44 @@ pub fn parse_condition(body: &str) -> Result<TemplateRef, TemplateError> {
     let r = parse_path(body)?;
     validate_root(&r)?;
     Ok(r)
+}
+
+/// Compile-time parse + root validation for a `trigger.condition:`.
+/// Stricter than [`parse_condition`]: rejects any reference to
+/// `steps` because no step has run yet at trigger-evaluation time —
+/// the run hasn't even been created. Only `trigger` is in scope.
+pub fn parse_trigger_condition(body: &str) -> Result<TemplateRef, TemplateError> {
+    let r = parse_path(body)?;
+    let program = Program::compile(&r.body)
+        .map_err(|e| TemplateError::Compile(r.raw.clone(), e.to_string()))?;
+    for ident in program.references().variables() {
+        if ident == "trigger" {
+            continue;
+        }
+        if ident == "steps" {
+            return Err(TemplateError::StepsNotInScopeAtTrigger(r.raw.clone()));
+        }
+        return Err(TemplateError::UnknownRoot(r.raw.clone(), ident.to_string()));
+    }
+    Ok(r)
+}
+
+/// Evaluate a `trigger.condition:` body against a payload-only
+/// context. Mirrors [`TemplateContext::evaluate_condition`] but with
+/// `steps` deliberately empty — no step has run yet. Returns the
+/// usual `ConditionOutcome` (True / False / NotBoolean) so callers
+/// can distinguish a clean `false` (suppress run) from a malformed
+/// body (audit-error + suppress run).
+pub fn evaluate_trigger_condition(
+    body: &str,
+    trigger_payload: &Value,
+) -> Result<ConditionOutcome, TemplateError> {
+    let empty_steps: std::collections::HashMap<String, Value> = std::collections::HashMap::new();
+    let ctx = TemplateContext {
+        trigger: trigger_payload,
+        steps: &empty_steps,
+    };
+    ctx.evaluate_condition(body)
 }
 
 /// Reject expressions that reference identifiers other than the two
@@ -988,6 +1028,110 @@ mod tests {
     fn referenced_step_names_ignores_trigger() {
         let r = parse_path("trigger.payload.build").unwrap();
         assert!(referenced_step_names(&r).is_empty());
+    }
+
+    #[test]
+    fn parse_trigger_condition_accepts_trigger_only() {
+        parse_trigger_condition("trigger.payload.action == 'opened'").unwrap();
+    }
+
+    #[test]
+    fn parse_trigger_condition_rejects_steps_reference() {
+        let err = parse_trigger_condition("steps.x.outputs.y == 1").unwrap_err();
+        assert!(matches!(err, TemplateError::StepsNotInScopeAtTrigger(_)));
+    }
+
+    #[test]
+    fn parse_trigger_condition_rejects_unknown_root() {
+        let err = parse_trigger_condition("env.HOME == 'x'").unwrap_err();
+        assert!(matches!(err, TemplateError::UnknownRoot(_, _)));
+    }
+
+    #[test]
+    fn parse_trigger_condition_rejects_compile_error() {
+        let err = parse_trigger_condition("trigger.payload.x ==").unwrap_err();
+        assert!(matches!(err, TemplateError::Compile(_, _)));
+    }
+
+    #[test]
+    fn parse_trigger_condition_accepts_function_calls_over_trigger() {
+        parse_trigger_condition("has(trigger.payload.action)").unwrap();
+        parse_trigger_condition("size(trigger.payload.commits) > 0").unwrap();
+    }
+
+    #[test]
+    fn evaluate_trigger_condition_true() {
+        let payload = json!({ "action": "opened", "repo": { "name": "drua" } });
+        assert_eq!(
+            evaluate_trigger_condition("trigger.payload.action == 'opened'", &payload).unwrap(),
+            ConditionOutcome::True
+        );
+    }
+
+    #[test]
+    fn evaluate_trigger_condition_false() {
+        let payload = json!({ "action": "closed" });
+        assert_eq!(
+            evaluate_trigger_condition("trigger.payload.action == 'opened'", &payload).unwrap(),
+            ConditionOutcome::False
+        );
+    }
+
+    /// Missing field on a NON-null payload surfaces as a CEL
+    /// `NoSuchKey` runtime error — the null-coalescing path only
+    /// kicks in when the whole payload is `null`. Authors writing
+    /// conditions over heterogeneous webhook payloads must guard
+    /// optional fields with `has(...)` to avoid spurious
+    /// `trigger.condition_errored` audit rows.
+    #[test]
+    fn evaluate_trigger_condition_missing_field_surfaces_as_runtime_error() {
+        let payload = json!({ "other": 1 });
+        let err =
+            evaluate_trigger_condition("trigger.payload.action == 'opened'", &payload).unwrap_err();
+        assert!(matches!(err, TemplateError::Resolve(_, _)));
+    }
+
+    /// Null payload (no body / manual `trigger` with no payload)
+    /// behaves the same as an empty-object payload — `build_cel_context`
+    /// coerces both to `{}` before binding, so `trigger.payload.x`
+    /// raises `NoSuchKey` rather than collapsing silently. Authors
+    /// must guard with `has(...)` (see following test).
+    #[test]
+    fn evaluate_trigger_condition_null_payload_unguarded_errors() {
+        let err = evaluate_trigger_condition("trigger.payload.action == 'opened'", &json!(null))
+            .unwrap_err();
+        assert!(matches!(err, TemplateError::Resolve(_, _)));
+    }
+
+    /// `has(...)`-guarded conditions are the recommended idiom for
+    /// optional fields — they evaluate cleanly to false instead of
+    /// raising NoSuchKey, even on payloads that lack the key.
+    #[test]
+    fn evaluate_trigger_condition_has_guard_handles_missing_field() {
+        let payload = json!({ "other": 1 });
+        assert_eq!(
+            evaluate_trigger_condition(
+                "has(trigger.payload.action) && trigger.payload.action == 'opened'",
+                &payload,
+            )
+            .unwrap(),
+            ConditionOutcome::False
+        );
+    }
+
+    #[test]
+    fn evaluate_trigger_condition_non_boolean_surfaces() {
+        let payload = json!({ "x": "y" });
+        match evaluate_trigger_condition("trigger.payload.x + '!'", &payload) {
+            Ok(ConditionOutcome::NotBoolean(s)) => assert!(s.contains("y!")),
+            other => panic!("expected NotBoolean, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn evaluate_trigger_condition_propagates_compile_error() {
+        let err = evaluate_trigger_condition("trigger.payload.x ==", &json!({})).unwrap_err();
+        assert!(matches!(err, TemplateError::Compile(_, _)));
     }
 
     /// Hyphens fall outside the CEL identifier alphabet, so the

--- a/core/src/workflow/yaml.rs
+++ b/core/src/workflow/yaml.rs
@@ -171,32 +171,56 @@ impl WorkflowSandboxYaml {
     }
 }
 
-#[derive(Debug, Default, serde::Serialize, serde::Deserialize)]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum WorkflowTriggerYaml {
-    #[default]
-    Manual,
+    Manual {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        condition: Option<String>,
+    },
     Webhook {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         provider: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        condition: Option<String>,
     },
     Cron {
         schedule: String,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         timezone: Option<String>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        condition: Option<String>,
     },
+}
+
+impl Default for WorkflowTriggerYaml {
+    fn default() -> Self {
+        Self::Manual { condition: None }
+    }
 }
 
 impl WorkflowTriggerYaml {
     fn from_runtime(t: &WorkflowTrigger) -> Self {
         match t {
-            WorkflowTrigger::Manual => WorkflowTriggerYaml::Manual,
-            WorkflowTrigger::Webhook { provider, .. } => WorkflowTriggerYaml::Webhook {
-                provider: provider.clone(),
+            WorkflowTrigger::Manual { condition } => WorkflowTriggerYaml::Manual {
+                condition: condition.clone(),
             },
-            WorkflowTrigger::Cron { schedule, timezone } => WorkflowTriggerYaml::Cron {
+            WorkflowTrigger::Webhook {
+                provider,
+                condition,
+                ..
+            } => WorkflowTriggerYaml::Webhook {
+                provider: provider.clone(),
+                condition: condition.clone(),
+            },
+            WorkflowTrigger::Cron {
+                schedule,
+                timezone,
+                condition,
+            } => WorkflowTriggerYaml::Cron {
                 schedule: schedule.clone(),
                 timezone: timezone.clone(),
+                condition: condition.clone(),
             },
         }
     }
@@ -381,14 +405,24 @@ pub fn parse_workflow_yaml(content: &str, path: &str) -> Option<ParsedWorkflow> 
     };
 
     let trigger = match yaml.trigger {
-        WorkflowTriggerYaml::Manual => WorkflowTrigger::Manual,
-        WorkflowTriggerYaml::Webhook { provider } => WorkflowTrigger::Webhook {
+        WorkflowTriggerYaml::Manual { condition } => WorkflowTrigger::Manual { condition },
+        WorkflowTriggerYaml::Webhook {
+            provider,
+            condition,
+        } => WorkflowTrigger::Webhook {
             provider,
             secret: String::new(),
+            condition,
         },
-        WorkflowTriggerYaml::Cron { schedule, timezone } => {
-            WorkflowTrigger::Cron { schedule, timezone }
-        }
+        WorkflowTriggerYaml::Cron {
+            schedule,
+            timezone,
+            condition,
+        } => WorkflowTrigger::Cron {
+            schedule,
+            timezone,
+            condition,
+        },
     };
 
     let steps: Vec<WorkflowStepDef> = yaml
@@ -511,6 +545,7 @@ mod tests {
         let trigger = WorkflowTrigger::Webhook {
             provider: Some("honeycomb".to_string()),
             secret: "whsec_should-not-be-serialized".to_string(),
+            condition: None,
         };
         let content = render(
             id,
@@ -536,6 +571,7 @@ mod tests {
             WorkflowTrigger::Webhook {
                 ref provider,
                 ref secret,
+                ..
             } => {
                 assert_eq!(provider.as_deref(), Some("honeycomb"));
                 assert_eq!(secret, "");
@@ -552,7 +588,7 @@ mod tests {
             id,
             "alert-response",
             None,
-            &WorkflowTrigger::Manual,
+            &WorkflowTrigger::Manual { condition: None },
             &sample_sandboxes(),
         );
         let path = canonical_workflow_path("alert-response", None);
@@ -604,7 +640,7 @@ steps:
         let parsed = parse_workflow_yaml(content, path).expect("parses");
         assert!(parsed.needs_rewrite);
         assert_eq!(parsed.name, "simple-flow");
-        assert!(matches!(parsed.trigger, WorkflowTrigger::Manual));
+        assert!(matches!(parsed.trigger, WorkflowTrigger::Manual { .. }));
     }
 
     #[test]
@@ -613,6 +649,7 @@ steps:
         let trigger = WorkflowTrigger::Cron {
             schedule: "0 */6 * * * *".to_string(),
             timezone: Some("America/New_York".to_string()),
+            condition: None,
         };
         let content = render(id, "scheduled", None, &trigger, &sample_sandboxes());
         assert!(content.contains("type: cron"));
@@ -622,7 +659,9 @@ steps:
         let path = canonical_workflow_path("scheduled", None);
         let parsed = parse_workflow_yaml(&content, &path).expect("parses");
         match parsed.trigger {
-            WorkflowTrigger::Cron { schedule, timezone } => {
+            WorkflowTrigger::Cron {
+                schedule, timezone, ..
+            } => {
                 assert_eq!(schedule, "0 */6 * * * *");
                 assert_eq!(timezone.as_deref(), Some("America/New_York"));
             }
@@ -645,7 +684,9 @@ steps:
         let path = "runtime/workflows/scheduled.yml";
         let parsed = parse_workflow_yaml(content, path).expect("parses");
         match parsed.trigger {
-            WorkflowTrigger::Cron { schedule, timezone } => {
+            WorkflowTrigger::Cron {
+                schedule, timezone, ..
+            } => {
                 assert_eq!(schedule, "0 */6 * * * *");
                 assert!(timezone.is_none());
             }
@@ -683,7 +724,7 @@ steps:
             id,
             "judge-flow",
             None,
-            &WorkflowTrigger::Manual,
+            &WorkflowTrigger::Manual { condition: None },
             &steps,
             &[],
             None,
@@ -737,7 +778,7 @@ steps:
             id,
             "alert-response",
             None,
-            &WorkflowTrigger::Manual,
+            &WorkflowTrigger::Manual { condition: None },
             &[
                 WorkflowSandboxDecl::Provisioned {
                     name: "investigation".to_string(),
@@ -777,7 +818,7 @@ steps:
             id,
             "uses-existing",
             None,
-            &WorkflowTrigger::Manual,
+            &WorkflowTrigger::Manual { condition: None },
             &[WorkflowSandboxDecl::Preexisting {
                 name: "investigation".to_string(),
             }],

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1714,8 +1714,10 @@ fn workflow_definition_to_view_for_list(
     d: &domain::workflow::WorkflowDefinition,
 ) -> WorkflowDefinitionView {
     let (trigger_type, trigger_provider, secret) = match &d.trigger {
-        WorkflowTrigger::Manual => ("manual".to_string(), None, None),
-        WorkflowTrigger::Webhook { provider, secret } => (
+        WorkflowTrigger::Manual { .. } => ("manual".to_string(), None, None),
+        WorkflowTrigger::Webhook {
+            provider, secret, ..
+        } => (
             "webhook".to_string(),
             provider.clone(),
             Some(secret.clone()),
@@ -1743,13 +1745,17 @@ fn workflow_definition_to_view_for_detail(
     public_host: Option<&str>,
 ) -> WorkflowDefinitionView {
     let (trigger_type, trigger_provider, secret) = match &d.trigger {
-        WorkflowTrigger::Manual => ("manual".to_string(), None, None),
-        WorkflowTrigger::Webhook { provider, secret } => (
+        WorkflowTrigger::Manual { .. } => ("manual".to_string(), None, None),
+        WorkflowTrigger::Webhook {
+            provider, secret, ..
+        } => (
             "webhook".to_string(),
             provider.clone(),
             Some(secret.clone()),
         ),
-        WorkflowTrigger::Cron { schedule, timezone } => {
+        WorkflowTrigger::Cron {
+            schedule, timezone, ..
+        } => {
             let label = match timezone {
                 Some(tz) => format!("cron ({schedule} {tz})"),
                 None => format!("cron ({schedule})"),
@@ -2041,8 +2047,16 @@ async fn project_workflow_trigger(
         .trigger_run(&sub, workflow_id, payload)
         .await
     {
-        Ok(run) => Redirect::to(&format!("/projects/{id}/workflows/{wf_id}/runs/{}", run.id))
+        Ok(Some(run)) => Redirect::to(&format!("/projects/{id}/workflows/{wf_id}/runs/{}", run.id))
             .into_response(),
+        Ok(None) => {
+            let msg = "trigger condition evaluated to false; no run created".to_string();
+            Redirect::to(&format!(
+                "/projects/{id}/workflows/{wf_id}?flash={}",
+                encode_query_value(&msg)
+            ))
+            .into_response()
+        }
         Err(e) => {
             let msg = format!("failed to trigger run: {e}");
             Redirect::to(&format!(

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -50,8 +50,10 @@ pub async fn handle_webhook(
     };
 
     let (provider, expected_secret) = match &definition.trigger {
-        WorkflowTrigger::Webhook { provider, secret } => (provider.clone(), secret.clone()),
-        WorkflowTrigger::Manual | WorkflowTrigger::Cron { .. } => {
+        WorkflowTrigger::Webhook {
+            provider, secret, ..
+        } => (provider.clone(), secret.clone()),
+        WorkflowTrigger::Manual { .. } | WorkflowTrigger::Cron { .. } => {
             return StatusCode::METHOD_NOT_ALLOWED.into_response();
         }
     };
@@ -89,9 +91,13 @@ pub async fn handle_webhook(
         .trigger_run_for_definition(definition, trigger_context)
         .await
     {
-        Ok(run) => {
+        Ok(Some(run)) => {
             tracing::info!(run_id = %run.id, "workflow run triggered via webhook");
             (StatusCode::OK, run.id.to_string()).into_response()
+        }
+        Ok(None) => {
+            tracing::info!("webhook accepted; run suppressed by trigger condition");
+            (StatusCode::OK, "filtered").into_response()
         }
         Err(e) => {
             tracing::error!(error = %e, "webhook: failed to trigger run");


### PR DESCRIPTION
## Summary

Implements memory [`019e20a2`](https://memory/019e20a2) — promote the CEL
`condition:` gate from `WorkflowStepDef` to `WorkflowTrigger`. When a
trigger declares `condition:`, the bare CEL boolean is evaluated against
the trigger payload **before** a `WorkflowRun` row is created. False →
no run + suppression audit. Error → no run + error audit.

Composes with the step-level `condition:` from PR #312 (`019e06a1`).
Trigger-level is the coarse filter ("should this event enter the
workflow?"); step-level is the fine filter ("which steps inside an
already-started run?"). Materially relevant to the parent
github-router use case (`019e1004`): one global GitHub App webhook
fans out to every `provider: github_app` workflow, each gating with
its own `trigger.condition:` — no more hundreds-of-skip-runs per day.

## Change shape

### YAML (new field per variant)

```yaml
trigger:
  type: webhook
  provider: github_app
  condition: |
    trigger.payload.action == 'opened'
```

`condition:` is `Option<String>` on each variant
(`Manual` / `Webhook` / `Cron`) — `#[serde(default, skip_serializing_if = "Option::is_none")]`,
so old event-sourcing rows hydrate cleanly as `None` (back-compat).

### Webhook flow

| Stage | Before this PR | After this PR |
| --- | --- | --- |
| Definition load | `find_by_id_unchecked` | unchanged |
| Header / secret verify | unchanged | unchanged |
| **NEW: trigger gate** | n/a | `evaluate_trigger_condition(condition, payload)` |
| ↳ `None` (no condition) | n/a | fall through to create run |
| ↳ `Some(True)` | n/a | fall through to create run |
| ↳ `Some(False)` | n/a | audit `workflow.trigger_filtered`; return `200 OK` body=`"filtered"` |
| ↳ Compile / runtime err | n/a | audit `workflow.trigger_condition_errored`; return `500` |
| Run create | always | only when gate allows |

The gate lives in `Workflows::spawn_run_static` ([`core/src/workflow/mod.rs`](core/src/workflow/mod.rs)) — the single bottleneck for all three trigger paths (webhook, MCP `workflow trigger`, cron `cron_job`). One insertion point, one set of audit semantics.

### Audit shape (memo §7, adapted to this codebase)

The memo's typed `AuditAction::WorkflowTriggerFiltered { ... }` enum
doesn't match drua's audit model — `Audit::record_action` takes a
string + JSON metadata. So:

```text
action       = "workflow.trigger_filtered" | "workflow.trigger_condition_errored"
workflow_id  = definition.id              (resource_ids)
metadata     = { definition_id, trigger_kind, condition_body,
                 payload_digest, [error] }
outcome      = Success (filtered) | Error{message} (errored)
```

Payload is **never** stored — only `sha256(json(trigger_context))` as a
correlation key (memo §7).

### Behaviour decisions

Three deltas vs. the memo I want reviewers to confirm:

1. **`trigger_context` shape unchanged** — only `trigger.payload.*` is
   bound today. The memo §5.1 sketches `trigger.headers` /
   `trigger.provider` / `trigger.delivery_id` too, but those aren't
   threaded through the webhook handler yet. Authors gate on payload
   contents in this PR; header / provider bindings are a follow-up
   tied to the sibling provider-fan-out PR (memo §6).
2. **Return type now `Result<Option<WorkflowRun>, _>`** on `trigger_run`,
   `trigger_run_for_definition`, and `spawn_run_static`. `None` =
   filtered. Webhook → `200 OK` body `"filtered"`. MCP → text "Trigger
   condition evaluated to false; no run created." Cron → log +
   reschedule. HTTP route → flash message.
3. **Runtime CEL errors are `Err(TriggerConditionErrored)`** (new
   `WorkflowError` variant), distinct from a clean `false`. Authors
   guard optional fields with `has(trigger.payload.X) && …` to avoid
   `NoSuchKey` errors on heterogeneous webhook payloads — see the new
   `evaluate_trigger_condition_has_guard_handles_missing_field` test.

## Files touched

- `core/src/workflow/definition.rs` — add `condition` field per variant + `WorkflowTrigger::condition()` accessor.
- `core/src/workflow/yaml.rs` — mirror in `WorkflowTriggerYaml`, replay-safe round-trip.
- `core/src/workflow/template.rs` — `parse_trigger_condition` (rejects `steps`), `evaluate_trigger_condition`, new `StepsNotInScopeAtTrigger` error.
- `core/src/workflow/mod.rs` — gate in `spawn_run_static`, audit helpers, `validate_trigger` extended to compile the condition.
- `core/src/workflow/error.rs` — new `TriggerConditionErrored { body, reason }` variant.
- `core/src/workflow/entity.rs` — propagate `condition` in the Webhook secret-merge path.
- `core/src/workflow/cron_job.rs` — handle `Ok(None)` (suppressed) case.
- `core/src/toolset/{searchable/admin,top_level/workflow}.rs` — add `trigger_condition` to create/update params; handle `Ok(None)` in the trigger dispatcher.
- `server/src/{webhook,routes}.rs` — return 200/`"filtered"` and flash-message respectively on suppression.
- `bats/workflow.bats` — end-to-end gate test (true / false / invalid CEL / steps-reference).

## Test plan

- [x] `nix flake check` clean (`cargo fmt`, `clippy --deny warnings`, `nextest`).
- [x] All 502 `drua-core` unit tests pass — 9 new tests cover trigger-condition parsing, evaluation, validation, and back-compat round-trips.
- [x] `bats/workflow.bats` adds an end-to-end test: condition-true creates run, condition-false yields no run, malformed CEL rejected at create time, `steps` reference rejected.
- [ ] (Sibling-PR scope) Provider fan-out endpoint `POST /webhooks/providers/{provider}` — explicitly deferred per memo §6.

## References

- Memory [`019e20a2`](https://memory/019e20a2) — authoritative design.
- Memory [`019e06a1`](https://memory/019e06a1) + PR #312 — step-level `condition:`, the line-for-line precedent.
- Memory [`019e1004`](https://memory/019e1004) — github-router meta-workflow, now obsoleted by this + the §6 fan-out PR.
- Memory [`019e01a4`](https://memory/019e01a4) — `ToolStep` + `workflow.trigger` (orthogonal but uses the same `trigger_context`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the workflow triggering path (manual/webhook/cron) to optionally suppress run creation based on a CEL expression, affecting core execution and audit behavior. Risk centers on altered return types/flows (`Option<WorkflowRun>`) and new condition-validation/runtime error handling across multiple entrypoints.
> 
> **Overview**
> Adds an optional `condition` on `WorkflowTrigger` (manual/webhook/cron) that is validated at create/update time and evaluated *before* creating a `WorkflowRun`, allowing triggers to be filtered without producing runs.
> 
> Updates all trigger entrypoints (admin/top-level tools, server UI trigger route, webhook handler, and cron job) to handle `Result<Option<WorkflowRun>>`, returning explicit "no run created"/`"filtered"` responses when conditions evaluate to false.
> 
> Introduces new audit actions (`workflow.trigger_filtered`, `workflow.trigger_condition_errored`) with payload hashing metadata, plus new template helpers to parse/evaluate trigger-only conditions (rejecting `steps` references) and expanded unit + Bats end-to-end coverage for the gating behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdec518c436015f5bb1d4c154725627383f4ed96. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->