### PR TITLE
fix(skill): slugify name at create/update + default_skill_path

### DIFF
--- a/core/src/skill/file.rs
+++ b/core/src/skill/file.rs
@@ -247,17 +247,26 @@ pub fn slugify(title: &str) -> String {
 /// DB-driven service surface (`Skills::create` / `create_in_space`).
 /// The importer does NOT use this — paths it sees are whatever the
 /// author wrote.
+///
+/// `name` is slugified before being embedded so non-kebab-case input
+/// (e.g. "Deploy Prod") produces a clean filename
+/// (`deploy-prod.md`). The reverse-sync importer reads the name back
+/// via [`name_from_filename`] which is itself a slugify — keeping
+/// both ends symmetric. `Skills::create` slugifies the same input
+/// before persisting `name` to the DB so round-trip matches without
+/// a reverse-sync reconcile rename.
 pub fn default_skill_path(
     name: &str,
     project_name: Option<&str>,
     space_slug: Option<&str>,
 ) -> String {
+    let slug = slugify(name);
     if let Some(space) = space_slug {
-        format!("spaces/{space}/skills/{name}.md")
+        format!("spaces/{space}/skills/{slug}.md")
     } else if let Some(project) = project_name {
-        format!("runtime/projects/{project}/skills/{name}.md")
+        format!("runtime/projects/{project}/skills/{slug}.md")
     } else {
-        format!("runtime/skills/{name}.md")
+        format!("runtime/skills/{slug}.md")
     }
 }
 
@@ -317,6 +326,25 @@ mod path_tests {
         assert_eq!(
             default_skill_path("deploy", Some("alpha"), Some("team")),
             "spaces/team/skills/deploy.md"
+        );
+    }
+
+    #[test]
+    fn default_path_slugifies_name() {
+        // Spaces / mixed-case / punctuation must not leak into the
+        // path. Symmetric with name_from_filename (which slugifies on
+        // the inverse direction).
+        assert_eq!(
+            default_skill_path("Deploy Prod", Some("alpha"), None),
+            "runtime/projects/alpha/skills/deploy-prod.md"
+        );
+        assert_eq!(
+            default_skill_path("Hello, World!", None, Some("team")),
+            "spaces/team/skills/hello-world.md"
+        );
+        assert_eq!(
+            default_skill_path("path/traversal/../etc", None, None),
+            "runtime/skills/path-traversal-etc.md"
         );
     }
 }

--- a/core/src/skill/file.rs
+++ b/core/src/skill/file.rs
@@ -247,14 +247,6 @@ pub fn slugify(title: &str) -> String {
 /// DB-driven service surface (`Skills::create` / `create_in_space`).
 /// The importer does NOT use this — paths it sees are whatever the
 /// author wrote.
-///
-/// `name` is slugified before being embedded so non-kebab-case input
-/// (e.g. "Deploy Prod") produces a clean filename
-/// (`deploy-prod.md`). The reverse-sync importer reads the name back
-/// via [`name_from_filename`] which is itself a slugify — keeping
-/// both ends symmetric. `Skills::create` slugifies the same input
-/// before persisting `name` to the DB so round-trip matches without
-/// a reverse-sync reconcile rename.
 pub fn default_skill_path(
     name: &str,
     project_name: Option<&str>,
@@ -331,9 +323,6 @@ mod path_tests {
 
     #[test]
     fn default_path_slugifies_name() {
-        // Spaces / mixed-case / punctuation must not leak into the
-        // path. Symmetric with name_from_filename (which slugifies on
-        // the inverse direction).
         assert_eq!(
             default_skill_path("Deploy Prod", Some("alpha"), None),
             "runtime/projects/alpha/skills/deploy-prod.md"

--- a/core/src/skill/mod.rs
+++ b/core/src/skill/mod.rs
@@ -4,6 +4,7 @@ pub mod file;
 pub mod importer;
 pub(crate) mod repo;
 
+use file::slugify;
 pub use file::{default_skill_path, name_from_filename, parse_skill_markdown, ParsedSkill};
 pub use importer::SkillsImporter;
 
@@ -730,7 +731,14 @@ impl Skills {
         sub.can(AuthVerb::Create, AuthResource::Skill(project_id, None))?;
         Audit::record_action_if_unset("skill.create");
         Audit::record_project_id(project_id);
-        if name.trim().is_empty() {
+        // Slugify before the empty-check — "Deploy Prod" must succeed,
+        // "   " (all whitespace) must reject. The slug is the
+        // canonical name: reverse-sync derives DB.name from
+        // `name_from_filename` (itself a slugify), so persisting the
+        // slug at create time keeps both ends symmetric and avoids a
+        // first-tick rename event.
+        let name = slugify(&name);
+        if name.is_empty() {
             return Err(SkillError::BuildEntity("skill name required".into()));
         }
 
@@ -780,6 +788,19 @@ impl Skills {
                 resource: AuthResource::Skill(project_id, Some(id)),
             }));
         }
+        // Slugify rename input — same reasoning as `Skills::create`. An
+        // empty-or-whitespace rename is rejected; an unchanged name is
+        // a no-op via `update_content`'s field-by-field idempotency.
+        let name = match name {
+            Some(raw) => {
+                let slug = slugify(&raw);
+                if slug.is_empty() {
+                    return Err(SkillError::BuildEntity("skill name required".into()));
+                }
+                Some(slug)
+            }
+            None => None,
+        };
         if skill.update_content(name, description, body).did_execute() {
             self.populate_attribution().await;
             self.repo.update_in_op(&mut op, &mut skill).await?;

--- a/core/src/skill/mod.rs
+++ b/core/src/skill/mod.rs
@@ -731,12 +731,6 @@ impl Skills {
         sub.can(AuthVerb::Create, AuthResource::Skill(project_id, None))?;
         Audit::record_action_if_unset("skill.create");
         Audit::record_project_id(project_id);
-        // Slugify before the empty-check — "Deploy Prod" must succeed,
-        // "   " (all whitespace) must reject. The slug is the
-        // canonical name: reverse-sync derives DB.name from
-        // `name_from_filename` (itself a slugify), so persisting the
-        // slug at create time keeps both ends symmetric and avoids a
-        // first-tick rename event.
         let name = slugify(&name);
         if name.is_empty() {
             return Err(SkillError::BuildEntity("skill name required".into()));
@@ -788,9 +782,6 @@ impl Skills {
                 resource: AuthResource::Skill(project_id, Some(id)),
             }));
         }
-        // Slugify rename input — same reasoning as `Skills::create`. An
-        // empty-or-whitespace rename is rejected; an unchanged name is
-        // a no-op via `update_content`'s field-by-field idempotency.
         let name = match name {
             Some(raw) => {
                 let slug = slugify(&raw);


### PR DESCRIPTION
## Summary

Closes the missing-slugification regression introduced by PR #266 and
flagged by cursor-bugbot in [comment 3187692604][c]: replacing
`canonical_skill_path` with `default_skill_path` dropped the
`slugify(name)` call, and nothing else normalises the name at the API
boundary.

## Bug reproduction (pre-fix)

```rust
app.skills().create(
    sub,
    project_id,
    project_name,
    "Deploy Prod".into(),  // ← user-supplied, not pre-slugified
    description,
    body,
).await?;
```

→ writes a DB row with `name = "Deploy Prod"` and
`path = "runtime/projects/<p>/skills/Deploy Prod.md"` — a literal
space in the on-disk filename.

Forward-sync then writes that file to the upstream git repo
verbatim. Reverse-sync reads it back via `name_from_filename`, which
**does** slugify (existing behaviour, used by the importer for every
file it sees), producing `parsed.name = "deploy-prod"`. The reconcile
path then fires an `Updated` event that silently renames the DB row
from `"Deploy Prod"` → `"deploy-prod"` on the first library sync
tick.

So the user-facing skill name silently changes after creation, and
the on-disk filename carries arbitrary characters (including
whitespace, punctuation, `/`) until the reconcile lands.

## Fix

Three-point normalisation that brings the create / update boundary
into line with `default_note_path` (which has always slugified):

1. **`default_skill_path`** (`core/src/skill/file.rs:250`) slugifies
   `name` before embedding it in the path.
2. **`Skills::create`** (`core/src/skill/mod.rs:722`) slugifies the
   input before the empty-check and persists the slug as `DB.name`.
   The empty-check still fires for whitespace-only input (the slug is
   empty in that case).
3. **`Skills::update`** (`core/src/skill/mod.rs:759`) slugifies a
   provided rename, rejects empty-slug-after-normalisation, and lets
   the entity's field-by-field idempotency no-op same-slug renames.

The skill-parser doc on `parse_skill_with_frontmatter` already
declares the contract:

> Name = filename slug (e.g. `data-validator.md` → `data-validator`).
> **Always** — the skill's invocation handle is the slug, not the
> heading or frontmatter `name:`.

This PR brings the DB-driven create / update path back into line with
that contract; the previous mismatch was a #266 regression.

## Migration impact

Existing rows with non-slug names migrate on the next update call
(the slug-after-normalisation differs from the stored name → one
`Updated` event, same path as today). Read-only access (find / list /
search / invoke) is unaffected.

## Notes are unaffected

`default_note_path` already slugifies its `title` input. Notes carry
the human title and a separate slug-derived filename, so there's no
round-trip mismatch to fix on that side.

## Test plan

- [x] `nix flake check` — all 7 checks green locally (clippy, fmt,
      nextest, graphql-schema, default-config, …)
- [x] `cargo test -p drua-core --lib skill` — 30 / 30 pass
- [x] New unit test `default_path_slugifies_name` covers spaces,
      punctuation, and `/`-injection
- [ ] CI green

## References

- PR #266 (delete-skill / path-as-identity introduction)
- [cursor-bugbot comment #3187692604][c]

[c]: https://github.com/GaloyMoney/drua/pull/266#discussion_r3187692604

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how skill names are normalized at the API boundary, which can affect persisted `name` values and on-disk filenames; risk is moderate due to potential behavior changes for existing non-slug names and any callers expecting raw names.
> 
> **Overview**
> Fixes a regression where DB-created/updated skills could persist un-sanitized names (spaces/punctuation/`/`) and generate unsafe/invalid markdown filenames.
> 
> `default_skill_path` now slugifies `name` before constructing paths, and `Skills::create`/`Skills::update` slugify incoming names (rejecting empty-after-slug) so the stored `Skill.name` and canonical file path consistently use the kebab-case slug. Adds unit coverage ensuring slugification handles whitespace, punctuation, and traversal-like input.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c86a9dfed126250f6dd1d0a2ac8b58fb4a6c9309. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->