### PR TITLE
docs(tool_output_fetch): advertise all four query modes

### DIFF
--- a/core/src/toolset/top_level/tool_output_fetch.rs
+++ b/core/src/toolset/top_level/tool_output_fetch.rs
@@ -32,8 +32,11 @@ impl ToolOutputFetch {
 const DESCRIPTION: &str = "Recover a slice of a previously-summarised tool output. \
     `invocation_id` is the uuid advertised inside the envelope's <recovery> block. \
     `path` (default `$`) is a json-path anchor against the persisted root value. \
-    `query` (optional) further slices the resolved value: `{mode:\"range\", offset, len}` \
-    returns bytes `[offset..offset+len]` of a string at the path. \
+    `query` (optional) further slices the resolved value: \
+    `{mode:\"range\", offset, len}` returns bytes `[offset..offset+len]` of a string at the path; \
+    `{mode:\"lines\", offset, len}` returns line range `[offset..offset+len]` of a string at the path; \
+    `{mode:\"json_array_slice\", offset, len}` returns item range `arr[offset..offset+len]` of an array at the path; \
+    `{mode:\"summary\"}` replays the original curated `<summary>+<recovery>` envelope (ignores `path`). \
     The response is the resolved (and optionally sliced) value, wrapped back at `path`.";
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]


### PR DESCRIPTION
## Summary
- `tool_output_fetch`'s tool-level `description` string only mentions `{mode:"range"}`, even though the schemars-derived `oneOf` correctly lists `range`, `lines`, `json_array_slice`, and `summary` after PR #345.
- Agents that read the description (rather than the JSON schema) miss three of the four modes — including `summary`, which is the natural follow-up for compose's `sub_invocations[i].invocation_id`.
- This patch lists all four modes inline in the description.

## Test plan
- [x] Build green (`cargo build --release -p drua-core`).
- [ ] Visual: after deploy, `mcp__drua__describe_tool` for `tool_output_fetch` shows all four modes in the description body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Doc-only change that updates the `tool_output_fetch` description string; no runtime logic or schema behavior changes.
> 
> **Overview**
> Updates the `tool_output_fetch` tool description to advertise all supported `query` modes (`range`, `lines`, `json_array_slice`, and `summary`), including clarifying that `summary` replays the curated `<summary>+<recovery>` envelope and ignores `path`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7f94c5394ab445470d1b1831285d981dba72b01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->