### PR TITLE
fix: use Zenduty schedules endpoint

### DIFF
--- a/lib/zenduty-client/src/client.rs
+++ b/lib/zenduty-client/src/client.rs
@@ -229,7 +229,7 @@ impl ZendutyClient {
     #[tracing::instrument(name = "zenduty_client.list_schedules", skip_all)]
     pub async fn list_schedules(&self, team_id: &str) -> Result<Vec<Schedule>, ZendutyError> {
         let page: Page<Schedule> = self
-            .get(&format!("/api/account/teams/{team_id}/schedule/"))
+            .get(&format!("/api/account/teams/{team_id}/schedules/"))
             .await?;
         Ok(page.into_results())
     }


### PR DESCRIPTION
## Summary
- Update Zenduty schedule listing to use the current plural /schedules/ endpoint.
- Keeps the patch isolated on top of latest main.

## Context
The old singular /schedule/ endpoint now returns a 404 HTML response, which causes Drua MCP schedule checks to fail while decoding the response body.

## Test
- direnv exec . cargo test -p zenduty-client

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a one-line change to the Zenduty schedules list URL; main risk is behavior change if any deployments still rely on the legacy singular endpoint.
> 
> **Overview**
> Fixes schedule listing in `ZendutyClient::list_schedules` by switching the API path from the deprecated `/schedule/` endpoint to the current plural `/schedules/` endpoint, avoiding 404/HTML responses during schedule checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebb543c27b91bc9c3880ec00968e7360af74d52a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->