### PR TITLE
ci: fix Lana Cachix deploy config

### DIFF
--- a/charts/drua/templates/_helpers.tpl
+++ b/charts/drua/templates/_helpers.tpl
@@ -99,6 +99,7 @@ Sandbox NIX_CONFIG contents for configured remote substituters.
 {{- end -}}
 
 {{- define "galoyAgents.sandbox.nixConfig" -}}
+fallback = true
 substituters ={{- with (include "galoyAgents.sandbox.nixSubstituterUrls" .) }} {{ . }}{{- end }} https://cache.nixos.org/
 trusted-public-keys ={{- with (include "galoyAgents.sandbox.nixPublicKeys" .) }} {{ . }}{{- end }} cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 {{- if .Values.sandbox.nixNetrc.enabled }}

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -176,25 +176,9 @@ jobs:
             LANA_BANK_CACHIX_ENABLED=false
             if [ -n "$LANA_BANK_CACHIX_AUTH_TOKEN" ]; then
               if [ -z "$LANA_BANK_CACHIX_PUBLIC_KEY" ]; then
-                cachix_home=$(mktemp -d)
-                CACHIX_AUTH_TOKEN="$LANA_BANK_CACHIX_AUTH_TOKEN" \
-                  HOME="$cachix_home" XDG_CONFIG_HOME="$cachix_home/.config" \
-                  cachix use lana-bank-github-actions --mode user-nixconf
-                LANA_BANK_CACHIX_PUBLIC_KEY=$(
-                  awk '
-                    /^trusted-public-keys =/ {
-                      for (i = 2; i <= NF; i++) {
-                        if ($i ~ /^lana-bank-github-actions\.cachix\.org-1:/) {
-                          print $i
-                        }
-                      }
-                    }
-                  ' "$cachix_home/.config/nix/nix.conf"
-                )
-                if [ -z "$LANA_BANK_CACHIX_PUBLIC_KEY" ]; then
-                  echo "Failed to derive lana-bank-github-actions Cachix public key" >&2
-                  exit 1
-                fi
+                echo "LANA_BANK_CACHIX_AUTH_TOKEN is set but LANA_BANK_CACHIX_PUBLIC_KEY is empty" >&2
+                echo "Set deploy_lana_bank_cachix_public_key; prepare-deployment does not contact Cachix." >&2
+                exit 1
               fi
               LANA_BANK_CACHIX_ENABLED=true
             fi

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -28,7 +28,9 @@ deploy_concourse_password: ((galoybot-concourse-creds.password))
 #! Provisioned by galoy-org-infra at
 #! concourse/galoy-agents/galoy-agents-bin/lana-bank-cachix-token.
 deploy_lana_bank_cachix_auth_token: ((lana-bank-cachix-token.token))
-deploy_lana_bank_cachix_public_key: ""
+#! Public signing key for the private cache above. This is not secret; keep it
+#! explicit so prepare-deployment does not need Cachix API access.
+deploy_lana_bank_cachix_public_key: "lana-bank-github-actions.cachix.org-1:31jDEkkTk7VarJjX1rsUEYkEoqhKtOGJeK6ZEsXvMsg="
 honeycomb_api_key: ((mcp-upstream.honeycomb_api_key))
 github_pat: ((mcp-upstream.github_pat))
 zenduty_api_token: ((zenduty.api_key))


### PR DESCRIPTION
## Summary

- stop `prepare-deployment` from calling Cachix to derive the Lana cache public key
- configure the Lana Cachix public signing key explicitly as non-secret deploy config
- add `fallback = true` to sandbox Nix config so sandbox builds can fall back when a substituter is unavailable

## Why

`deploy-to-prod` was failing before Terraform because the deployment prep task used `LANA_BANK_CACHIX_AUTH_TOKEN` to run `cachix use lana-bank-github-actions`. The Vault token is intended to become the sandbox netrc secret, not to make prod deployment depend on live Cachix auth.

Keeping the public key explicit lets deployment render the same sandbox cache configuration without reaching out to Cachix during CI prep. Terraform still creates `sandbox-nix-netrc` from the token for sandbox pods.

## Validation

- `ytt -f ci/values.yml -f ci/pipeline.yml -f ci/fragments.lib.yml >/tmp/galoy-agents-pipeline.yml`
- `fly -t galoy validate-pipeline -c /tmp/galoy-agents-pipeline.yml`
- `helm template galoy-agents charts/drua -n galoy-agents --set global.security.allowInsecureImages=true ...`
- `git diff --check HEAD~1..HEAD`
- repiped Concourse and reran `deploy-to-prod/656`; rerun `656.1` succeeded

## Follow-up

The existing Vault token still appears unauthorized for `lana-bank-github-actions` and should be rotated separately. This PR prevents that token check from blocking Drua deploys.
