### PR TITLE
fix(catalog): describe_tool bypasses tool-caching — preserve schemas

### DIFF
--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -329,19 +329,6 @@ impl TopLevelTool for DescribeCatalogTool {
         Some(&DESCRIBE_OUTPUT_SCHEMA)
     }
     fn default_tool_caching(&self) -> bool {
-        // describe_tool's whole purpose is to deliver a tool's complete
-        // schema (input_schema, output_schema, description) to an agent
-        // deciding how to call it. The structured payload IS the
-        // information — eliding `input_schema.properties.X.description`
-        // or truncating `examples[]` mangles the schema the agent needs.
-        // Unlike `search_tools`/`compose_types` which are filtered list
-        // queries (an agent can narrow the filter to shrink the
-        // response), `describe_tool` is one atomic schema per tool that
-        // can't be meaningfully trimmed. Opt out of tool-caching so the
-        // schema reaches the agent verbatim; if a single tool's schema
-        // exceeds the harness's own MCP output cap, that's an upstream-
-        // tool concision problem, not something drua's elision can fix
-        // without making the schema unusable.
         false
     }
 

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -328,6 +328,22 @@ impl TopLevelTool for DescribeCatalogTool {
     fn inner_output_schema(&self) -> Option<&serde_json::Value> {
         Some(&DESCRIBE_OUTPUT_SCHEMA)
     }
+    fn default_tool_caching(&self) -> bool {
+        // describe_tool's whole purpose is to deliver a tool's complete
+        // schema (input_schema, output_schema, description) to an agent
+        // deciding how to call it. The structured payload IS the
+        // information — eliding `input_schema.properties.X.description`
+        // or truncating `examples[]` mangles the schema the agent needs.
+        // Unlike `search_tools`/`compose_types` which are filtered list
+        // queries (an agent can narrow the filter to shrink the
+        // response), `describe_tool` is one atomic schema per tool that
+        // can't be meaningfully trimmed. Opt out of tool-caching so the
+        // schema reaches the agent verbatim; if a single tool's schema
+        // exceeds the harness's own MCP output cap, that's an upstream-
+        // tool concision problem, not something drua's elision can fix
+        // without making the schema unusable.
+        false
+    }
 
     async fn call(
         &self,


### PR DESCRIPTION
## Summary

`describe_tool` returns one atomic schema per tool — \`input_schema\`, \`output_schema\`, description, examples. Tool-caching's elision mangles exactly the data the agent needs to call the upstream tool: \`input_schema.properties.X.description\` gets a bulk-elided middle, deeply-nested \`oneOf\` alternatives lose entries, \`examples[]\` gets truncated. For tools with big schemas (e.g. \`honeycomb_run_query\` ≈ 15 KB structured), the elided output is unusable as a schema reference.

One-line change: \`default_tool_caching = false\` on \`DescribeCatalogTool\`. Schema reaches the agent verbatim.

### Why describe_tool specifically (not search/compose_types)

- \`search_tools(query, category)\` and \`compose_types(tool_names)\` are **filtered list queries** — an agent can narrow the filter to shrink the response. The caching layer's array truncation gives a sensible head-only preview while the agent narrows.
- \`describe_tool(tool_name)\` is **atomic per tool** — one schema, no filter knob. Trimming it doesn't help the agent narrow; it just delivers an incorrect schema.

### When the schema is too big for the harness

If a single tool's schema exceeds the harness's MCP output cap (Claude Code: \`MAX_MCP_OUTPUT_TOKENS = 25000\`), the harness truncates. That's the correct failure mode here:
- Raw truncation preserves the start (usually most informative — name, top-level params)
- A curated elided schema does NOT (it elides exactly the descriptions/examples/oneOf details the agent needs)
- And it's an **upstream tool concision problem**, not something drua's elision layer can fix without breaking the schema contract

### Test plan
- [x] \`cargo test -p drua-core --lib catalog\` — all 11 catalog tests pass
- [x] \`bats fake_mcp_upstream.bats\` — all 14 tests still green
- [ ] CI bats / check / integration
- [ ] Post-deploy E2E: \`describe_tool(honeycomb_run_query)\` returns full schema verbatim, no \`_elided\` wrapper, all \`input_schema.properties.*.description\` intact

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line behavior change that only affects `describe_tool` response shaping, but may increase response size since schemas are no longer elided by the caching layer.
> 
> **Overview**
> `describe_tool` now opts out of the default tool-caching wrapper by overriding `default_tool_caching()` to return `false`, ensuring its returned `input_schema`/`output_schema` and related details are not elided or altered.
> 
> This preserves full, verbatim tool schemas for agents at the cost of potentially larger `describe_tool` responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb82af3f916b50be72e11ac1f24ba8a816d9b6c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->