### PR TITLE
fix(toolset): drua_admin_* visibility gated by subject in progressive-disclosure note

### DIFF
--- a/core/src/agent/system_prompt.rs
+++ b/core/src/agent/system_prompt.rs
@@ -153,11 +153,7 @@ fn render_workflow_role(output_schema: Option<&crate::workflow::OutputSchema>) -
 
 /// Tools section: does NOT re-list top-level tools (already in `tools`
 /// array). Covers sandbox prerequisites and progressive disclosure.
-fn build_tools_section(
-    role: AgentRole,
-    toolsets: &Arc<ToolSets>,
-    _subject: &AuthSubject,
-) -> String {
+fn build_tools_section(role: AgentRole, toolsets: &Arc<ToolSets>, subject: &AuthSubject) -> String {
     let mut section = String::new();
 
     if matches!(role, AgentRole::Agent | AgentRole::WorkflowStepAgent) {
@@ -167,7 +163,7 @@ fn build_tools_section(
         );
     }
 
-    let gateway_info = toolsets.mcp_gateway_info();
+    let gateway_info = toolsets.mcp_gateway_info_for(subject);
     if !gateway_info.is_empty() {
         section.push_str("\n# Additional tools (progressive disclosure)\n\n");
         section.push_str(&gateway_info);

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -357,7 +357,22 @@ impl ToolSets {
     }
 
     /// Human-readable summary used as the MCP server's `instructions` payload.
+    /// Lists every registered toolset without filtering — the MCP gateway has
+    /// no per-client auth context at protocol-init time, and per-call paths
+    /// (`list_tools`, `search_tools`, dispatch) enforce visibility.
     pub fn mcp_gateway_info(&self) -> String {
+        self.render_gateway_info(|_| true)
+    }
+
+    /// Subject-filtered variant of [`Self::mcp_gateway_info`] for callers
+    /// that have an `AuthSubject` available (e.g. agent system prompts).
+    /// Only toolsets whose `SearchableToolSet::is_visible(subject)` returns
+    /// `true` are listed.
+    pub fn mcp_gateway_info_for(&self, subject: &AuthSubject) -> String {
+        self.render_gateway_info(|set| set.is_visible(subject))
+    }
+
+    fn render_gateway_info(&self, include: impl Fn(&dyn SearchableToolSet) -> bool) -> String {
         let sets = self.sets.read().expect("toolset lock poisoned");
         let mut lines = vec![
             "Tools from upstream services are available via progressive disclosure:".to_string(),
@@ -367,7 +382,7 @@ impl ToolSets {
             String::new(),
             "Available toolsets:".to_string(),
         ];
-        for set in sets.iter() {
+        for set in sets.iter().filter(|s| include(s.as_ref())) {
             lines.push(format!(
                 "  {} ({}, {} tools) — {}",
                 set.name(),
@@ -597,6 +612,7 @@ mod tests {
         name: String,
         scope: Option<ToolSetScope>,
         tools: Vec<ToolSetEntry>,
+        admin_only: bool,
     }
 
     impl StubToolSet {
@@ -608,6 +624,7 @@ mod tests {
                     session_id,
                 }),
                 tools: Vec::new(),
+                admin_only: false,
             }
         }
 
@@ -616,6 +633,16 @@ mod tests {
                 name: name.to_string(),
                 scope: None,
                 tools: Vec::new(),
+                admin_only: false,
+            }
+        }
+
+        fn admin_only(name: &str) -> Self {
+            Self {
+                name: name.to_string(),
+                scope: None,
+                tools: Vec::new(),
+                admin_only: true,
             }
         }
     }
@@ -636,6 +663,9 @@ mod tests {
         }
         fn scope(&self) -> Option<&ToolSetScope> {
             self.scope.as_ref()
+        }
+        fn is_visible(&self, subject: &AuthSubject) -> bool {
+            !self.admin_only || subject.is_admin()
         }
         async fn call(
             &self,
@@ -982,5 +1012,59 @@ mod tests {
             Err(WorkflowToolLookupError::NoOutputSchema(name)) => assert_eq!(name, "no_schema"),
             _ => panic!("expected NoOutputSchema"),
         }
+    }
+
+    #[test]
+    fn mcp_gateway_info_for_hides_admin_only_toolsets_from_non_admin() {
+        use crate::auth::AuthScope;
+        use crate::primitives::{AgentId, ProjectId};
+
+        let toolsets = ToolSets::empty_for_test();
+        toolsets.register_searchable(StubToolSet::static_("concourse"));
+        toolsets.register_searchable(StubToolSet::admin_only("drua_admin"));
+
+        let project_id = ProjectId::new();
+        let project_lead = AuthSubject::Agent(
+            project_id,
+            AgentId::new(),
+            vec![AuthScope::ProjectAdmin(project_id)],
+        );
+
+        let info = toolsets.mcp_gateway_info_for(&project_lead);
+        assert!(
+            !info.contains("drua_admin"),
+            "project lead must not see admin-only toolsets in progressive-disclosure note:\n{info}"
+        );
+        assert!(
+            info.contains("concourse"),
+            "non-admin toolsets must still be listed:\n{info}"
+        );
+    }
+
+    #[test]
+    fn mcp_gateway_info_for_shows_admin_only_toolsets_to_admin() {
+        use crate::primitives::UserId;
+
+        let toolsets = ToolSets::empty_for_test();
+        toolsets.register_searchable(StubToolSet::admin_only("drua_admin"));
+
+        let admin = AuthSubject::User(UserId::new());
+        let info = toolsets.mcp_gateway_info_for(&admin);
+        assert!(
+            info.contains("drua_admin"),
+            "admin must see admin-only toolsets:\n{info}"
+        );
+    }
+
+    #[test]
+    fn mcp_gateway_info_unfiltered_lists_admin_only_toolsets() {
+        let toolsets = ToolSets::empty_for_test();
+        toolsets.register_searchable(StubToolSet::admin_only("drua_admin"));
+
+        let info = toolsets.mcp_gateway_info();
+        assert!(
+            info.contains("drua_admin"),
+            "unfiltered gateway info lists every toolset:\n{info}"
+        );
     }
 }


### PR DESCRIPTION
## Summary

A manual test of a lead agent (`ProjectAdmin` scope) showed its system prompt's progressive-disclosure note listing `drua_admin` as an available toolset. That toolset is admin-tier and should only appear for `AuthScope::Admin` subjects.

## Root cause

`ToolSets::mcp_gateway_info()` (`core/src/toolset/mod.rs:360-380`) iterates every registered `SearchableToolSet` unconditionally — it takes no `subject` argument and never applies `SearchableToolSet::is_visible(subject)`. The agent system prompt renders this note from that method (`core/src/agent/system_prompt.rs:170`), and `build_tools_section` already had `subject` in scope but discarded it (`_subject: &AuthSubject`).

`AdminToolSet::is_visible` itself is correct: `subject.is_admin()` checks for `AuthScope::Admin`, which a `ProjectLead` agent does not carry.

## Severity: display-only, NOT an authz bypass

Every callable path already enforces `is_visible(subject)`:

- `search_tools` — `visible_entries` (`top_level/catalog.rs:516`)
- `describe_tool` / `call_tool` — `find_searchable` (`toolset/dispatch.rs:23`)
- `compose` — (`top_level/compose.rs:386,559,693`)
- `compose_types` — (`top_level/compose_types.rs:128`)

A non-admin invoking `drua_admin_*` gets `ToolNotFound`. The bug misled agents about what they could actually call; it did not grant access.

## Fix

- Add `ToolSets::mcp_gateway_info_for(&AuthSubject) -> String` that filters via `is_visible(subject)`.
- Route the agent system-prompt path through it (now using the existing `subject` parameter instead of ignoring it).
- Leave the existing unfiltered `mcp_gateway_info()` for the MCP gateway's static `get_info` (no per-client auth context at protocol init; access is enforced per-call by `list_tools`/dispatch).

## Related toolsets audited

`AdminToolSet` is the only toolset gated on `is_admin()`. Other scope-gated toolsets (`LibraryToolSet` requires non-anonymous; `UpstreamToolSet` honours `required_scopes`) flow through the same filter and now benefit from the same fix in the progressive-disclosure note path.

## Test plan

- [x] Regression: `mcp_gateway_info_for_hides_admin_only_toolsets_from_non_admin` — a `ProjectAdmin`-scoped subject does NOT see admin-only toolsets in the note.
- [x] Positive: `mcp_gateway_info_for_shows_admin_only_toolsets_to_admin` — a `User` subject (implicit admin) DOES see them.
- [x] Backstop: `mcp_gateway_info_unfiltered_lists_admin_only_toolsets` — the unfiltered variant kept for the MCP gateway path is still fully populated.
- [x] Existing `system_prompt::tests` still pass.
- [x] `nix flake check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the human-readable progressive-disclosure toolset listing in agent system prompts; enforcement of tool visibility remains on existing per-call authz paths.
> 
> **Overview**
> Agent system prompts now render the progressive-disclosure “available toolsets” note using a subject-filtered listing, so admin-only toolsets (e.g. `drua_admin`) are not advertised to non-admin subjects.
> 
> `ToolSets` adds `mcp_gateway_info_for(subject)` (backed by a shared renderer) while keeping `mcp_gateway_info()` unfiltered for the MCP gateway’s protocol-init `instructions`, and new unit tests cover both filtered and unfiltered behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81d261007f90f9c79013751f81c0bdb42e64105c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->