### PR TITLE
refactor(tool-caching): split cache API; drop WrapMode; add summary fetch + simplify compose

### DIFF
--- a/bats/fake_mcp_upstream.bats
+++ b/bats/fake_mcp_upstream.bats
@@ -422,16 +422,20 @@ assert_compose_snapshot() {
   local r1_struct
   r1_struct="$(echo "$output" | jq -r '.result.structuredContent')"
 
+  # Compose is a top-level cached tool — its structured channel is the
+  # `DruaToolResult<ComposeOutput>` wrapper. ComposeOutput fields live
+  # under `.result.` (outer wrap key).
+  #
   # Structural: 2 sub_invocations expected (small obj is passthrough →
   # no recovery; large str + large arr are persisted).
   local n_subs
-  n_subs="$(echo "$r1_struct" | jq -r '.sub_invocations | length')"
+  n_subs="$(echo "$r1_struct" | jq -r '.result.sub_invocations | length')"
   [ "$n_subs" = "2" ]
 
   # Each persisted sub_invocation carries a uuid + a kind discriminator.
   local subs_summary
   subs_summary="$(echo "$r1_struct" | jq -r \
-    '.sub_invocations | map({tool_name, kind})')"
+    '.result.sub_invocations | map({tool_name, kind})')"
   echo "$subs_summary"
   [[ "$subs_summary" == *"str-large-table"* ]]
   [[ "$subs_summary" == *"arr-large-passthrough-items"* ]]
@@ -440,23 +444,15 @@ assert_compose_snapshot() {
   assert_compose_snapshot "$r1_struct" "compose-roundtrip-1"
 
   # Round 2 — feed each captured invocation_id back through
-  # tool_output_fetch inside a fresh compose script, replaying the
-  # advertised query for each. Asserts end-to-end recoverability.
-  local str_id arr_id str_q arr_q
+  # tool_output_fetch inside a fresh compose script. Asserts end-to-end
+  # recoverability of sub-call data persisted by persist_for_compose.
+  local str_id arr_id
   str_id="$(echo "$r1_struct" | jq -r \
-    '.sub_invocations[] | select(.tool_name | endswith("str-large-table")) | .invocation_id')"
+    '.result.sub_invocations[] | select(.tool_name | endswith("str-large-table")) | .invocation_id')"
   arr_id="$(echo "$r1_struct" | jq -r \
-    '.sub_invocations[] | select(.tool_name | endswith("arr-large-passthrough-items")) | .invocation_id')"
+    '.result.sub_invocations[] | select(.tool_name | endswith("arr-large-passthrough-items")) | .invocation_id')"
   [[ "$str_id" =~ ^[0-9a-f-]{36}$ ]]
   [[ "$arr_id" =~ ^[0-9a-f-]{36}$ ]]
-
-  # Pull the advertised query off the rendered <recovery> block of the
-  # round-1 result (it's the curated compose:result envelope).
-  local r1_result_text
-  r1_result_text="$(echo "$r1_struct" | jq -r '.result')"
-  # str-large-table is line-mode; arr is json_array_slice.
-  str_q="$(echo "$r1_result_text" | grep -oE '"mode":"lines"[^}]*' | head -1)"
-  arr_q="$(echo "$r1_result_text" | grep -oE '"mode":"json_array_slice"[^}]*' | head -1)"
 
   # Construct a recovery script via jq so quoting is correct.
   local r2_script r2_body
@@ -470,14 +466,16 @@ assert_compose_snapshot() {
   [ "$status" -eq 0 ]
 
   # The recovered slices must match the elided middle of each fixture.
-  local r2_struct r2_result
+  # Outer compose wrap puts ComposeOutput at `.result`; ComposeOutput.result
+  # is the JS return — `{ str_slice: <fetched_string>, arr_slice: <fetched_array> }`.
+  local r2_struct r2_inner
   r2_struct="$(echo "$output" | jq -r '.result.structuredContent')"
-  r2_result="$(echo "$r2_struct" | jq -r '.result')"
+  r2_inner="$(echo "$r2_struct" | jq -r '.result.result')"
 
   # str_slice is a JSON string; arr_slice is a JSON array.
   local str_slice arr_slice_len
-  str_slice="$(echo "$r2_result" | jq -r '.str_slice' | head -c 60)"
-  arr_slice_len="$(echo "$r2_result" | jq -r '.arr_slice | length')"
+  str_slice="$(echo "$r2_inner" | jq -r '.str_slice' | head -c 60)"
+  arr_slice_len="$(echo "$r2_inner" | jq -r '.arr_slice | length')"
 
   # Sanity: line-mode slice begins with a known kubectl row prefix.
   [[ "$str_slice" == kube-system* ]] || {

--- a/bats/summarized-tool-responses/compose-roundtrip-1.json
+++ b/bats/summarized-tool-responses/compose-roundtrip-1.json
@@ -1647,7 +1647,6 @@
         "invocation_id": "<uuid>",
         "kind": "lines",
         "raw_size_bytes": 13051,
-        "seq": 0,
         "tool_name": "fake_upstream_str-large-table"
       },
       {
@@ -1655,7 +1654,6 @@
         "invocation_id": "<uuid>",
         "kind": "json_array_slice",
         "raw_size_bytes": 10391,
-        "seq": 1,
         "tool_name": "fake_upstream_arr-large-passthrough-items"
       }
     ],

--- a/bats/summarized-tool-responses/compose-roundtrip-1.json
+++ b/bats/summarized-tool-responses/compose-roundtrip-1.json
@@ -1,28 +1,1664 @@
 {
-  "console": [],
-  "execution_time_ms": "<ms>",
-  "fetch_hint": "invocation_id is either `result_invocation_id` (full JS return) or any `sub_invocations[].invocation_id` (specific sub-call's persisted output) — see `tool_output_fetch` for the full call shape.",
-  "result": "<summary path=\"$\" total-bytes=\"23562\" shown-bytes=\"12787\">\n{\"arr\":{\"result\":[{\"id\":0,\"tag\":\"x\"},{\"id\":1,\"tag\":\"x\"},{\"id\":2,\"tag\":\"x\"},{\"id\":3,\"tag\":\"x\"},{\"id\":4,\"tag\":\"x\"},{\"id\":5,\"tag\":\"x\"},{\"id\":6,\"tag\":\"x\"},{\"id\":7,\"tag\":\"x\"},{\"id\":8,\"tag\":\"x\"},{\"id\":9,\"tag\":\"x\"},{\"id\":10,\"tag\":\"x\"},{\"id\":11,\"tag\":\"x\"},{\"id\":12,\"tag\":\"x\"},{\"id\":13,\"tag\":\"x\"},{\"id\":14,\"tag\":\"x\"},{\"id\":15,\"tag\":\"x\"},{\"id\":16,\"tag\":\"x\"},{\"id\":17,\"tag\":\"x\"},{\"id\":18,\"tag\":\"x\"},{\"id\":19,\"tag\":\"x\"},{\"id\":20,\"tag\":\"x\"},{\"id\":21,\"tag\":\"x\"},{\"id\":22,\"tag\":\"x\"},{\"id\":23,\"tag\":\"x\"},{\"id\":24,\"tag\":\"x\"},{\"id\":25,\"tag\":\"x\"},{\"id\":26,\"tag\":\"x\"},{\"id\":27,\"tag\":\"x\"},{\"id\":28,\"tag\":\"x\"},{\"id\":29,\"tag\":\"x\"},{\"id\":30,\"tag\":\"x\"},{\"id\":31,\"tag\":\"x\"},{\"id\":32,\"tag\":\"x\"},{\"id\":33,\"tag\":\"x\"},{\"id\":34,\"tag\":\"x\"},{\"id\":35,\"tag\":\"x\"},{\"id\":36,\"tag\":\"x\"},{\"id\":37,\"tag\":\"x\"},{\"id\":38,\"tag\":\"x\"},{\"id\":39,\"tag\":\"x\"},{\"id\":40,\"tag\":\"x\"},{\"id\":41,\"tag\":\"x\"},{\"id\":42,\"tag\":\"x\"},{\"id\":43,\"tag\":\"x\"},{\"id\":44,\"tag\":\"x\"},{\"id\":45,\"tag\":\"x\"},{\"id\":46,\"tag\":\"x\"},{\"id\":47,\"tag\":\"x\"},{\"id\":48,\"tag\":\"x\"},{\"id\":49,\"tag\":\"x\"},{\"id\":50,\"tag\":\"x\"},{\"id\":51,\"tag\":\"x\"},{\"id\":52,\"tag\":\"x\"},{\"id\":53,\"tag\":\"x\"},{\"id\":54,\"tag\":\"x\"},{\"id\":55,\"tag\":\"x\"},{\"id\":56,\"tag\":\"x\"},{\"id\":57,\"tag\":\"x\"},{\"id\":58,\"tag\":\"x\"},{\"id\":59,\"tag\":\"x\"},{\"id\":60,\"tag\":\"x\"},{\"id\":61,\"tag\":\"x\"},{\"id\":62,\"tag\":\"x\"},{\"id\":63,\"tag\":\"x\"},{\"id\":64,\"tag\":\"x\"},{\"id\":65,\"tag\":\"x\"},{\"id\":66,\"tag\":\"x\"},{\"id\":67,\"tag\":\"x\"},{\"id\":68,\"tag\":\"x\"},{\"id\":69,\"tag\":\"x\"},{\"id\":70,\"tag\":\"x\"},{\"id\":71,\"tag\":\"x\"},{\"id\":72,\"tag\":\"x\"},{\"id\":73,\"tag\":\"x\"},{\"id\":74,\"tag\":\"x\"},{\"id\":75,\"tag\":\"x\"},{\"id\":76,\"tag\":\"x\"},{\"id\":77,\"tag\":\"x\"},{\"id\":78,\"tag\":\"x\"},{\"id\":79,\"tag\":\"x\"},{\"id\":80,\"tag\":\"x\"},{\"id\":81,\"tag\":\"x\"},{\"id\":82,\"tag\":\"x\"},{\"id\":83,\"tag\":\"x\"},{\"id\":84,\"tag\":\"x\"},{\"id\":85,\"tag\":\"x\"},{\"id\":86,\"tag\":\"x\"},{\"id\":87,\"tag\":\"x\"},{\"id\":88,\"tag\":\"x\"},{\"id\":89,\"tag\":\"x\"},{\"id\":90,\"tag\":\"x\"},{\"id\":91,\"tag\":\"x\"},{\"id\":92,\"tag\":\"x\"},{\"id\":93,\"tag\":\"x\"},{\"id\":94,\"tag\":\"x\"},{\"id\":95,\"tag\":\"x\"},{\"id\":96,\"tag\":\"x\"},{\"id\":97,\"tag\":\"x\"},{\"id\":98,\"tag\":\"x\"},{\"id\":99,\"tag\":\"x\"},{\"id\":100,\"tag\":\"x\"},{\"id\":101,\"tag\":\"x\"},{\"id\":102,\"tag\":\"x\"},{\"id\":103,\"tag\":\"x\"},{\"id\":104,\"tag\":\"x\"},{\"id\":105,\"tag\":\"x\"},{\"id\":106,\"tag\":\"x\"},{\"id\":107,\"tag\":\"x\"},{\"id\":108,\"tag\":\"x\"},{\"id\":109,\"tag\":\"x\"},{\"id\":110,\"tag\":\"x\"},{\"id\":111,\"tag\":\"x\"},{\"id\":112,\"tag\":\"x\"},{\"id\":113,\"tag\":\"x\"},{\"id\":114,\"tag\":\"x\"},{\"id\":115,\"tag\":\"x\"},{\"id\":116,\"tag\":\"x\"},{\"id\":117,\"tag\":\"x\"},{\"id\":118,\"tag\":\"x\"},{\"id\":119,\"tag\":\"x\"},{\"id\":120,\"tag\":\"x\"},{\"id\":121,\"tag\":\"x\"},{\"id\":122,\"tag\":\"x\"},{\"id\":123,\"tag\":\"x\"},{\"id\":124,\"tag\":\"x\"},{\"id\":125,\"tag\":\"x\"},{\"id\":126,\"tag\":\"x\"},{\"id\":127,\"tag\":\"x\"},{\"id\":128,\"tag\":\"x\"},{\"id\":129,\"tag\":\"x\"},{\"id\":130,\"tag\":\"x\"},{\"id\":131,\"tag\":\"x\"},{\"id\":132,\"tag\":\"x\"},{\"id\":133,\"tag\":\"x\"},{\"id\":134,\"tag\":\"x\"},{\"id\":135,\"tag\":\"x\"},{\"id\":136,\"tag\":\"x\"},{\"id\":137,\"tag\":\"x\"},{\"id\":138,\"tag\":\"x\"},{\"id\":139,\"tag\":\"x\"},{\"id\":140,\"tag\":\"x\"},{\"id\":141,\"tag\":\"x\"},{\"id\":142,\"tag\":\"x\"},{\"id\":143,\"tag\":\"x\"},{\"id\":144,\"tag\":\"x\"},{\"id\":145,\"tag\":\"x\"},{\"id\":146,\"tag\":\"x\"},{\"id\":147,\"tag\":\"x\"},{\"id\":148,\"tag\":\"x\"},{\"id\":149,\"tag\":\"x\"},{\"id\":150,\"tag\":\"x\"},{\"id\":151,\"tag\":\"x\"},{\"id\":152,\"tag\":\"x\"},{\"id\":153,\"tag\":\"x\"},{\"id\":154,\"tag\":\"x\"},{\"id\":155,\"tag\":\"x\"},{\"id\":156,\"tag\":\"x\"},{\"id\":157,\"tag\":\"x\"},{\"id\":158,\"tag\":\"x\"},{\"id\":159,\"tag\":\"x\"},{\"id\":160,\"tag\":\"x\"},{\"id\":161,\"tag\":\"x\"},{\"id\":162,\"tag\":\"x\"},{\"id\":163,\"tag\":\"x\"},{\"id\":164,\"tag\":\"x\"},{\"id\":165,\"tag\":\"x\"},{\"id\":166,\"tag\":\"x\"},{\"id\":167,\"tag\":\"x\"},{\"id\":168,\"tag\":\"x\"},{\"id\":169,\"tag\":\"x\"},{\"id\":170,\"tag\":\"x\"},{\"id\":171,\"tag\":\"x\"},{\"id\":172,\"tag\":\"x\"},{\"id\":173,\"tag\":\"x\"},{\"id\":174,\"tag\":\"x\"},{\"id\":175,\"tag\":\"x\"},{\"id\":176,\"tag\":\"x\"},{\"id\":177,\"tag\":\"x\"},{\"id\":178,\"tag\":\"x\"},{\"id\":179,\"tag\":\"x\"},{\"id\":180,\"tag\":\"x\"},{\"id\":181,\"tag\":\"x\"},{\"id\":182,\"tag\":\"x\"},{\"id\":183,\"tag\":\"x\"},{\"id\":184,\"tag\":\"x\"},{\"id\":185,\"tag\":\"x\"},{\"id\":186,\"tag\":\"x\"},{\"id\":187,\"tag\":\"x\"},{\"id\":188,\"tag\":\"x\"},{\"id\":189,\"tag\":\"x\"},{\"id\":190,\"tag\":\"x\"},{\"id\":191,\"tag\":\"x\"},{\"id\":192,\"tag\":\"x\"},{\"id\":193,\"tag\":\"x\"},{\"id\":194,\"tag\":\"x\"},{\"id\":195,\"tag\":\"x\"},{\"id\":196,\"tag\":\"x\"},{\"id\":197,\"tag\":\"x\"},{\"id\":198,\"tag\":\"x\"},{\"id\":199,\"tag\":\"x\"},{\"id\":200,\"tag\":\"x\"},{\"id\":201,\"tag\":\"x\"},{\"id\":202,\"tag\":\"x\"},{\"id\":203,\"tag\":\"x\"},{\"id\":204,\"tag\":\"x\"},{\"id\":205,\"tag\":\"x\"},{\"id\":206,\"tag\":\"x\"},{\"id\":207,\"tag\":\"x\"},{\"id\":208,\"tag\":\"x\"},{\"id\":209,\"tag\":\"x\"},{\"id\":210,\"tag\":\"x\"},{\"id\":211,\"tag\":\"x\"},{\"id\":212,\"tag\":\"x\"},{\"id\":213,\"tag\":\"x\"},{\"id\":214,\"tag\":\"x\"},{\"id\":215,\"tag\":\"x\"},{\"id\":216,\"tag\":\"x\"},{\"id\":217,\"tag\":\"x\"},{\"id\":218,\"tag\":\"x\"},{\"id\":219,\"tag\":\"x\"},{\"id\":220,\"tag\":\"x\"},{\"id\":221,\"tag\":\"x\"},{\"id\":222,\"tag\":\"x\"},{\"id\":223,\"tag\":\"x\"},{\"id\":224,\"tag\":\"x\"},{\"id\":225,\"tag\":\"x\"},{\"id\":226,\"tag\":\"x\"},{\"id\":227,\"tag\":\"x\"},{\"id\":228,\"tag\":\"x\"},{\"id\":229,\"tag\":\"x\"},{\"id\":230,\"tag\":\"x\"},{\"id\":231,\"tag\":\"x\"},{\"id\":232,\"tag\":\"x\"},{\"id\":233,\"tag\":\"x\"},{\"id\":234,\"tag\":\"x\"},{\"id\":235,\"tag\":\"x\"},{\"id\":236,\"tag\":\"x\"},{\"id\":237,\"tag\":\"x\"},{\"id\":238,\"tag\":\"x\"},{\"id\":239,\"tag\":\"x\"},{\"id\":240,\"tag\":\"x\"},{\"id\":241,\"tag\":\"x\"},{\"id\":242,\"tag\":\"x\"},{\"id\":243,\"tag\":\"x\"},{\"id\":244,\"tag\":\"x\"},{\"id\":245,\"tag\":\"x\"},{\"id\":246,\"tag\":\"x\"},{\"id\":247,\"tag\":\"x\"},{\"id\":248,\"tag\":\"x\"},{\"id\":249,\"tag\":\"x\"},{\"id\":250,\"tag\":\"x\"},{\"id\":251,\"tag\":\"x\"},{\"id\":252,\"tag\":\"x\"},{\"id\":253,\"tag\":\"x\"},{\"id\":254,\"tag\":\"x\"},{\"id\":255,\"tag\":\"x\"},{\"id\":256,\"tag\":\"x\"},{\"id\":257,\"tag\":\"x\"},{\"id\":258,\"tag\":\"x\"},{\"id\":259,\"tag\":\"x\"},{\"id\":260,\"tag\":\"x\"},{\"id\":261,\"tag\":\"x\"},{\"id\":262,\"tag\":\"x\"},{\"id\":263,\"tag\":\"x\"},{\"id\":264,\"tag\":\"x\"},{\"id\":265,\"tag\":\"x\"},{\"id\":266,\"tag\":\"x\"},{\"id\":267,\"tag\":\"x\"},{\"id\":268,\"tag\":\"x\"},{\"id\":269,\"tag\":\"x\"},{\"id\":270,\"tag\":\"x\"},{\"id\":271,\"tag\":\"x\"},{\"id\":272,\"tag\":\"x\"},{\"id\":273,\"tag\":\"x\"},{\"id\":274,\"tag\":\"x\"},{\"id\":275,\"tag\":\"x\"},{\"id\":276,\"tag\":\"x\"},{\"id\":277,\"tag\":\"x\"},{\"id\":278,\"tag\":\"x\"},{\"id\":279,\"tag\":\"x\"},{\"id\":280,\"tag\":\"x\"},{\"id\":281,\"tag\":\"x\"},{\"id\":282,\"tag\":\"x\"},{\"id\":283,\"tag\":\"x\"},{\"id\":284,\"tag\":\"x\"},{\"id\":285,\"tag\":\"x\"},{\"id\":286,\"tag\":\"x\"},{\"id\":287,\"tag\":\"x\"},{\"id\":288,\"tag\":\"x\"},{\"id\":289,\"tag\":\"x\"},{\"id\":290,\"tag\":\"x\"},{\"id\":291,\"tag\":\"x\"},{\"id\":292,\"tag\":\"x\"},{\"id\":293,\"tag\":\"x\"},{\"id\":294,\"tag\":\"x\"},{\"id\":295,\"tag\":\"x\"},{\"id\":296,\"tag\":\"x\"},{\"id\":297,\"tag\":\"x\"},{\"id\":298,\"tag\":\"x\"},{\"id\":299,\"tag\":\"x\"},{\"id\":300,\"tag\":\"x\"},{\"id\":301,\"tag\":\"x\"},{\"id\":302,\"tag\":\"x\"},{\"id\":303,\"tag\":\"x\"},{\"id\":304,\"tag\":\"x\"},{\"id\":305,\"tag\":\"x\"},{\"id\":306,\"tag\":\"x\"},{\"id\":307,\"tag\":\"x\"},{\"id\":308,\"tag\":\"x\"},{\"id\":309,\"tag\":\"x\"},{\"id\":310,\"tag\":\"x\"},{\"id\":311,\"tag\":\"x\"},{\"id\":312,\"tag\":\"x\"},{\"id\":313,\"tag\":\"x\"},{\"id\":314,\"tag\":\"x\"},{\"id\":315,\"tag\":\"x\"},{\"id\":316,\"tag\":\"x\"},{\"id\":317,\"tag\":\"x\"},{\"id\":318,\"tag\":\"x\"},{\"id\":319,\"tag\":\"x\"},{\"id\":320,\"tag\":\"x\"},{\"id\":321,\"tag\":\"x\"},{\"id\":322,\"tag\":\"x\"},{\"id\":323,\"tag\":\"x\"},{\"id\":324,\"tag\":\"x\"},{\"id\":325,\"tag\":\"x\"},{\"id\":326,\"tag\":\"x\"},{\"id\":327,\"tag\":\"x\"},{\"id\":328,\"tag\":\"x\"},{\"id\":329,\"tag\":\"x\"},{\"id\":330,\"tag\":\"x\"},{\"id\":331,\"tag\":\"x\"},{\"id\":332,\"tag\":\"x\"},{\"id\":333,\"tag\":\"x\"},{\"id\":334,\"tag\":\"x\"},{\"id\":335,\"tag\":\"x\"},{\"id\":336,\"tag\":\"x\"},{\"id\":337,\"tag\":\"x\"},{\"id\":338,\"tag\":\"x\"},{\"id\":339,\"tag\":\"x\"},{\"id\":340,\"tag\":\"x\"},{\"id\":341,\"tag\":\"x\"},{\"id\":342,\"tag\":\"x\"},{\"id\":343,\"tag\":\"x\"},{\"id\":344,\"tag\":\"x\"},{\"id\":345,\"tag\":\"x\"},{\"id\":346,\"tag\":\"x\"},{\"id\":347,\"tag\":\"x\"},{\"id\":348,\"tag\":\"x\"},{\"id\":349,\"tag\":\"x\"},{\"id\":350,\"tag\":\"x\"},{\"id\":351,\"tag\":\"x\"},{\"id\":352,\"tag\":\"x\"},{\"id\":353,\"tag\":\"x\"},{\"id\":354,\"tag\":\"x\"},{\"id\":355,\"tag\":\"x\"},{\"id\":356,\"tag\":\"x\"},{\"id\":357,\"tag\":\"x\"},{\"id\":358,\"tag\":\"x\"},{\"id\":359,\"tag\":\"x\"},{\"id\":360,\"tag\":\"x\"},{\"id\":361,\"tag\":\"x\"},{\"id\":362,\"tag\":\"x\"},{\"id\":363,\"tag\":\"x\"},{\"id\":364,\"tag\":\"x\"},{\"id\":365,\"tag\":\"x\"},{\"id\":366,\"tag\":\"x\"},{\"id\":367,\"tag\":\"x\"},{\"id\":368,\"tag\":\"x\"},{\"id\":369,\"tag\":\"x\"},{\"id\":370,\"tag\":\"x\"},{\"id\":371,\"tag\":\"x\"},{\"id\":372,\"tag\":\"x\"},{\"id\":373,\"tag\":\"x\"},{\"id\":374,\"tag\":\"x\"},{\"id\":375,\"tag\":\"x\"},{\"id\":376,\"tag\":\"x\"},{\"id\":377,\"tag\":\"x\"},{\"id\":378,\"tag\":\"x\"},{\"id\":379,\"tag\":\"x\"},{\"id\":380,\"tag\":\"x\"},{\"id\":381,\"tag\":\"x\"},{\"id\":382,\"tag\":\"x\"},{\"id\":383,\"tag\":\"x\"},{\"id\":384,\"tag\":\"x\"},{\"id\":385,\"tag\":\"x\"},{\"id\":386,\"tag\":\"x\"},{\"id\":387,\"tag\":\"x\"},{\"id\":388,\"tag\":\"x\"},{\"id\":389,\"tag\":\"x\"},{\"id\":390,\"tag\":\"x\"},{\"id\":391,\"tag\":\"x\"},{\"id\":392,\"tag\":\"x\"},{\"id\":393,\"tag\":\"x\"},{\"id\":394,\"tag\":\"x\"}]},\"small\":{\"result\":{\"count\":3,\"ok\":true}},\"str\":{\"result\":\"<head lines=\\\"7\\\">\\nNAMESPACE     APIVERSION   KIND   NAME                                                             READY   STATUS    RESTARTS   AGE    IP             NODE                                                  NOMINATED NODE   READINESS GATES   LABELS\\nkube-system   v1           Pod    calico-node-kxw8s                                                1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\\nkube-system   v1           Pod    calico-node-qjjtd                                                1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\\nkube-system   v1           Pod    calico-node-v5nmp                                                1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\\nkube-system   v1           Pod    calico-node-vertical-autoscaler-bbb8bfb74-r76x7                  1/1     Running   0          21h    192.168.1.5    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=calico-node-autoscaler,pod-template-hash=bbb8bfb74\\nkube-system   v1           Pod    calico-typha-5d84858687-2zhk7                                    1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=calico-typha,pod-template-hash=5d84858687\\nkube-system   v1           Pod    calico-typha-5d84858687-9bx5b                                    1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            k8s-app=calico-typha,pod-template-hash=5d84858687\\n</head>\\n<bulk-elided lines=\\\"27\\\">\\n27 lines elided\\n</bulk-elided>\\n<tail lines=\\\"7\\\">\\nkube-system   v1           Pod    netd-k9w4z                                                       3/3     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\\nkube-system   v1           Pod    netd-vgs2g                                                       3/3     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\\nkube-system   v1           Pod    netd-xxd4r                                                       3/3     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\\nkube-system   v1           Pod    pdcsi-node-5tr4q                                                 2/2     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\\nkube-system   v1           Pod    pdcsi-node-7z9zs                                                 2/2     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\\nkube-system   v1           Pod    pdcsi-node-lcxtr                                                 2/2     Running   0          21h    10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\\nkube-system   v1           Pod    runsc-metric-server-qr24t                                        1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=6b657887d,k8s-app=runsc-metric-server,pod-template-generation=2\\n</tail>\"}}\n</summary>\n<recovery>\n  <elided path=\"$.arr.result\" total-bytes=\"10391\" shown-bytes=\"8186\" total-items=\"500\" shown-items=\"395\">\n    tool_output_fetch(invocation_id=\"<uuid>\", path=\"$.arr.result\", query={\"len\":105,\"mode\":\"json_array_slice\",\"offset\":395})\n  </elided>\n  <elided path=\"$.str.result\" total-bytes=\"13051\" shown-bytes=\"4495\" total-lines=\"41\" shown-lines=\"14\">\n    tool_output_fetch(invocation_id=\"<uuid>\", path=\"$.str.result\", query={\"len\":27,\"mode\":\"lines\",\"offset\":7})\n  </elided>\n</recovery>\n",
-  "result_invocation_id": "<uuid>",
-  "sub_invocations": [
-    {
-      "args_digest": "fake_upstream_str-large-table({})",
-      "invocation_id": "<uuid>",
-      "kind": "lines",
-      "raw_size_bytes": 13051,
-      "seq": 0,
-      "summary_size_bytes": 8233,
-      "tool_name": "fake_upstream_str-large-table"
+  "_elided": {
+    "invocation_id": "<uuid>",
+    "paths": [
+      {
+        "path": "$.result.arr.result",
+        "recover": {
+          "args_template": {
+            "invocation_id": "<uuid>",
+            "path": "$.result.arr.result",
+            "query": {
+              "len": 105,
+              "mode": "json_array_slice",
+              "offset": 395
+            }
+          },
+          "tool": "tool_output_fetch"
+        },
+        "shown_bytes": 8186,
+        "shown_items": 395,
+        "total_bytes": 10391,
+        "total_items": 500
+      },
+      {
+        "path": "$.result.str.result",
+        "recover": {
+          "args_template": {
+            "invocation_id": "<uuid>",
+            "path": "$.result.str.result",
+            "query": {
+              "len": 28,
+              "mode": "lines",
+              "offset": 6
+            }
+          },
+          "tool": "tool_output_fetch"
+        },
+        "shown_bytes": 4206,
+        "shown_lines": 13,
+        "total_bytes": 13051,
+        "total_lines": 41
+      }
+    ]
+  },
+  "result": {
+    "console": [],
+    "execution_time_ms": "<ms>",
+    "fetch_hint": "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated `<summary>+<recovery>` envelope you'd have seen calling that tool directly.",
+    "result": {
+      "arr": {
+        "result": [
+          {
+            "id": 0,
+            "tag": "x"
+          },
+          {
+            "id": 1,
+            "tag": "x"
+          },
+          {
+            "id": 2,
+            "tag": "x"
+          },
+          {
+            "id": 3,
+            "tag": "x"
+          },
+          {
+            "id": 4,
+            "tag": "x"
+          },
+          {
+            "id": 5,
+            "tag": "x"
+          },
+          {
+            "id": 6,
+            "tag": "x"
+          },
+          {
+            "id": 7,
+            "tag": "x"
+          },
+          {
+            "id": 8,
+            "tag": "x"
+          },
+          {
+            "id": 9,
+            "tag": "x"
+          },
+          {
+            "id": 10,
+            "tag": "x"
+          },
+          {
+            "id": 11,
+            "tag": "x"
+          },
+          {
+            "id": 12,
+            "tag": "x"
+          },
+          {
+            "id": 13,
+            "tag": "x"
+          },
+          {
+            "id": 14,
+            "tag": "x"
+          },
+          {
+            "id": 15,
+            "tag": "x"
+          },
+          {
+            "id": 16,
+            "tag": "x"
+          },
+          {
+            "id": 17,
+            "tag": "x"
+          },
+          {
+            "id": 18,
+            "tag": "x"
+          },
+          {
+            "id": 19,
+            "tag": "x"
+          },
+          {
+            "id": 20,
+            "tag": "x"
+          },
+          {
+            "id": 21,
+            "tag": "x"
+          },
+          {
+            "id": 22,
+            "tag": "x"
+          },
+          {
+            "id": 23,
+            "tag": "x"
+          },
+          {
+            "id": 24,
+            "tag": "x"
+          },
+          {
+            "id": 25,
+            "tag": "x"
+          },
+          {
+            "id": 26,
+            "tag": "x"
+          },
+          {
+            "id": 27,
+            "tag": "x"
+          },
+          {
+            "id": 28,
+            "tag": "x"
+          },
+          {
+            "id": 29,
+            "tag": "x"
+          },
+          {
+            "id": 30,
+            "tag": "x"
+          },
+          {
+            "id": 31,
+            "tag": "x"
+          },
+          {
+            "id": 32,
+            "tag": "x"
+          },
+          {
+            "id": 33,
+            "tag": "x"
+          },
+          {
+            "id": 34,
+            "tag": "x"
+          },
+          {
+            "id": 35,
+            "tag": "x"
+          },
+          {
+            "id": 36,
+            "tag": "x"
+          },
+          {
+            "id": 37,
+            "tag": "x"
+          },
+          {
+            "id": 38,
+            "tag": "x"
+          },
+          {
+            "id": 39,
+            "tag": "x"
+          },
+          {
+            "id": 40,
+            "tag": "x"
+          },
+          {
+            "id": 41,
+            "tag": "x"
+          },
+          {
+            "id": 42,
+            "tag": "x"
+          },
+          {
+            "id": 43,
+            "tag": "x"
+          },
+          {
+            "id": 44,
+            "tag": "x"
+          },
+          {
+            "id": 45,
+            "tag": "x"
+          },
+          {
+            "id": 46,
+            "tag": "x"
+          },
+          {
+            "id": 47,
+            "tag": "x"
+          },
+          {
+            "id": 48,
+            "tag": "x"
+          },
+          {
+            "id": 49,
+            "tag": "x"
+          },
+          {
+            "id": 50,
+            "tag": "x"
+          },
+          {
+            "id": 51,
+            "tag": "x"
+          },
+          {
+            "id": 52,
+            "tag": "x"
+          },
+          {
+            "id": 53,
+            "tag": "x"
+          },
+          {
+            "id": 54,
+            "tag": "x"
+          },
+          {
+            "id": 55,
+            "tag": "x"
+          },
+          {
+            "id": 56,
+            "tag": "x"
+          },
+          {
+            "id": 57,
+            "tag": "x"
+          },
+          {
+            "id": 58,
+            "tag": "x"
+          },
+          {
+            "id": 59,
+            "tag": "x"
+          },
+          {
+            "id": 60,
+            "tag": "x"
+          },
+          {
+            "id": 61,
+            "tag": "x"
+          },
+          {
+            "id": 62,
+            "tag": "x"
+          },
+          {
+            "id": 63,
+            "tag": "x"
+          },
+          {
+            "id": 64,
+            "tag": "x"
+          },
+          {
+            "id": 65,
+            "tag": "x"
+          },
+          {
+            "id": 66,
+            "tag": "x"
+          },
+          {
+            "id": 67,
+            "tag": "x"
+          },
+          {
+            "id": 68,
+            "tag": "x"
+          },
+          {
+            "id": 69,
+            "tag": "x"
+          },
+          {
+            "id": 70,
+            "tag": "x"
+          },
+          {
+            "id": 71,
+            "tag": "x"
+          },
+          {
+            "id": 72,
+            "tag": "x"
+          },
+          {
+            "id": 73,
+            "tag": "x"
+          },
+          {
+            "id": 74,
+            "tag": "x"
+          },
+          {
+            "id": 75,
+            "tag": "x"
+          },
+          {
+            "id": 76,
+            "tag": "x"
+          },
+          {
+            "id": 77,
+            "tag": "x"
+          },
+          {
+            "id": 78,
+            "tag": "x"
+          },
+          {
+            "id": 79,
+            "tag": "x"
+          },
+          {
+            "id": 80,
+            "tag": "x"
+          },
+          {
+            "id": 81,
+            "tag": "x"
+          },
+          {
+            "id": 82,
+            "tag": "x"
+          },
+          {
+            "id": 83,
+            "tag": "x"
+          },
+          {
+            "id": 84,
+            "tag": "x"
+          },
+          {
+            "id": 85,
+            "tag": "x"
+          },
+          {
+            "id": 86,
+            "tag": "x"
+          },
+          {
+            "id": 87,
+            "tag": "x"
+          },
+          {
+            "id": 88,
+            "tag": "x"
+          },
+          {
+            "id": 89,
+            "tag": "x"
+          },
+          {
+            "id": 90,
+            "tag": "x"
+          },
+          {
+            "id": 91,
+            "tag": "x"
+          },
+          {
+            "id": 92,
+            "tag": "x"
+          },
+          {
+            "id": 93,
+            "tag": "x"
+          },
+          {
+            "id": 94,
+            "tag": "x"
+          },
+          {
+            "id": 95,
+            "tag": "x"
+          },
+          {
+            "id": 96,
+            "tag": "x"
+          },
+          {
+            "id": 97,
+            "tag": "x"
+          },
+          {
+            "id": 98,
+            "tag": "x"
+          },
+          {
+            "id": 99,
+            "tag": "x"
+          },
+          {
+            "id": 100,
+            "tag": "x"
+          },
+          {
+            "id": 101,
+            "tag": "x"
+          },
+          {
+            "id": 102,
+            "tag": "x"
+          },
+          {
+            "id": 103,
+            "tag": "x"
+          },
+          {
+            "id": 104,
+            "tag": "x"
+          },
+          {
+            "id": 105,
+            "tag": "x"
+          },
+          {
+            "id": 106,
+            "tag": "x"
+          },
+          {
+            "id": 107,
+            "tag": "x"
+          },
+          {
+            "id": 108,
+            "tag": "x"
+          },
+          {
+            "id": 109,
+            "tag": "x"
+          },
+          {
+            "id": 110,
+            "tag": "x"
+          },
+          {
+            "id": 111,
+            "tag": "x"
+          },
+          {
+            "id": 112,
+            "tag": "x"
+          },
+          {
+            "id": 113,
+            "tag": "x"
+          },
+          {
+            "id": 114,
+            "tag": "x"
+          },
+          {
+            "id": 115,
+            "tag": "x"
+          },
+          {
+            "id": 116,
+            "tag": "x"
+          },
+          {
+            "id": 117,
+            "tag": "x"
+          },
+          {
+            "id": 118,
+            "tag": "x"
+          },
+          {
+            "id": 119,
+            "tag": "x"
+          },
+          {
+            "id": 120,
+            "tag": "x"
+          },
+          {
+            "id": 121,
+            "tag": "x"
+          },
+          {
+            "id": 122,
+            "tag": "x"
+          },
+          {
+            "id": 123,
+            "tag": "x"
+          },
+          {
+            "id": 124,
+            "tag": "x"
+          },
+          {
+            "id": 125,
+            "tag": "x"
+          },
+          {
+            "id": 126,
+            "tag": "x"
+          },
+          {
+            "id": 127,
+            "tag": "x"
+          },
+          {
+            "id": 128,
+            "tag": "x"
+          },
+          {
+            "id": 129,
+            "tag": "x"
+          },
+          {
+            "id": 130,
+            "tag": "x"
+          },
+          {
+            "id": 131,
+            "tag": "x"
+          },
+          {
+            "id": 132,
+            "tag": "x"
+          },
+          {
+            "id": 133,
+            "tag": "x"
+          },
+          {
+            "id": 134,
+            "tag": "x"
+          },
+          {
+            "id": 135,
+            "tag": "x"
+          },
+          {
+            "id": 136,
+            "tag": "x"
+          },
+          {
+            "id": 137,
+            "tag": "x"
+          },
+          {
+            "id": 138,
+            "tag": "x"
+          },
+          {
+            "id": 139,
+            "tag": "x"
+          },
+          {
+            "id": 140,
+            "tag": "x"
+          },
+          {
+            "id": 141,
+            "tag": "x"
+          },
+          {
+            "id": 142,
+            "tag": "x"
+          },
+          {
+            "id": 143,
+            "tag": "x"
+          },
+          {
+            "id": 144,
+            "tag": "x"
+          },
+          {
+            "id": 145,
+            "tag": "x"
+          },
+          {
+            "id": 146,
+            "tag": "x"
+          },
+          {
+            "id": 147,
+            "tag": "x"
+          },
+          {
+            "id": 148,
+            "tag": "x"
+          },
+          {
+            "id": 149,
+            "tag": "x"
+          },
+          {
+            "id": 150,
+            "tag": "x"
+          },
+          {
+            "id": 151,
+            "tag": "x"
+          },
+          {
+            "id": 152,
+            "tag": "x"
+          },
+          {
+            "id": 153,
+            "tag": "x"
+          },
+          {
+            "id": 154,
+            "tag": "x"
+          },
+          {
+            "id": 155,
+            "tag": "x"
+          },
+          {
+            "id": 156,
+            "tag": "x"
+          },
+          {
+            "id": 157,
+            "tag": "x"
+          },
+          {
+            "id": 158,
+            "tag": "x"
+          },
+          {
+            "id": 159,
+            "tag": "x"
+          },
+          {
+            "id": 160,
+            "tag": "x"
+          },
+          {
+            "id": 161,
+            "tag": "x"
+          },
+          {
+            "id": 162,
+            "tag": "x"
+          },
+          {
+            "id": 163,
+            "tag": "x"
+          },
+          {
+            "id": 164,
+            "tag": "x"
+          },
+          {
+            "id": 165,
+            "tag": "x"
+          },
+          {
+            "id": 166,
+            "tag": "x"
+          },
+          {
+            "id": 167,
+            "tag": "x"
+          },
+          {
+            "id": 168,
+            "tag": "x"
+          },
+          {
+            "id": 169,
+            "tag": "x"
+          },
+          {
+            "id": 170,
+            "tag": "x"
+          },
+          {
+            "id": 171,
+            "tag": "x"
+          },
+          {
+            "id": 172,
+            "tag": "x"
+          },
+          {
+            "id": 173,
+            "tag": "x"
+          },
+          {
+            "id": 174,
+            "tag": "x"
+          },
+          {
+            "id": 175,
+            "tag": "x"
+          },
+          {
+            "id": 176,
+            "tag": "x"
+          },
+          {
+            "id": 177,
+            "tag": "x"
+          },
+          {
+            "id": 178,
+            "tag": "x"
+          },
+          {
+            "id": 179,
+            "tag": "x"
+          },
+          {
+            "id": 180,
+            "tag": "x"
+          },
+          {
+            "id": 181,
+            "tag": "x"
+          },
+          {
+            "id": 182,
+            "tag": "x"
+          },
+          {
+            "id": 183,
+            "tag": "x"
+          },
+          {
+            "id": 184,
+            "tag": "x"
+          },
+          {
+            "id": 185,
+            "tag": "x"
+          },
+          {
+            "id": 186,
+            "tag": "x"
+          },
+          {
+            "id": 187,
+            "tag": "x"
+          },
+          {
+            "id": 188,
+            "tag": "x"
+          },
+          {
+            "id": 189,
+            "tag": "x"
+          },
+          {
+            "id": 190,
+            "tag": "x"
+          },
+          {
+            "id": 191,
+            "tag": "x"
+          },
+          {
+            "id": 192,
+            "tag": "x"
+          },
+          {
+            "id": 193,
+            "tag": "x"
+          },
+          {
+            "id": 194,
+            "tag": "x"
+          },
+          {
+            "id": 195,
+            "tag": "x"
+          },
+          {
+            "id": 196,
+            "tag": "x"
+          },
+          {
+            "id": 197,
+            "tag": "x"
+          },
+          {
+            "id": 198,
+            "tag": "x"
+          },
+          {
+            "id": 199,
+            "tag": "x"
+          },
+          {
+            "id": 200,
+            "tag": "x"
+          },
+          {
+            "id": 201,
+            "tag": "x"
+          },
+          {
+            "id": 202,
+            "tag": "x"
+          },
+          {
+            "id": 203,
+            "tag": "x"
+          },
+          {
+            "id": 204,
+            "tag": "x"
+          },
+          {
+            "id": 205,
+            "tag": "x"
+          },
+          {
+            "id": 206,
+            "tag": "x"
+          },
+          {
+            "id": 207,
+            "tag": "x"
+          },
+          {
+            "id": 208,
+            "tag": "x"
+          },
+          {
+            "id": 209,
+            "tag": "x"
+          },
+          {
+            "id": 210,
+            "tag": "x"
+          },
+          {
+            "id": 211,
+            "tag": "x"
+          },
+          {
+            "id": 212,
+            "tag": "x"
+          },
+          {
+            "id": 213,
+            "tag": "x"
+          },
+          {
+            "id": 214,
+            "tag": "x"
+          },
+          {
+            "id": 215,
+            "tag": "x"
+          },
+          {
+            "id": 216,
+            "tag": "x"
+          },
+          {
+            "id": 217,
+            "tag": "x"
+          },
+          {
+            "id": 218,
+            "tag": "x"
+          },
+          {
+            "id": 219,
+            "tag": "x"
+          },
+          {
+            "id": 220,
+            "tag": "x"
+          },
+          {
+            "id": 221,
+            "tag": "x"
+          },
+          {
+            "id": 222,
+            "tag": "x"
+          },
+          {
+            "id": 223,
+            "tag": "x"
+          },
+          {
+            "id": 224,
+            "tag": "x"
+          },
+          {
+            "id": 225,
+            "tag": "x"
+          },
+          {
+            "id": 226,
+            "tag": "x"
+          },
+          {
+            "id": 227,
+            "tag": "x"
+          },
+          {
+            "id": 228,
+            "tag": "x"
+          },
+          {
+            "id": 229,
+            "tag": "x"
+          },
+          {
+            "id": 230,
+            "tag": "x"
+          },
+          {
+            "id": 231,
+            "tag": "x"
+          },
+          {
+            "id": 232,
+            "tag": "x"
+          },
+          {
+            "id": 233,
+            "tag": "x"
+          },
+          {
+            "id": 234,
+            "tag": "x"
+          },
+          {
+            "id": 235,
+            "tag": "x"
+          },
+          {
+            "id": 236,
+            "tag": "x"
+          },
+          {
+            "id": 237,
+            "tag": "x"
+          },
+          {
+            "id": 238,
+            "tag": "x"
+          },
+          {
+            "id": 239,
+            "tag": "x"
+          },
+          {
+            "id": 240,
+            "tag": "x"
+          },
+          {
+            "id": 241,
+            "tag": "x"
+          },
+          {
+            "id": 242,
+            "tag": "x"
+          },
+          {
+            "id": 243,
+            "tag": "x"
+          },
+          {
+            "id": 244,
+            "tag": "x"
+          },
+          {
+            "id": 245,
+            "tag": "x"
+          },
+          {
+            "id": 246,
+            "tag": "x"
+          },
+          {
+            "id": 247,
+            "tag": "x"
+          },
+          {
+            "id": 248,
+            "tag": "x"
+          },
+          {
+            "id": 249,
+            "tag": "x"
+          },
+          {
+            "id": 250,
+            "tag": "x"
+          },
+          {
+            "id": 251,
+            "tag": "x"
+          },
+          {
+            "id": 252,
+            "tag": "x"
+          },
+          {
+            "id": 253,
+            "tag": "x"
+          },
+          {
+            "id": 254,
+            "tag": "x"
+          },
+          {
+            "id": 255,
+            "tag": "x"
+          },
+          {
+            "id": 256,
+            "tag": "x"
+          },
+          {
+            "id": 257,
+            "tag": "x"
+          },
+          {
+            "id": 258,
+            "tag": "x"
+          },
+          {
+            "id": 259,
+            "tag": "x"
+          },
+          {
+            "id": 260,
+            "tag": "x"
+          },
+          {
+            "id": 261,
+            "tag": "x"
+          },
+          {
+            "id": 262,
+            "tag": "x"
+          },
+          {
+            "id": 263,
+            "tag": "x"
+          },
+          {
+            "id": 264,
+            "tag": "x"
+          },
+          {
+            "id": 265,
+            "tag": "x"
+          },
+          {
+            "id": 266,
+            "tag": "x"
+          },
+          {
+            "id": 267,
+            "tag": "x"
+          },
+          {
+            "id": 268,
+            "tag": "x"
+          },
+          {
+            "id": 269,
+            "tag": "x"
+          },
+          {
+            "id": 270,
+            "tag": "x"
+          },
+          {
+            "id": 271,
+            "tag": "x"
+          },
+          {
+            "id": 272,
+            "tag": "x"
+          },
+          {
+            "id": 273,
+            "tag": "x"
+          },
+          {
+            "id": 274,
+            "tag": "x"
+          },
+          {
+            "id": 275,
+            "tag": "x"
+          },
+          {
+            "id": 276,
+            "tag": "x"
+          },
+          {
+            "id": 277,
+            "tag": "x"
+          },
+          {
+            "id": 278,
+            "tag": "x"
+          },
+          {
+            "id": 279,
+            "tag": "x"
+          },
+          {
+            "id": 280,
+            "tag": "x"
+          },
+          {
+            "id": 281,
+            "tag": "x"
+          },
+          {
+            "id": 282,
+            "tag": "x"
+          },
+          {
+            "id": 283,
+            "tag": "x"
+          },
+          {
+            "id": 284,
+            "tag": "x"
+          },
+          {
+            "id": 285,
+            "tag": "x"
+          },
+          {
+            "id": 286,
+            "tag": "x"
+          },
+          {
+            "id": 287,
+            "tag": "x"
+          },
+          {
+            "id": 288,
+            "tag": "x"
+          },
+          {
+            "id": 289,
+            "tag": "x"
+          },
+          {
+            "id": 290,
+            "tag": "x"
+          },
+          {
+            "id": 291,
+            "tag": "x"
+          },
+          {
+            "id": 292,
+            "tag": "x"
+          },
+          {
+            "id": 293,
+            "tag": "x"
+          },
+          {
+            "id": 294,
+            "tag": "x"
+          },
+          {
+            "id": 295,
+            "tag": "x"
+          },
+          {
+            "id": 296,
+            "tag": "x"
+          },
+          {
+            "id": 297,
+            "tag": "x"
+          },
+          {
+            "id": 298,
+            "tag": "x"
+          },
+          {
+            "id": 299,
+            "tag": "x"
+          },
+          {
+            "id": 300,
+            "tag": "x"
+          },
+          {
+            "id": 301,
+            "tag": "x"
+          },
+          {
+            "id": 302,
+            "tag": "x"
+          },
+          {
+            "id": 303,
+            "tag": "x"
+          },
+          {
+            "id": 304,
+            "tag": "x"
+          },
+          {
+            "id": 305,
+            "tag": "x"
+          },
+          {
+            "id": 306,
+            "tag": "x"
+          },
+          {
+            "id": 307,
+            "tag": "x"
+          },
+          {
+            "id": 308,
+            "tag": "x"
+          },
+          {
+            "id": 309,
+            "tag": "x"
+          },
+          {
+            "id": 310,
+            "tag": "x"
+          },
+          {
+            "id": 311,
+            "tag": "x"
+          },
+          {
+            "id": 312,
+            "tag": "x"
+          },
+          {
+            "id": 313,
+            "tag": "x"
+          },
+          {
+            "id": 314,
+            "tag": "x"
+          },
+          {
+            "id": 315,
+            "tag": "x"
+          },
+          {
+            "id": 316,
+            "tag": "x"
+          },
+          {
+            "id": 317,
+            "tag": "x"
+          },
+          {
+            "id": 318,
+            "tag": "x"
+          },
+          {
+            "id": 319,
+            "tag": "x"
+          },
+          {
+            "id": 320,
+            "tag": "x"
+          },
+          {
+            "id": 321,
+            "tag": "x"
+          },
+          {
+            "id": 322,
+            "tag": "x"
+          },
+          {
+            "id": 323,
+            "tag": "x"
+          },
+          {
+            "id": 324,
+            "tag": "x"
+          },
+          {
+            "id": 325,
+            "tag": "x"
+          },
+          {
+            "id": 326,
+            "tag": "x"
+          },
+          {
+            "id": 327,
+            "tag": "x"
+          },
+          {
+            "id": 328,
+            "tag": "x"
+          },
+          {
+            "id": 329,
+            "tag": "x"
+          },
+          {
+            "id": 330,
+            "tag": "x"
+          },
+          {
+            "id": 331,
+            "tag": "x"
+          },
+          {
+            "id": 332,
+            "tag": "x"
+          },
+          {
+            "id": 333,
+            "tag": "x"
+          },
+          {
+            "id": 334,
+            "tag": "x"
+          },
+          {
+            "id": 335,
+            "tag": "x"
+          },
+          {
+            "id": 336,
+            "tag": "x"
+          },
+          {
+            "id": 337,
+            "tag": "x"
+          },
+          {
+            "id": 338,
+            "tag": "x"
+          },
+          {
+            "id": 339,
+            "tag": "x"
+          },
+          {
+            "id": 340,
+            "tag": "x"
+          },
+          {
+            "id": 341,
+            "tag": "x"
+          },
+          {
+            "id": 342,
+            "tag": "x"
+          },
+          {
+            "id": 343,
+            "tag": "x"
+          },
+          {
+            "id": 344,
+            "tag": "x"
+          },
+          {
+            "id": 345,
+            "tag": "x"
+          },
+          {
+            "id": 346,
+            "tag": "x"
+          },
+          {
+            "id": 347,
+            "tag": "x"
+          },
+          {
+            "id": 348,
+            "tag": "x"
+          },
+          {
+            "id": 349,
+            "tag": "x"
+          },
+          {
+            "id": 350,
+            "tag": "x"
+          },
+          {
+            "id": 351,
+            "tag": "x"
+          },
+          {
+            "id": 352,
+            "tag": "x"
+          },
+          {
+            "id": 353,
+            "tag": "x"
+          },
+          {
+            "id": 354,
+            "tag": "x"
+          },
+          {
+            "id": 355,
+            "tag": "x"
+          },
+          {
+            "id": 356,
+            "tag": "x"
+          },
+          {
+            "id": 357,
+            "tag": "x"
+          },
+          {
+            "id": 358,
+            "tag": "x"
+          },
+          {
+            "id": 359,
+            "tag": "x"
+          },
+          {
+            "id": 360,
+            "tag": "x"
+          },
+          {
+            "id": 361,
+            "tag": "x"
+          },
+          {
+            "id": 362,
+            "tag": "x"
+          },
+          {
+            "id": 363,
+            "tag": "x"
+          },
+          {
+            "id": 364,
+            "tag": "x"
+          },
+          {
+            "id": 365,
+            "tag": "x"
+          },
+          {
+            "id": 366,
+            "tag": "x"
+          },
+          {
+            "id": 367,
+            "tag": "x"
+          },
+          {
+            "id": 368,
+            "tag": "x"
+          },
+          {
+            "id": 369,
+            "tag": "x"
+          },
+          {
+            "id": 370,
+            "tag": "x"
+          },
+          {
+            "id": 371,
+            "tag": "x"
+          },
+          {
+            "id": 372,
+            "tag": "x"
+          },
+          {
+            "id": 373,
+            "tag": "x"
+          },
+          {
+            "id": 374,
+            "tag": "x"
+          },
+          {
+            "id": 375,
+            "tag": "x"
+          },
+          {
+            "id": 376,
+            "tag": "x"
+          },
+          {
+            "id": 377,
+            "tag": "x"
+          },
+          {
+            "id": 378,
+            "tag": "x"
+          },
+          {
+            "id": 379,
+            "tag": "x"
+          },
+          {
+            "id": 380,
+            "tag": "x"
+          },
+          {
+            "id": 381,
+            "tag": "x"
+          },
+          {
+            "id": 382,
+            "tag": "x"
+          },
+          {
+            "id": 383,
+            "tag": "x"
+          },
+          {
+            "id": 384,
+            "tag": "x"
+          },
+          {
+            "id": 385,
+            "tag": "x"
+          },
+          {
+            "id": 386,
+            "tag": "x"
+          },
+          {
+            "id": 387,
+            "tag": "x"
+          },
+          {
+            "id": 388,
+            "tag": "x"
+          },
+          {
+            "id": 389,
+            "tag": "x"
+          },
+          {
+            "id": 390,
+            "tag": "x"
+          },
+          {
+            "id": 391,
+            "tag": "x"
+          },
+          {
+            "id": 392,
+            "tag": "x"
+          },
+          {
+            "id": 393,
+            "tag": "x"
+          },
+          {
+            "id": 394,
+            "tag": "x"
+          }
+        ]
+      },
+      "small": {
+        "result": {
+          "count": 3,
+          "ok": true
+        }
+      },
+      "str": {
+        "result": "<head lines=\"6\">\nNAMESPACE     APIVERSION   KIND   NAME                                                             READY   STATUS    RESTARTS   AGE    IP             NODE                                                  NOMINATED NODE   READINESS GATES   LABELS\nkube-system   v1           Pod    calico-node-kxw8s                                                1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-qjjtd                                                1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-v5nmp                                                1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-vertical-autoscaler-bbb8bfb74-r76x7                  1/1     Running   0          21h    192.168.1.5    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=calico-node-autoscaler,pod-template-hash=bbb8bfb74\nkube-system   v1           Pod    calico-typha-5d84858687-2zhk7                                    1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=calico-typha,pod-template-hash=5d84858687\n</head>\n<bulk-elided lines=\"28\">\n28 lines elided\n</bulk-elided>\n<tail lines=\"7\">\nkube-system   v1           Pod    netd-k9w4z                                                       3/3     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    netd-vgs2g                                                       3/3     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    netd-xxd4r                                                       3/3     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    pdcsi-node-5tr4q                                                 2/2     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    pdcsi-node-7z9zs                                                 2/2     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    pdcsi-node-lcxtr                                                 2/2     Running   0          21h    10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    runsc-metric-server-qr24t                                        1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=6b657887d,k8s-app=runsc-metric-server,pod-template-generation=2\n</tail>"
+      }
     },
-    {
-      "args_digest": "fake_upstream_arr-large-passthrough-items({})",
-      "invocation_id": "<uuid>",
-      "kind": "json_array_slice",
-      "raw_size_bytes": 10391,
-      "seq": 1,
-      "summary_size_bytes": 8566,
-      "tool_name": "fake_upstream_arr-large-passthrough-items"
-    }
-  ],
-  "tool_calls": 3
+    "sub_invocations": [
+      {
+        "args_digest": "fake_upstream_str-large-table({})",
+        "invocation_id": "<uuid>",
+        "kind": "lines",
+        "raw_size_bytes": 13051,
+        "seq": 0,
+        "tool_name": "fake_upstream_str-large-table"
+      },
+      {
+        "args_digest": "fake_upstream_arr-large-passthrough-items({})",
+        "invocation_id": "<uuid>",
+        "kind": "json_array_slice",
+        "raw_size_bytes": 10391,
+        "seq": 1,
+        "tool_name": "fake_upstream_arr-large-passthrough-items"
+      }
+    ],
+    "tool_calls": 3
+  }
 }

--- a/bats/summarized-tool-responses/compose-roundtrip-2.json
+++ b/bats/summarized-tool-responses/compose-roundtrip-2.json
@@ -1,448 +1,450 @@
 {
-  "console": [],
-  "execution_time_ms": "<ms>",
-  "fetch_hint": "invocation_id is either `result_invocation_id` (full JS return) or any `sub_invocations[].invocation_id` (specific sub-call's persisted output) — see `tool_output_fetch` for the full call shape.",
   "result": {
-    "arr_slice": [
-      {
-        "id": 195,
-        "tag": "x"
-      },
-      {
-        "id": 196,
-        "tag": "x"
-      },
-      {
-        "id": 197,
-        "tag": "x"
-      },
-      {
-        "id": 198,
-        "tag": "x"
-      },
-      {
-        "id": 199,
-        "tag": "x"
-      },
-      {
-        "id": 200,
-        "tag": "x"
-      },
-      {
-        "id": 201,
-        "tag": "x"
-      },
-      {
-        "id": 202,
-        "tag": "x"
-      },
-      {
-        "id": 203,
-        "tag": "x"
-      },
-      {
-        "id": 204,
-        "tag": "x"
-      },
-      {
-        "id": 205,
-        "tag": "x"
-      },
-      {
-        "id": 206,
-        "tag": "x"
-      },
-      {
-        "id": 207,
-        "tag": "x"
-      },
-      {
-        "id": 208,
-        "tag": "x"
-      },
-      {
-        "id": 209,
-        "tag": "x"
-      },
-      {
-        "id": 210,
-        "tag": "x"
-      },
-      {
-        "id": 211,
-        "tag": "x"
-      },
-      {
-        "id": 212,
-        "tag": "x"
-      },
-      {
-        "id": 213,
-        "tag": "x"
-      },
-      {
-        "id": 214,
-        "tag": "x"
-      },
-      {
-        "id": 215,
-        "tag": "x"
-      },
-      {
-        "id": 216,
-        "tag": "x"
-      },
-      {
-        "id": 217,
-        "tag": "x"
-      },
-      {
-        "id": 218,
-        "tag": "x"
-      },
-      {
-        "id": 219,
-        "tag": "x"
-      },
-      {
-        "id": 220,
-        "tag": "x"
-      },
-      {
-        "id": 221,
-        "tag": "x"
-      },
-      {
-        "id": 222,
-        "tag": "x"
-      },
-      {
-        "id": 223,
-        "tag": "x"
-      },
-      {
-        "id": 224,
-        "tag": "x"
-      },
-      {
-        "id": 225,
-        "tag": "x"
-      },
-      {
-        "id": 226,
-        "tag": "x"
-      },
-      {
-        "id": 227,
-        "tag": "x"
-      },
-      {
-        "id": 228,
-        "tag": "x"
-      },
-      {
-        "id": 229,
-        "tag": "x"
-      },
-      {
-        "id": 230,
-        "tag": "x"
-      },
-      {
-        "id": 231,
-        "tag": "x"
-      },
-      {
-        "id": 232,
-        "tag": "x"
-      },
-      {
-        "id": 233,
-        "tag": "x"
-      },
-      {
-        "id": 234,
-        "tag": "x"
-      },
-      {
-        "id": 235,
-        "tag": "x"
-      },
-      {
-        "id": 236,
-        "tag": "x"
-      },
-      {
-        "id": 237,
-        "tag": "x"
-      },
-      {
-        "id": 238,
-        "tag": "x"
-      },
-      {
-        "id": 239,
-        "tag": "x"
-      },
-      {
-        "id": 240,
-        "tag": "x"
-      },
-      {
-        "id": 241,
-        "tag": "x"
-      },
-      {
-        "id": 242,
-        "tag": "x"
-      },
-      {
-        "id": 243,
-        "tag": "x"
-      },
-      {
-        "id": 244,
-        "tag": "x"
-      },
-      {
-        "id": 245,
-        "tag": "x"
-      },
-      {
-        "id": 246,
-        "tag": "x"
-      },
-      {
-        "id": 247,
-        "tag": "x"
-      },
-      {
-        "id": 248,
-        "tag": "x"
-      },
-      {
-        "id": 249,
-        "tag": "x"
-      },
-      {
-        "id": 250,
-        "tag": "x"
-      },
-      {
-        "id": 251,
-        "tag": "x"
-      },
-      {
-        "id": 252,
-        "tag": "x"
-      },
-      {
-        "id": 253,
-        "tag": "x"
-      },
-      {
-        "id": 254,
-        "tag": "x"
-      },
-      {
-        "id": 255,
-        "tag": "x"
-      },
-      {
-        "id": 256,
-        "tag": "x"
-      },
-      {
-        "id": 257,
-        "tag": "x"
-      },
-      {
-        "id": 258,
-        "tag": "x"
-      },
-      {
-        "id": 259,
-        "tag": "x"
-      },
-      {
-        "id": 260,
-        "tag": "x"
-      },
-      {
-        "id": 261,
-        "tag": "x"
-      },
-      {
-        "id": 262,
-        "tag": "x"
-      },
-      {
-        "id": 263,
-        "tag": "x"
-      },
-      {
-        "id": 264,
-        "tag": "x"
-      },
-      {
-        "id": 265,
-        "tag": "x"
-      },
-      {
-        "id": 266,
-        "tag": "x"
-      },
-      {
-        "id": 267,
-        "tag": "x"
-      },
-      {
-        "id": 268,
-        "tag": "x"
-      },
-      {
-        "id": 269,
-        "tag": "x"
-      },
-      {
-        "id": 270,
-        "tag": "x"
-      },
-      {
-        "id": 271,
-        "tag": "x"
-      },
-      {
-        "id": 272,
-        "tag": "x"
-      },
-      {
-        "id": 273,
-        "tag": "x"
-      },
-      {
-        "id": 274,
-        "tag": "x"
-      },
-      {
-        "id": 275,
-        "tag": "x"
-      },
-      {
-        "id": 276,
-        "tag": "x"
-      },
-      {
-        "id": 277,
-        "tag": "x"
-      },
-      {
-        "id": 278,
-        "tag": "x"
-      },
-      {
-        "id": 279,
-        "tag": "x"
-      },
-      {
-        "id": 280,
-        "tag": "x"
-      },
-      {
-        "id": 281,
-        "tag": "x"
-      },
-      {
-        "id": 282,
-        "tag": "x"
-      },
-      {
-        "id": 283,
-        "tag": "x"
-      },
-      {
-        "id": 284,
-        "tag": "x"
-      },
-      {
-        "id": 285,
-        "tag": "x"
-      },
-      {
-        "id": 286,
-        "tag": "x"
-      },
-      {
-        "id": 287,
-        "tag": "x"
-      },
-      {
-        "id": 288,
-        "tag": "x"
-      },
-      {
-        "id": 289,
-        "tag": "x"
-      },
-      {
-        "id": 290,
-        "tag": "x"
-      },
-      {
-        "id": 291,
-        "tag": "x"
-      },
-      {
-        "id": 292,
-        "tag": "x"
-      },
-      {
-        "id": 293,
-        "tag": "x"
-      },
-      {
-        "id": 294,
-        "tag": "x"
-      },
-      {
-        "id": 295,
-        "tag": "x"
-      },
-      {
-        "id": 296,
-        "tag": "x"
-      },
-      {
-        "id": 297,
-        "tag": "x"
-      },
-      {
-        "id": 298,
-        "tag": "x"
-      },
-      {
-        "id": 299,
-        "tag": "x"
-      },
-      {
-        "id": 300,
-        "tag": "x"
-      },
-      {
-        "id": 301,
-        "tag": "x"
-      },
-      {
-        "id": 302,
-        "tag": "x"
-      },
-      {
-        "id": 303,
-        "tag": "x"
-      }
-    ],
-    "str_slice": "kube-system   v1           Pod    fluentbit-gke-vdjth                                              3/3     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            component=fluentbit-gke,controller-revision-hash=55dd6c6454,k8s-app=fluentbit-gke,kubernetes.io/cluster-service=true,pod-template-generation=3\nkube-system   v1           Pod    gke-metadata-server-2djzv                                        1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            addonmanager.kubernetes.io/mode=Reconcile,controller-revision-hash=6dcfdfb77d,k8s-app=gke-metadata-server,pod-template-generation=2\nkube-system   v1           Pod    gke-metadata-server-dhlhp                                        1/1     Running   0          21h    10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            addonmanager.kubernetes.io/mode=Reconcile,controller-revision-hash=6dcfdfb77d,k8s-app=gke-metadata-server,pod-template-generation=2\nkube-system   v1           Pod    gke-metadata-server-kx2sb                                        1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            addonmanager.kubernetes.io/mode=Reconcile,controller-revision-hash=6dcfdfb77d,k8s-app=gke-metadata-server,pod-template-generation=2\nkube-system   v1           Pod    gke-metrics-agent-2p2xn                                          2/2     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            component=gke-metrics-agent,controller-revision-hash=5b595f7969,k8s-app=gke-metrics-agent,pod-template-generation=2\nkube-system   v1           Pod    gke-metrics-agent-kqq22                                          2/2     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            component=gke-metrics-agent,controller-revision-hash=5b595f7969,k8s-app=gke-metrics-agent,pod-template-generation=2\nkube-system   v1           Pod    gke-metrics-agent-nczml                                          2/2     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            component=gke-metrics-agent,controller-revision-hash=5b595f7969,k8s-app=gke-metrics-agent,pod-template-generation=2\nkube-system   v1           Pod    ip-masq-agent-4r6cf                                              1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=7cbdb6bd86,k8s-app=ip-masq-agent,pod-template-generation=3\nkube-system   v1           Pod    ip-masq-agent-nj4qv                                              1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=7cbdb6bd86,k8s-app=ip-masq-agent,pod-template-generation=3\nkube-system   v1           Pod    ip-masq-agent-svtk6                                              1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=7cbdb6bd86,k8s-app=ip-masq-agent,pod-template-generation=3\nkube-system   v1           Pod    konnectivity-agent-6857bb85bd-jr9sc                              2/2     Running   0          21h    192.168.1.8    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=konnectivity-agent,pod-template-hash=6857bb85bd\nkube-system   v1           Pod    konnectivity-agent-6857bb85bd-wjpw6                              2/2     Running   0          21h    192.168.0.8    gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            k8s-app=konnectivity-agent,pod-template-hash=6857bb85bd\nkube-system   v1           Pod    konnectivity-agent-6857bb85bd-x4ml9                              2/2     Running   0          21h    192.168.2.13   gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            k8s-app=konnectivity-agent,pod-template-hash=6857bb85bd\nkube-system   v1           Pod    konnectivity-agent-autoscaler-d67c74bb7-f6c29                    1/1     Running   0          21h    192.168.1.13   gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=konnectivity-agent-autoscaler,pod-template-hash=d67c74bb7\nkube-system   v1           Pod    kube-dns-6f8c46f48b-4nksr                                        4/4     Running   0          21h    192.168.2.14   gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            k8s-app=kube-dns,pod-template-hash=6f8c46f48b\nkube-system   v1           Pod    kube-dns-6f8c46f48b-jqvhn                                        4/4     Running   0          21h    192.168.1.7    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=kube-dns,pod-template-hash=6f8c46f48b"
-  },
-  "sub_invocations": [],
-  "tool_calls": 2
+    "console": [],
+    "execution_time_ms": "<ms>",
+    "fetch_hint": "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated `<summary>+<recovery>` envelope you'd have seen calling that tool directly.",
+    "result": {
+      "arr_slice": [
+        {
+          "id": 195,
+          "tag": "x"
+        },
+        {
+          "id": 196,
+          "tag": "x"
+        },
+        {
+          "id": 197,
+          "tag": "x"
+        },
+        {
+          "id": 198,
+          "tag": "x"
+        },
+        {
+          "id": 199,
+          "tag": "x"
+        },
+        {
+          "id": 200,
+          "tag": "x"
+        },
+        {
+          "id": 201,
+          "tag": "x"
+        },
+        {
+          "id": 202,
+          "tag": "x"
+        },
+        {
+          "id": 203,
+          "tag": "x"
+        },
+        {
+          "id": 204,
+          "tag": "x"
+        },
+        {
+          "id": 205,
+          "tag": "x"
+        },
+        {
+          "id": 206,
+          "tag": "x"
+        },
+        {
+          "id": 207,
+          "tag": "x"
+        },
+        {
+          "id": 208,
+          "tag": "x"
+        },
+        {
+          "id": 209,
+          "tag": "x"
+        },
+        {
+          "id": 210,
+          "tag": "x"
+        },
+        {
+          "id": 211,
+          "tag": "x"
+        },
+        {
+          "id": 212,
+          "tag": "x"
+        },
+        {
+          "id": 213,
+          "tag": "x"
+        },
+        {
+          "id": 214,
+          "tag": "x"
+        },
+        {
+          "id": 215,
+          "tag": "x"
+        },
+        {
+          "id": 216,
+          "tag": "x"
+        },
+        {
+          "id": 217,
+          "tag": "x"
+        },
+        {
+          "id": 218,
+          "tag": "x"
+        },
+        {
+          "id": 219,
+          "tag": "x"
+        },
+        {
+          "id": 220,
+          "tag": "x"
+        },
+        {
+          "id": 221,
+          "tag": "x"
+        },
+        {
+          "id": 222,
+          "tag": "x"
+        },
+        {
+          "id": 223,
+          "tag": "x"
+        },
+        {
+          "id": 224,
+          "tag": "x"
+        },
+        {
+          "id": 225,
+          "tag": "x"
+        },
+        {
+          "id": 226,
+          "tag": "x"
+        },
+        {
+          "id": 227,
+          "tag": "x"
+        },
+        {
+          "id": 228,
+          "tag": "x"
+        },
+        {
+          "id": 229,
+          "tag": "x"
+        },
+        {
+          "id": 230,
+          "tag": "x"
+        },
+        {
+          "id": 231,
+          "tag": "x"
+        },
+        {
+          "id": 232,
+          "tag": "x"
+        },
+        {
+          "id": 233,
+          "tag": "x"
+        },
+        {
+          "id": 234,
+          "tag": "x"
+        },
+        {
+          "id": 235,
+          "tag": "x"
+        },
+        {
+          "id": 236,
+          "tag": "x"
+        },
+        {
+          "id": 237,
+          "tag": "x"
+        },
+        {
+          "id": 238,
+          "tag": "x"
+        },
+        {
+          "id": 239,
+          "tag": "x"
+        },
+        {
+          "id": 240,
+          "tag": "x"
+        },
+        {
+          "id": 241,
+          "tag": "x"
+        },
+        {
+          "id": 242,
+          "tag": "x"
+        },
+        {
+          "id": 243,
+          "tag": "x"
+        },
+        {
+          "id": 244,
+          "tag": "x"
+        },
+        {
+          "id": 245,
+          "tag": "x"
+        },
+        {
+          "id": 246,
+          "tag": "x"
+        },
+        {
+          "id": 247,
+          "tag": "x"
+        },
+        {
+          "id": 248,
+          "tag": "x"
+        },
+        {
+          "id": 249,
+          "tag": "x"
+        },
+        {
+          "id": 250,
+          "tag": "x"
+        },
+        {
+          "id": 251,
+          "tag": "x"
+        },
+        {
+          "id": 252,
+          "tag": "x"
+        },
+        {
+          "id": 253,
+          "tag": "x"
+        },
+        {
+          "id": 254,
+          "tag": "x"
+        },
+        {
+          "id": 255,
+          "tag": "x"
+        },
+        {
+          "id": 256,
+          "tag": "x"
+        },
+        {
+          "id": 257,
+          "tag": "x"
+        },
+        {
+          "id": 258,
+          "tag": "x"
+        },
+        {
+          "id": 259,
+          "tag": "x"
+        },
+        {
+          "id": 260,
+          "tag": "x"
+        },
+        {
+          "id": 261,
+          "tag": "x"
+        },
+        {
+          "id": 262,
+          "tag": "x"
+        },
+        {
+          "id": 263,
+          "tag": "x"
+        },
+        {
+          "id": 264,
+          "tag": "x"
+        },
+        {
+          "id": 265,
+          "tag": "x"
+        },
+        {
+          "id": 266,
+          "tag": "x"
+        },
+        {
+          "id": 267,
+          "tag": "x"
+        },
+        {
+          "id": 268,
+          "tag": "x"
+        },
+        {
+          "id": 269,
+          "tag": "x"
+        },
+        {
+          "id": 270,
+          "tag": "x"
+        },
+        {
+          "id": 271,
+          "tag": "x"
+        },
+        {
+          "id": 272,
+          "tag": "x"
+        },
+        {
+          "id": 273,
+          "tag": "x"
+        },
+        {
+          "id": 274,
+          "tag": "x"
+        },
+        {
+          "id": 275,
+          "tag": "x"
+        },
+        {
+          "id": 276,
+          "tag": "x"
+        },
+        {
+          "id": 277,
+          "tag": "x"
+        },
+        {
+          "id": 278,
+          "tag": "x"
+        },
+        {
+          "id": 279,
+          "tag": "x"
+        },
+        {
+          "id": 280,
+          "tag": "x"
+        },
+        {
+          "id": 281,
+          "tag": "x"
+        },
+        {
+          "id": 282,
+          "tag": "x"
+        },
+        {
+          "id": 283,
+          "tag": "x"
+        },
+        {
+          "id": 284,
+          "tag": "x"
+        },
+        {
+          "id": 285,
+          "tag": "x"
+        },
+        {
+          "id": 286,
+          "tag": "x"
+        },
+        {
+          "id": 287,
+          "tag": "x"
+        },
+        {
+          "id": 288,
+          "tag": "x"
+        },
+        {
+          "id": 289,
+          "tag": "x"
+        },
+        {
+          "id": 290,
+          "tag": "x"
+        },
+        {
+          "id": 291,
+          "tag": "x"
+        },
+        {
+          "id": 292,
+          "tag": "x"
+        },
+        {
+          "id": 293,
+          "tag": "x"
+        },
+        {
+          "id": 294,
+          "tag": "x"
+        },
+        {
+          "id": 295,
+          "tag": "x"
+        },
+        {
+          "id": 296,
+          "tag": "x"
+        },
+        {
+          "id": 297,
+          "tag": "x"
+        },
+        {
+          "id": 298,
+          "tag": "x"
+        },
+        {
+          "id": 299,
+          "tag": "x"
+        },
+        {
+          "id": 300,
+          "tag": "x"
+        },
+        {
+          "id": 301,
+          "tag": "x"
+        },
+        {
+          "id": 302,
+          "tag": "x"
+        },
+        {
+          "id": 303,
+          "tag": "x"
+        }
+      ],
+      "str_slice": "kube-system   v1           Pod    fluentbit-gke-vdjth                                              3/3     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            component=fluentbit-gke,controller-revision-hash=55dd6c6454,k8s-app=fluentbit-gke,kubernetes.io/cluster-service=true,pod-template-generation=3\nkube-system   v1           Pod    gke-metadata-server-2djzv                                        1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            addonmanager.kubernetes.io/mode=Reconcile,controller-revision-hash=6dcfdfb77d,k8s-app=gke-metadata-server,pod-template-generation=2\nkube-system   v1           Pod    gke-metadata-server-dhlhp                                        1/1     Running   0          21h    10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            addonmanager.kubernetes.io/mode=Reconcile,controller-revision-hash=6dcfdfb77d,k8s-app=gke-metadata-server,pod-template-generation=2\nkube-system   v1           Pod    gke-metadata-server-kx2sb                                        1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            addonmanager.kubernetes.io/mode=Reconcile,controller-revision-hash=6dcfdfb77d,k8s-app=gke-metadata-server,pod-template-generation=2\nkube-system   v1           Pod    gke-metrics-agent-2p2xn                                          2/2     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            component=gke-metrics-agent,controller-revision-hash=5b595f7969,k8s-app=gke-metrics-agent,pod-template-generation=2\nkube-system   v1           Pod    gke-metrics-agent-kqq22                                          2/2     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            component=gke-metrics-agent,controller-revision-hash=5b595f7969,k8s-app=gke-metrics-agent,pod-template-generation=2\nkube-system   v1           Pod    gke-metrics-agent-nczml                                          2/2     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            component=gke-metrics-agent,controller-revision-hash=5b595f7969,k8s-app=gke-metrics-agent,pod-template-generation=2\nkube-system   v1           Pod    ip-masq-agent-4r6cf                                              1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=7cbdb6bd86,k8s-app=ip-masq-agent,pod-template-generation=3\nkube-system   v1           Pod    ip-masq-agent-nj4qv                                              1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=7cbdb6bd86,k8s-app=ip-masq-agent,pod-template-generation=3\nkube-system   v1           Pod    ip-masq-agent-svtk6                                              1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=7cbdb6bd86,k8s-app=ip-masq-agent,pod-template-generation=3\nkube-system   v1           Pod    konnectivity-agent-6857bb85bd-jr9sc                              2/2     Running   0          21h    192.168.1.8    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=konnectivity-agent,pod-template-hash=6857bb85bd\nkube-system   v1           Pod    konnectivity-agent-6857bb85bd-wjpw6                              2/2     Running   0          21h    192.168.0.8    gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            k8s-app=konnectivity-agent,pod-template-hash=6857bb85bd\nkube-system   v1           Pod    konnectivity-agent-6857bb85bd-x4ml9                              2/2     Running   0          21h    192.168.2.13   gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            k8s-app=konnectivity-agent,pod-template-hash=6857bb85bd\nkube-system   v1           Pod    konnectivity-agent-autoscaler-d67c74bb7-f6c29                    1/1     Running   0          21h    192.168.1.13   gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=konnectivity-agent-autoscaler,pod-template-hash=d67c74bb7\nkube-system   v1           Pod    kube-dns-6f8c46f48b-4nksr                                        4/4     Running   0          21h    192.168.2.14   gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            k8s-app=kube-dns,pod-template-hash=6f8c46f48b\nkube-system   v1           Pod    kube-dns-6f8c46f48b-jqvhn                                        4/4     Running   0          21h    192.168.1.7    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=kube-dns,pod-template-hash=6f8c46f48b"
+    },
+    "sub_invocations": [],
+    "tool_calls": 2
+  }
 }

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -128,32 +128,20 @@ impl StoredInvocation {
 
     /// Replay the curated `<summary>+<recovery>` envelope from the
     /// persisted `ToolCallSummary`. Output is byte-identical to what
-    /// `cache()` originally returned for this invocation — both text
-    /// channel (envelope) and structured channel
-    /// (`{result, _elided?: {invocation_id, paths}}`) are set on the
-    /// returned `CallToolResult`.
+    /// `cache()` originally returned — both share
+    /// `ToolCallSummary::build_wire`.
     fn summary_view(&self, max_bytes: usize) -> Result<FetchResult, ToolCachingError> {
-        let envelope = self.summary.build_envelope_text();
-        if envelope.len() > max_bytes {
+        let (result, structured) = self.summary.build_wire(self.id);
+        let envelope_len = match result.content.first().map(|c| &c.raw) {
+            Some(rmcp::model::RawContent::Text(t)) => t.text.len(),
+            _ => 0,
+        };
+        if envelope_len > max_bytes {
             return Err(ToolCachingError::FetchResponseTooLarge {
-                size: envelope.len(),
+                size: envelope_len,
                 max: max_bytes,
             });
         }
-        let mut obj = serde_json::Map::new();
-        obj.insert("result".to_string(), self.summary.wire_result.clone());
-        if !self.summary.elided_paths.is_empty() {
-            obj.insert(
-                "_elided".to_string(),
-                serde_json::json!({
-                    "invocation_id": self.id.to_string(),
-                    "paths": self.summary.elided_paths.clone(),
-                }),
-            );
-        }
-        let structured = Value::Object(obj);
-        let mut result = CallToolResult::success(vec![Content::text(envelope)]);
-        result.structured_content = Some(structured.clone());
         Ok(FetchResult { result, structured })
     }
 

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -22,6 +22,14 @@ pub enum FetchQuery {
     /// Item range on an array-typed value at `path`. Returns the slice
     /// `arr[offset..offset+len]` as a `Value::Array`.
     JsonArraySlice { offset: usize, len: usize },
+    /// Return the persisted curated `<summary>+<recovery>` envelope —
+    /// the same view the agent would have seen from a top-level
+    /// `call_tool` invocation. Useful for inspecting a compose
+    /// sub-invocation's curated form (JS scripts see verbatim T; the
+    /// agent reading `sub_invocations[i].invocation_id` post-hoc can
+    /// fetch the summary view here). `path` is ignored — the summary
+    /// is always the root view.
+    Summary,
 }
 
 impl FetchQuery {
@@ -61,6 +69,11 @@ impl FetchQuery {
                 let end = offset.saturating_add(*len).min(arr.len());
                 Ok(Value::Array(arr[start..end].to_vec()))
             }
+            // Summary is short-circuited in `StoredInvocation::query` —
+            // it doesn't fit the slice-at-resolved-path pattern.
+            FetchQuery::Summary => Err(ToolCachingError::InvalidPath(
+                "summary query is handled at the invocation level".into(),
+            )),
         }
     }
 }
@@ -86,6 +99,11 @@ impl StoredInvocation {
         query: Option<&FetchQuery>,
         max_bytes: usize,
     ) -> Result<FetchResult, ToolCachingError> {
+        // `Summary` short-circuits navigation — return the stored
+        // envelope and its structured wrapper, regardless of `path`.
+        if matches!(query, Some(FetchQuery::Summary)) {
+            return self.summary_view(max_bytes);
+        }
         let resolved = self.navigate(path)?.clone();
         let sliced = match query {
             Some(q) => q.apply(resolved)?,
@@ -106,6 +124,37 @@ impl StoredInvocation {
             result: CallToolResult::success(vec![Content::text(text)]),
             structured: wrapped,
         })
+    }
+
+    /// Replay the curated `<summary>+<recovery>` envelope from the
+    /// persisted `ToolCallSummary`. Output is byte-identical to what
+    /// `cache()` originally returned for this invocation — both text
+    /// channel (envelope) and structured channel
+    /// (`{result, _elided?: {invocation_id, paths}}`) are set on the
+    /// returned `CallToolResult`.
+    fn summary_view(&self, max_bytes: usize) -> Result<FetchResult, ToolCachingError> {
+        let envelope = self.summary.build_envelope_text();
+        if envelope.len() > max_bytes {
+            return Err(ToolCachingError::FetchResponseTooLarge {
+                size: envelope.len(),
+                max: max_bytes,
+            });
+        }
+        let mut obj = serde_json::Map::new();
+        obj.insert("result".to_string(), self.summary.wire_result.clone());
+        if !self.summary.elided_paths.is_empty() {
+            obj.insert(
+                "_elided".to_string(),
+                serde_json::json!({
+                    "invocation_id": self.id.to_string(),
+                    "paths": self.summary.elided_paths.clone(),
+                }),
+            );
+        }
+        let structured = Value::Object(obj);
+        let mut result = CallToolResult::success(vec![Content::text(envelope)]);
+        result.structured_content = Some(structured.clone());
+        Ok(FetchResult { result, structured })
     }
 
     fn navigate(&self, path: &str) -> Result<&Value, ToolCachingError> {

--- a/core/crates/tool-caching/src/lib.rs
+++ b/core/crates/tool-caching/src/lib.rs
@@ -62,6 +62,12 @@ impl ToolCaching {
     /// * structured channel: `{result: T-elided, _elided?: {invocation_id, paths}}`
     /// * text channel: `<summary path="…" …>…</summary><recovery><elided …>…</elided></recovery>`
     ///
+    /// If the upstream has no text content but does carry a structured
+    /// channel, the text channel is filled with `serde_json::to_string_pretty`
+    /// of the structured payload before walking — so callers (notably
+    /// compose) can hand off an empty text channel and let cache() produce
+    /// the agent-facing rendering.
+    ///
     /// Passthrough early-returns (no persistence, raw CTR with the
     /// `{result: T}` wrapper added to structured for schema parity):
     ///   * no owner (workflow executor / anonymous)
@@ -74,6 +80,7 @@ impl ToolCaching {
         args: &serde_json::Value,
         result: CallToolResult,
     ) -> Result<ToolCacheResponse, ToolCachingError> {
+        let result = ensure_text_channel(result);
         let Some(owner_id) = owner.into() else {
             return Ok(passthrough_no_owner(result));
         };
@@ -125,6 +132,7 @@ impl ToolCaching {
         args: &serde_json::Value,
         result: CallToolResult,
     ) -> Result<ToolCacheResponse, ToolCachingError> {
+        let result = ensure_text_channel(result);
         let Some(owner_id) = owner.into() else {
             return Ok(passthrough_no_owner(result));
         };
@@ -282,4 +290,26 @@ fn extract_text(result: &CallToolResult) -> String {
 
 fn is_simple_text_result(result: &CallToolResult) -> bool {
     result.content.len() == 1 && matches!(result.content[0].raw, RawContent::Text(_))
+}
+
+/// If the upstream carries a structured channel but no text content,
+/// fill the text channel with a pretty-printed JSON rendering of the
+/// structured payload. Lets callers (notably compose) pass an empty
+/// text channel and rely on `cache()` to produce the agent-facing
+/// rendering — either as the passthrough text or, when walking elides
+/// something, replaced in place by the `<summary>+<recovery>` envelope.
+fn ensure_text_channel(mut result: CallToolResult) -> CallToolResult {
+    let has_text = result
+        .content
+        .iter()
+        .any(|c| matches!(&c.raw, RawContent::Text(_)));
+    if has_text {
+        return result;
+    }
+    let Some(structured) = result.structured_content.as_ref() else {
+        return result;
+    };
+    let text = serde_json::to_string_pretty(structured).unwrap_or_default();
+    result.content = vec![Content::text(text)];
+    result
 }

--- a/core/crates/tool-caching/src/lib.rs
+++ b/core/crates/tool-caching/src/lib.rs
@@ -13,7 +13,7 @@ pub use error::ToolCachingError;
 pub use fetch::{FetchQuery, FetchResult};
 pub use primitives::{
     ElidedPath, QueryStructure, ToolCacheResponse, ToolCallOwnerId, ToolCallSummary,
-    ToolInvocationId, WrapMode,
+    ToolInvocationId,
 };
 pub use repo::StoredInvocation;
 pub use string_summarizer::StringSummarizerChain;
@@ -21,7 +21,8 @@ pub use walker::Walker;
 
 use repo::ToolCacheRepo;
 
-use rmcp::model::{CallToolResult, RawContent};
+use rmcp::model::{CallToolResult, Content, RawContent};
+use serde_json::Value;
 
 #[derive(Clone)]
 pub struct ToolCaching {
@@ -30,6 +31,14 @@ pub struct ToolCaching {
     config: ToolCachingConfig,
     repo: ToolCacheRepo,
     walker: Walker,
+}
+
+/// Internal walk + persist result. Shared by the two public entry points.
+struct Processed {
+    summary: ToolCallSummary,
+    invocation_id: ToolInvocationId,
+    upstream_t: Value,
+    persisted: bool,
 }
 
 impl ToolCaching {
@@ -46,93 +55,42 @@ impl ToolCaching {
         }
     }
 
-    /// Cache an upstream tool result and emit a `DruaToolResult<T>`-shaped
-    /// `CallToolResult`. `mode` selects how `T` is presented on the wire:
+    /// Agent-facing call path. Walks the upstream's structured channel
+    /// (or parsed text as fallback), elides if over threshold, persists
+    /// for `tool_output_fetch` recovery. Wire shape:
     ///
-    /// * [`WrapMode::Elide`] — top-level / catalog dispatch. Walk and elide
-    ///   in place; structured channel emits `{result: T-elided, _elided: M}`
-    ///   when something was elided, `{result: T}` on passthrough.
-    /// * [`WrapMode::Persist`] — compose sub-dispatch. Persist for
-    ///   `tool_output_fetch` recovery but emit `{result: T verbatim}` always —
-    ///   the JS engine has its own size cap and pre-summarising sub-call
-    ///   results would force every compose script to recover through fetch
-    ///   instead of using the value directly.
+    /// * structured channel: `{result: T-elided, _elided?: {invocation_id, paths}}`
+    /// * text channel: `<summary path="…" …>…</summary><recovery><elided …>…</elided></recovery>`
     ///
-    /// Passthrough early-returns (no persistence, no wrap, raw CTR):
-    ///   * no owner (workflow executor / anonymous) — nothing to attribute
-    ///   * upstream marked the result `is_error` — error responses flow through
-    ///   * non-text content (image, multi-part) — only single-text-content
-    ///     results are summarisable today
-    ///
-    /// When the walker decides no elision is needed, the text channel
-    /// stays raw (no envelope) but the structured channel is still wrapped
-    /// per `mode` — otherwise sub-threshold results would emit `T` on the
-    /// wire while `outputSchema` / `compose_types` advertise `{result: T}`.
+    /// Passthrough early-returns (no persistence, raw CTR with the
+    /// `{result: T}` wrapper added to structured for schema parity):
+    ///   * no owner (workflow executor / anonymous)
+    ///   * upstream marked the result `is_error`
+    ///   * non-text content (image, multi-part)
     pub async fn cache(
         &self,
         owner: impl Into<Option<ToolCallOwnerId>>,
         tool_name: &str,
         args: &serde_json::Value,
         result: CallToolResult,
-        mode: WrapMode,
     ) -> Result<ToolCacheResponse, ToolCachingError> {
         let Some(owner_id) = owner.into() else {
-            return Ok(ToolCacheResponse {
-                result,
-                elided_paths: Vec::new(),
-                invocation_id: None,
-            });
+            return Ok(passthrough_no_owner(result));
         };
         if result.is_error == Some(true) || !is_simple_text_result(&result) {
-            return Ok(ToolCacheResponse {
-                result,
-                elided_paths: Vec::new(),
-                invocation_id: None,
-            });
+            return Ok(passthrough_no_owner(result));
         }
 
-        let original_structured = result.structured_content.clone();
-        let original_text = extract_text(&result);
+        let processed = self.process(owner_id, tool_name, args, &result).await?;
 
-        // Walk the upstream's structured channel when present — that's
-        // the canonical `T` whose shape MCP clients validate against the
-        // advertised outputSchema. The walked summary becomes `result`
-        // in `{result: T-elided, _elided?: M}`; for the (text-only)
-        // tools that don't emit structured_content, fall back to the
-        // parsed-text Value (matches today's behaviour for bash, k8s
-        // logs, etc.).
-        //
-        // Why this matters for meta-tools: `search_tools`/`describe_tool`/
-        // `compose_types` emit human-readable markdown text PLUS a
-        // structured object of a different shape. Walking the text
-        // channel produced a `Value::String(elided_markdown)` for
-        // `result`, breaking schema validation. Walking structured
-        // yields the schema-conforming object.
-        let query_structure = QueryStructure {
-            root: original_structured
-                .clone()
-                .unwrap_or_else(|| QueryStructure::new(&original_text).root),
-        };
-        // Mint the id up front so recover templates carry the real uuid;
-        // persistence reuses the same value as the row's primary key.
-        let invocation_id = ToolInvocationId::new();
-        let summary = self
-            .walker
-            .summarize(&query_structure, invocation_id, tool_name);
-
-        // Nothing was elided ⇒ skip persistence, keep the text channel
-        // raw. Structured channel is still wrapped to match what
-        // `output_schema()` and `compose_types` advertise so sub- and
-        // over-threshold responses share one wire shape.
-        if summary.elided_paths.is_empty() {
+        if !processed.persisted {
+            // Sub-threshold passthrough — keep the text channel raw,
+            // still wrap structured as `{result: T}` so the wire shape
+            // matches what `output_schema()` / `compose_types` advertise.
             let mut passthrough = result;
-            passthrough.structured_content = match mode {
-                WrapMode::Elide | WrapMode::Persist => {
-                    let t = original_structured.unwrap_or_else(|| query_structure.root.clone());
-                    Some(serde_json::json!({ "result": t }))
-                }
-                WrapMode::TextOnly => original_structured,
-            };
+            passthrough.structured_content = Some(serde_json::json!({
+                "result": processed.upstream_t,
+            }));
             return Ok(ToolCacheResponse {
                 result: passthrough,
                 elided_paths: Vec::new(),
@@ -140,38 +98,61 @@ impl ToolCaching {
             });
         }
 
-        self.repo
-            .persist(
-                invocation_id,
-                owner_id,
-                tool_name,
-                args,
-                &query_structure,
-                &summary,
-                &original_text,
-                original_structured.as_ref(),
-            )
-            .await?;
-
-        // `upstream_t` is what `{result: …}` carries on the wire in Persist
-        // mode (verbatim T) and is unused in Elide / TextOnly. Prefer the
-        // upstream's structured channel when present so JS engines see the
-        // same JSON shape the upstream emits; otherwise fall back to the
-        // parsed text root.
-        let upstream_t = original_structured
-            .clone()
-            .unwrap_or_else(|| query_structure.root.clone());
-        let elided_paths = summary.elided_paths.clone();
-        let wrapped = summary.into_call_tool_result(
-            mode,
-            Some(invocation_id),
-            original_structured,
-            upstream_t,
-        );
+        let elided_paths = processed.summary.elided_paths.clone();
+        let wrapped = build_elide_ctr(processed.summary, processed.invocation_id);
         Ok(ToolCacheResponse {
             result: wrapped,
             elided_paths,
-            invocation_id: Some(invocation_id),
+            invocation_id: Some(processed.invocation_id),
+        })
+    }
+
+    /// Compose sub-dispatch call path. The JS engine has its own size
+    /// cap and scripts use the sub-tool's return directly — pre-elided
+    /// data would force every script to recover through
+    /// `tool_output_fetch`. So the wire shape is `{result: T verbatim}`
+    /// even when the value is over threshold.
+    ///
+    /// Walker still runs, summary is still persisted: the agent (out of
+    /// the JS sandbox, reading `compose_response.sub_invocations[i].invocation_id`)
+    /// can later call `tool_output_fetch(invocation_id, query={mode:"summary"})`
+    /// to get the curated envelope they'd have seen from a top-level
+    /// `call_tool` invocation.
+    pub async fn persist_for_compose(
+        &self,
+        owner: impl Into<Option<ToolCallOwnerId>>,
+        tool_name: &str,
+        args: &serde_json::Value,
+        result: CallToolResult,
+    ) -> Result<ToolCacheResponse, ToolCachingError> {
+        let Some(owner_id) = owner.into() else {
+            return Ok(passthrough_no_owner(result));
+        };
+        if result.is_error == Some(true) || !is_simple_text_result(&result) {
+            return Ok(passthrough_no_owner(result));
+        }
+
+        let processed = self.process(owner_id, tool_name, args, &result).await?;
+
+        // For compose JS engine: always emit T verbatim, regardless of
+        // whether the walker found anything elision-worthy.
+        let mut wrapped = result;
+        wrapped.structured_content = Some(serde_json::json!({
+            "result": processed.upstream_t,
+        }));
+
+        if !processed.persisted {
+            return Ok(ToolCacheResponse {
+                result: wrapped,
+                elided_paths: Vec::new(),
+                invocation_id: None,
+            });
+        }
+
+        Ok(ToolCacheResponse {
+            result: wrapped,
+            elided_paths: processed.summary.elided_paths,
+            invocation_id: Some(processed.invocation_id),
         })
     }
 
@@ -191,6 +172,100 @@ impl ToolCaching {
         let stored = self.repo.find_by_id(id, owner_id).await?;
         stored.query(path, query, self.config.max_fetch_response_bytes)
     }
+
+    /// Shared walk + persist. Both public entry points feed into this:
+    /// `cache()` consumes `processed.summary` to build the elided wire
+    /// shape; `persist_for_compose()` discards the summary on the wire
+    /// (emits T verbatim) but persists it so the agent can re-fetch
+    /// with `{mode: "summary"}` later.
+    async fn process(
+        &self,
+        owner_id: ToolCallOwnerId,
+        tool_name: &str,
+        args: &serde_json::Value,
+        result: &CallToolResult,
+    ) -> Result<Processed, ToolCachingError> {
+        let original_structured = result.structured_content.clone();
+        let original_text = extract_text(result);
+
+        // Walk the upstream's structured channel when present — that's
+        // the canonical `T` whose shape MCP clients validate against the
+        // advertised outputSchema. Fall back to parsed-text Value for
+        // text-only tools (bash, k8s logs, etc.).
+        let query_structure = QueryStructure {
+            root: original_structured
+                .clone()
+                .unwrap_or_else(|| QueryStructure::new(&original_text).root),
+        };
+        let invocation_id = ToolInvocationId::new();
+        let summary = self
+            .walker
+            .summarize(&query_structure, invocation_id, tool_name);
+
+        let upstream_t = original_structured
+            .clone()
+            .unwrap_or_else(|| query_structure.root.clone());
+
+        if summary.elided_paths.is_empty() {
+            return Ok(Processed {
+                summary,
+                invocation_id,
+                upstream_t,
+                persisted: false,
+            });
+        }
+
+        self.repo
+            .persist(
+                invocation_id,
+                owner_id,
+                tool_name,
+                args,
+                &query_structure,
+                &summary,
+                &original_text,
+                original_structured.as_ref(),
+            )
+            .await?;
+
+        Ok(Processed {
+            summary,
+            invocation_id,
+            upstream_t,
+            persisted: true,
+        })
+    }
+}
+
+/// Owner-less passthrough — workflow executor / anonymous callers
+/// don't get persistence or wrapping.
+fn passthrough_no_owner(result: CallToolResult) -> ToolCacheResponse {
+    ToolCacheResponse {
+        result,
+        elided_paths: Vec::new(),
+        invocation_id: None,
+    }
+}
+
+/// Build the agent-facing wrapped `CallToolResult`:
+///   * text channel: `<summary>+<recovery>` envelope from the walked summary
+///   * structured channel: `{result: walked, _elided?: {invocation_id, paths}}`
+fn build_elide_ctr(summary: ToolCallSummary, invocation_id: ToolInvocationId) -> CallToolResult {
+    let envelope = summary.build_envelope_text();
+    let mut obj = serde_json::Map::new();
+    obj.insert("result".to_string(), summary.wire_result.clone());
+    if !summary.elided_paths.is_empty() {
+        obj.insert(
+            "_elided".to_string(),
+            serde_json::json!({
+                "invocation_id": invocation_id.to_string(),
+                "paths": summary.elided_paths,
+            }),
+        );
+    }
+    let mut ctr = CallToolResult::success(vec![Content::text(envelope)]);
+    ctr.structured_content = Some(Value::Object(obj));
+    ctr
 }
 
 fn extract_text(result: &CallToolResult) -> String {

--- a/core/crates/tool-caching/src/lib.rs
+++ b/core/crates/tool-caching/src/lib.rs
@@ -255,25 +255,11 @@ fn passthrough_no_owner(result: CallToolResult) -> ToolCacheResponse {
     }
 }
 
-/// Build the agent-facing wrapped `CallToolResult`:
-///   * text channel: `<summary>+<recovery>` envelope from the walked summary
-///   * structured channel: `{result: walked, _elided?: {invocation_id, paths}}`
+/// Build the agent-facing wrapped `CallToolResult` — delegates to
+/// `ToolCallSummary::build_wire` so this and the `FetchQuery::Summary`
+/// replay path share one wire-shape construction site.
 fn build_elide_ctr(summary: ToolCallSummary, invocation_id: ToolInvocationId) -> CallToolResult {
-    let envelope = summary.build_envelope_text();
-    let mut obj = serde_json::Map::new();
-    obj.insert("result".to_string(), summary.wire_result.clone());
-    if !summary.elided_paths.is_empty() {
-        obj.insert(
-            "_elided".to_string(),
-            serde_json::json!({
-                "invocation_id": invocation_id.to_string(),
-                "paths": summary.elided_paths,
-            }),
-        );
-    }
-    let mut ctr = CallToolResult::success(vec![Content::text(envelope)]);
-    ctr.structured_content = Some(Value::Object(obj));
-    ctr
+    summary.build_wire(invocation_id).0
 }
 
 fn extract_text(result: &CallToolResult) -> String {

--- a/core/crates/tool-caching/src/lib.rs
+++ b/core/crates/tool-caching/src/lib.rs
@@ -278,18 +278,19 @@ fn is_simple_text_result(result: &CallToolResult) -> bool {
     result.content.len() == 1 && matches!(result.content[0].raw, RawContent::Text(_))
 }
 
-/// If the upstream carries a structured channel but no text content,
-/// fill the text channel with a pretty-printed JSON rendering of the
-/// structured payload. Lets callers (notably compose) pass an empty
-/// text channel and rely on `cache()` to produce the agent-facing
+/// If the upstream carries a structured channel and the content vec is
+/// empty, fill the text channel with a pretty-printed JSON rendering of
+/// the structured payload. Lets callers (notably compose) pass an empty
+/// content vec and rely on `cache()` to produce the agent-facing
 /// rendering — either as the passthrough text or, when walking elides
 /// something, replaced in place by the `<summary>+<recovery>` envelope.
+///
+/// Strictly `is_empty()`, not "no text content present": multi-part
+/// results (e.g. images alongside structured data) must keep their
+/// non-text parts intact and fall through to the
+/// `!is_simple_text_result` passthrough below.
 fn ensure_text_channel(mut result: CallToolResult) -> CallToolResult {
-    let has_text = result
-        .content
-        .iter()
-        .any(|c| matches!(&c.raw, RawContent::Text(_)));
-    if has_text {
+    if !result.content.is_empty() {
         return result;
     }
     let Some(structured) = result.structured_content.as_ref() else {

--- a/core/crates/tool-caching/src/primitives.rs
+++ b/core/crates/tool-caching/src/primitives.rs
@@ -1,4 +1,4 @@
-use rmcp::model::CallToolResult;
+use rmcp::model::{CallToolResult, Content};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -79,6 +79,30 @@ pub struct ToolCallSummary {
 }
 
 impl ToolCallSummary {
+    /// Build the full agent-facing wire shape: text-channel envelope +
+    /// structured-channel `{result, _elided?: {invocation_id, paths}}`
+    /// payload. Both `cache()` (initial elision) and the `FetchQuery::Summary`
+    /// replay path go through this single helper so the byte-identical
+    /// guarantee between original-call and re-fetched summary can't drift.
+    pub fn build_wire(&self, invocation_id: ToolInvocationId) -> (CallToolResult, Value) {
+        let envelope = self.build_envelope_text();
+        let mut obj = serde_json::Map::new();
+        obj.insert("result".to_string(), self.wire_result.clone());
+        if !self.elided_paths.is_empty() {
+            obj.insert(
+                "_elided".to_string(),
+                serde_json::json!({
+                    "invocation_id": invocation_id.to_string(),
+                    "paths": self.elided_paths.clone(),
+                }),
+            );
+        }
+        let structured = Value::Object(obj);
+        let mut result = CallToolResult::success(vec![Content::text(envelope)]);
+        result.structured_content = Some(structured.clone());
+        (result, structured)
+    }
+
     /// Build the `<summary>…</summary><recovery>…</recovery>` text-channel
     /// envelope from the walked summary. The structured channel is built
     /// separately by the caller (lib.rs) since its shape varies between

--- a/core/crates/tool-caching/src/primitives.rs
+++ b/core/crates/tool-caching/src/primitives.rs
@@ -1,4 +1,4 @@
-use rmcp::model::{CallToolResult, Content};
+use rmcp::model::CallToolResult;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
@@ -78,50 +78,12 @@ pub struct ToolCallSummary {
     pub shown_lines: Option<u32>,
 }
 
-/// Which channel-wrapping strategy `cache()` should apply.
-///
-/// All modes persist the upstream result for `tool_output_fetch` recovery.
-/// They differ in what reaches the wire:
-///
-/// * [`WrapMode::Elide`] — top-level agent-facing. Walk and elide in place;
-///   structured channel becomes `{result: T-elided, _elided?: M}` and the
-///   text channel carries the `<summary>+<recovery>` envelope.
-/// * [`WrapMode::Persist`] — compose sub-dispatch. Persist for recovery but
-///   emit `{result: T verbatim}` on the structured channel — the JS engine
-///   has its own size cap and we don't want sub-call results pre-summarised
-///   before scripts touch them.
-/// * [`WrapMode::TextOnly`] — compose's own output (and other tools whose
-///   `default_tool_caching() == false`). Persist for recovery and emit the
-///   `<summary>+<recovery>` text envelope, but leave `structured_content`
-///   exactly as the upstream tool produced it. These tools own their own
-///   structured shape (e.g. `ComposeOutput`) so the `DruaToolResult<T>`
-///   wrapper would shadow their native fields.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum WrapMode {
-    Elide,
-    Persist,
-    TextOnly,
-}
-
 impl ToolCallSummary {
-    /// Build the wrapped `CallToolResult` the agent sees.
-    ///
-    /// Text channel: the `<summary>` + `<recovery>` envelope, identical for
-    /// every mode. Tag style mirrors the kebab-case convention used inside
-    /// chain markers (`<head bytes="…">` etc.) so the agent sees one
-    /// consistent grammar.
-    ///
-    /// Structured channel varies by mode:
-    /// * `Elide` — `{result: T-elided, _elided?: {invocation_id, paths}}`
-    /// * `Persist` — `{result: T verbatim}` (no `_elided`)
-    /// * `TextOnly` — `original_structured` verbatim (no wrapper at all)
-    pub fn into_call_tool_result(
-        self,
-        mode: WrapMode,
-        invocation_id: Option<ToolInvocationId>,
-        original_structured: Option<serde_json::Value>,
-        upstream_t: serde_json::Value,
-    ) -> CallToolResult {
+    /// Build the `<summary>…</summary><recovery>…</recovery>` text-channel
+    /// envelope from the walked summary. The structured channel is built
+    /// separately by the caller (lib.rs) since its shape varies between
+    /// the two public entry points.
+    pub fn build_envelope_text(&self) -> String {
         let summary_text = match &self.summary {
             Value::String(s) => s.clone(),
             other => serde_json::to_string(other).unwrap_or_default(),
@@ -149,30 +111,7 @@ impl ToolCallSummary {
             envelope.push_str(&path.render());
         }
         envelope.push_str("</recovery>\n");
-
-        let structured = match mode {
-            WrapMode::Elide => {
-                let mut obj = serde_json::Map::new();
-                obj.insert("result".to_string(), self.wire_result);
-                if !self.elided_paths.is_empty() {
-                    let inv = invocation_id.map(|id| id.to_string()).unwrap_or_default();
-                    obj.insert(
-                        "_elided".to_string(),
-                        serde_json::json!({
-                            "invocation_id": inv,
-                            "paths": self.elided_paths,
-                        }),
-                    );
-                }
-                Some(Value::Object(obj))
-            }
-            WrapMode::Persist => Some(serde_json::json!({ "result": upstream_t })),
-            WrapMode::TextOnly => original_structured,
-        };
-
-        let mut result = CallToolResult::success(vec![Content::text(envelope)]);
-        result.structured_content = structured;
-        result
+        envelope
     }
 }
 

--- a/core/crates/tool-caching/tests/envelope.rs
+++ b/core/crates/tool-caching/tests/envelope.rs
@@ -189,12 +189,7 @@ async fn persisted_invocation_round_trips_through_find_by_id() {
     let owner = ToolCallOwnerId::new();
 
     let response = caching
-        .cache(
-            owner,
-            "bash",
-            &serde_json::json!({}),
-            upstream,
-        )
+        .cache(owner, "bash", &serde_json::json!({}), upstream)
         .await
         .expect("persist must succeed");
 
@@ -277,12 +272,7 @@ async fn no_owner_is_passthrough() {
     let upstream = CallToolResult::success(vec![Content::text(big.clone())]);
 
     let response = caching
-        .cache(
-            None,
-            "bash",
-            &serde_json::json!({}),
-            upstream,
-        )
+        .cache(None, "bash", &serde_json::json!({}), upstream)
         .await
         .expect("no-owner path must not error");
 

--- a/core/crates/tool-caching/tests/envelope.rs
+++ b/core/crates/tool-caching/tests/envelope.rs
@@ -1,6 +1,6 @@
 use rmcp::model::{CallToolResult, Content, RawContent};
 
-use drua_tool_caching::{ToolCaching, ToolCachingConfig, ToolCallOwnerId, WrapMode};
+use drua_tool_caching::{ToolCaching, ToolCachingConfig, ToolCallOwnerId};
 
 const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
 
@@ -47,7 +47,6 @@ async fn root_string_over_threshold_yields_envelope_with_recovery_section() {
             "bash",
             &serde_json::json!({}),
             upstream,
-            WrapMode::Elide,
         )
         .await
         .expect("persistence is stubbed; this must not error");
@@ -148,7 +147,6 @@ async fn sub_threshold_input_is_passthrough_with_no_envelope() {
             "bash",
             &serde_json::json!({}),
             upstream,
-            WrapMode::Elide,
         )
         .await
         .expect("persistence is stubbed; this must not error");
@@ -196,7 +194,6 @@ async fn persisted_invocation_round_trips_through_find_by_id() {
             "bash",
             &serde_json::json!({}),
             upstream,
-            WrapMode::Elide,
         )
         .await
         .expect("persist must succeed");
@@ -239,12 +236,11 @@ async fn persist_mode_emits_verbatim_t_without_elided_block() {
     let upstream = CallToolResult::success(vec![Content::text(big.clone())]);
 
     let response = caching
-        .cache(
+        .persist_for_compose(
             ToolCallOwnerId::new(),
             "bash",
             &serde_json::json!({}),
             upstream,
-            WrapMode::Persist,
         )
         .await
         .expect("persistence must succeed");
@@ -286,7 +282,6 @@ async fn no_owner_is_passthrough() {
             "bash",
             &serde_json::json!({}),
             upstream,
-            WrapMode::Elide,
         )
         .await
         .expect("no-owner path must not error");

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -526,9 +526,7 @@ impl ToolSets {
                             let args_for_cache = args_value
                                 .clone()
                                 .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
-                            tc.cache(subject, name, &args_for_cache, raw)
-                                .await?
-                                .result
+                            tc.cache(subject, name, &args_for_cache, raw).await?.result
                         }
                         _ => raw,
                     };

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -22,7 +22,7 @@ pub use traits::*;
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-use drua_tool_caching::{ToolCaching, WrapMode};
+use drua_tool_caching::ToolCaching;
 use rmcp::model::{CallToolResult, JsonObject};
 
 use crate::audit::Audit;
@@ -526,7 +526,7 @@ impl ToolSets {
                             let args_for_cache = args_value
                                 .clone()
                                 .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
-                            tc.cache(subject, name, &args_for_cache, raw, WrapMode::Elide)
+                            tc.cache(subject, name, &args_for_cache, raw)
                                 .await?
                                 .result
                         }

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -10,7 +10,7 @@
 
 use std::sync::{Arc, LazyLock, RwLock};
 
-use drua_tool_caching::{ToolCaching, WrapMode};
+use drua_tool_caching::ToolCaching;
 use serde_json::json;
 
 use rmcp::model::{CallToolResult, Content, JsonObject, Tool};
@@ -472,15 +472,9 @@ impl TopLevelTool for CallCatalogTool {
                 let args_for_cache = inner_args
                     .map(serde_json::Value::Object)
                     .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
-                tc.cache(
-                    subject,
-                    &tool_name,
-                    &args_for_cache,
-                    result,
-                    WrapMode::Elide,
-                )
-                .await?
-                .result
+                tc.cache(subject, &tool_name, &args_for_cache, result)
+                    .await?
+                    .result
             }
             None => result,
         };

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -6,7 +6,7 @@ use std::time::Duration;
 
 use drua_tool_caching::ToolCaching;
 use es_entity::context::{EventContext, WithEventContext};
-use rmcp::model::{CallToolResult, Content, JsonObject};
+use rmcp::model::{CallToolResult, JsonObject};
 use serde::Deserialize;
 
 use crate::audit::{Audit, InteractionType};
@@ -187,47 +187,16 @@ impl TopLevelTool for ComposeTool {
             execution_time_ms: result.execution_time.as_millis() as u64,
         };
 
-        let mut sections = Vec::new();
-        let value_str =
-            serde_json::to_string_pretty(&out.result).unwrap_or_else(|_| "null".to_string());
-        sections.push(format!("=== Result ===\n{value_str}"));
-        if !out.console.is_empty() {
-            sections.push(format!("=== Console ===\n{}", out.console.join("\n")));
-        }
-        if !dts.is_empty() {
-            sections.push(format!("=== Available Types ===\n{dts}"));
-        }
-        if !out.sub_invocations.is_empty() {
-            let lines: Vec<String> = out
-                .sub_invocations
-                .iter()
-                .map(|s| {
-                    format!(
-                        "  [{}] {} → {} ({} bytes raw, kind={})",
-                        s.seq, s.args_digest, s.invocation_id, s.raw_size_bytes, s.kind,
-                    )
-                })
-                .collect();
-            sections.push(format!("=== Sub Invocations ===\n{}", lines.join("\n"),));
-        }
-        sections.push(format!(
-            "=== Metadata ===\ntool_calls: {}\nexecution_time: {:?}",
-            out.tool_calls,
-            std::time::Duration::from_millis(out.execution_time_ms),
-        ));
-
-        let text = sections.join("\n\n");
         let structured = serde_json::to_value(&out).expect("ComposeOutput serialization");
-        let mut ctr = CallToolResult::success(vec![Content::text(text)]);
+        let mut ctr = CallToolResult::success(Vec::new());
         ctr.structured_content = Some(structured);
 
         let ctr = match self.tool_caching.as_ref() {
             Some(tc) => {
                 // Plain `cache()` — same path every other top-level tool
-                // takes. Walker walks the full ComposeOutput on structured;
-                // elides `.result` / `.console` / `.sub_invocations` in
-                // place if any overflow. Wire shape:
-                // `{result: ComposeOutput-elided, _elided?: M}`.
+                // takes. We hand off an empty text channel; cache() fills
+                // it from the structured payload (or replaces it with the
+                // `<summary>+<recovery>` envelope when walking elides).
                 tc.cache(subject, "compose", &recorded_args, ctr)
                     .await?
                     .result
@@ -244,10 +213,9 @@ const COMPOSE_FETCH_HINT: &str =
      `<summary>+<recovery>` envelope you'd have seen calling that tool directly.";
 
 /// Recovery metadata for one sub-tool dispatch inside a compose script.
+/// Array order is completion order (0-based).
 #[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
 pub struct SubInvocation {
-    /// Order within the script (0-based, stable across re-runs).
-    pub seq: u32,
     pub tool_name: String,
     /// `tool(key=value, ...)` truncated to 80 chars.
     pub args_digest: String,
@@ -470,14 +438,8 @@ impl CatalogDispatcherShared {
             return;
         };
         let kind = sub_invocation_kind(&resp.elided_paths);
-        let seq = self
-            .sub_invocations
-            .lock()
-            .map(|guard| guard.len() as u32)
-            .unwrap_or(0);
         if let Ok(mut guard) = self.sub_invocations.lock() {
             guard.push(SubInvocation {
-                seq,
                 tool_name: tool_name.to_string(),
                 args_digest: format_args_digest(tool_name, args),
                 invocation_id: uuid::Uuid::from(invocation_id),

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, LazyLock, Mutex, RwLock};
 use std::time::Duration;
 
-use drua_tool_caching::{ToolCaching, WrapMode};
+use drua_tool_caching::ToolCaching;
 use es_entity::context::{EventContext, WithEventContext};
 use rmcp::model::{CallToolResult, Content, JsonObject};
 use serde::Deserialize;
@@ -56,12 +56,13 @@ static COMPOSE_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<
 
 #[derive(serde::Serialize, schemars::JsonSchema)]
 struct ComposeOutput {
-    /// The JS script's return value. Curated when oversize; recoverable via `tool_output_fetch` using `result_invocation_id`.
+    /// The JS script's return value, verbatim. If oversize, the outer
+    /// `cache()` call walks the full ComposeOutput tree and elides this
+    /// field in place; the agent recovers via `tool_output_fetch` with
+    /// `path: "$.result.result"` (outer `DruaToolResult` wrap + this
+    /// field) or `query: {mode: "summary"}` for the full envelope.
     #[schemars(schema_with = "crate::toolset::any_json_schema")]
     result: serde_json::Value,
-    /// Set when `result` was curated; pass to `tool_output_fetch` to recover the full JS return.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    result_invocation_id: Option<uuid::Uuid>,
     /// Recoverable sub-tool calls; excludes passthrough, errored, and bypass-marked calls.
     sub_invocations: Vec<SubInvocation>,
     fetch_hint: String,
@@ -170,37 +171,15 @@ impl TopLevelTool for ComposeTool {
             .map(|guard| guard.clone())
             .unwrap_or_default();
 
-        // Cache the JS return value itself — if it's oversized the agent
-        // gets a `result_invocation_id` to recover the full value via
-        // `tool_output_fetch`. Builds a fake `CallToolResult` carrying
-        // the value as JSON text so the existing pipeline can summarise it.
-        let (curated_result, result_invocation_id) = match self.tool_caching.as_ref() {
-            Some(tc) => {
-                let pretty = serde_json::to_string_pretty(&result.value).unwrap_or_default();
-                let mut ctr = CallToolResult::success(vec![Content::text(pretty)]);
-                ctr.structured_content = Some(result.value.clone());
-                let resp = tc
-                    .cache(
-                        subject,
-                        "compose:result",
-                        &recorded_args,
-                        ctr,
-                        WrapMode::Elide,
-                    )
-                    .await?;
-                let id = resp.invocation_id.map(uuid::Uuid::from);
-                let curated = match id {
-                    Some(_) => serde_json::Value::String(extract_text(&resp.result)),
-                    None => result.value.clone(),
-                };
-                (curated, id)
-            }
-            None => (result.value.clone(), None),
-        };
-
+        // The JS return value goes into `ComposeOutput.result` verbatim.
+        // The outer `cache()` below walks the full ComposeOutput on the
+        // structured channel — if `.result` is oversize the walker
+        // elides it in place + records the path in `_elided.paths`.
+        // Agents can recover via `tool_output_fetch(invocation_id, path:
+        // "$.result.result")` (outer wrap + ComposeOutput.result field)
+        // or `query: {mode: "summary"}` for the full curated envelope.
         let out = ComposeOutput {
-            result: curated_result,
-            result_invocation_id,
+            result: result.value.clone(),
             sub_invocations: collected_sub_invocations,
             fetch_hint: COMPOSE_FETCH_HINT.to_string(),
             console: result.console_output.clone(),
@@ -224,25 +203,17 @@ impl TopLevelTool for ComposeTool {
                 .iter()
                 .map(|s| {
                     format!(
-                        "  [{}] {} → {} ({} bytes raw / {} bytes summary, kind={})",
-                        s.seq,
-                        s.args_digest,
-                        s.invocation_id,
-                        s.raw_size_bytes,
-                        s.summary_size_bytes,
-                        s.kind,
+                        "  [{}] {} → {} ({} bytes raw, kind={})",
+                        s.seq, s.args_digest, s.invocation_id, s.raw_size_bytes, s.kind,
                     )
                 })
                 .collect();
             sections.push(format!("=== Sub Invocations ===\n{}", lines.join("\n"),));
         }
         sections.push(format!(
-            "=== Metadata ===\ntool_calls: {}\nexecution_time: {:?}\n{}",
+            "=== Metadata ===\ntool_calls: {}\nexecution_time: {:?}",
             out.tool_calls,
             std::time::Duration::from_millis(out.execution_time_ms),
-            out.result_invocation_id
-                .map(|id| format!("result_invocation_id: {id}"))
-                .unwrap_or_else(|| "result: verbatim (small enough)".to_string()),
         ));
 
         let text = sections.join("\n\n");
@@ -252,12 +223,12 @@ impl TopLevelTool for ComposeTool {
 
         let ctr = match self.tool_caching.as_ref() {
             Some(tc) => {
-                // Compose's structured channel is `ComposeOutput`, not a
-                // `DruaToolResult<T>` wrapper (`default_tool_caching=false`).
-                // `TextOnly` persists for recovery + elides the multi-section
-                // text envelope while preserving `ComposeOutput` verbatim on
-                // the structured channel.
-                tc.cache(subject, "compose", &recorded_args, ctr, WrapMode::TextOnly)
+                // Plain `cache()` — same path every other top-level tool
+                // takes. Walker walks the full ComposeOutput on structured;
+                // elides `.result` / `.console` / `.sub_invocations` in
+                // place if any overflow. Wire shape:
+                // `{result: ComposeOutput-elided, _elided?: M}`.
+                tc.cache(subject, "compose", &recorded_args, ctr)
                     .await?
                     .result
             }
@@ -267,9 +238,10 @@ impl TopLevelTool for ComposeTool {
     }
 }
 
-const COMPOSE_FETCH_HINT: &str = "invocation_id is either `result_invocation_id` (full JS return) \
-     or any `sub_invocations[].invocation_id` (specific sub-call's \
-     persisted output) — see `tool_output_fetch` for the full call shape.";
+const COMPOSE_FETCH_HINT: &str =
+    "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a \
+     sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated \
+     `<summary>+<recovery>` envelope you'd have seen calling that tool directly.";
 
 /// Recovery metadata for one sub-tool dispatch inside a compose script.
 #[derive(Debug, Clone, serde::Serialize, schemars::JsonSchema)]
@@ -281,10 +253,11 @@ pub struct SubInvocation {
     pub args_digest: String,
     /// `tool_invocations.id` — pass to `tool_output_fetch`.
     pub invocation_id: uuid::Uuid,
-    /// Summary kind discriminator (e.g. `concourse`, `structured_elision`, `generic`).
+    /// Summary kind discriminator (`lines`, `range`, `json_array_slice`,
+    /// `summarized`) — hint for which `tool_output_fetch` query mode
+    /// would naturally slice this sub-call's output.
     pub kind: String,
     pub raw_size_bytes: u64,
-    pub summary_size_bytes: u64,
 }
 
 struct CatalogDispatcher {
@@ -485,13 +458,7 @@ impl CatalogDispatcherShared {
         };
         let raw_size = extract_text(raw).len() as u64;
         let Ok(resp) = tc
-            .cache(
-                &self.subject,
-                tool_name,
-                args,
-                raw.clone(),
-                WrapMode::Persist,
-            )
+            .persist_for_compose(&self.subject, tool_name, args, raw.clone())
             .await
         else {
             return;
@@ -502,7 +469,6 @@ impl CatalogDispatcherShared {
         let Some(invocation_id) = resp.invocation_id else {
             return;
         };
-        let summary_size = extract_text(&resp.result).len() as u64;
         let kind = sub_invocation_kind(&resp.elided_paths);
         let seq = self
             .sub_invocations
@@ -517,7 +483,6 @@ impl CatalogDispatcherShared {
                 invocation_id: uuid::Uuid::from(invocation_id),
                 kind,
                 raw_size_bytes: raw_size,
-                summary_size_bytes: summary_size,
             });
         }
     }

--- a/core/src/toolset/wrap.rs
+++ b/core/src/toolset/wrap.rs
@@ -13,7 +13,7 @@
 use serde_json::{json, Value};
 
 /// Advertise the `DruaToolResult<T>` wrapper as a tool's outputSchema —
-/// matches what `cache(WrapMode::Elide)` actually emits on the structured
+/// matches what `cache()` actually emits on the structured
 /// channel. MCP clients that validate `structuredContent` against
 /// `outputSchema` need this to see the same shape.
 pub fn wrap_output_schema(upstream: &Value) -> Value {
@@ -56,7 +56,7 @@ pub fn wrap_output_schema(upstream: &Value) -> Value {
 }
 
 /// Wrap a TS type into `{ result: T }` — the compose-script-visible shape.
-/// Compose sub-dispatch is `WrapMode::Persist`, so `_elided` is always
+/// Compose sub-dispatch uses `persist_for_compose`, so `_elided` is always
 /// absent; the TS signature stays a single field.
 pub fn wrap_output_ts(inner_ts: &str) -> String {
     format!("{{ result: {inner_ts} }}")


### PR DESCRIPTION
## Summary

A four-part refactor that simplifies the tool-caching public surface and unifies compose's behavior with every other top-level tool.

### 1. Split `cache(...)` by purpose

The `WrapMode` enum was conflating two distinct call paths into one method. Replace with two purpose-named public methods on `ToolCaching`:

* `cache(...)` — agent-facing. Walks structured (or parsed text), elides if over threshold, persists for recovery. Wire shape `{result: T-elided, _elided?: M}` + `<summary>+<recovery>` envelope.
* `persist_for_compose(...)` — compose sub-dispatch. Walks (to populate the `kind` discriminator) and persists, but always emits `{result: T verbatim}` on structured. JS scripts get usable data without forced recovery roundtrips.

Both paths share a private `process()` helper that walks + persists; each public method shapes the wire response differently.

### 2. Add `FetchQuery::Summary`

Replays the persisted `<summary>+<recovery>` envelope (and its `{result, _elided?}` structured wrapper) **byte-for-byte identical** to what `cache()` originally returned. Useful for:

* Re-fetching the curated view after the original response scrolled out of an agent's context
* Inspecting a compose sub-invocation's curated form — JS sees verbatim `T`; the agent reads `sub_invocations[i].invocation_id` and asks for `{mode: \"summary\"}` to see the curated view

### 3. Simplify compose

Now that `cache()` walks the structured tree uniformly, compose's special-case work disappears:

* **Drop the inner `compose:result` cache call** — the outer `cache()` walks `ComposeOutput.result` in place as part of the structured tree, eliding it if oversize. One cache pass instead of two.
* **`ComposeOutput.result` is the JS return value verbatim** (not a pre-stringified envelope). Outer wrap surfaces elision via `_elided.paths[\"$.result.result\", ...]`; agent recovers with `path: \"$.result.result\"` or `query: {mode: \"summary\"}`.
* **Drop `result_invocation_id`** from `ComposeOutput` — the outer invocation_id surfaces via `_elided.invocation_id` (visible on the structured channel) and covers the whole response including the JS return.
* **Drop `summary_size_bytes`** from `SubInvocation` — meaningless now that JS scripts always see verbatim sub-call results.
* **Compose uses plain `cache()`** like every other top-level tool. Wire shape `{result: ComposeOutput, _elided?: M}` — one less special case in the system.

### 4. Drop `WrapMode` from the public API

Falls out of the split — the enum had three variants (Elide / Persist / TextOnly) all subsumed by the two methods or removed entirely (TextOnly was a compose-only workaround).

### Wire-shape changes (breaking for callers)

* `compose_response.sub_invocations` → `compose_response.result.sub_invocations`
* `compose_response.result` (was: curated envelope string) → `compose_response.result.result` (now: the JS return Value, with elision markers in place if oversize)
* `compose_response.result_invocation_id` → `compose_response._elided.invocation_id` (when the outer cache elided)

Updated the bats compose-roundtrip test and regenerated `compose-roundtrip-{1,2}.json` fixtures.

### Test plan
- [x] `cargo test -p drua-tool-caching --tests` — all 8 tests pass
- [x] `cargo test -p drua-core --test compose_audit` — all 3 pass
- [x] `bats fake_mcp_upstream.bats` — all 14 tests pass
- [ ] CI bats / check / integration
- [ ] Post-deploy E2E: `compose({script})` returns `{result: ComposeOutput, _elided?: M}`; `tool_output_fetch({invocation_id, query: {mode: \"summary\"}})` returns the persisted envelope byte-identical to a fresh `call_tool` of the same upstream

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the tool-caching public API and the wire/structured response shapes (notably `compose`) and adds a new `tool_output_fetch` query mode that replays cached envelopes.
> 
> **Overview**
> **Tool-caching API is refactored and simplified.** `WrapMode` is removed and `ToolCaching` now exposes two explicit paths: `cache()` for agent-facing elision + envelope generation, and `persist_for_compose()` for compose sub-invocations that still persist/annotate but always return verbatim `{result: T}` to JS.
> 
> **`tool_output_fetch` gains `query: {mode: "summary"}`.** This replays the persisted `<summary>+<recovery>` envelope (and its structured `{result, _elided?}` wrapper) byte-for-byte, bypassing path navigation.
> 
> **Compose output/wire shape is updated to match the standard caching wrapper.** `compose` now relies on the outer `cache()` call (empty text is filled from structured), drops the special `compose:result` caching and `result_invocation_id`, moves `sub_invocations` under the wrapped `.result`, and trims `SubInvocation` metadata; bats tests and compose snapshot fixtures are regenerated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8bd9f4ca1145f387f3e826893f3d13b821541b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->