### PR TITLE
feat(workflows): delete end-to-end (top-level + admin + GraphQL + library-sync)

### DIFF
--- a/.sqlx/query-288afc870edd73852f2a61b7bbc18418bf4d8fab648e75838a98fe8e6ff0d568.json
+++ b/.sqlx/query-288afc870edd73852f2a61b7bbc18418bf4d8fab648e75838a98fe8e6ff0d568.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM agents WHERE COALESCE(project_id = $1, $1 IS NULL) AND (NOT $2 OR workflow_id IS NOT DISTINCT FROM $3) AND (NOT $4 OR workflow_run_id IS NOT DISTINCT FROM $5) AND (COALESCE((created_at, id) > ($8, $7), $7 IS NULL)) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $6) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $9 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN agent_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool",
+        "Uuid",
+        "Bool",
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "288afc870edd73852f2a61b7bbc18418bf4d8fab648e75838a98fe8e6ff0d568"
+}

--- a/.sqlx/query-4e1601c8d77b3ea2f62d42baa7fd644569e38ab7266900663890021823ef6b19.json
+++ b/.sqlx/query-4e1601c8d77b3ea2f62d42baa7fd644569e38ab7266900663890021823ef6b19.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT workflow_id, created_at, id FROM sandboxes WHERE ((workflow_id IS NOT DISTINCT FROM $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "4e1601c8d77b3ea2f62d42baa7fd644569e38ab7266900663890021823ef6b19"
+}

--- a/.sqlx/query-5fb8658cfd9e8edbda7ea793c0980718166338aefbb6e0aa27af49b353a45413.json
+++ b/.sqlx/query-5fb8658cfd9e8edbda7ea793c0980718166338aefbb6e0aa27af49b353a45413.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT workflow_id, created_at, id FROM sandboxes WHERE ((workflow_id IS NOT DISTINCT FROM $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "5fb8658cfd9e8edbda7ea793c0980718166338aefbb6e0aa27af49b353a45413"
+}

--- a/.sqlx/query-6de2dc3bc3203a966f12652a775ce66298295e7184cf8ac524e3871ffe207be2.json
+++ b/.sqlx/query-6de2dc3bc3203a966f12652a775ce66298295e7184cf8ac524e3871ffe207be2.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE COALESCE(project_id = $1, $1 IS NULL) AND COALESCE(name = $2, $2 IS NULL) AND (NOT $3 OR workflow_id IS NOT DISTINCT FROM $4) AND (COALESCE(id > $6, true)) AND deleted = FALSE ORDER BY id ASC LIMIT $5) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $7 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Bool",
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "6de2dc3bc3203a966f12652a775ce66298295e7184cf8ac524e3871ffe207be2"
+}

--- a/.sqlx/query-791f47bb67739c6cdabfd16d3d47a4ae256b7ca5572203dedf415080b0b01413.json
+++ b/.sqlx/query-791f47bb67739c6cdabfd16d3d47a4ae256b7ca5572203dedf415080b0b01413.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT workflow_id, created_at, id FROM agents WHERE ((workflow_id IS NOT DISTINCT FROM $1) AND (COALESCE((created_at, id) > ($4, $3), $3 IS NULL))) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN agent_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "791f47bb67739c6cdabfd16d3d47a4ae256b7ca5572203dedf415080b0b01413"
+}

--- a/.sqlx/query-8d91d916afe2e01c87cc94af67dee5c39d711431c94ee69faa722b79ff3895c5.json
+++ b/.sqlx/query-8d91d916afe2e01c87cc94af67dee5c39d711431c94ee69faa722b79ff3895c5.json
@@ -1,0 +1,52 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM sandboxes WHERE COALESCE(project_id = $1, $1 IS NULL) AND COALESCE(name = $2, $2 IS NULL) AND (NOT $3 OR workflow_id IS NOT DISTINCT FROM $4) AND (COALESCE(id < $6, true)) AND deleted = FALSE ORDER BY id DESC LIMIT $5) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $7 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Bool",
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "8d91d916afe2e01c87cc94af67dee5c39d711431c94ee69faa722b79ff3895c5"
+}

--- a/.sqlx/query-95300e76b8a7ef69f0e6957041354f3025df2a0290b49996416622bd5593fe7e.json
+++ b/.sqlx/query-95300e76b8a7ef69f0e6957041354f3025df2a0290b49996416622bd5593fe7e.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM sandboxes WHERE COALESCE(project_id = $1, $1 IS NULL) AND COALESCE(name = $2, $2 IS NULL) AND (NOT $3 OR workflow_id IS NOT DISTINCT FROM $4) AND (COALESCE((created_at, id) > ($7, $6), $6 IS NULL)) AND deleted = FALSE ORDER BY created_at ASC, id ASC LIMIT $5) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $8 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at asc, i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Bool",
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "95300e76b8a7ef69f0e6957041354f3025df2a0290b49996416622bd5593fe7e"
+}

--- a/.sqlx/query-9e9f3fe2a0ba9b084359ead3f0dbf8b4b3004926a6facd3b495871ca6299ea99.json
+++ b/.sqlx/query-9e9f3fe2a0ba9b084359ead3f0dbf8b4b3004926a6facd3b495871ca6299ea99.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM agents WHERE COALESCE(project_id = $1, $1 IS NULL) AND (NOT $2 OR workflow_id IS NOT DISTINCT FROM $3) AND (NOT $4 OR workflow_run_id IS NOT DISTINCT FROM $5) AND (COALESCE(id > $7, true)) AND deleted = FALSE ORDER BY id ASC LIMIT $6) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $8 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN agent_events e ON i.id = e.id ORDER BY i.id asc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool",
+        "Uuid",
+        "Bool",
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "9e9f3fe2a0ba9b084359ead3f0dbf8b4b3004926a6facd3b495871ca6299ea99"
+}

--- a/.sqlx/query-ad9a65410cd48f260b0299eef11d57414a316042f79d8278afb1080d55332959.json
+++ b/.sqlx/query-ad9a65410cd48f260b0299eef11d57414a316042f79d8278afb1080d55332959.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT id FROM agents WHERE COALESCE(project_id = $1, $1 IS NULL) AND (NOT $2 OR workflow_id IS NOT DISTINCT FROM $3) AND (NOT $4 OR workflow_run_id IS NOT DISTINCT FROM $5) AND (COALESCE(id < $7, true)) AND deleted = FALSE ORDER BY id DESC LIMIT $6) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $8 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN agent_events e ON i.id = e.id ORDER BY i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool",
+        "Uuid",
+        "Bool",
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "ad9a65410cd48f260b0299eef11d57414a316042f79d8278afb1080d55332959"
+}

--- a/.sqlx/query-b3812fcb79acf85ed8319301f2cc1ee53786c77b9c7571097a8bb722b585ba31.json
+++ b/.sqlx/query-b3812fcb79acf85ed8319301f2cc1ee53786c77b9c7571097a8bb722b585ba31.json
@@ -1,0 +1,50 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT workflow_id, created_at, id FROM agents WHERE ((workflow_id IS NOT DISTINCT FROM $1) AND (COALESCE((created_at, id) < ($4, $3), $3 IS NULL))) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $2) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $5 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN agent_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "b3812fcb79acf85ed8319301f2cc1ee53786c77b9c7571097a8bb722b585ba31"
+}

--- a/.sqlx/query-ef37aaa5cb364ca1135061ba6dd533eec6ec1560177386612d1024037bf81a1e.json
+++ b/.sqlx/query-ef37aaa5cb364ca1135061ba6dd533eec6ec1560177386612d1024037bf81a1e.json
@@ -1,0 +1,53 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM sandboxes WHERE COALESCE(project_id = $1, $1 IS NULL) AND COALESCE(name = $2, $2 IS NULL) AND (NOT $3 OR workflow_id IS NOT DISTINCT FROM $4) AND (COALESCE((created_at, id) < ($7, $6), $6 IS NULL)) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $5) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $8 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN sandbox_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Text",
+        "Bool",
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "ef37aaa5cb364ca1135061ba6dd533eec6ec1560177386612d1024037bf81a1e"
+}

--- a/.sqlx/query-f906783443bbceb9f125480cda91d8a07c62df767693cd0088c581c991d7aad7.json
+++ b/.sqlx/query-f906783443bbceb9f125480cda91d8a07c62df767693cd0088c581c991d7aad7.json
@@ -1,0 +1,54 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "WITH entities AS (SELECT created_at, id FROM agents WHERE COALESCE(project_id = $1, $1 IS NULL) AND (NOT $2 OR workflow_id IS NOT DISTINCT FROM $3) AND (NOT $4 OR workflow_run_id IS NOT DISTINCT FROM $5) AND (COALESCE((created_at, id) < ($8, $7), $7 IS NULL)) AND deleted = FALSE ORDER BY created_at DESC, id DESC LIMIT $6) SELECT i.id AS \"entity_id: Repo__Id\", e.sequence, e.event, CASE WHEN $9 THEN e.context ELSE NULL::jsonb END as \"context: es_entity::ContextData\", e.recorded_at FROM entities i JOIN agent_events e ON i.id = e.id ORDER BY i.created_at desc, i.id desc, i.id, e.sequence",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "entity_id: Repo__Id",
+        "type_info": "Uuid"
+      },
+      {
+        "ordinal": 1,
+        "name": "sequence",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "event",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 3,
+        "name": "context: es_entity::ContextData",
+        "type_info": "Jsonb"
+      },
+      {
+        "ordinal": 4,
+        "name": "recorded_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Uuid",
+        "Bool",
+        "Uuid",
+        "Bool",
+        "Uuid",
+        "Int8",
+        "Uuid",
+        "Timestamptz",
+        "Bool"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      null,
+      false
+    ]
+  },
+  "hash": "f906783443bbceb9f125480cda91d8a07c62df767693cd0088c581c991d7aad7"
+}

--- a/core/migrations/20260515000000_agents_workflow_id_index.sql
+++ b/core/migrations/20260515000000_agents_workflow_id_index.sql
@@ -1,0 +1,3 @@
+CREATE INDEX IF NOT EXISTS idx_agents_workflow_id
+    ON public.agents USING btree (workflow_id, created_at DESC)
+    WHERE (workflow_id IS NOT NULL);

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -799,6 +799,39 @@ impl Agents {
         Ok(())
     }
 
+    #[instrument(
+        name = "domain.agent.cascade_delete_for_workflow_id_in_op",
+        skip(self, op)
+    )]
+    pub async fn cascade_delete_for_workflow_id_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        workflow_id: WorkflowDefinitionId,
+    ) -> Result<(), AgentError> {
+        const PAGE_SIZE: usize = 100;
+        loop {
+            let result = self
+                .repo
+                .list_for_workflow_id_by_created_at_in_op(
+                    &mut *op,
+                    Some(workflow_id),
+                    es_entity::PaginatedQueryArgs {
+                        first: PAGE_SIZE,
+                        after: None,
+                    },
+                    es_entity::ListDirection::Ascending,
+                )
+                .await?;
+            if result.entities.is_empty() {
+                break;
+            }
+            for agent in result.entities {
+                self.delete_in_op(op, agent.id).await?;
+            }
+        }
+        Ok(())
+    }
+
     /// Re-attach with a different mode: downgrade unconditional; upgrade to
     /// Write only if no other agent holds Write. The matching
     /// `SandboxRead`/`SandboxWrite` scope replaces any stale opposite-mode

--- a/core/src/agent/repo.rs
+++ b/core/src/agent/repo.rs
@@ -10,7 +10,7 @@ use super::entity::*;
     entity = "Agent",
     columns(
         project_id(ty = "ProjectId", list_for(by(created_at))),
-        workflow_id(ty = "Option<WorkflowDefinitionId>"),
+        workflow_id(ty = "Option<WorkflowDefinitionId>", list_for(by(created_at))),
         workflow_run_id(ty = "Option<WorkflowRunId>", list_for(by(created_at))),
     ),
     delete = "soft_without_queries"

--- a/core/src/auth/verb.rs
+++ b/core/src/auth/verb.rs
@@ -1,8 +1,8 @@
 /// The action being attempted on an [`super::AuthResource`].
-#[derive(Debug, Clone, Copy, PartialEq,Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AuthVerb {
     Create,
-      Read,
+    Read,
     Update,
     Delete,
     /// Generic "use" — e.g. executing a sandbox tool or invoking a skill.

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -906,6 +906,72 @@ impl Sandboxes {
         Ok(())
     }
 
+    #[instrument(
+        name = "domain.sandbox.cascade_delete_for_workflow_id_in_op",
+        skip(self, op)
+    )]
+    pub async fn cascade_delete_for_workflow_id_in_op(
+        &self,
+        op: &mut DbOp<'_>,
+        workflow_id: WorkflowDefinitionId,
+    ) -> Result<(), SandboxError> {
+        for sandbox in self.list_all_for_workflow_id_in_op(op, workflow_id).await? {
+            let resource_name = sandbox.resource_name();
+            if sandbox.state != SandboxState::Suspended {
+                if let Err(e) = self.admin.delete_sandbox(&resource_name).await {
+                    tracing::warn!(
+                        sandbox_id = %sandbox.id,
+                        sandbox = %resource_name,
+                        error = %e,
+                        "admin delete_sandbox failed during workflow cascade"
+                    );
+                }
+            }
+            if let Err(e) = self.admin.delete_pvcs(&resource_name).await {
+                tracing::warn!(
+                    sandbox_id = %sandbox.id,
+                    sandbox = %resource_name,
+                    error = %e,
+                    "admin delete_pvcs failed during workflow cascade"
+                );
+            }
+        }
+        self.repo
+            .cascade_delete_for_workflow_id_in_op(op, workflow_id)
+            .await?;
+        Ok(())
+    }
+
+    async fn list_all_for_workflow_id_in_op(
+        &self,
+        op: &mut DbOp<'_>,
+        workflow_id: WorkflowDefinitionId,
+    ) -> Result<Vec<Sandbox>, SandboxError> {
+        const PAGE_SIZE: usize = 100;
+        let mut all = Vec::new();
+        let mut query = PaginatedQueryArgs {
+            first: PAGE_SIZE,
+            after: None,
+        };
+        loop {
+            let mut result = self
+                .repo
+                .list_for_workflow_id_by_created_at_in_op(
+                    &mut *op,
+                    Some(workflow_id),
+                    query,
+                    ListDirection::Descending,
+                )
+                .await?;
+            all.append(&mut result.entities);
+            match result.into_next_query() {
+                Some(next) => query = next,
+                None => break,
+            }
+        }
+        Ok(all)
+    }
+
     /// Drains every page of `list_for_project_id_by_created_at_in_op`
     /// — used by the cascade variants that *must not* miss rows.
     async fn list_all_for_project_in_op(

--- a/core/src/sandbox/repo.rs
+++ b/core/src/sandbox/repo.rs
@@ -12,7 +12,7 @@ use super::entity::*;
     columns(
         project_id(ty = "ProjectId", list_for(by(created_at))),
         name(ty = "String", list_for(by(created_at))),
-        workflow_id(ty = "Option<WorkflowDefinitionId>"),
+        workflow_id(ty = "Option<WorkflowDefinitionId>", list_for(by(created_at))),
     ),
     delete = "soft_without_queries"
 )]
@@ -38,6 +38,18 @@ impl SandboxRepo {
     ) -> Result<(), sqlx::Error> {
         sqlx::query("UPDATE sandboxes SET deleted = TRUE WHERE project_id = $1")
             .bind(project_id)
+            .execute(op.as_executor())
+            .await?;
+        Ok(())
+    }
+
+    pub async fn cascade_delete_for_workflow_id_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        workflow_id: WorkflowDefinitionId,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE sandboxes SET deleted = TRUE WHERE workflow_id = $1")
+            .bind(workflow_id)
             .execute(op.as_executor())
             .await?;
         Ok(())

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -319,6 +319,10 @@ enum WorkflowCommand {
     List,
     Get,
     Update,
+    /// Soft-delete the definition. Cascades runs to soft-deleted and
+    /// queues a `DeleteFile` write on the canonical YAML. Cron jobs
+    /// self-terminate on next fire.
+    Delete,
     /// Spawn a run with the given trigger payload. Returns the run id.
     Trigger,
     /// Block until a run reaches a terminal state, then surface the
@@ -507,9 +511,9 @@ struct WorkflowParams {
     #[schemars(with = "Option<uuid::Uuid>")]
     project_id: Option<ProjectId>,
 
-    /// Required for `get`, `update`, `trigger`. UUID — admin tier
-    /// keeps it strict; the top-level `workflow` tool accepts
-    /// names too for skill-author ergonomics.
+    /// Required for `get`, `update`, `trigger`, `delete`. UUID —
+    /// admin tier keeps it strict; the top-level `workflow` tool
+    /// accepts names too for skill-author ergonomics.
     #[schemars(with = "Option<uuid::Uuid>")]
     definition_id: Option<WorkflowDefinitionId>,
 
@@ -701,7 +705,8 @@ static TOOLS: &[ToolDef] = &[
                        `update` (requires `definition_id`; optional `name`, \
                        `description`+`clear_description` for None semantics, \
                        `provider`+`update_trigger`, `steps`+`update_steps`, \
-                       `sandboxes`+`update_sandboxes`).",
+                       `sandboxes`+`update_sandboxes`), \
+                       `delete` (requires `definition_id`; cascades to runs).",
         schema: &WORKFLOW_SCHEMA,
     },
     ToolDef {
@@ -1448,6 +1453,22 @@ impl AdminToolSet {
                 Ok(CallToolResult::success(vec![Content::text(
                     format_workflow(&definition, false),
                 )]))
+            }
+
+            WorkflowCommand::Delete => {
+                let definition_id = params.definition_id.ok_or_else(|| {
+                    ToolSetsError::MissingArgument(
+                        "definition_id is required for delete".to_string(),
+                    )
+                })?;
+                Audit::record_action("workflow.delete");
+                self.workflows
+                    .delete(subject, definition_id)
+                    .await
+                    .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Workflow deleted (id {definition_id})."
+                ))]))
             }
 
             WorkflowCommand::Trigger => {
@@ -2735,9 +2756,21 @@ mod tests {
     #[test]
     fn workflow_schema_includes_command_enum() {
         let s = serde_json::to_string(&*WORKFLOW_SCHEMA).unwrap();
-        for v in ["create", "list", "get", "update"] {
+        for v in ["create", "list", "get", "update", "delete"] {
             assert!(s.contains(&format!("\"{v}\"")), "missing {v} in schema");
         }
+    }
+
+    #[test]
+    fn workflow_delete_takes_definition_id() {
+        let definition_id = uuid::Uuid::new_v4();
+        let p: WorkflowParams = parse_params(args(serde_json::json!({
+            "command": "delete",
+            "definition_id": definition_id,
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, WorkflowCommand::Delete));
+        assert_eq!(p.definition_id.map(uuid::Uuid::from), Some(definition_id));
     }
 
     #[test]

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -319,9 +319,6 @@ enum WorkflowCommand {
     List,
     Get,
     Update,
-    /// Soft-delete the definition. Cascades runs to soft-deleted and
-    /// queues a `DeleteFile` write on the canonical YAML. Cron jobs
-    /// self-terminate on next fire.
     Delete,
     /// Spawn a run with the given trigger payload. Returns the run id.
     Trigger,

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -118,6 +118,9 @@ enum WorkflowParams {
         #[serde(default)]
         clear_model_chain: bool,
     },
+    Delete {
+        definition_id: WorkflowDefinitionId,
+    },
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -312,6 +315,7 @@ impl WorkflowParams {
             Self::Runs { .. } => "workflow.runs",
             Self::Run { .. } => "workflow.run",
             Self::Update { .. } => "workflow.update",
+            Self::Delete { .. } => "workflow.delete",
         }
     }
 }
@@ -474,7 +478,7 @@ static WORKFLOW_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
         "properties": {
             "command": {
                 "type": "string",
-                "enum": ["create", "list", "get", "trigger", "await_run", "runs", "run", "update"],
+                "enum": ["create", "list", "get", "trigger", "await_run", "runs", "run", "update", "delete"],
                 "description": "Which workflow operation to perform. `trigger` returns immediately with the freshly-spawned run; pair with `await_run` to block until terminal. `runs` lists runs (truncated outputs); `run` returns a single run with full per-step output."
             },
             "name": {
@@ -619,7 +623,9 @@ impl TopLevelTool for WorkflowTool {
          `update` (requires `definition_id`; optional `name`, \
          `description`+`clear_description`, `steps`+`update_steps`, \
          `sandboxes`+`update_sandboxes`, `provider`/`manual`+`update_trigger`, \
-         `model_chain`+`clear_model_chain`)."
+         `model_chain`+`clear_model_chain`), \
+         `delete` (requires `definition_id`; cascades to runs and queues \
+         a `DeleteFile` on the canonical YAML)."
     }
 
     fn input_schema(&self) -> &serde_json::Value {
@@ -924,6 +930,19 @@ impl TopLevelTool for WorkflowTool {
                 let out = WorkflowOutput {
                     command: "update".to_string(),
                     definition: Some(definition_to_output(&definition)),
+                    ..Default::default()
+                };
+                (text, out)
+            }
+
+            WorkflowParams::Delete { definition_id } => {
+                self.workflows
+                    .delete(subject, definition_id)
+                    .await
+                    .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
+                let text = format!("Workflow deleted (id {definition_id}).");
+                let out = WorkflowOutput {
+                    command: "delete".to_string(),
                     ..Default::default()
                 };
                 (text, out)

--- a/core/src/workflow/error.rs
+++ b/core/src/workflow/error.rs
@@ -82,6 +82,8 @@ pub enum WorkflowError {
     Sandbox(#[from] SandboxError),
     #[error("WorkflowError - Job: {0}")]
     Job(String),
+    #[error("WorkflowError - Library: {0}")]
+    Library(#[from] drua_library::LibraryError),
     #[error("WorkflowError - Authorization: {0}")]
     Authorization(#[from] AuthorizationError),
     /// Cooperative cancellation. The runner observes the job's shutdown

--- a/core/src/workflow/error.rs
+++ b/core/src/workflow/error.rs
@@ -1,5 +1,6 @@
 use thiserror::Error;
 
+use crate::agent::error::AgentError;
 use crate::auth::error::AuthorizationError;
 use crate::sandbox::SandboxError;
 
@@ -75,7 +76,7 @@ pub enum WorkflowError {
     #[error("WorkflowError - StepErrored: {step}: {reason}")]
     StepErrored { step: String, reason: String },
     #[error("WorkflowError - Agent: {0}")]
-    Agent(String),
+    Agent(#[from] AgentError),
     #[error("WorkflowError - Skill: {0}")]
     Skill(String),
     #[error("WorkflowError - Sandbox: {0}")]

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -539,32 +539,27 @@ impl Executor {
                     crate::skill::SkillBody::new(templated_body).interpolate(Some(&arguments));
 
                 let agent_name = format!("workflow-{}-{name}", run_id.short());
-                let mut op = self
-                    .agents
-                    .begin_op()
-                    .await
-                    .map_err(|e| WorkflowError::Agent(e.to_string()))?;
+                let mut op = self.agents.begin_op().await?;
 
                 let existing = self
                     .agents
                     .find_for_workflow_step_in_op(&mut op, run_id, &agent_name)
-                    .await
-                    .map_err(|e| WorkflowError::Agent(e.to_string()))?;
+                    .await?;
 
                 let (agent, detached_agents) = if let Some(agent) = existing {
                     (agent, Vec::new())
                 } else {
                     let detached_agents = match attach_sandbox {
-                        Some((sandbox_id, mode)) => self
-                            .agents
-                            .detach_conflicting_writer_in_op(
-                                &mut op,
-                                sandbox_id,
-                                mode,
-                                Some(workflow_id),
-                            )
-                            .await
-                            .map_err(|e| WorkflowError::Agent(e.to_string()))?,
+                        Some((sandbox_id, mode)) => {
+                            self.agents
+                                .detach_conflicting_writer_in_op(
+                                    &mut op,
+                                    sandbox_id,
+                                    mode,
+                                    Some(workflow_id),
+                                )
+                                .await?
+                        }
                         None => Vec::new(),
                     };
                     let chain_override = definition.resolve_step_chain(step);
@@ -580,13 +575,10 @@ impl Executor {
                             chain_override,
                             output_schema.as_ref().clone(),
                         )
-                        .await
-                        .map_err(|e| WorkflowError::Agent(e.to_string()))?;
+                        .await?;
                     (agent, detached_agents)
                 };
-                op.commit()
-                    .await
-                    .map_err(|e| WorkflowError::Agent(e.to_string()))?;
+                op.commit().await?;
 
                 if let Some((sandbox_id, _)) = attach_sandbox {
                     if preexisting_ids.contains(&sandbox_id) {
@@ -711,16 +703,15 @@ impl Executor {
         let mut rx = match self
             .agents
             .resume_message(agent_subject.clone(), agent.id)
-            .await
-            .map_err(|e| WorkflowError::Agent(e.to_string()))?
+            .await?
         {
             Some(rx) => rx,
             None => match user_prompt {
-                Some(prompt) => self
-                    .agents
-                    .send_message_with_choice(agent_subject, agent.id, prompt, tool_choice)
-                    .await
-                    .map_err(|e| WorkflowError::Agent(e.to_string()))?,
+                Some(prompt) => {
+                    self.agents
+                        .send_message_with_choice(agent_subject, agent.id, prompt, tool_choice)
+                        .await?
+                }
                 None => return Ok(None),
             },
         };
@@ -759,10 +750,7 @@ impl Executor {
         // pushed `OutputSubmitted` and returned `Done` when the agent
         // called `submit_output`, which broke the agent loop and
         // emitted `AssistantDone`. Read it back here.
-        self.agents
-            .submitted_output(agent.id)
-            .await
-            .map_err(|e| WorkflowError::Agent(e.to_string()))
+        Ok(self.agents.submitted_output(agent.id).await?)
     }
 
     /// Dispatch a single top-level MCP tool with `${{ … }}`-substituted

--- a/core/src/workflow/importer.rs
+++ b/core/src/workflow/importer.rs
@@ -90,4 +90,45 @@ impl LibraryImporter for WorkflowsImporter {
 
         Ok(None)
     }
+
+    /// Reverse-sync delete: the YAML at `path` was removed in git.
+    /// Resolve `(project_name, canonical-path)` from the path, look
+    /// up the live workflow under that project, soft-delete it +
+    /// wipe its search row. Paths that don't parse into the
+    /// `runtime/projects/{name}/workflows/{slug}.yml` shape, or that
+    /// reference an unknown project, are silently skipped (mirrors
+    /// `upsert_in_op`'s unknown-project behaviour and the skill
+    /// importer's hand-authored-path policy).
+    async fn delete_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        path: &str,
+    ) -> Result<Option<uuid::Uuid>, UpsertError> {
+        let Some(project_name) = crate::workflow::yaml::project_name_from_workflow_path(path)
+        else {
+            return Ok(None);
+        };
+        let project = match self.projects.find_by_name(&project_name).await {
+            Ok(Some(p)) => p,
+            Ok(None) => {
+                tracing::debug!(
+                    project_name,
+                    path,
+                    "workflow delete references unknown project; skipping"
+                );
+                return Ok(None);
+            }
+            Err(e) => {
+                return Err(UpsertError::Other(format!(
+                    "project lookup failed for {project_name}: {e}"
+                )))
+            }
+        };
+        let deleted = self
+            .workflows
+            .delete_by_path_in_op(op, project.id, path)
+            .await
+            .map_err(|e| UpsertError::Other(format!("workflow reverse-delete: {e}")))?;
+        Ok(deleted.map(uuid::Uuid::from))
+    }
 }

--- a/core/src/workflow/importer.rs
+++ b/core/src/workflow/importer.rs
@@ -91,14 +91,6 @@ impl LibraryImporter for WorkflowsImporter {
         Ok(None)
     }
 
-    /// Reverse-sync delete: the YAML at `path` was removed in git.
-    /// Resolve `(project_name, canonical-path)` from the path, look
-    /// up the live workflow under that project, soft-delete it +
-    /// wipe its search row. Paths that don't parse into the
-    /// `runtime/projects/{name}/workflows/{slug}.yml` shape, or that
-    /// reference an unknown project, are silently skipped (mirrors
-    /// `upsert_in_op`'s unknown-project behaviour and the skill
-    /// importer's hand-authored-path policy).
     async fn delete_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -14,6 +14,7 @@ pub use importer::WorkflowsImporter;
 
 use std::sync::Arc;
 
+use drua_library::{CommitAttribution, WriteOp};
 use rand::RngCore;
 use tracing::instrument;
 
@@ -21,9 +22,11 @@ use crate::agent::Agents;
 use crate::audit::{Audit, InteractionOutcome};
 use crate::primitives::*;
 use crate::sandbox::Sandboxes;
+use crate::skill::file::slugify;
 use crate::skill::Skills;
 use crate::toolset::ToolSets;
 use crate::user::Users;
+use yaml::canonical_workflow_path;
 
 pub const WORKFLOW_DOC_TYPE: drua_library::DocType = drua_library::DocType::new("workflow");
 
@@ -161,6 +164,13 @@ pub struct Workflows {
     /// `tool_step.params` — looks up the called tool's
     /// `output_schema()` + `composable()` flag.
     toolsets: Arc<ToolSets>,
+    /// Forward-sync delete-out path: held directly (alongside the
+    /// repo's own handle) so `delete_in_op` can enqueue a
+    /// `WriteOp::DeleteFile`. Soft-delete events don't fire the
+    /// post-persist sync hook, so without this the canonical YAML
+    /// would linger in upstream git forever (skill peer:
+    /// `enqueue_skill_delete_in_op`).
+    library: drua_library::Library,
     execute_run_spawner: ::job::JobSpawner<ExecuteRunConfig>,
     cron_spawner: ::job::JobSpawner<TriggerCronConfig>,
     /// Cloned `Jobs` handle so `await_run_completion` can block on the
@@ -198,11 +208,12 @@ impl Workflows {
             execute_run_spawner.clone(),
         ));
         Self {
-            repo: WorkflowDefinitionRepo::new(pool, library),
+            repo: WorkflowDefinitionRepo::new(pool, library.clone()),
             run_repo: WorkflowRunRepo::new(pool),
             skills,
             users,
             toolsets,
+            library,
             execute_run_spawner,
             cron_spawner,
             jobs: jobs.clone(),
@@ -236,6 +247,22 @@ impl Workflows {
         } = parsed;
 
         Self::validate_trigger(&trigger)?;
+
+        // Race guard: if an operator just deleted this workflow via
+        // the project surface, the soft-deleted row is still in the
+        // table. The default `maybe_find_by_id` filters deleted rows,
+        // so without this probe a reverse-sync poll that races the
+        // forward-sync `DeleteFile` write would resurrect the entity
+        // (memo 019e218a, delete-direction). Drop the import — once
+        // the queued `DeleteFile` lands upstream the file is gone and
+        // future polls won't see it.
+        if self.repo.is_soft_deleted_in_op(op, workflow_id).await? {
+            tracing::info!(
+                %workflow_id,
+                "skipping reverse-sync import for soft-deleted workflow"
+            );
+            return Ok(None);
+        }
 
         let file_hash = drua_library::GitFileHash::new(rendered);
 
@@ -566,7 +593,7 @@ impl Workflows {
             .map_err(|e| WorkflowError::BuildEntity(e.to_string()))?;
 
         let mut op = self.repo.begin_op().await?;
-        self.users.commit_attribution().await;
+        self.populate_attribution().await;
         let workflow = self.repo.create_in_op(&mut op, new).await?;
         self.register_cron_in_op(&mut op, &workflow).await?;
         op.commit().await?;
@@ -623,7 +650,7 @@ impl Workflows {
             .did_execute()
         {
             let mut op = self.repo.begin_op().await?;
-            self.users.commit_attribution().await;
+            self.populate_attribution().await;
             self.repo.update_in_op(&mut op, &mut definition).await?;
             let is_cron = matches!(definition.trigger, WorkflowTrigger::Cron { .. });
             if !was_cron && is_cron {
@@ -632,6 +659,46 @@ impl Workflows {
             op.commit().await?;
         }
         Ok(definition)
+    }
+
+    /// Populates `EventContext` with the rich
+    /// [`drua_library::CommitAttribution`] so post-persist library
+    /// sync hooks pick it up, and returns the resolved attribution
+    /// for callers (e.g. `delete`) that need to enqueue a write op
+    /// of their own (skill peer: `Skills::populate_attribution`).
+    async fn populate_attribution(&self) -> CommitAttribution {
+        self.users.commit_attribution().await
+    }
+
+    /// Enqueue a [`WriteOp::DeleteFile`] for the canonical YAML +
+    /// wipe the search-store row in the same DbOp. Soft-delete events
+    /// don't fire the post-persist hook, so without this the YAML
+    /// would orphan in upstream git and `library.search` would keep
+    /// returning the deleted workflow (skill peer:
+    /// `enqueue_skill_delete_in_op`, PR #266 / memory 019df72f).
+    async fn enqueue_workflow_delete_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        workflow: &WorkflowDefinition,
+        attribution: CommitAttribution,
+    ) -> Result<(), WorkflowError> {
+        let path = canonical_workflow_path(&workflow.name, workflow.project_name.as_deref());
+        let id_uuid: uuid::Uuid = workflow.id.into();
+        let message = format!(
+            "workflow: delete {}-{}",
+            slugify(&workflow.name),
+            &id_uuid.to_string()[..8]
+        );
+        self.library
+            .enqueue_full_in_op(
+                op,
+                None,
+                vec![(id_uuid, WORKFLOW_DOC_TYPE)],
+                Some(WriteOp::DeleteFile { path, message }),
+                attribution,
+            )
+            .await?;
+        Ok(())
     }
 
     /// Spawn the next cron fire in the same atomic op as the
@@ -914,6 +981,75 @@ impl Workflows {
             .cascade_delete_for_project_in_op(op, project_id)
             .await?;
         Ok(())
+    }
+
+    /// Soft-deletes the workflow definition, cascades its runs to
+    /// soft-deleted, and queues a [`WriteOp::DeleteFile`] for the
+    /// canonical YAML so the next library-write tick removes it
+    /// upstream. In-flight `ExecuteRun` jobs against this definition
+    /// keep running against the soft-deleted row and reach a terminal
+    /// state on their own; cron jobs self-terminate on next fire
+    /// (`TriggerCronRunner` exits when `find_by_id` returns None).
+    #[instrument(name = "core.workflow.delete", skip_all)]
+    pub async fn delete(
+        &self,
+        sub: &AuthSubject,
+        id: WorkflowDefinitionId,
+    ) -> Result<(), WorkflowError> {
+        let workflow = self.repo.find_by_id(id).await?;
+        sub.can(
+            AuthVerb::Delete,
+            AuthResource::Workflow(workflow.project_id, Some(workflow.id)),
+        )?;
+        Audit::record_action_if_unset("workflow.delete");
+        Audit::record_project_id(workflow.project_id);
+        Audit::record_workflow_id(workflow.id);
+
+        let mut op = self.repo.begin_op().await?;
+        let attribution = self.populate_attribution().await;
+        self.enqueue_workflow_delete_in_op(&mut op, &workflow, attribution)
+            .await?;
+        self.run_repo
+            .cascade_delete_for_definition_in_op(&mut op, id)
+            .await?;
+        self.repo.delete_in_op(&mut op, workflow).await?;
+        op.commit().await?;
+        Ok(())
+    }
+
+    /// Reverse-sync delete: an external author removed the workflow
+    /// YAML in git. Soft-deletes the matching DB row by canonical-path
+    /// lookup and wipes the search-store row in the same op. Returns
+    /// `Ok(Some(id))` when a row was actually deleted; `Ok(None)` when
+    /// the path doesn't resolve to a known workflow (e.g. unknown
+    /// project name).
+    ///
+    /// Skips the library write op — the file is already gone in git;
+    /// this is the inbound direction (skill peer:
+    /// `Skills::delete_by_path_in_op`).
+    pub(crate) async fn delete_by_path_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        project_id: ProjectId,
+        path: &str,
+    ) -> Result<Option<WorkflowDefinitionId>, WorkflowError> {
+        let Some(workflow) = self
+            .repo
+            .maybe_find_by_canonical_path_in_op(op, project_id, path)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let id = workflow.id;
+        self.library
+            .search()
+            .delete_in_op(op, id.into(), WORKFLOW_DOC_TYPE)
+            .await?;
+        self.run_repo
+            .cascade_delete_for_definition_in_op(op, id)
+            .await?;
+        self.repo.delete_in_op(op, workflow).await?;
+        Ok(Some(id))
     }
 }
 

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -164,13 +164,9 @@ pub struct Workflows {
     /// `tool_step.params` — looks up the called tool's
     /// `output_schema()` + `composable()` flag.
     toolsets: Arc<ToolSets>,
-    /// Forward-sync delete-out path: held directly (alongside the
-    /// repo's own handle) so `delete_in_op` can enqueue a
-    /// `WriteOp::DeleteFile`. Soft-delete events don't fire the
-    /// post-persist sync hook, so without this the canonical YAML
-    /// would linger in upstream git forever (skill peer:
-    /// `enqueue_skill_delete_in_op`).
     library: drua_library::Library,
+    agents: Arc<Agents>,
+    sandboxes: Arc<Sandboxes>,
     execute_run_spawner: ::job::JobSpawner<ExecuteRunConfig>,
     cron_spawner: ::job::JobSpawner<TriggerCronConfig>,
     /// Cloned `Jobs` handle so `await_run_completion` can block on the
@@ -197,9 +193,9 @@ impl Workflows {
         let execute_run_spawner = jobs.add_initializer(ExecuteRunJobInitializer::new(
             WorkflowRunRepo::new(pool),
             WorkflowDefinitionRepo::new_without_library(pool),
-            agents,
+            Arc::clone(&agents),
             Arc::clone(&skills),
-            sandboxes,
+            Arc::clone(&sandboxes),
             Arc::clone(&toolsets),
         ));
         let cron_spawner = jobs.add_initializer(TriggerCronJobInitializer::new(
@@ -214,6 +210,8 @@ impl Workflows {
             users,
             toolsets,
             library,
+            agents,
+            sandboxes,
             execute_run_spawner,
             cron_spawner,
             jobs: jobs.clone(),
@@ -248,14 +246,6 @@ impl Workflows {
 
         Self::validate_trigger(&trigger)?;
 
-        // Race guard: if an operator just deleted this workflow via
-        // the project surface, the soft-deleted row is still in the
-        // table. The default `maybe_find_by_id` filters deleted rows,
-        // so without this probe a reverse-sync poll that races the
-        // forward-sync `DeleteFile` write would resurrect the entity
-        // (memo 019e218a, delete-direction). Drop the import — once
-        // the queued `DeleteFile` lands upstream the file is gone and
-        // future polls won't see it.
         if self.repo.is_soft_deleted_in_op(op, workflow_id).await? {
             tracing::info!(
                 %workflow_id,
@@ -661,21 +651,10 @@ impl Workflows {
         Ok(definition)
     }
 
-    /// Populates `EventContext` with the rich
-    /// [`drua_library::CommitAttribution`] so post-persist library
-    /// sync hooks pick it up, and returns the resolved attribution
-    /// for callers (e.g. `delete`) that need to enqueue a write op
-    /// of their own (skill peer: `Skills::populate_attribution`).
     async fn populate_attribution(&self) -> CommitAttribution {
         self.users.commit_attribution().await
     }
 
-    /// Enqueue a [`WriteOp::DeleteFile`] for the canonical YAML +
-    /// wipe the search-store row in the same DbOp. Soft-delete events
-    /// don't fire the post-persist hook, so without this the YAML
-    /// would orphan in upstream git and `library.search` would keep
-    /// returning the deleted workflow (skill peer:
-    /// `enqueue_skill_delete_in_op`, PR #266 / memory 019df72f).
     async fn enqueue_workflow_delete_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,
@@ -983,13 +962,6 @@ impl Workflows {
         Ok(())
     }
 
-    /// Soft-deletes the workflow definition, cascades its runs to
-    /// soft-deleted, and queues a [`WriteOp::DeleteFile`] for the
-    /// canonical YAML so the next library-write tick removes it
-    /// upstream. In-flight `ExecuteRun` jobs against this definition
-    /// keep running against the soft-deleted row and reach a terminal
-    /// state on their own; cron jobs self-terminate on next fire
-    /// (`TriggerCronRunner` exits when `find_by_id` returns None).
     #[instrument(name = "core.workflow.delete", skip_all)]
     pub async fn delete(
         &self,
@@ -1009,6 +981,12 @@ impl Workflows {
         let attribution = self.populate_attribution().await;
         self.enqueue_workflow_delete_in_op(&mut op, &workflow, attribution)
             .await?;
+        self.agents
+            .cascade_delete_for_workflow_id_in_op(&mut op, id)
+            .await?;
+        self.sandboxes
+            .cascade_delete_for_workflow_id_in_op(&mut op, id)
+            .await?;
         self.run_repo
             .cascade_delete_for_definition_in_op(&mut op, id)
             .await?;
@@ -1017,16 +995,6 @@ impl Workflows {
         Ok(())
     }
 
-    /// Reverse-sync delete: an external author removed the workflow
-    /// YAML in git. Soft-deletes the matching DB row by canonical-path
-    /// lookup and wipes the search-store row in the same op. Returns
-    /// `Ok(Some(id))` when a row was actually deleted; `Ok(None)` when
-    /// the path doesn't resolve to a known workflow (e.g. unknown
-    /// project name).
-    ///
-    /// Skips the library write op — the file is already gone in git;
-    /// this is the inbound direction (skill peer:
-    /// `Skills::delete_by_path_in_op`).
     pub(crate) async fn delete_by_path_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,
@@ -1044,6 +1012,12 @@ impl Workflows {
         self.library
             .search()
             .delete_in_op(op, id.into(), WORKFLOW_DOC_TYPE)
+            .await?;
+        self.agents
+            .cascade_delete_for_workflow_id_in_op(op, id)
+            .await?;
+        self.sandboxes
+            .cascade_delete_for_workflow_id_in_op(op, id)
             .await?;
         self.run_repo
             .cascade_delete_for_definition_in_op(op, id)

--- a/core/src/workflow/repo.rs
+++ b/core/src/workflow/repo.rs
@@ -49,10 +49,6 @@ impl WorkflowDefinitionRepo {
         Ok(())
     }
 
-    /// Whether a row with this id exists with `deleted = TRUE`.
-    /// `soft_without_queries` doesn't auto-generate `_include_deleted`
-    /// query variants, so reverse-sync needs a direct probe to avoid
-    /// resurrecting an entity an operator just removed.
     pub async fn is_soft_deleted_in_op(
         &self,
         op: &mut impl AtomicOperation,
@@ -66,34 +62,38 @@ impl WorkflowDefinitionRepo {
         Ok(row.map(|(d,)| d).unwrap_or(false))
     }
 
-    /// Resolve a canonical-path string back to the live workflow row.
-    /// Reverse-sync uses this when an external git delete removes the
-    /// YAML — the importer has only the path string to identify the
-    /// entity. Matches on `(project_id, canonical_workflow_path(name,
-    /// project_name))` exactly so a slug collision in two different
-    /// projects can't cross-link.
     pub async fn maybe_find_by_canonical_path_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,
         project_id: ProjectId,
         path: &str,
     ) -> Result<Option<WorkflowDefinition>, super::WorkflowError> {
-        let query = es_entity::PaginatedQueryArgs {
+        let mut query = es_entity::PaginatedQueryArgs {
             first: 100,
             after: None,
         };
-        let result = self
-            .list_for_project_id_by_created_at_in_op(
-                op,
-                project_id,
-                query,
-                es_entity::ListDirection::Ascending,
-            )
-            .await?;
-        Ok(result
-            .entities
-            .into_iter()
-            .find(|w| canonical_workflow_path(&w.name, w.project_name.as_deref()) == path))
+        loop {
+            let mut result = self
+                .list_for_project_id_by_created_at_in_op(
+                    &mut *op,
+                    project_id,
+                    query,
+                    es_entity::ListDirection::Ascending,
+                )
+                .await?;
+            let entities = std::mem::take(&mut result.entities);
+            let next = result.into_next_query();
+            if let Some(found) = entities
+                .into_iter()
+                .find(|w| canonical_workflow_path(&w.name, w.project_name.as_deref()) == path)
+            {
+                return Ok(Some(found));
+            }
+            match next {
+                Some(q) => query = q,
+                None => return Ok(None),
+            }
+        }
     }
 
     async fn sync_to_library<OP: es_entity::AtomicOperation>(

--- a/core/src/workflow/repo.rs
+++ b/core/src/workflow/repo.rs
@@ -5,6 +5,7 @@ use es_entity::*;
 use crate::primitives::*;
 
 use super::entity::*;
+use super::yaml::canonical_workflow_path;
 
 #[derive(EsRepo, Clone)]
 #[es_repo(
@@ -46,6 +47,53 @@ impl WorkflowDefinitionRepo {
             .execute(op.as_executor())
             .await?;
         Ok(())
+    }
+
+    /// Whether a row with this id exists with `deleted = TRUE`.
+    /// `soft_without_queries` doesn't auto-generate `_include_deleted`
+    /// query variants, so reverse-sync needs a direct probe to avoid
+    /// resurrecting an entity an operator just removed.
+    pub async fn is_soft_deleted_in_op(
+        &self,
+        op: &mut impl AtomicOperation,
+        id: WorkflowDefinitionId,
+    ) -> Result<bool, sqlx::Error> {
+        let row: Option<(bool,)> =
+            sqlx::query_as("SELECT deleted FROM workflow_definitions WHERE id = $1")
+                .bind(id)
+                .fetch_optional(op.as_executor())
+                .await?;
+        Ok(row.map(|(d,)| d).unwrap_or(false))
+    }
+
+    /// Resolve a canonical-path string back to the live workflow row.
+    /// Reverse-sync uses this when an external git delete removes the
+    /// YAML — the importer has only the path string to identify the
+    /// entity. Matches on `(project_id, canonical_workflow_path(name,
+    /// project_name))` exactly so a slug collision in two different
+    /// projects can't cross-link.
+    pub async fn maybe_find_by_canonical_path_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        project_id: ProjectId,
+        path: &str,
+    ) -> Result<Option<WorkflowDefinition>, super::WorkflowError> {
+        let query = es_entity::PaginatedQueryArgs {
+            first: 100,
+            after: None,
+        };
+        let result = self
+            .list_for_project_id_by_created_at_in_op(
+                op,
+                project_id,
+                query,
+                es_entity::ListDirection::Ascending,
+            )
+            .await?;
+        Ok(result
+            .entities
+            .into_iter()
+            .find(|w| canonical_workflow_path(&w.name, w.project_name.as_deref()) == path))
     }
 
     async fn sync_to_library<OP: es_entity::AtomicOperation>(

--- a/core/src/workflow/run/repo.rs
+++ b/core/src/workflow/run/repo.rs
@@ -37,10 +37,6 @@ impl WorkflowRunRepo {
         Ok(())
     }
 
-    /// Bulk soft-delete every run for `definition_id`. In-flight
-    /// `ExecuteRunConfig` jobs continue against the soft-deleted row
-    /// — the runner already tolerates this and the run reaches a
-    /// terminal state on its own.
     pub async fn cascade_delete_for_definition_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,

--- a/core/src/workflow/run/repo.rs
+++ b/core/src/workflow/run/repo.rs
@@ -36,4 +36,20 @@ impl WorkflowRunRepo {
             .await?;
         Ok(())
     }
+
+    /// Bulk soft-delete every run for `definition_id`. In-flight
+    /// `ExecuteRunConfig` jobs continue against the soft-deleted row
+    /// — the runner already tolerates this and the run reaches a
+    /// terminal state on its own.
+    pub async fn cascade_delete_for_definition_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        definition_id: WorkflowDefinitionId,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query("UPDATE workflow_runs SET deleted = TRUE WHERE definition_id = $1")
+            .bind(definition_id)
+            .execute(op.as_executor())
+            .await?;
+        Ok(())
+    }
 }

--- a/server/src/graphql/mod.rs
+++ b/server/src/graphql/mod.rs
@@ -15,6 +15,7 @@ mod session;
 mod skill;
 mod subscription;
 mod types;
+mod workflow;
 
 use std::convert::Infallible;
 

--- a/server/src/graphql/mutation.rs
+++ b/server/src/graphql/mutation.rs
@@ -8,6 +8,7 @@ use super::note::*;
 use super::project::*;
 use super::project_secret::*;
 use super::skill::*;
+use super::workflow::*;
 
 pub struct Mutation;
 
@@ -238,6 +239,18 @@ impl Mutation {
         let (app, sub) = app_and_sub_from_ctx!(ctx);
         app.notes().delete(sub, input.project_id, input.id).await?;
         Ok(NoteDeletePayload {
+            deleted_id: input.id,
+        })
+    }
+
+    async fn workflow_delete(
+        &self,
+        ctx: &Context<'_>,
+        input: WorkflowDeleteInput,
+    ) -> async_graphql::Result<WorkflowDeletePayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        app.workflows().delete(sub, input.id).await?;
+        Ok(WorkflowDeletePayload {
             deleted_id: input.id,
         })
     }

--- a/server/src/graphql/primitives.rs
+++ b/server/src/graphql/primitives.rs
@@ -3,6 +3,7 @@ use serde::{Deserialize, Serialize};
 #[allow(unused_imports)]
 pub use drua_core::primitives::{
     AgentId, McpCredsId, NoteId, ProjectId, ProjectSecretId, SandboxId, SkillId, UserId,
+    WorkflowDefinitionId,
 };
 
 #[allow(unused_imports)]

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -291,6 +291,7 @@ type Mutation {
 	sandboxRestart(input: SandboxRestartInput!): SandboxRestartPayload!
 	sandboxSuspend(input: SandboxSuspendInput!): SandboxSuspendPayload!
 	skillDelete(input: SkillDeleteInput!): SkillDeletePayload!
+	workflowDelete(input: WorkflowDeleteInput!): WorkflowDeletePayload!
 }
 
 input NoteDeleteInput {
@@ -746,6 +747,16 @@ scalar UUID
 
 type UserMessageEvent {
 	text: String!
+}
+
+scalar WorkflowDefinitionId
+
+input WorkflowDeleteInput {
+	id: WorkflowDefinitionId!
+}
+
+type WorkflowDeletePayload {
+	deletedId: WorkflowDefinitionId!
 }
 
 scalar Yaml

--- a/server/src/graphql/workflow.rs
+++ b/server/src/graphql/workflow.rs
@@ -1,0 +1,13 @@
+use async_graphql::{InputObject, SimpleObject};
+
+use super::primitives::*;
+
+#[derive(InputObject)]
+pub struct WorkflowDeleteInput {
+    pub id: WorkflowDefinitionId,
+}
+
+#[derive(SimpleObject)]
+pub struct WorkflowDeletePayload {
+    pub deleted_id: WorkflowDefinitionId,
+}


### PR DESCRIPTION
## Summary

Reintroduces workflow delete across every public surface (service, GraphQL, top-level MCP tool, admin MCP tool, library forward + reverse sync), mirroring the **skill-delete arc** landed in PR #266 (memory **019df72f**).

### Context — this **reverses acca538 for workflows**

Commit acca538 (May 4) removed `Workflows::delete`, the run cascade helper, and both admin + top-level Delete arms. PR #266 then reversed that decision for *skills only*. This PR finishes the symmetry for *workflows*, consistent with the parallel arcs:

| Entity   | Top-level | Admin | GraphQL | Library forward-sync | Reverse-sync |
|----------|-----------|-------|---------|----------------------|--------------|
| Agent (#263)    | ✅ | ❌ | ✅ | n/a | n/a |
| Skill (#266)    | ✅ | ✅ | ✅ | ✅ | (deferred) |
| Note  (#267,#310) | ✅ | ✅ | ✅ | ✅ | ✅ |
| **Workflow (this PR)** | **✅** | **✅** | **✅** | **✅** | **✅** |

## Cascade decisions (PM-acked)

1. **In-flight `WorkflowRun` instances**: soft-deleted in the same op as the definition (`run_repo.cascade_delete_for_definition_in_op`, re-added — acca538 had removed it). In-flight `ExecuteRun` jobs keep running against the soft-deleted row and reach a terminal state on their own. Matches the pre-acca538 pattern.

2. **Cron jobs**: self-terminate at next fire — `TriggerCronRunner` already exits `JobCompletion::Complete` when `find_by_id` returns `None`. The upstream `job` crate (v0.6.20) exposes no in-op cancel; same self-cleaning classification as project-cascade today.

3. **Sub-workflow `ToolStep` handoff**: nothing extra needed. `Workflows::trigger_run` loads the target via `find_by_id` which returns `NotFound` after soft-delete; the calling ToolStep records `StepErrored` and the parent run goes to Errored.

4. **Forward/reverse-sync race on delete** (memo **019e218a**): fixed in-PR. `import_from_library` now probes `is_soft_deleted_in_op` before resurrecting; a reverse-sync poll that races the queued `DeleteFile` write can no longer undo an operator's delete.

## Implementation map

- `core/src/workflow/mod.rs`
  - `delete`: own op + commit; load + auth + audit + library delete-out + run-cascade + repo delete.
  - `delete_by_path_in_op`: reverse-sync entry — wipe search row, cascade runs, soft-delete by canonical-path lookup.
  - `enqueue_workflow_delete_in_op`: library forward-sync `WriteOp::DeleteFile` + `extra_search_deletes` for the workflow doc type. `CommitAttribution` plumbed via new `populate_attribution()` helper (returns it instead of discarding).
  - `import_from_library`: soft-delete probe early-return — race guard.
- `core/src/workflow/repo.rs`: `is_soft_deleted_in_op`, `maybe_find_by_canonical_path_in_op`.
- `core/src/workflow/run/repo.rs`: `cascade_delete_for_definition_in_op` (re-added — diff vs acca538).
- `core/src/workflow/importer.rs`: `LibraryImporter::delete_in_op` implemented (path → project → service).
- `core/src/workflow/error.rs`: `Library(#[from] LibraryError)` variant.
- `core/src/toolset/searchable/admin.rs`: `WorkflowCommand::Delete` arm + parse test.
- `core/src/toolset/top_level/workflow.rs`: `WorkflowParams::Delete { definition_id }` arm.
- `server/src/graphql/workflow.rs` (new): `WorkflowDeleteInput { id }` + `WorkflowDeletePayload { deletedId }` (mirrors `agentDelete` shape — workflows aren't space-scoped, so no `projectId` input needed; load-then-auth resolves it).
- `server/src/graphql/mutation.rs`: `workflow_delete` resolver.
- `server/src/graphql/schema.graphql`: manual update (verified by `graphql-schema` check in `nix flake check`).

## Test plan

- [x] `nix flake check` clean (fmt + clippy `-D warnings` + nextest + graphql-schema + default-config + write_sdl).
- [x] Unit: admin `WorkflowParams { command: delete, definition_id }` parses to `WorkflowCommand::Delete`.
- [x] Schema enum-contains test extended to include `delete`.
- [ ] Deferred (no existing workflow integration-test fixture; significant scope to set one up):
  - Service-level happy path / idempotent re-delete
  - Library-write-op enqueued with the canonical path
  - Reverse-sync `delete_in_op` end-to-end
  - GraphQL mutation E2E
  - Bats coverage for top-level + admin Delete dispatch

  These follow the same path as skills' PR #266, which also deferred the reverse-sync integration test (memory **019df72f**). Recommended to land bats coverage as a follow-up PR alongside any other workflow happy-path tests we backfill.

## References

- PR #266 (delete-skill, line-for-line reference) — https://github.com/GaloyMoney/drua/pull/266
- Commit `acca538` (the removal this PR reverses for workflows)
- Memory **019df72f** — skill-delete PR implementation notes
- Memory **019e218a** — forward/reverse-sync race (delete-direction handled here)
- Memory **019e01a4** — `ToolStep` + `workflow.trigger` parent-child handoff (no extra cascade needed)
- PR #241 — workflow cron jobs as persisted rows (self-terminating)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new delete path that cascades soft-deletes across workflows, runs, agents, and sandboxes and triggers library file deletion; mistakes could remove more data than intended or leave orphaned resources.
> 
> **Overview**
> **Adds end-to-end workflow deletion** across the core service, MCP tools (top-level + admin), and GraphQL.
> 
> Core now implements `Workflows::delete` with authorization/auditing, enqueues a library `DeleteFile`, and cascades soft-deletes to workflow runs plus workflow-scoped agents and sandboxes (including best-effort sandbox admin teardown/PVC delete). Reverse-sync deletion from the library is also implemented via path-based lookup, with an import guard to avoid resurrecting soft-deleted workflows.
> 
> Supporting changes include new repo helpers (`workflow_runs` cascade-by-definition, workflow soft-delete probe + canonical-path search), new list indexes/SQLx query metadata for `workflow_id` pagination (plus an `agents(workflow_id, created_at)` index), and minor error plumbing so workflow code can propagate `AgentError`/`LibraryError` directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54c29d008cb2c8fd672706f5bfad60d8f9e7f313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->