### PR TITLE
feat(graphql): expose workflows for TUI

### DIFF
--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -968,14 +968,12 @@ fn definition_to_output(d: &WorkflowDefinition) -> WorkflowDefinitionOutput {
         } => {
             cron_schedule = Some(schedule.clone());
             cron_timezone = timezone.clone();
-            next_run_at = crate::workflow::next_cron_fire_at(
-                schedule,
-                timezone.as_deref(),
-                chrono::Utc::now(),
-            )
-            .ok()
-            .flatten()
-            .map(|t| t.to_rfc3339());
+            next_run_at = d
+                .trigger
+                .next_fire_at(chrono::Utc::now())
+                .ok()
+                .flatten()
+                .map(|t| t.to_rfc3339());
             ("cron".to_string(), None)
         }
     };
@@ -1204,17 +1202,13 @@ fn format_get_text(d: &WorkflowDefinition) -> String {
             };
             format!("{label}\n  webhook_secret: {secret}")
         }
-        WorkflowTrigger::Cron {
+        trigger @ WorkflowTrigger::Cron {
             schedule, timezone, ..
         } => {
             let mut s = format!("cron\n  schedule:    {schedule}");
             let tz_label = timezone.as_deref().unwrap_or("UTC");
             s.push_str(&format!("\n  timezone:    {tz_label}"));
-            if let Ok(Some(next)) = crate::workflow::next_cron_fire_at(
-                schedule,
-                timezone.as_deref(),
-                chrono::Utc::now(),
-            ) {
+            if let Ok(Some(next)) = trigger.next_fire_at(chrono::Utc::now()) {
                 s.push_str(&format!("\n  next_run_at: {}", next.to_rfc3339()));
             }
             s

--- a/core/src/workflow/cron_job.rs
+++ b/core/src/workflow/cron_job.rs
@@ -19,7 +19,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::primitives::WorkflowDefinitionId;
 
-use super::definition::{next_cron_fire_at, WorkflowTrigger};
+use super::definition::WorkflowTrigger;
 use super::repo::WorkflowDefinitionRepo;
 use super::run::WorkflowRunRepo;
 
@@ -120,6 +120,7 @@ impl JobRunner for TriggerCronRunner {
 
         let definition_id = definition.id;
         let fired_at = chrono::Utc::now();
+        let next_fire = definition.trigger.next_fire_at(fired_at);
         let trigger_context = serde_json::json!({
             "triggered_by": "cron",
             "fired_at": fired_at.to_rfc3339(),
@@ -148,7 +149,7 @@ impl JobRunner for TriggerCronRunner {
             }
         }
 
-        let next_at = match next_cron_fire_at(&schedule, timezone.as_deref(), fired_at) {
+        let next_at = match next_fire {
             Ok(Some(t)) => t,
             Ok(None) => {
                 tracing::info!("cron expression yields no future fire; schedule terminating");

--- a/core/src/workflow/definition.rs
+++ b/core/src/workflow/definition.rs
@@ -112,6 +112,32 @@ impl WorkflowTrigger {
             | Self::Cron { condition, .. } => condition.as_deref(),
         }
     }
+
+    pub fn kind_label(&self) -> &'static str {
+        match self {
+            Self::Manual { .. } => "manual",
+            Self::Webhook { .. } => "webhook",
+            Self::Cron { .. } => "cron",
+        }
+    }
+
+    /// `None` when this is not a cron trigger, or when the cron
+    /// schedule has no future fire after the supplied instant.
+    pub fn next_fire_at(&self, after: DateTime<Utc>) -> Result<Option<DateTime<Utc>>, String> {
+        match self {
+            Self::Cron {
+                schedule, timezone, ..
+            } => {
+                let sched = parse_cron_schedule(schedule)?;
+                let tz = parse_timezone(timezone.as_deref())?;
+                Ok(sched
+                    .after(&after.with_timezone(&tz))
+                    .next()
+                    .map(|dt| dt.with_timezone(&Utc)))
+            }
+            _ => Ok(None),
+        }
+    }
 }
 
 /// IANA name parses through `chrono_tz`; `None` → `UTC`. Surfaces a
@@ -128,21 +154,6 @@ pub fn parse_timezone(tz: Option<&str>) -> Result<chrono_tz::Tz, String> {
 
 pub fn parse_cron_schedule(expr: &str) -> Result<cron::Schedule, String> {
     cron::Schedule::from_str(expr).map_err(|e| format!("invalid cron expression '{expr}': {e}"))
-}
-
-/// `None` when the schedule has no future fire (e.g. a one-shot
-/// expression whose only date already passed).
-pub fn next_cron_fire_at(
-    schedule: &str,
-    timezone: Option<&str>,
-    after: DateTime<Utc>,
-) -> Result<Option<DateTime<Utc>>, String> {
-    let sched = parse_cron_schedule(schedule)?;
-    let tz = parse_timezone(timezone)?;
-    Ok(sched
-        .after(&after.with_timezone(&tz))
-        .next()
-        .map(|dt| dt.with_timezone(&Utc)))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -527,18 +538,28 @@ mod tests {
     }
 
     #[test]
-    fn next_cron_fire_at_returns_future_time() {
+    fn cron_trigger_next_fire_at_returns_future_time() {
         let now = chrono::Utc::now();
-        let next = next_cron_fire_at("0 0 */6 * * *", None, now)
+        let trigger = WorkflowTrigger::Cron {
+            schedule: "0 0 */6 * * *".to_string(),
+            timezone: None,
+            condition: None,
+        };
+        let next = trigger
+            .next_fire_at(now)
             .unwrap()
             .expect("expression always has a next fire");
         assert!(next > now);
     }
 
     #[test]
-    fn next_cron_fire_at_propagates_timezone_errors() {
-        let err =
-            next_cron_fire_at("0 0 */6 * * *", Some("Not/AZone"), chrono::Utc::now()).unwrap_err();
+    fn cron_trigger_next_fire_at_propagates_timezone_errors() {
+        let trigger = WorkflowTrigger::Cron {
+            schedule: "0 0 */6 * * *".to_string(),
+            timezone: Some("Not/AZone".to_string()),
+            condition: None,
+        };
+        let err = trigger.next_fire_at(chrono::Utc::now()).unwrap_err();
         assert!(err.contains("invalid timezone"));
     }
 

--- a/core/src/workflow/entity.rs
+++ b/core/src/workflow/entity.rs
@@ -86,6 +86,10 @@ impl WorkflowDefinition {
             .expect("entity should have at least one persisted timestamp")
     }
 
+    pub fn canonical_yaml(&self) -> String {
+        self.rendered()
+    }
+
     /// Canonical on-disk content (YAML).
     pub(crate) fn rendered(&self) -> String {
         render_workflow_yaml(

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -31,12 +31,12 @@ use yaml::canonical_workflow_path;
 pub const WORKFLOW_DOC_TYPE: drua_library::DocType = drua_library::DocType::new("workflow");
 
 pub use definition::{
-    default_output_schema, next_cron_fire_at, parse_cron_schedule, parse_timezone, OutputSchema,
-    OutputSchemaError, WorkflowSandboxDecl, WorkflowStepDef, WorkflowTrigger,
+    default_output_schema, parse_cron_schedule, parse_timezone, OutputSchema, OutputSchemaError,
+    WorkflowSandboxDecl, WorkflowStepDef, WorkflowTrigger,
 };
 pub use entity::*;
 pub use error::*;
-pub use run::{StepResult, WorkflowRun, WorkflowRunRepo, WorkflowRunState};
+pub use run::{StepResult, WorkflowRun, WorkflowRunRepo, WorkflowRunState, WorkflowStepState};
 
 use cron_job::{cron_queue_id, TriggerCronConfig, TriggerCronJobInitializer};
 use job::{ExecuteRunConfig, ExecuteRunJobInitializer};
@@ -75,7 +75,7 @@ fn record_trigger_filtered_audit(
     Audit::record_workflow_id(definition.id);
     Audit::record_metadata(serde_json::json!({
         "definition_id": definition.id.to_string(),
-        "trigger_kind": trigger_kind_label(&definition.trigger),
+        "trigger_kind": definition.trigger.kind_label(),
         "condition_body": condition_body,
         "payload_digest": payload_digest(trigger_context),
     }));
@@ -98,7 +98,7 @@ fn record_trigger_condition_errored_audit(
     Audit::record_workflow_id(definition.id);
     Audit::record_metadata(serde_json::json!({
         "definition_id": definition.id.to_string(),
-        "trigger_kind": trigger_kind_label(&definition.trigger),
+        "trigger_kind": definition.trigger.kind_label(),
         "condition_body": condition_body,
         "payload_digest": payload_digest(trigger_context),
         "error": reason,
@@ -110,14 +110,6 @@ fn record_trigger_condition_errored_audit(
         error = reason,
         "trigger condition errored; run not created"
     );
-}
-
-fn trigger_kind_label(trigger: &WorkflowTrigger) -> &'static str {
-    match trigger {
-        WorkflowTrigger::Manual { .. } => "manual",
-        WorkflowTrigger::Webhook { .. } => "webhook",
-        WorkflowTrigger::Cron { .. } => "cron",
-    }
 }
 
 /// CEL identifier shape — `[A-Za-z_][A-Za-z0-9_]*`. Step names
@@ -690,13 +682,12 @@ impl Workflows {
         op: &mut OP,
         workflow: &WorkflowDefinition,
     ) -> Result<(), WorkflowError> {
-        let WorkflowTrigger::Cron {
-            schedule, timezone, ..
-        } = &workflow.trigger
-        else {
+        let WorkflowTrigger::Cron { schedule, .. } = &workflow.trigger else {
             return Ok(());
         };
-        let next_at = match next_cron_fire_at(schedule, timezone.as_deref(), chrono::Utc::now())
+        let next_at = match workflow
+            .trigger
+            .next_fire_at(chrono::Utc::now())
             .map_err(WorkflowError::InvalidCronExpression)?
         {
             Some(t) => t,

--- a/core/src/workflow/run/entity.rs
+++ b/core/src/workflow/run/entity.rs
@@ -39,6 +39,46 @@ pub struct StepResult {
     pub skipped: Option<String>,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowStepState {
+    Pending,
+    Succeeded,
+    Failed,
+    Errored,
+    Skipped,
+}
+
+impl StepResult {
+    pub fn step_state(&self) -> WorkflowStepState {
+        if self.skipped.is_some() {
+            WorkflowStepState::Skipped
+        } else if self.error.is_some() {
+            WorkflowStepState::Errored
+        } else if self.step_reported_agent_failure() {
+            WorkflowStepState::Failed
+        } else if self.output.is_some() {
+            WorkflowStepState::Succeeded
+        } else {
+            WorkflowStepState::Pending
+        }
+    }
+
+    fn step_reported_agent_failure(&self) -> bool {
+        if self.error.is_some() || self.skipped.is_some() {
+            return false;
+        }
+        let reported_success = self
+            .output
+            .as_ref()
+            .and_then(|v| v.as_object())
+            .and_then(|o| o.get("success"))
+            .and_then(|s| s.as_bool())
+            .unwrap_or(true);
+        !reported_success
+    }
+}
+
 #[derive(EsEvent, Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 #[es_event(id = "WorkflowRunId")]
@@ -114,7 +154,9 @@ impl WorkflowRun {
     }
 
     fn any_step_reported_failure(&self) -> bool {
-        self.step_results.iter().any(step_reported_agent_failure)
+        self.step_results
+            .iter()
+            .any(StepResult::step_reported_agent_failure)
     }
 
     pub fn step_already_terminal(&self, step_name: &str) -> bool {
@@ -317,26 +359,6 @@ impl WorkflowRun {
         });
         Idempotent::Executed(())
     }
-}
-
-/// True when a cleanly-completed step's structured output carries
-/// `success: false` (top-level boolean). Infrastructure-errored and
-/// condition-skipped steps return false here — they're classified
-/// as `Errored` and Succeeded respectively, never `Failed`.
-/// Missing or non-boolean `success` defaults to "no agent-reported
-/// failure" (back-compat for non-default-schema steps).
-fn step_reported_agent_failure(step: &StepResult) -> bool {
-    if step.error.is_some() || step.skipped.is_some() {
-        return false;
-    }
-    let reported_success = step
-        .output
-        .as_ref()
-        .and_then(|v| v.as_object())
-        .and_then(|o| o.get("success"))
-        .and_then(|s| s.as_bool())
-        .unwrap_or(true);
-    !reported_success
 }
 
 impl core::fmt::Display for WorkflowRun {

--- a/server/src/graphql/mutation.rs
+++ b/server/src/graphql/mutation.rs
@@ -5,6 +5,7 @@ use super::mcp_creds::*;
 use super::sandbox::*;
 
 use super::note::*;
+use super::primitives::JsonValue;
 use super::project::*;
 use super::project_secret::*;
 use super::skill::*;
@@ -29,6 +30,26 @@ impl Mutation {
             .create(sub, input.name, input.description)
             .await?;
         Ok(ProjectCreatePayload::from(Project::from(project)))
+    }
+
+    async fn workflow_trigger(
+        &self,
+        ctx: &Context<'_>,
+        input: WorkflowTriggerInput,
+    ) -> async_graphql::Result<WorkflowTriggerPayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let payload = input
+            .payload
+            .map(JsonValue::into_inner)
+            .unwrap_or_else(|| serde_json::json!({}));
+        let run = app
+            .workflows()
+            .trigger_run(sub, input.definition_id, payload)
+            .await?;
+        Ok(WorkflowTriggerPayload {
+            filtered: run.is_none(),
+            run: run.map(WorkflowRun::from),
+        })
     }
 
     async fn project_update(

--- a/server/src/graphql/primitives.rs
+++ b/server/src/graphql/primitives.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 #[allow(unused_imports)]
 pub use drua_core::primitives::{
     AgentId, McpCredsId, NoteId, ProjectId, ProjectSecretId, SandboxId, SkillId, UserId,
-    WorkflowDefinitionId,
+    WorkflowDefinitionId, WorkflowRunId,
 };
 
 #[allow(unused_imports)]
@@ -13,6 +13,23 @@ pub use drua_core::agent::session::SessionThreadId;
 pub use drua_core::auth::AuthSubject;
 
 pub use es_entity::graphql::UUID;
+
+#[derive(Clone, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct JsonValue(serde_json::Value);
+async_graphql::scalar!(JsonValue, "Json", "Arbitrary JSON value.");
+
+impl From<serde_json::Value> for JsonValue {
+    fn from(value: serde_json::Value) -> Self {
+        Self(value)
+    }
+}
+
+impl JsonValue {
+    pub fn into_inner(self) -> serde_json::Value {
+        self.0
+    }
+}
 
 #[derive(Clone, Serialize, Deserialize, Default)]
 #[serde(transparent)]

--- a/server/src/graphql/query.rs
+++ b/server/src/graphql/query.rs
@@ -9,6 +9,7 @@ use super::library::{LibrarySearchHit, LibrarySearchInput};
 use super::primitives::*;
 use super::project::Project;
 use super::sandbox::Sandbox;
+use super::workflow::{limit, WorkflowDefinition, WorkflowRun};
 use super::AppConfigYaml;
 
 use drua_core::project::ProjectByCreatedAtCursor;
@@ -67,6 +68,59 @@ impl Query {
         match app.projects().find_by_id(sub, id).await {
             Ok(project) => Ok(Some(Project::from(project))),
             Err(drua_core::project::ProjectError::Find(_)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn workflow_definitions(
+        &self,
+        ctx: &Context<'_>,
+        project_id: ProjectId,
+    ) -> async_graphql::Result<Vec<WorkflowDefinition>> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let definitions = app.workflows().list_for_project(sub, project_id).await?;
+        Ok(definitions
+            .into_iter()
+            .map(WorkflowDefinition::from)
+            .collect())
+    }
+
+    async fn workflow_definition(
+        &self,
+        ctx: &Context<'_>,
+        id: WorkflowDefinitionId,
+    ) -> async_graphql::Result<Option<WorkflowDefinition>> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        match app.workflows().find_by_id(sub, id).await {
+            Ok(definition) => Ok(Some(WorkflowDefinition::from(definition))),
+            Err(drua_core::workflow::WorkflowError::DefinitionFind(_)) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn workflow_runs(
+        &self,
+        ctx: &Context<'_>,
+        definition_id: WorkflowDefinitionId,
+        #[graphql(default = 50)] first: i32,
+    ) -> async_graphql::Result<Vec<WorkflowRun>> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let runs = app.workflows().list_runs(sub, definition_id).await?;
+        Ok(limit(runs, first)
+            .into_iter()
+            .map(WorkflowRun::from)
+            .collect())
+    }
+
+    async fn workflow_run(
+        &self,
+        ctx: &Context<'_>,
+        id: WorkflowRunId,
+    ) -> async_graphql::Result<Option<WorkflowRun>> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        match app.workflows().find_run_by_id(sub, id).await {
+            Ok(run) => Ok(Some(WorkflowRun::from(run))),
+            Err(drua_core::workflow::WorkflowError::RunFind(_)) => Ok(None),
             Err(e) => Err(e.into()),
         }
     }

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -171,6 +171,11 @@ type ErrorEvent {
 }
 
 """
+Arbitrary JSON value.
+"""
+scalar Json
+
+"""
 Workflow files are git-synced to the library repo but not exposed
 here — `AuthedSearch::search` filters them out at the boundary.
 """
@@ -302,6 +307,7 @@ type Mutation {
 	sandboxSuspend(input: SandboxSuspendInput!): SandboxSuspendPayload!
 	skillDelete(input: SkillDeleteInput!): SkillDeletePayload!
 	workflowDelete(input: WorkflowDeleteInput!): WorkflowDeletePayload!
+	workflowTrigger(input: WorkflowTriggerInput!): WorkflowTriggerPayload!
 }
 
 input NoteDeleteInput {
@@ -480,6 +486,10 @@ type Query {
 	project(id: ProjectId!): Project
 	projects(after: String, first: Int!): ProjectConnection!
 	sandbox(id: SandboxId!): Sandbox
+	workflowDefinition(id: WorkflowDefinitionId!): WorkflowDefinition
+	workflowDefinitions(projectId: ProjectId!): [WorkflowDefinition!]!
+	workflowRun(id: WorkflowRunId!): WorkflowRun
+	workflowRuns(definitionId: WorkflowDefinitionId!, first: Int! = 50): [WorkflowRun!]!
 }
 
 type Sandbox {
@@ -759,6 +769,21 @@ type UserMessageEvent {
 	text: String!
 }
 
+type WorkflowDefinition {
+	createdAt: Timestamp!
+	description: String
+	id: WorkflowDefinitionId!
+	modelChain: ModelChain
+	name: String!
+	projectId: ProjectId!
+	recentRuns(first: Int! = 10): [WorkflowRun!]!
+	sandboxes: [WorkflowSandbox!]!
+	steps: [WorkflowStep!]!
+	trigger: WorkflowTrigger!
+	updatedAt: Timestamp!
+	yaml: String!
+}
+
 scalar WorkflowDefinitionId
 
 input WorkflowDeleteInput {
@@ -767,6 +792,105 @@ input WorkflowDeleteInput {
 
 type WorkflowDeletePayload {
 	deletedId: WorkflowDefinitionId!
+}
+
+type WorkflowRun {
+	agents: [Agent!]!
+	completedAt: Timestamp
+	definitionId: WorkflowDefinitionId!
+	id: WorkflowRunId!
+	projectId: ProjectId!
+	startedAt: Timestamp!
+	state: WorkflowRunState!
+	stepResults: [WorkflowStepResult!]!
+	stepsSnapshot: [WorkflowStep!]!
+	triggerContext: Json!
+}
+
+scalar WorkflowRunId
+
+enum WorkflowRunState {
+	ERRORED
+	FAILED
+	PENDING
+	RUNNING
+	SUCCEEDED
+}
+
+type WorkflowSandbox {
+	branch: String
+	cpu: String
+	diskSize: String
+	kind: WorkflowSandboxKind!
+	memory: String
+	name: String!
+	repoUrl: String
+}
+
+enum WorkflowSandboxKind {
+	PREEXISTING
+	REPO
+	SCRATCH
+}
+
+type WorkflowStep {
+	condition: String
+	name: String!
+	outputSchema: Json
+	sandbox: String
+	sandboxMode: SandboxAttachmentMode
+	skill: String
+	stepType: WorkflowStepType!
+	timeoutSeconds: Int
+	tool: String
+}
+
+type WorkflowStepResult {
+	completedAt: Timestamp
+	error: String
+	name: String!
+	output: Json
+	skipped: String
+	state: WorkflowStepState!
+}
+
+enum WorkflowStepState {
+	ERRORED
+	FAILED
+	PENDING
+	SKIPPED
+	SUCCEEDED
+}
+
+enum WorkflowStepType {
+	AGENT_STEP
+	TOOL_STEP
+}
+
+type WorkflowTrigger {
+	condition: String
+	cronSchedule: String
+	cronTimezone: String
+	kind: WorkflowTriggerKind!
+	nextRunAt: Timestamp
+	provider: String
+	webhookUrl: String
+}
+
+input WorkflowTriggerInput {
+	definitionId: WorkflowDefinitionId!
+	payload: Json
+}
+
+enum WorkflowTriggerKind {
+	CRON
+	MANUAL
+	WEBHOOK
+}
+
+type WorkflowTriggerPayload {
+	filtered: Boolean!
+	run: WorkflowRun
 }
 
 scalar Yaml

--- a/server/src/graphql/workflow.rs
+++ b/server/src/graphql/workflow.rs
@@ -1,6 +1,17 @@
-use async_graphql::{InputObject, SimpleObject};
+use std::sync::Arc;
 
+use async_graphql::{ComplexObject, Context, Enum, InputObject, SimpleObject};
+
+use super::agent::{Agent, ModelChain, SandboxAttachmentMode};
 use super::primitives::*;
+
+use drua_core::sandbox::{SandboxMode, SandboxSpecs};
+use drua_core::workflow::{
+    StepResult as DomainStepResult, WorkflowDefinition as DomainWorkflowDefinition,
+    WorkflowRun as DomainWorkflowRun, WorkflowRunState as DomainWorkflowRunState,
+    WorkflowSandboxDecl as DomainWorkflowSandboxDecl, WorkflowStepDef as DomainWorkflowStepDef,
+    WorkflowStepState as DomainWorkflowStepState, WorkflowTrigger as DomainWorkflowTrigger,
+};
 
 #[derive(InputObject)]
 pub struct WorkflowDeleteInput {
@@ -10,4 +21,428 @@ pub struct WorkflowDeleteInput {
 #[derive(SimpleObject)]
 pub struct WorkflowDeletePayload {
     pub deleted_id: WorkflowDefinitionId,
+}
+
+#[derive(SimpleObject, Clone)]
+#[graphql(complex)]
+pub struct WorkflowDefinition {
+    id: WorkflowDefinitionId,
+    project_id: ProjectId,
+    name: String,
+    description: Option<String>,
+    trigger: WorkflowTrigger,
+    steps: Vec<WorkflowStep>,
+    sandboxes: Vec<WorkflowSandbox>,
+    model_chain: Option<ModelChain>,
+    created_at: Timestamp,
+    updated_at: Timestamp,
+    yaml: String,
+
+    #[graphql(skip)]
+    pub(super) entity: Arc<DomainWorkflowDefinition>,
+}
+
+#[ComplexObject]
+impl WorkflowDefinition {
+    async fn recent_runs(
+        &self,
+        ctx: &Context<'_>,
+        #[graphql(default = 10)] first: i32,
+    ) -> async_graphql::Result<Vec<WorkflowRun>> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let runs = app.workflows().list_runs(sub, self.entity.id).await?;
+        Ok(limit(runs, first)
+            .into_iter()
+            .map(WorkflowRun::from)
+            .collect())
+    }
+}
+
+impl From<DomainWorkflowDefinition> for WorkflowDefinition {
+    fn from(entity: DomainWorkflowDefinition) -> Self {
+        let created_at = entity.created_at();
+        let updated_at = entity.updated_at();
+        let mut trigger = WorkflowTrigger::from(&entity.trigger);
+        if matches!(entity.trigger, DomainWorkflowTrigger::Webhook { .. }) {
+            trigger.webhook_url = Some(format!("/webhooks/{}", entity.id));
+        }
+        let yaml = entity.canonical_yaml();
+        Self {
+            id: entity.id,
+            project_id: entity.project_id,
+            name: entity.name.clone(),
+            description: entity.description.clone(),
+            trigger,
+            steps: entity.steps.iter().map(WorkflowStep::from).collect(),
+            sandboxes: entity.sandboxes.iter().map(WorkflowSandbox::from).collect(),
+            model_chain: entity.model_chain.clone().map(Into::into),
+            created_at: created_at.into(),
+            updated_at: updated_at.into(),
+            yaml,
+            entity: Arc::new(entity),
+        }
+    }
+}
+
+#[derive(SimpleObject, Clone)]
+pub struct WorkflowTrigger {
+    kind: WorkflowTriggerKind,
+    provider: Option<String>,
+    cron_schedule: Option<String>,
+    cron_timezone: Option<String>,
+    next_run_at: Option<Timestamp>,
+    condition: Option<String>,
+    webhook_url: Option<String>,
+}
+
+impl From<&DomainWorkflowTrigger> for WorkflowTrigger {
+    fn from(trigger: &DomainWorkflowTrigger) -> Self {
+        match trigger {
+            DomainWorkflowTrigger::Manual { condition } => Self {
+                kind: WorkflowTriggerKind::Manual,
+                provider: None,
+                cron_schedule: None,
+                cron_timezone: None,
+                next_run_at: None,
+                condition: condition.clone(),
+                webhook_url: None,
+            },
+            DomainWorkflowTrigger::Webhook {
+                provider,
+                condition,
+                ..
+            } => Self {
+                kind: WorkflowTriggerKind::Webhook,
+                provider: provider.clone(),
+                cron_schedule: None,
+                cron_timezone: None,
+                next_run_at: None,
+                condition: condition.clone(),
+                webhook_url: None,
+            },
+            DomainWorkflowTrigger::Cron {
+                schedule,
+                timezone,
+                condition,
+            } => Self {
+                kind: WorkflowTriggerKind::Cron,
+                provider: None,
+                cron_schedule: Some(schedule.clone()),
+                cron_timezone: timezone.clone(),
+                next_run_at: trigger
+                    .next_fire_at(chrono::Utc::now())
+                    .ok()
+                    .flatten()
+                    .map(Into::into),
+                condition: condition.clone(),
+                webhook_url: None,
+            },
+        }
+    }
+}
+
+#[derive(Enum, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowTriggerKind {
+    Manual,
+    Webhook,
+    Cron,
+}
+
+#[derive(SimpleObject, Clone)]
+pub struct WorkflowStep {
+    name: String,
+    step_type: WorkflowStepType,
+    skill: Option<String>,
+    tool: Option<String>,
+    sandbox: Option<String>,
+    sandbox_mode: Option<SandboxAttachmentMode>,
+    timeout_seconds: Option<i32>,
+    condition: Option<String>,
+    output_schema: Option<JsonValue>,
+}
+
+impl From<&DomainWorkflowStepDef> for WorkflowStep {
+    fn from(step: &DomainWorkflowStepDef) -> Self {
+        match step {
+            DomainWorkflowStepDef::AgentStep {
+                name,
+                skill,
+                sandbox,
+                sandbox_mode,
+                timeout_seconds,
+                output_schema,
+                condition,
+                ..
+            } => Self {
+                name: name.clone(),
+                step_type: WorkflowStepType::AgentStep,
+                skill: Some(skill.clone()),
+                tool: None,
+                sandbox: sandbox.clone(),
+                sandbox_mode: sandbox_mode.map(SandboxAttachmentMode::from),
+                timeout_seconds: timeout_seconds.map(|s| s.min(i32::MAX as u64) as i32),
+                condition: condition.clone(),
+                output_schema: serde_json::to_value(output_schema.root_schema())
+                    .ok()
+                    .map(Into::into),
+            },
+            DomainWorkflowStepDef::ToolStep {
+                name,
+                tool,
+                timeout_seconds,
+                condition,
+                ..
+            } => Self {
+                name: name.clone(),
+                step_type: WorkflowStepType::ToolStep,
+                skill: None,
+                tool: Some(tool.clone()),
+                sandbox: None,
+                sandbox_mode: None,
+                timeout_seconds: timeout_seconds.map(|s| s.min(i32::MAX as u64) as i32),
+                condition: condition.clone(),
+                output_schema: None,
+            },
+        }
+    }
+}
+
+#[derive(Enum, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowStepType {
+    AgentStep,
+    ToolStep,
+}
+
+#[derive(SimpleObject, Clone)]
+pub struct WorkflowSandbox {
+    name: String,
+    kind: WorkflowSandboxKind,
+    repo_url: Option<String>,
+    branch: Option<String>,
+    cpu: Option<String>,
+    memory: Option<String>,
+    disk_size: Option<String>,
+}
+
+impl From<&DomainWorkflowSandboxDecl> for WorkflowSandbox {
+    fn from(sandbox: &DomainWorkflowSandboxDecl) -> Self {
+        match sandbox {
+            DomainWorkflowSandboxDecl::Preexisting { name } => Self {
+                name: name.clone(),
+                kind: WorkflowSandboxKind::Preexisting,
+                repo_url: None,
+                branch: None,
+                cpu: None,
+                memory: None,
+                disk_size: None,
+            },
+            DomainWorkflowSandboxDecl::Provisioned { name, mode, specs } => {
+                let (kind, repo_url, branch) = match mode {
+                    SandboxMode::Scratch => (WorkflowSandboxKind::Scratch, None, None),
+                    SandboxMode::Repo { repo_url, branch } => (
+                        WorkflowSandboxKind::Repo,
+                        Some(repo_url.clone()),
+                        branch.clone(),
+                    ),
+                };
+                let (cpu, memory, disk_size) = specs_parts(specs.as_ref());
+                Self {
+                    name: name.clone(),
+                    kind,
+                    repo_url,
+                    branch,
+                    cpu,
+                    memory,
+                    disk_size,
+                }
+            }
+        }
+    }
+}
+
+fn specs_parts(specs: Option<&SandboxSpecs>) -> (Option<String>, Option<String>, Option<String>) {
+    match specs {
+        Some(specs) => (
+            Some(specs.cpu.clone()),
+            Some(specs.memory.clone()),
+            Some(specs.disk_size.clone()),
+        ),
+        None => (None, None, None),
+    }
+}
+
+#[derive(Enum, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowSandboxKind {
+    Scratch,
+    Repo,
+    Preexisting,
+}
+
+#[derive(SimpleObject, Clone)]
+#[graphql(complex)]
+pub struct WorkflowRun {
+    id: WorkflowRunId,
+    definition_id: WorkflowDefinitionId,
+    project_id: ProjectId,
+    state: WorkflowRunState,
+    started_at: Timestamp,
+    completed_at: Option<Timestamp>,
+    trigger_context: JsonValue,
+    step_results: Vec<WorkflowStepResult>,
+    steps_snapshot: Vec<WorkflowStep>,
+
+    #[graphql(skip)]
+    pub(super) entity: Arc<DomainWorkflowRun>,
+}
+
+#[ComplexObject]
+impl WorkflowRun {
+    async fn agents(&self, ctx: &Context<'_>) -> async_graphql::Result<Vec<Agent>> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let agents = app
+            .agents()
+            .list_for_workflow_run(sub, self.entity.project_id, self.entity.id)
+            .await?;
+        Ok(agents.into_iter().map(Agent::from).collect())
+    }
+}
+
+impl From<DomainWorkflowRun> for WorkflowRun {
+    fn from(entity: DomainWorkflowRun) -> Self {
+        Self {
+            id: entity.id,
+            definition_id: entity.definition_id,
+            project_id: entity.project_id,
+            state: WorkflowRunState::from(entity.state),
+            started_at: entity.started_at().into(),
+            completed_at: entity.completed_at.map(Into::into),
+            trigger_context: entity.trigger_context.clone().into(),
+            step_results: entity
+                .step_results
+                .iter()
+                .map(WorkflowStepResult::from)
+                .collect(),
+            steps_snapshot: entity
+                .steps_snapshot
+                .iter()
+                .map(WorkflowStep::from)
+                .collect(),
+            entity: Arc::new(entity),
+        }
+    }
+}
+
+#[derive(Enum, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowRunState {
+    Pending,
+    Running,
+    Succeeded,
+    Failed,
+    Errored,
+}
+
+impl From<DomainWorkflowRunState> for WorkflowRunState {
+    fn from(state: DomainWorkflowRunState) -> Self {
+        match state {
+            DomainWorkflowRunState::Pending => Self::Pending,
+            DomainWorkflowRunState::Running => Self::Running,
+            DomainWorkflowRunState::Succeeded => Self::Succeeded,
+            DomainWorkflowRunState::Failed => Self::Failed,
+            DomainWorkflowRunState::Errored => Self::Errored,
+        }
+    }
+}
+
+#[derive(SimpleObject, Clone)]
+pub struct WorkflowStepResult {
+    name: String,
+    output: Option<JsonValue>,
+    error: Option<String>,
+    completed_at: Option<Timestamp>,
+    skipped: Option<String>,
+    state: WorkflowStepState,
+}
+
+impl From<&DomainStepResult> for WorkflowStepResult {
+    fn from(result: &DomainStepResult) -> Self {
+        Self {
+            name: result.name.clone(),
+            output: result.output.clone().map(Into::into),
+            error: result.error.clone(),
+            completed_at: result.completed_at.map(Into::into),
+            skipped: result.skipped.clone(),
+            state: result.step_state().into(),
+        }
+    }
+}
+
+impl From<DomainWorkflowStepState> for WorkflowStepState {
+    fn from(state: DomainWorkflowStepState) -> Self {
+        match state {
+            DomainWorkflowStepState::Pending => Self::Pending,
+            DomainWorkflowStepState::Succeeded => Self::Succeeded,
+            DomainWorkflowStepState::Failed => Self::Failed,
+            DomainWorkflowStepState::Errored => Self::Errored,
+            DomainWorkflowStepState::Skipped => Self::Skipped,
+        }
+    }
+}
+
+#[derive(Enum, Clone, Copy, PartialEq, Eq)]
+pub enum WorkflowStepState {
+    Pending,
+    Succeeded,
+    Failed,
+    Errored,
+    Skipped,
+}
+
+#[derive(InputObject)]
+pub struct WorkflowTriggerInput {
+    pub definition_id: WorkflowDefinitionId,
+    pub payload: Option<JsonValue>,
+}
+
+#[derive(SimpleObject)]
+pub struct WorkflowTriggerPayload {
+    pub run: Option<WorkflowRun>,
+    pub filtered: bool,
+}
+
+pub fn limit<T>(items: Vec<T>, first: i32) -> Vec<T> {
+    let limit = first.clamp(1, 100) as usize;
+    items.into_iter().take(limit).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn step_result(output: Option<serde_json::Value>) -> DomainStepResult {
+        DomainStepResult {
+            name: "step".to_string(),
+            output,
+            error: None,
+            completed_at: None,
+            skipped: None,
+        }
+    }
+
+    #[test]
+    fn step_state_failed_for_agent_reported_failure() {
+        let result = step_result(Some(serde_json::json!({ "success": false })));
+        let result = WorkflowStepResult::from(&result);
+        assert!(matches!(result.state, WorkflowStepState::Failed));
+    }
+
+    #[test]
+    fn step_state_succeeded_for_success_or_legacy_output() {
+        let success = step_result(Some(serde_json::json!({ "success": true })));
+        let success = WorkflowStepResult::from(&success);
+        assert!(matches!(success.state, WorkflowStepState::Succeeded));
+
+        let legacy = step_result(Some(serde_json::json!({ "value": "done" })));
+        let legacy = WorkflowStepResult::from(&legacy);
+        assert!(matches!(legacy.state, WorkflowStepState::Succeeded));
+    }
 }

--- a/server/tests/graphql.rs
+++ b/server/tests/graphql.rs
@@ -27,12 +27,13 @@ fn scratch_bare_repo() -> std::path::PathBuf {
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| std::env::temp_dir().join("drua-server-tests"));
     let stamp = format!(
-        "{}-{}",
+        "{}-{}-{}",
         std::process::id(),
         std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_nanos(),
+        uuid::Uuid::new_v4(),
     );
     let upstream = scratch.join(format!("graphql-upstream-{stamp}.git"));
     std::fs::create_dir_all(&upstream).expect("mkdir upstream");
@@ -101,7 +102,7 @@ async fn test_app(pool: &sqlx::PgPool) -> drua_core::App {
     let upstream = scratch_bare_repo();
     let library_data_dir = upstream
         .parent()
-        .map(|p| p.join(format!("library-{}", std::process::id())))
+        .map(|p| p.join(format!("library-{}", uuid::Uuid::new_v4())))
         .map(|p| p.to_string_lossy().into_owned());
     let library = drua_core::library::LibraryConfig {
         data_dir: library_data_dir,
@@ -486,6 +487,210 @@ async fn sandbox_query_returns_null_for_missing() {
     assert!(data["sandbox"].is_null());
 }
 
+// ─── Workflow query / mutation tests ──────────────────────────────────────
+
+#[tokio::test]
+async fn workflow_definitions_query_exposes_yaml_and_structured_fields() {
+    let pool = pool().await;
+    let app = test_app(&pool).await;
+    let schema = drua_server::graphql::schema(Some(app.clone()));
+    let sub = test_sub();
+
+    let project_name = format!("workflow-query-project-{}", uuid::Uuid::new_v4());
+    let project = app
+        .projects()
+        .create(&sub, project_name, None)
+        .await
+        .expect("create project");
+    let skill = app
+        .skills()
+        .create(
+            &sub,
+            project.id,
+            &project.name,
+            "workflow-query-skill".to_string(),
+            "GraphQL workflow test skill".to_string(),
+            "Return a short test result.".to_string(),
+        )
+        .await
+        .expect("create skill");
+    let workflow = app
+        .workflows()
+        .create(
+            &sub,
+            project.id,
+            &project.name,
+            "graphql-workflow-query".to_string(),
+            Some("GraphQL workflow query test".to_string()),
+            drua_core::workflow::WorkflowTrigger::Manual { condition: None },
+            vec![drua_core::workflow::WorkflowStepDef::AgentStep {
+                name: "investigate".to_string(),
+                skill: skill.name.clone(),
+                sandbox: None,
+                sandbox_mode: None,
+                timeout_seconds: Some(60),
+                model_chain: None,
+                output_schema: Box::new(drua_core::workflow::default_output_schema()),
+                condition: None,
+            }],
+            Vec::new(),
+            None,
+        )
+        .await
+        .expect("create workflow");
+
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"query($projectId: ProjectId!) {
+            workflowDefinitions(projectId: $projectId) {
+                id
+                name
+                description
+                yaml
+                trigger { kind condition }
+                steps { name stepType skill timeoutSeconds outputSchema }
+                recentRuns(first: 5) { id }
+            }
+        }"#,
+        serde_json::json!({ "projectId": project.id.to_string() }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    let definitions = data["workflowDefinitions"].as_array().unwrap();
+    let found = definitions
+        .iter()
+        .find(|d| d["id"] == workflow.id.to_string())
+        .expect("workflow returned");
+    assert_eq!(found["name"], "graphql-workflow-query");
+    assert_eq!(found["description"], "GraphQL workflow query test");
+    assert_eq!(found["trigger"]["kind"], "MANUAL");
+    assert!(found["yaml"]
+        .as_str()
+        .unwrap()
+        .contains("name: graphql-workflow-query"));
+    assert_eq!(found["steps"][0]["name"], "investigate");
+    assert_eq!(found["steps"][0]["stepType"], "AGENT_STEP");
+    assert_eq!(found["steps"][0]["skill"], skill.name);
+    assert!(found["steps"][0]["outputSchema"].is_object());
+}
+
+#[tokio::test]
+async fn workflow_trigger_mutation_returns_run_or_filtered() {
+    let pool = pool().await;
+    let app = test_app(&pool).await;
+    let schema = drua_server::graphql::schema(Some(app.clone()));
+    let sub = test_sub();
+
+    let project_name = format!("workflow-trigger-project-{}", uuid::Uuid::new_v4());
+    let project = app
+        .projects()
+        .create(&sub, project_name, None)
+        .await
+        .expect("create project");
+    let skill = app
+        .skills()
+        .create(
+            &sub,
+            project.id,
+            &project.name,
+            "workflow-trigger-skill".to_string(),
+            "GraphQL workflow trigger skill".to_string(),
+            "Return a short test result.".to_string(),
+        )
+        .await
+        .expect("create skill");
+
+    let steps = || {
+        vec![drua_core::workflow::WorkflowStepDef::AgentStep {
+            name: "act".to_string(),
+            skill: skill.name.clone(),
+            sandbox: None,
+            sandbox_mode: None,
+            timeout_seconds: Some(60),
+            model_chain: None,
+            output_schema: Box::new(drua_core::workflow::default_output_schema()),
+            condition: None,
+        }]
+    };
+    let runnable = app
+        .workflows()
+        .create(
+            &sub,
+            project.id,
+            &project.name,
+            "graphql-workflow-trigger".to_string(),
+            None,
+            drua_core::workflow::WorkflowTrigger::Manual { condition: None },
+            steps(),
+            Vec::new(),
+            None,
+        )
+        .await
+        .expect("create runnable workflow");
+    let filtered = app
+        .workflows()
+        .create(
+            &sub,
+            project.id,
+            &project.name,
+            "graphql-workflow-filtered".to_string(),
+            None,
+            drua_core::workflow::WorkflowTrigger::Manual {
+                condition: Some("false".to_string()),
+            },
+            steps(),
+            Vec::new(),
+            None,
+        )
+        .await
+        .expect("create filtered workflow");
+
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: WorkflowTriggerInput!) {
+            workflowTrigger(input: $input) {
+                filtered
+                run { id definitionId projectId state triggerContext }
+            }
+        }"#,
+        serde_json::json!({
+            "input": {
+                "definitionId": runnable.id.to_string(),
+                "payload": { "source": "graphql-test" }
+            }
+        }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    assert_eq!(data["workflowTrigger"]["filtered"], false);
+    assert_eq!(
+        data["workflowTrigger"]["run"]["definitionId"],
+        runnable.id.to_string()
+    );
+    assert_eq!(
+        data["workflowTrigger"]["run"]["triggerContext"]["source"],
+        "graphql-test"
+    );
+
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: WorkflowTriggerInput!) {
+            workflowTrigger(input: $input) { filtered run { id } }
+        }"#,
+        serde_json::json!({ "input": { "definitionId": filtered.id.to_string() } }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    assert_eq!(data["workflowTrigger"]["filtered"], true);
+    assert!(data["workflowTrigger"]["run"].is_null());
+}
+
 // ─── Library search query tests ────────────────────────────────────────────
 
 #[tokio::test]
@@ -653,6 +858,7 @@ async fn schema_has_expected_mutations() {
         "projectSecretDelete",
         "mcpCredentialsCreate",
         "mcpCredentialsRevoke",
+        "workflowTrigger",
         "projectCreate",
         "projectUpdate",
         "projectDelete",
@@ -689,6 +895,10 @@ async fn schema_has_expected_queries() {
         "project",
         "projects",
         "librarySearch",
+        "workflowDefinitions",
+        "workflowDefinition",
+        "workflowRuns",
+        "workflowRun",
     ];
     for name in expected {
         assert!(
@@ -756,6 +966,85 @@ async fn schema_sandbox_type_has_expected_fields() {
         assert!(
             fields.contains(&name.to_string()),
             "Missing sandbox field: {name}. Available: {fields:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn schema_workflow_types_have_expected_fields() {
+    let schema = drua_server::graphql::schema(None);
+    let response = schema
+        .execute(async_graphql::Request::new(
+            r#"
+            {
+                definition: __type(name: "WorkflowDefinition") { fields { name } }
+                run: __type(name: "WorkflowRun") { fields { name } }
+                triggerInput: __type(name: "WorkflowTriggerInput") { inputFields { name } }
+            }
+            "#,
+        ))
+        .await;
+    let json = serde_json::to_value(&response).unwrap();
+    let definition_fields: Vec<String> = json["data"]["definition"]["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["name"].as_str().unwrap().to_string())
+        .collect();
+    for name in [
+        "id",
+        "projectId",
+        "name",
+        "description",
+        "trigger",
+        "steps",
+        "sandboxes",
+        "modelChain",
+        "createdAt",
+        "updatedAt",
+        "recentRuns",
+        "yaml",
+    ] {
+        assert!(
+            definition_fields.contains(&name.to_string()),
+            "Missing workflow definition field: {name}. Available: {definition_fields:?}"
+        );
+    }
+
+    let run_fields: Vec<String> = json["data"]["run"]["fields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["name"].as_str().unwrap().to_string())
+        .collect();
+    for name in [
+        "id",
+        "definitionId",
+        "projectId",
+        "state",
+        "startedAt",
+        "completedAt",
+        "triggerContext",
+        "stepResults",
+        "stepsSnapshot",
+        "agents",
+    ] {
+        assert!(
+            run_fields.contains(&name.to_string()),
+            "Missing workflow run field: {name}. Available: {run_fields:?}"
+        );
+    }
+
+    let trigger_input_fields: Vec<String> = json["data"]["triggerInput"]["inputFields"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|f| f["name"].as_str().unwrap().to_string())
+        .collect();
+    for name in ["definitionId", "payload"] {
+        assert!(
+            trigger_input_fields.contains(&name.to_string()),
+            "Missing workflow trigger input field: {name}. Available: {trigger_input_fields:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- add GraphQL workflow definition/run queries and manual trigger mutation
- expose canonical WorkflowDefinition.yaml for YAML-first TUI detail
- add workflow GraphQL types, Json scalar support, regenerated SDL, and focused GraphQL tests

## Validation
- cargo fmt
- nix develop -c cargo check -p drua-server
- nix develop -c make sdl-rust
- nix develop -c cargo test -p drua-server --test graphql schema_
- nix develop -c cargo test -p drua-server --test graphql workflow_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new GraphQL queries/mutation that can create workflow runs and expose run/definition data (including arbitrary JSON payloads), plus small workflow-domain refactors around cron scheduling and step state classification; mistakes could affect triggering behavior or API consumers.
> 
> **Overview**
> Exposes workflows over GraphQL for the TUI: adds `workflowDefinitions`/`workflowDefinition` queries, `workflowRuns`/`workflowRun` queries, and a `workflowTrigger` mutation that triggers a run with an optional JSON payload and reports whether it was filtered.
> 
> Introduces GraphQL workflow types (`WorkflowDefinition`, `WorkflowRun`, trigger/step/sandbox shapes), a `Json` scalar, and returns canonical workflow YAML via `WorkflowDefinition.yaml`; adds run step result `state` derived from output/error/skipped and an `agents` field resolved per run.
> 
> Refactors cron “next fire time” logic by moving it onto `WorkflowTrigger::next_fire_at` (replacing `next_cron_fire_at`) and uses `WorkflowTrigger::kind_label` for audit metadata; updates cron scheduling and CLI/top-level workflow outputs accordingly, and extends GraphQL tests + SDL with the new workflow surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c547837c34d35815fa663cd8c379ee8b250a2c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->