### PR TITLE
fix(tool-caching): tighten recovery and compose contracts

### DIFF
--- a/bats/summarized-tool-responses/compose-roundtrip-1.json
+++ b/bats/summarized-tool-responses/compose-roundtrip-1.json
@@ -3,11 +3,11 @@
     "invocation_id": "<uuid>",
     "paths": [
       {
-        "path": "$.result.arr.result",
+        "path": "$.result.arr",
         "recover": {
           "args_template": {
             "invocation_id": "<uuid>",
-            "path": "$.result.arr.result",
+            "path": "$.result.arr",
             "query": {
               "len": 105,
               "mode": "json_array_slice",
@@ -22,11 +22,11 @@
         "total_items": 500
       },
       {
-        "path": "$.result.str.result",
+        "path": "$.result.str",
         "recover": {
           "args_template": {
             "invocation_id": "<uuid>",
-            "path": "$.result.str.result",
+            "path": "$.result.str",
             "query": {
               "len": 28,
               "mode": "lines",
@@ -42,1604 +42,1686 @@
       }
     ]
   },
+  "_recovery": {
+    "invocation_id": "<uuid>",
+    "paths": [
+      {
+        "path": "$.result.arr",
+        "recover": {
+          "args_template": {
+            "invocation_id": "<uuid>",
+            "path": "$.result.arr",
+            "query": {
+              "len": 105,
+              "mode": "json_array_slice",
+              "offset": 395
+            }
+          },
+          "tool": "tool_output_fetch"
+        },
+        "shown_bytes": 8186,
+        "shown_items": 395,
+        "total_bytes": 10391,
+        "total_items": 500
+      },
+      {
+        "path": "$.result.str",
+        "recover": {
+          "args_template": {
+            "invocation_id": "<uuid>",
+            "path": "$.result.str",
+            "query": {
+              "len": 28,
+              "mode": "lines",
+              "offset": 6
+            }
+          },
+          "tool": "tool_output_fetch"
+        },
+        "shown_bytes": 4206,
+        "shown_lines": 13,
+        "total_bytes": 13051,
+        "total_lines": 41
+      }
+    ],
+    "persisted_root": "upstream T directly; not the outer {result: ...} wire wrapper",
+    "recommended_queries": [
+      {
+        "args_template": {
+          "invocation_id": "<uuid>",
+          "path": "$.result.arr",
+          "query": {
+            "len": 105,
+            "mode": "json_array_slice",
+            "offset": 395
+          }
+        },
+        "tool": "tool_output_fetch"
+      },
+      {
+        "args_template": {
+          "invocation_id": "<uuid>",
+          "path": "$.result.str",
+          "query": {
+            "len": 28,
+            "mode": "lines",
+            "offset": 6
+          }
+        },
+        "tool": "tool_output_fetch"
+      }
+    ],
+    "root_kind": "object",
+    "root_path": "$",
+    "sub_invocations": [
+      {
+        "args_digest": "fake_upstream_str-large-table({})",
+        "invocation_id": "<uuid>",
+        "kind": "lines",
+        "raw_size_bytes": 13051,
+        "tool_name": "fake_upstream_str-large-table"
+      },
+      {
+        "args_digest": "fake_upstream_arr-large-passthrough-items({})",
+        "invocation_id": "<uuid>",
+        "kind": "json_array_slice",
+        "raw_size_bytes": 10391,
+        "tool_name": "fake_upstream_arr-large-passthrough-items"
+      }
+    ]
+  },
   "result": {
     "console": [],
     "execution_time_ms": "<ms>",
     "fetch_hint": "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated `<summary>+<recovery>` envelope you'd have seen calling that tool directly.",
     "result": {
-      "arr": {
-        "result": [
-          {
-            "id": 0,
-            "tag": "x"
-          },
-          {
-            "id": 1,
-            "tag": "x"
-          },
-          {
-            "id": 2,
-            "tag": "x"
-          },
-          {
-            "id": 3,
-            "tag": "x"
-          },
-          {
-            "id": 4,
-            "tag": "x"
-          },
-          {
-            "id": 5,
-            "tag": "x"
-          },
-          {
-            "id": 6,
-            "tag": "x"
-          },
-          {
-            "id": 7,
-            "tag": "x"
-          },
-          {
-            "id": 8,
-            "tag": "x"
-          },
-          {
-            "id": 9,
-            "tag": "x"
-          },
-          {
-            "id": 10,
-            "tag": "x"
-          },
-          {
-            "id": 11,
-            "tag": "x"
-          },
-          {
-            "id": 12,
-            "tag": "x"
-          },
-          {
-            "id": 13,
-            "tag": "x"
-          },
-          {
-            "id": 14,
-            "tag": "x"
-          },
-          {
-            "id": 15,
-            "tag": "x"
-          },
-          {
-            "id": 16,
-            "tag": "x"
-          },
-          {
-            "id": 17,
-            "tag": "x"
-          },
-          {
-            "id": 18,
-            "tag": "x"
-          },
-          {
-            "id": 19,
-            "tag": "x"
-          },
-          {
-            "id": 20,
-            "tag": "x"
-          },
-          {
-            "id": 21,
-            "tag": "x"
-          },
-          {
-            "id": 22,
-            "tag": "x"
-          },
-          {
-            "id": 23,
-            "tag": "x"
-          },
-          {
-            "id": 24,
-            "tag": "x"
-          },
-          {
-            "id": 25,
-            "tag": "x"
-          },
-          {
-            "id": 26,
-            "tag": "x"
-          },
-          {
-            "id": 27,
-            "tag": "x"
-          },
-          {
-            "id": 28,
-            "tag": "x"
-          },
-          {
-            "id": 29,
-            "tag": "x"
-          },
-          {
-            "id": 30,
-            "tag": "x"
-          },
-          {
-            "id": 31,
-            "tag": "x"
-          },
-          {
-            "id": 32,
-            "tag": "x"
-          },
-          {
-            "id": 33,
-            "tag": "x"
-          },
-          {
-            "id": 34,
-            "tag": "x"
-          },
-          {
-            "id": 35,
-            "tag": "x"
-          },
-          {
-            "id": 36,
-            "tag": "x"
-          },
-          {
-            "id": 37,
-            "tag": "x"
-          },
-          {
-            "id": 38,
-            "tag": "x"
-          },
-          {
-            "id": 39,
-            "tag": "x"
-          },
-          {
-            "id": 40,
-            "tag": "x"
-          },
-          {
-            "id": 41,
-            "tag": "x"
-          },
-          {
-            "id": 42,
-            "tag": "x"
-          },
-          {
-            "id": 43,
-            "tag": "x"
-          },
-          {
-            "id": 44,
-            "tag": "x"
-          },
-          {
-            "id": 45,
-            "tag": "x"
-          },
-          {
-            "id": 46,
-            "tag": "x"
-          },
-          {
-            "id": 47,
-            "tag": "x"
-          },
-          {
-            "id": 48,
-            "tag": "x"
-          },
-          {
-            "id": 49,
-            "tag": "x"
-          },
-          {
-            "id": 50,
-            "tag": "x"
-          },
-          {
-            "id": 51,
-            "tag": "x"
-          },
-          {
-            "id": 52,
-            "tag": "x"
-          },
-          {
-            "id": 53,
-            "tag": "x"
-          },
-          {
-            "id": 54,
-            "tag": "x"
-          },
-          {
-            "id": 55,
-            "tag": "x"
-          },
-          {
-            "id": 56,
-            "tag": "x"
-          },
-          {
-            "id": 57,
-            "tag": "x"
-          },
-          {
-            "id": 58,
-            "tag": "x"
-          },
-          {
-            "id": 59,
-            "tag": "x"
-          },
-          {
-            "id": 60,
-            "tag": "x"
-          },
-          {
-            "id": 61,
-            "tag": "x"
-          },
-          {
-            "id": 62,
-            "tag": "x"
-          },
-          {
-            "id": 63,
-            "tag": "x"
-          },
-          {
-            "id": 64,
-            "tag": "x"
-          },
-          {
-            "id": 65,
-            "tag": "x"
-          },
-          {
-            "id": 66,
-            "tag": "x"
-          },
-          {
-            "id": 67,
-            "tag": "x"
-          },
-          {
-            "id": 68,
-            "tag": "x"
-          },
-          {
-            "id": 69,
-            "tag": "x"
-          },
-          {
-            "id": 70,
-            "tag": "x"
-          },
-          {
-            "id": 71,
-            "tag": "x"
-          },
-          {
-            "id": 72,
-            "tag": "x"
-          },
-          {
-            "id": 73,
-            "tag": "x"
-          },
-          {
-            "id": 74,
-            "tag": "x"
-          },
-          {
-            "id": 75,
-            "tag": "x"
-          },
-          {
-            "id": 76,
-            "tag": "x"
-          },
-          {
-            "id": 77,
-            "tag": "x"
-          },
-          {
-            "id": 78,
-            "tag": "x"
-          },
-          {
-            "id": 79,
-            "tag": "x"
-          },
-          {
-            "id": 80,
-            "tag": "x"
-          },
-          {
-            "id": 81,
-            "tag": "x"
-          },
-          {
-            "id": 82,
-            "tag": "x"
-          },
-          {
-            "id": 83,
-            "tag": "x"
-          },
-          {
-            "id": 84,
-            "tag": "x"
-          },
-          {
-            "id": 85,
-            "tag": "x"
-          },
-          {
-            "id": 86,
-            "tag": "x"
-          },
-          {
-            "id": 87,
-            "tag": "x"
-          },
-          {
-            "id": 88,
-            "tag": "x"
-          },
-          {
-            "id": 89,
-            "tag": "x"
-          },
-          {
-            "id": 90,
-            "tag": "x"
-          },
-          {
-            "id": 91,
-            "tag": "x"
-          },
-          {
-            "id": 92,
-            "tag": "x"
-          },
-          {
-            "id": 93,
-            "tag": "x"
-          },
-          {
-            "id": 94,
-            "tag": "x"
-          },
-          {
-            "id": 95,
-            "tag": "x"
-          },
-          {
-            "id": 96,
-            "tag": "x"
-          },
-          {
-            "id": 97,
-            "tag": "x"
-          },
-          {
-            "id": 98,
-            "tag": "x"
-          },
-          {
-            "id": 99,
-            "tag": "x"
-          },
-          {
-            "id": 100,
-            "tag": "x"
-          },
-          {
-            "id": 101,
-            "tag": "x"
-          },
-          {
-            "id": 102,
-            "tag": "x"
-          },
-          {
-            "id": 103,
-            "tag": "x"
-          },
-          {
-            "id": 104,
-            "tag": "x"
-          },
-          {
-            "id": 105,
-            "tag": "x"
-          },
-          {
-            "id": 106,
-            "tag": "x"
-          },
-          {
-            "id": 107,
-            "tag": "x"
-          },
-          {
-            "id": 108,
-            "tag": "x"
-          },
-          {
-            "id": 109,
-            "tag": "x"
-          },
-          {
-            "id": 110,
-            "tag": "x"
-          },
-          {
-            "id": 111,
-            "tag": "x"
-          },
-          {
-            "id": 112,
-            "tag": "x"
-          },
-          {
-            "id": 113,
-            "tag": "x"
-          },
-          {
-            "id": 114,
-            "tag": "x"
-          },
-          {
-            "id": 115,
-            "tag": "x"
-          },
-          {
-            "id": 116,
-            "tag": "x"
-          },
-          {
-            "id": 117,
-            "tag": "x"
-          },
-          {
-            "id": 118,
-            "tag": "x"
-          },
-          {
-            "id": 119,
-            "tag": "x"
-          },
-          {
-            "id": 120,
-            "tag": "x"
-          },
-          {
-            "id": 121,
-            "tag": "x"
-          },
-          {
-            "id": 122,
-            "tag": "x"
-          },
-          {
-            "id": 123,
-            "tag": "x"
-          },
-          {
-            "id": 124,
-            "tag": "x"
-          },
-          {
-            "id": 125,
-            "tag": "x"
-          },
-          {
-            "id": 126,
-            "tag": "x"
-          },
-          {
-            "id": 127,
-            "tag": "x"
-          },
-          {
-            "id": 128,
-            "tag": "x"
-          },
-          {
-            "id": 129,
-            "tag": "x"
-          },
-          {
-            "id": 130,
-            "tag": "x"
-          },
-          {
-            "id": 131,
-            "tag": "x"
-          },
-          {
-            "id": 132,
-            "tag": "x"
-          },
-          {
-            "id": 133,
-            "tag": "x"
-          },
-          {
-            "id": 134,
-            "tag": "x"
-          },
-          {
-            "id": 135,
-            "tag": "x"
-          },
-          {
-            "id": 136,
-            "tag": "x"
-          },
-          {
-            "id": 137,
-            "tag": "x"
-          },
-          {
-            "id": 138,
-            "tag": "x"
-          },
-          {
-            "id": 139,
-            "tag": "x"
-          },
-          {
-            "id": 140,
-            "tag": "x"
-          },
-          {
-            "id": 141,
-            "tag": "x"
-          },
-          {
-            "id": 142,
-            "tag": "x"
-          },
-          {
-            "id": 143,
-            "tag": "x"
-          },
-          {
-            "id": 144,
-            "tag": "x"
-          },
-          {
-            "id": 145,
-            "tag": "x"
-          },
-          {
-            "id": 146,
-            "tag": "x"
-          },
-          {
-            "id": 147,
-            "tag": "x"
-          },
-          {
-            "id": 148,
-            "tag": "x"
-          },
-          {
-            "id": 149,
-            "tag": "x"
-          },
-          {
-            "id": 150,
-            "tag": "x"
-          },
-          {
-            "id": 151,
-            "tag": "x"
-          },
-          {
-            "id": 152,
-            "tag": "x"
-          },
-          {
-            "id": 153,
-            "tag": "x"
-          },
-          {
-            "id": 154,
-            "tag": "x"
-          },
-          {
-            "id": 155,
-            "tag": "x"
-          },
-          {
-            "id": 156,
-            "tag": "x"
-          },
-          {
-            "id": 157,
-            "tag": "x"
-          },
-          {
-            "id": 158,
-            "tag": "x"
-          },
-          {
-            "id": 159,
-            "tag": "x"
-          },
-          {
-            "id": 160,
-            "tag": "x"
-          },
-          {
-            "id": 161,
-            "tag": "x"
-          },
-          {
-            "id": 162,
-            "tag": "x"
-          },
-          {
-            "id": 163,
-            "tag": "x"
-          },
-          {
-            "id": 164,
-            "tag": "x"
-          },
-          {
-            "id": 165,
-            "tag": "x"
-          },
-          {
-            "id": 166,
-            "tag": "x"
-          },
-          {
-            "id": 167,
-            "tag": "x"
-          },
-          {
-            "id": 168,
-            "tag": "x"
-          },
-          {
-            "id": 169,
-            "tag": "x"
-          },
-          {
-            "id": 170,
-            "tag": "x"
-          },
-          {
-            "id": 171,
-            "tag": "x"
-          },
-          {
-            "id": 172,
-            "tag": "x"
-          },
-          {
-            "id": 173,
-            "tag": "x"
-          },
-          {
-            "id": 174,
-            "tag": "x"
-          },
-          {
-            "id": 175,
-            "tag": "x"
-          },
-          {
-            "id": 176,
-            "tag": "x"
-          },
-          {
-            "id": 177,
-            "tag": "x"
-          },
-          {
-            "id": 178,
-            "tag": "x"
-          },
-          {
-            "id": 179,
-            "tag": "x"
-          },
-          {
-            "id": 180,
-            "tag": "x"
-          },
-          {
-            "id": 181,
-            "tag": "x"
-          },
-          {
-            "id": 182,
-            "tag": "x"
-          },
-          {
-            "id": 183,
-            "tag": "x"
-          },
-          {
-            "id": 184,
-            "tag": "x"
-          },
-          {
-            "id": 185,
-            "tag": "x"
-          },
-          {
-            "id": 186,
-            "tag": "x"
-          },
-          {
-            "id": 187,
-            "tag": "x"
-          },
-          {
-            "id": 188,
-            "tag": "x"
-          },
-          {
-            "id": 189,
-            "tag": "x"
-          },
-          {
-            "id": 190,
-            "tag": "x"
-          },
-          {
-            "id": 191,
-            "tag": "x"
-          },
-          {
-            "id": 192,
-            "tag": "x"
-          },
-          {
-            "id": 193,
-            "tag": "x"
-          },
-          {
-            "id": 194,
-            "tag": "x"
-          },
-          {
-            "id": 195,
-            "tag": "x"
-          },
-          {
-            "id": 196,
-            "tag": "x"
-          },
-          {
-            "id": 197,
-            "tag": "x"
-          },
-          {
-            "id": 198,
-            "tag": "x"
-          },
-          {
-            "id": 199,
-            "tag": "x"
-          },
-          {
-            "id": 200,
-            "tag": "x"
-          },
-          {
-            "id": 201,
-            "tag": "x"
-          },
-          {
-            "id": 202,
-            "tag": "x"
-          },
-          {
-            "id": 203,
-            "tag": "x"
-          },
-          {
-            "id": 204,
-            "tag": "x"
-          },
-          {
-            "id": 205,
-            "tag": "x"
-          },
-          {
-            "id": 206,
-            "tag": "x"
-          },
-          {
-            "id": 207,
-            "tag": "x"
-          },
-          {
-            "id": 208,
-            "tag": "x"
-          },
-          {
-            "id": 209,
-            "tag": "x"
-          },
-          {
-            "id": 210,
-            "tag": "x"
-          },
-          {
-            "id": 211,
-            "tag": "x"
-          },
-          {
-            "id": 212,
-            "tag": "x"
-          },
-          {
-            "id": 213,
-            "tag": "x"
-          },
-          {
-            "id": 214,
-            "tag": "x"
-          },
-          {
-            "id": 215,
-            "tag": "x"
-          },
-          {
-            "id": 216,
-            "tag": "x"
-          },
-          {
-            "id": 217,
-            "tag": "x"
-          },
-          {
-            "id": 218,
-            "tag": "x"
-          },
-          {
-            "id": 219,
-            "tag": "x"
-          },
-          {
-            "id": 220,
-            "tag": "x"
-          },
-          {
-            "id": 221,
-            "tag": "x"
-          },
-          {
-            "id": 222,
-            "tag": "x"
-          },
-          {
-            "id": 223,
-            "tag": "x"
-          },
-          {
-            "id": 224,
-            "tag": "x"
-          },
-          {
-            "id": 225,
-            "tag": "x"
-          },
-          {
-            "id": 226,
-            "tag": "x"
-          },
-          {
-            "id": 227,
-            "tag": "x"
-          },
-          {
-            "id": 228,
-            "tag": "x"
-          },
-          {
-            "id": 229,
-            "tag": "x"
-          },
-          {
-            "id": 230,
-            "tag": "x"
-          },
-          {
-            "id": 231,
-            "tag": "x"
-          },
-          {
-            "id": 232,
-            "tag": "x"
-          },
-          {
-            "id": 233,
-            "tag": "x"
-          },
-          {
-            "id": 234,
-            "tag": "x"
-          },
-          {
-            "id": 235,
-            "tag": "x"
-          },
-          {
-            "id": 236,
-            "tag": "x"
-          },
-          {
-            "id": 237,
-            "tag": "x"
-          },
-          {
-            "id": 238,
-            "tag": "x"
-          },
-          {
-            "id": 239,
-            "tag": "x"
-          },
-          {
-            "id": 240,
-            "tag": "x"
-          },
-          {
-            "id": 241,
-            "tag": "x"
-          },
-          {
-            "id": 242,
-            "tag": "x"
-          },
-          {
-            "id": 243,
-            "tag": "x"
-          },
-          {
-            "id": 244,
-            "tag": "x"
-          },
-          {
-            "id": 245,
-            "tag": "x"
-          },
-          {
-            "id": 246,
-            "tag": "x"
-          },
-          {
-            "id": 247,
-            "tag": "x"
-          },
-          {
-            "id": 248,
-            "tag": "x"
-          },
-          {
-            "id": 249,
-            "tag": "x"
-          },
-          {
-            "id": 250,
-            "tag": "x"
-          },
-          {
-            "id": 251,
-            "tag": "x"
-          },
-          {
-            "id": 252,
-            "tag": "x"
-          },
-          {
-            "id": 253,
-            "tag": "x"
-          },
-          {
-            "id": 254,
-            "tag": "x"
-          },
-          {
-            "id": 255,
-            "tag": "x"
-          },
-          {
-            "id": 256,
-            "tag": "x"
-          },
-          {
-            "id": 257,
-            "tag": "x"
-          },
-          {
-            "id": 258,
-            "tag": "x"
-          },
-          {
-            "id": 259,
-            "tag": "x"
-          },
-          {
-            "id": 260,
-            "tag": "x"
-          },
-          {
-            "id": 261,
-            "tag": "x"
-          },
-          {
-            "id": 262,
-            "tag": "x"
-          },
-          {
-            "id": 263,
-            "tag": "x"
-          },
-          {
-            "id": 264,
-            "tag": "x"
-          },
-          {
-            "id": 265,
-            "tag": "x"
-          },
-          {
-            "id": 266,
-            "tag": "x"
-          },
-          {
-            "id": 267,
-            "tag": "x"
-          },
-          {
-            "id": 268,
-            "tag": "x"
-          },
-          {
-            "id": 269,
-            "tag": "x"
-          },
-          {
-            "id": 270,
-            "tag": "x"
-          },
-          {
-            "id": 271,
-            "tag": "x"
-          },
-          {
-            "id": 272,
-            "tag": "x"
-          },
-          {
-            "id": 273,
-            "tag": "x"
-          },
-          {
-            "id": 274,
-            "tag": "x"
-          },
-          {
-            "id": 275,
-            "tag": "x"
-          },
-          {
-            "id": 276,
-            "tag": "x"
-          },
-          {
-            "id": 277,
-            "tag": "x"
-          },
-          {
-            "id": 278,
-            "tag": "x"
-          },
-          {
-            "id": 279,
-            "tag": "x"
-          },
-          {
-            "id": 280,
-            "tag": "x"
-          },
-          {
-            "id": 281,
-            "tag": "x"
-          },
-          {
-            "id": 282,
-            "tag": "x"
-          },
-          {
-            "id": 283,
-            "tag": "x"
-          },
-          {
-            "id": 284,
-            "tag": "x"
-          },
-          {
-            "id": 285,
-            "tag": "x"
-          },
-          {
-            "id": 286,
-            "tag": "x"
-          },
-          {
-            "id": 287,
-            "tag": "x"
-          },
-          {
-            "id": 288,
-            "tag": "x"
-          },
-          {
-            "id": 289,
-            "tag": "x"
-          },
-          {
-            "id": 290,
-            "tag": "x"
-          },
-          {
-            "id": 291,
-            "tag": "x"
-          },
-          {
-            "id": 292,
-            "tag": "x"
-          },
-          {
-            "id": 293,
-            "tag": "x"
-          },
-          {
-            "id": 294,
-            "tag": "x"
-          },
-          {
-            "id": 295,
-            "tag": "x"
-          },
-          {
-            "id": 296,
-            "tag": "x"
-          },
-          {
-            "id": 297,
-            "tag": "x"
-          },
-          {
-            "id": 298,
-            "tag": "x"
-          },
-          {
-            "id": 299,
-            "tag": "x"
-          },
-          {
-            "id": 300,
-            "tag": "x"
-          },
-          {
-            "id": 301,
-            "tag": "x"
-          },
-          {
-            "id": 302,
-            "tag": "x"
-          },
-          {
-            "id": 303,
-            "tag": "x"
-          },
-          {
-            "id": 304,
-            "tag": "x"
-          },
-          {
-            "id": 305,
-            "tag": "x"
-          },
-          {
-            "id": 306,
-            "tag": "x"
-          },
-          {
-            "id": 307,
-            "tag": "x"
-          },
-          {
-            "id": 308,
-            "tag": "x"
-          },
-          {
-            "id": 309,
-            "tag": "x"
-          },
-          {
-            "id": 310,
-            "tag": "x"
-          },
-          {
-            "id": 311,
-            "tag": "x"
-          },
-          {
-            "id": 312,
-            "tag": "x"
-          },
-          {
-            "id": 313,
-            "tag": "x"
-          },
-          {
-            "id": 314,
-            "tag": "x"
-          },
-          {
-            "id": 315,
-            "tag": "x"
-          },
-          {
-            "id": 316,
-            "tag": "x"
-          },
-          {
-            "id": 317,
-            "tag": "x"
-          },
-          {
-            "id": 318,
-            "tag": "x"
-          },
-          {
-            "id": 319,
-            "tag": "x"
-          },
-          {
-            "id": 320,
-            "tag": "x"
-          },
-          {
-            "id": 321,
-            "tag": "x"
-          },
-          {
-            "id": 322,
-            "tag": "x"
-          },
-          {
-            "id": 323,
-            "tag": "x"
-          },
-          {
-            "id": 324,
-            "tag": "x"
-          },
-          {
-            "id": 325,
-            "tag": "x"
-          },
-          {
-            "id": 326,
-            "tag": "x"
-          },
-          {
-            "id": 327,
-            "tag": "x"
-          },
-          {
-            "id": 328,
-            "tag": "x"
-          },
-          {
-            "id": 329,
-            "tag": "x"
-          },
-          {
-            "id": 330,
-            "tag": "x"
-          },
-          {
-            "id": 331,
-            "tag": "x"
-          },
-          {
-            "id": 332,
-            "tag": "x"
-          },
-          {
-            "id": 333,
-            "tag": "x"
-          },
-          {
-            "id": 334,
-            "tag": "x"
-          },
-          {
-            "id": 335,
-            "tag": "x"
-          },
-          {
-            "id": 336,
-            "tag": "x"
-          },
-          {
-            "id": 337,
-            "tag": "x"
-          },
-          {
-            "id": 338,
-            "tag": "x"
-          },
-          {
-            "id": 339,
-            "tag": "x"
-          },
-          {
-            "id": 340,
-            "tag": "x"
-          },
-          {
-            "id": 341,
-            "tag": "x"
-          },
-          {
-            "id": 342,
-            "tag": "x"
-          },
-          {
-            "id": 343,
-            "tag": "x"
-          },
-          {
-            "id": 344,
-            "tag": "x"
-          },
-          {
-            "id": 345,
-            "tag": "x"
-          },
-          {
-            "id": 346,
-            "tag": "x"
-          },
-          {
-            "id": 347,
-            "tag": "x"
-          },
-          {
-            "id": 348,
-            "tag": "x"
-          },
-          {
-            "id": 349,
-            "tag": "x"
-          },
-          {
-            "id": 350,
-            "tag": "x"
-          },
-          {
-            "id": 351,
-            "tag": "x"
-          },
-          {
-            "id": 352,
-            "tag": "x"
-          },
-          {
-            "id": 353,
-            "tag": "x"
-          },
-          {
-            "id": 354,
-            "tag": "x"
-          },
-          {
-            "id": 355,
-            "tag": "x"
-          },
-          {
-            "id": 356,
-            "tag": "x"
-          },
-          {
-            "id": 357,
-            "tag": "x"
-          },
-          {
-            "id": 358,
-            "tag": "x"
-          },
-          {
-            "id": 359,
-            "tag": "x"
-          },
-          {
-            "id": 360,
-            "tag": "x"
-          },
-          {
-            "id": 361,
-            "tag": "x"
-          },
-          {
-            "id": 362,
-            "tag": "x"
-          },
-          {
-            "id": 363,
-            "tag": "x"
-          },
-          {
-            "id": 364,
-            "tag": "x"
-          },
-          {
-            "id": 365,
-            "tag": "x"
-          },
-          {
-            "id": 366,
-            "tag": "x"
-          },
-          {
-            "id": 367,
-            "tag": "x"
-          },
-          {
-            "id": 368,
-            "tag": "x"
-          },
-          {
-            "id": 369,
-            "tag": "x"
-          },
-          {
-            "id": 370,
-            "tag": "x"
-          },
-          {
-            "id": 371,
-            "tag": "x"
-          },
-          {
-            "id": 372,
-            "tag": "x"
-          },
-          {
-            "id": 373,
-            "tag": "x"
-          },
-          {
-            "id": 374,
-            "tag": "x"
-          },
-          {
-            "id": 375,
-            "tag": "x"
-          },
-          {
-            "id": 376,
-            "tag": "x"
-          },
-          {
-            "id": 377,
-            "tag": "x"
-          },
-          {
-            "id": 378,
-            "tag": "x"
-          },
-          {
-            "id": 379,
-            "tag": "x"
-          },
-          {
-            "id": 380,
-            "tag": "x"
-          },
-          {
-            "id": 381,
-            "tag": "x"
-          },
-          {
-            "id": 382,
-            "tag": "x"
-          },
-          {
-            "id": 383,
-            "tag": "x"
-          },
-          {
-            "id": 384,
-            "tag": "x"
-          },
-          {
-            "id": 385,
-            "tag": "x"
-          },
-          {
-            "id": 386,
-            "tag": "x"
-          },
-          {
-            "id": 387,
-            "tag": "x"
-          },
-          {
-            "id": 388,
-            "tag": "x"
-          },
-          {
-            "id": 389,
-            "tag": "x"
-          },
-          {
-            "id": 390,
-            "tag": "x"
-          },
-          {
-            "id": 391,
-            "tag": "x"
-          },
-          {
-            "id": 392,
-            "tag": "x"
-          },
-          {
-            "id": 393,
-            "tag": "x"
-          },
-          {
-            "id": 394,
-            "tag": "x"
-          }
-        ]
-      },
-      "small": {
-        "result": {
-          "count": 3,
-          "ok": true
+      "arr": [
+        {
+          "id": 0,
+          "tag": "x"
+        },
+        {
+          "id": 1,
+          "tag": "x"
+        },
+        {
+          "id": 2,
+          "tag": "x"
+        },
+        {
+          "id": 3,
+          "tag": "x"
+        },
+        {
+          "id": 4,
+          "tag": "x"
+        },
+        {
+          "id": 5,
+          "tag": "x"
+        },
+        {
+          "id": 6,
+          "tag": "x"
+        },
+        {
+          "id": 7,
+          "tag": "x"
+        },
+        {
+          "id": 8,
+          "tag": "x"
+        },
+        {
+          "id": 9,
+          "tag": "x"
+        },
+        {
+          "id": 10,
+          "tag": "x"
+        },
+        {
+          "id": 11,
+          "tag": "x"
+        },
+        {
+          "id": 12,
+          "tag": "x"
+        },
+        {
+          "id": 13,
+          "tag": "x"
+        },
+        {
+          "id": 14,
+          "tag": "x"
+        },
+        {
+          "id": 15,
+          "tag": "x"
+        },
+        {
+          "id": 16,
+          "tag": "x"
+        },
+        {
+          "id": 17,
+          "tag": "x"
+        },
+        {
+          "id": 18,
+          "tag": "x"
+        },
+        {
+          "id": 19,
+          "tag": "x"
+        },
+        {
+          "id": 20,
+          "tag": "x"
+        },
+        {
+          "id": 21,
+          "tag": "x"
+        },
+        {
+          "id": 22,
+          "tag": "x"
+        },
+        {
+          "id": 23,
+          "tag": "x"
+        },
+        {
+          "id": 24,
+          "tag": "x"
+        },
+        {
+          "id": 25,
+          "tag": "x"
+        },
+        {
+          "id": 26,
+          "tag": "x"
+        },
+        {
+          "id": 27,
+          "tag": "x"
+        },
+        {
+          "id": 28,
+          "tag": "x"
+        },
+        {
+          "id": 29,
+          "tag": "x"
+        },
+        {
+          "id": 30,
+          "tag": "x"
+        },
+        {
+          "id": 31,
+          "tag": "x"
+        },
+        {
+          "id": 32,
+          "tag": "x"
+        },
+        {
+          "id": 33,
+          "tag": "x"
+        },
+        {
+          "id": 34,
+          "tag": "x"
+        },
+        {
+          "id": 35,
+          "tag": "x"
+        },
+        {
+          "id": 36,
+          "tag": "x"
+        },
+        {
+          "id": 37,
+          "tag": "x"
+        },
+        {
+          "id": 38,
+          "tag": "x"
+        },
+        {
+          "id": 39,
+          "tag": "x"
+        },
+        {
+          "id": 40,
+          "tag": "x"
+        },
+        {
+          "id": 41,
+          "tag": "x"
+        },
+        {
+          "id": 42,
+          "tag": "x"
+        },
+        {
+          "id": 43,
+          "tag": "x"
+        },
+        {
+          "id": 44,
+          "tag": "x"
+        },
+        {
+          "id": 45,
+          "tag": "x"
+        },
+        {
+          "id": 46,
+          "tag": "x"
+        },
+        {
+          "id": 47,
+          "tag": "x"
+        },
+        {
+          "id": 48,
+          "tag": "x"
+        },
+        {
+          "id": 49,
+          "tag": "x"
+        },
+        {
+          "id": 50,
+          "tag": "x"
+        },
+        {
+          "id": 51,
+          "tag": "x"
+        },
+        {
+          "id": 52,
+          "tag": "x"
+        },
+        {
+          "id": 53,
+          "tag": "x"
+        },
+        {
+          "id": 54,
+          "tag": "x"
+        },
+        {
+          "id": 55,
+          "tag": "x"
+        },
+        {
+          "id": 56,
+          "tag": "x"
+        },
+        {
+          "id": 57,
+          "tag": "x"
+        },
+        {
+          "id": 58,
+          "tag": "x"
+        },
+        {
+          "id": 59,
+          "tag": "x"
+        },
+        {
+          "id": 60,
+          "tag": "x"
+        },
+        {
+          "id": 61,
+          "tag": "x"
+        },
+        {
+          "id": 62,
+          "tag": "x"
+        },
+        {
+          "id": 63,
+          "tag": "x"
+        },
+        {
+          "id": 64,
+          "tag": "x"
+        },
+        {
+          "id": 65,
+          "tag": "x"
+        },
+        {
+          "id": 66,
+          "tag": "x"
+        },
+        {
+          "id": 67,
+          "tag": "x"
+        },
+        {
+          "id": 68,
+          "tag": "x"
+        },
+        {
+          "id": 69,
+          "tag": "x"
+        },
+        {
+          "id": 70,
+          "tag": "x"
+        },
+        {
+          "id": 71,
+          "tag": "x"
+        },
+        {
+          "id": 72,
+          "tag": "x"
+        },
+        {
+          "id": 73,
+          "tag": "x"
+        },
+        {
+          "id": 74,
+          "tag": "x"
+        },
+        {
+          "id": 75,
+          "tag": "x"
+        },
+        {
+          "id": 76,
+          "tag": "x"
+        },
+        {
+          "id": 77,
+          "tag": "x"
+        },
+        {
+          "id": 78,
+          "tag": "x"
+        },
+        {
+          "id": 79,
+          "tag": "x"
+        },
+        {
+          "id": 80,
+          "tag": "x"
+        },
+        {
+          "id": 81,
+          "tag": "x"
+        },
+        {
+          "id": 82,
+          "tag": "x"
+        },
+        {
+          "id": 83,
+          "tag": "x"
+        },
+        {
+          "id": 84,
+          "tag": "x"
+        },
+        {
+          "id": 85,
+          "tag": "x"
+        },
+        {
+          "id": 86,
+          "tag": "x"
+        },
+        {
+          "id": 87,
+          "tag": "x"
+        },
+        {
+          "id": 88,
+          "tag": "x"
+        },
+        {
+          "id": 89,
+          "tag": "x"
+        },
+        {
+          "id": 90,
+          "tag": "x"
+        },
+        {
+          "id": 91,
+          "tag": "x"
+        },
+        {
+          "id": 92,
+          "tag": "x"
+        },
+        {
+          "id": 93,
+          "tag": "x"
+        },
+        {
+          "id": 94,
+          "tag": "x"
+        },
+        {
+          "id": 95,
+          "tag": "x"
+        },
+        {
+          "id": 96,
+          "tag": "x"
+        },
+        {
+          "id": 97,
+          "tag": "x"
+        },
+        {
+          "id": 98,
+          "tag": "x"
+        },
+        {
+          "id": 99,
+          "tag": "x"
+        },
+        {
+          "id": 100,
+          "tag": "x"
+        },
+        {
+          "id": 101,
+          "tag": "x"
+        },
+        {
+          "id": 102,
+          "tag": "x"
+        },
+        {
+          "id": 103,
+          "tag": "x"
+        },
+        {
+          "id": 104,
+          "tag": "x"
+        },
+        {
+          "id": 105,
+          "tag": "x"
+        },
+        {
+          "id": 106,
+          "tag": "x"
+        },
+        {
+          "id": 107,
+          "tag": "x"
+        },
+        {
+          "id": 108,
+          "tag": "x"
+        },
+        {
+          "id": 109,
+          "tag": "x"
+        },
+        {
+          "id": 110,
+          "tag": "x"
+        },
+        {
+          "id": 111,
+          "tag": "x"
+        },
+        {
+          "id": 112,
+          "tag": "x"
+        },
+        {
+          "id": 113,
+          "tag": "x"
+        },
+        {
+          "id": 114,
+          "tag": "x"
+        },
+        {
+          "id": 115,
+          "tag": "x"
+        },
+        {
+          "id": 116,
+          "tag": "x"
+        },
+        {
+          "id": 117,
+          "tag": "x"
+        },
+        {
+          "id": 118,
+          "tag": "x"
+        },
+        {
+          "id": 119,
+          "tag": "x"
+        },
+        {
+          "id": 120,
+          "tag": "x"
+        },
+        {
+          "id": 121,
+          "tag": "x"
+        },
+        {
+          "id": 122,
+          "tag": "x"
+        },
+        {
+          "id": 123,
+          "tag": "x"
+        },
+        {
+          "id": 124,
+          "tag": "x"
+        },
+        {
+          "id": 125,
+          "tag": "x"
+        },
+        {
+          "id": 126,
+          "tag": "x"
+        },
+        {
+          "id": 127,
+          "tag": "x"
+        },
+        {
+          "id": 128,
+          "tag": "x"
+        },
+        {
+          "id": 129,
+          "tag": "x"
+        },
+        {
+          "id": 130,
+          "tag": "x"
+        },
+        {
+          "id": 131,
+          "tag": "x"
+        },
+        {
+          "id": 132,
+          "tag": "x"
+        },
+        {
+          "id": 133,
+          "tag": "x"
+        },
+        {
+          "id": 134,
+          "tag": "x"
+        },
+        {
+          "id": 135,
+          "tag": "x"
+        },
+        {
+          "id": 136,
+          "tag": "x"
+        },
+        {
+          "id": 137,
+          "tag": "x"
+        },
+        {
+          "id": 138,
+          "tag": "x"
+        },
+        {
+          "id": 139,
+          "tag": "x"
+        },
+        {
+          "id": 140,
+          "tag": "x"
+        },
+        {
+          "id": 141,
+          "tag": "x"
+        },
+        {
+          "id": 142,
+          "tag": "x"
+        },
+        {
+          "id": 143,
+          "tag": "x"
+        },
+        {
+          "id": 144,
+          "tag": "x"
+        },
+        {
+          "id": 145,
+          "tag": "x"
+        },
+        {
+          "id": 146,
+          "tag": "x"
+        },
+        {
+          "id": 147,
+          "tag": "x"
+        },
+        {
+          "id": 148,
+          "tag": "x"
+        },
+        {
+          "id": 149,
+          "tag": "x"
+        },
+        {
+          "id": 150,
+          "tag": "x"
+        },
+        {
+          "id": 151,
+          "tag": "x"
+        },
+        {
+          "id": 152,
+          "tag": "x"
+        },
+        {
+          "id": 153,
+          "tag": "x"
+        },
+        {
+          "id": 154,
+          "tag": "x"
+        },
+        {
+          "id": 155,
+          "tag": "x"
+        },
+        {
+          "id": 156,
+          "tag": "x"
+        },
+        {
+          "id": 157,
+          "tag": "x"
+        },
+        {
+          "id": 158,
+          "tag": "x"
+        },
+        {
+          "id": 159,
+          "tag": "x"
+        },
+        {
+          "id": 160,
+          "tag": "x"
+        },
+        {
+          "id": 161,
+          "tag": "x"
+        },
+        {
+          "id": 162,
+          "tag": "x"
+        },
+        {
+          "id": 163,
+          "tag": "x"
+        },
+        {
+          "id": 164,
+          "tag": "x"
+        },
+        {
+          "id": 165,
+          "tag": "x"
+        },
+        {
+          "id": 166,
+          "tag": "x"
+        },
+        {
+          "id": 167,
+          "tag": "x"
+        },
+        {
+          "id": 168,
+          "tag": "x"
+        },
+        {
+          "id": 169,
+          "tag": "x"
+        },
+        {
+          "id": 170,
+          "tag": "x"
+        },
+        {
+          "id": 171,
+          "tag": "x"
+        },
+        {
+          "id": 172,
+          "tag": "x"
+        },
+        {
+          "id": 173,
+          "tag": "x"
+        },
+        {
+          "id": 174,
+          "tag": "x"
+        },
+        {
+          "id": 175,
+          "tag": "x"
+        },
+        {
+          "id": 176,
+          "tag": "x"
+        },
+        {
+          "id": 177,
+          "tag": "x"
+        },
+        {
+          "id": 178,
+          "tag": "x"
+        },
+        {
+          "id": 179,
+          "tag": "x"
+        },
+        {
+          "id": 180,
+          "tag": "x"
+        },
+        {
+          "id": 181,
+          "tag": "x"
+        },
+        {
+          "id": 182,
+          "tag": "x"
+        },
+        {
+          "id": 183,
+          "tag": "x"
+        },
+        {
+          "id": 184,
+          "tag": "x"
+        },
+        {
+          "id": 185,
+          "tag": "x"
+        },
+        {
+          "id": 186,
+          "tag": "x"
+        },
+        {
+          "id": 187,
+          "tag": "x"
+        },
+        {
+          "id": 188,
+          "tag": "x"
+        },
+        {
+          "id": 189,
+          "tag": "x"
+        },
+        {
+          "id": 190,
+          "tag": "x"
+        },
+        {
+          "id": 191,
+          "tag": "x"
+        },
+        {
+          "id": 192,
+          "tag": "x"
+        },
+        {
+          "id": 193,
+          "tag": "x"
+        },
+        {
+          "id": 194,
+          "tag": "x"
+        },
+        {
+          "id": 195,
+          "tag": "x"
+        },
+        {
+          "id": 196,
+          "tag": "x"
+        },
+        {
+          "id": 197,
+          "tag": "x"
+        },
+        {
+          "id": 198,
+          "tag": "x"
+        },
+        {
+          "id": 199,
+          "tag": "x"
+        },
+        {
+          "id": 200,
+          "tag": "x"
+        },
+        {
+          "id": 201,
+          "tag": "x"
+        },
+        {
+          "id": 202,
+          "tag": "x"
+        },
+        {
+          "id": 203,
+          "tag": "x"
+        },
+        {
+          "id": 204,
+          "tag": "x"
+        },
+        {
+          "id": 205,
+          "tag": "x"
+        },
+        {
+          "id": 206,
+          "tag": "x"
+        },
+        {
+          "id": 207,
+          "tag": "x"
+        },
+        {
+          "id": 208,
+          "tag": "x"
+        },
+        {
+          "id": 209,
+          "tag": "x"
+        },
+        {
+          "id": 210,
+          "tag": "x"
+        },
+        {
+          "id": 211,
+          "tag": "x"
+        },
+        {
+          "id": 212,
+          "tag": "x"
+        },
+        {
+          "id": 213,
+          "tag": "x"
+        },
+        {
+          "id": 214,
+          "tag": "x"
+        },
+        {
+          "id": 215,
+          "tag": "x"
+        },
+        {
+          "id": 216,
+          "tag": "x"
+        },
+        {
+          "id": 217,
+          "tag": "x"
+        },
+        {
+          "id": 218,
+          "tag": "x"
+        },
+        {
+          "id": 219,
+          "tag": "x"
+        },
+        {
+          "id": 220,
+          "tag": "x"
+        },
+        {
+          "id": 221,
+          "tag": "x"
+        },
+        {
+          "id": 222,
+          "tag": "x"
+        },
+        {
+          "id": 223,
+          "tag": "x"
+        },
+        {
+          "id": 224,
+          "tag": "x"
+        },
+        {
+          "id": 225,
+          "tag": "x"
+        },
+        {
+          "id": 226,
+          "tag": "x"
+        },
+        {
+          "id": 227,
+          "tag": "x"
+        },
+        {
+          "id": 228,
+          "tag": "x"
+        },
+        {
+          "id": 229,
+          "tag": "x"
+        },
+        {
+          "id": 230,
+          "tag": "x"
+        },
+        {
+          "id": 231,
+          "tag": "x"
+        },
+        {
+          "id": 232,
+          "tag": "x"
+        },
+        {
+          "id": 233,
+          "tag": "x"
+        },
+        {
+          "id": 234,
+          "tag": "x"
+        },
+        {
+          "id": 235,
+          "tag": "x"
+        },
+        {
+          "id": 236,
+          "tag": "x"
+        },
+        {
+          "id": 237,
+          "tag": "x"
+        },
+        {
+          "id": 238,
+          "tag": "x"
+        },
+        {
+          "id": 239,
+          "tag": "x"
+        },
+        {
+          "id": 240,
+          "tag": "x"
+        },
+        {
+          "id": 241,
+          "tag": "x"
+        },
+        {
+          "id": 242,
+          "tag": "x"
+        },
+        {
+          "id": 243,
+          "tag": "x"
+        },
+        {
+          "id": 244,
+          "tag": "x"
+        },
+        {
+          "id": 245,
+          "tag": "x"
+        },
+        {
+          "id": 246,
+          "tag": "x"
+        },
+        {
+          "id": 247,
+          "tag": "x"
+        },
+        {
+          "id": 248,
+          "tag": "x"
+        },
+        {
+          "id": 249,
+          "tag": "x"
+        },
+        {
+          "id": 250,
+          "tag": "x"
+        },
+        {
+          "id": 251,
+          "tag": "x"
+        },
+        {
+          "id": 252,
+          "tag": "x"
+        },
+        {
+          "id": 253,
+          "tag": "x"
+        },
+        {
+          "id": 254,
+          "tag": "x"
+        },
+        {
+          "id": 255,
+          "tag": "x"
+        },
+        {
+          "id": 256,
+          "tag": "x"
+        },
+        {
+          "id": 257,
+          "tag": "x"
+        },
+        {
+          "id": 258,
+          "tag": "x"
+        },
+        {
+          "id": 259,
+          "tag": "x"
+        },
+        {
+          "id": 260,
+          "tag": "x"
+        },
+        {
+          "id": 261,
+          "tag": "x"
+        },
+        {
+          "id": 262,
+          "tag": "x"
+        },
+        {
+          "id": 263,
+          "tag": "x"
+        },
+        {
+          "id": 264,
+          "tag": "x"
+        },
+        {
+          "id": 265,
+          "tag": "x"
+        },
+        {
+          "id": 266,
+          "tag": "x"
+        },
+        {
+          "id": 267,
+          "tag": "x"
+        },
+        {
+          "id": 268,
+          "tag": "x"
+        },
+        {
+          "id": 269,
+          "tag": "x"
+        },
+        {
+          "id": 270,
+          "tag": "x"
+        },
+        {
+          "id": 271,
+          "tag": "x"
+        },
+        {
+          "id": 272,
+          "tag": "x"
+        },
+        {
+          "id": 273,
+          "tag": "x"
+        },
+        {
+          "id": 274,
+          "tag": "x"
+        },
+        {
+          "id": 275,
+          "tag": "x"
+        },
+        {
+          "id": 276,
+          "tag": "x"
+        },
+        {
+          "id": 277,
+          "tag": "x"
+        },
+        {
+          "id": 278,
+          "tag": "x"
+        },
+        {
+          "id": 279,
+          "tag": "x"
+        },
+        {
+          "id": 280,
+          "tag": "x"
+        },
+        {
+          "id": 281,
+          "tag": "x"
+        },
+        {
+          "id": 282,
+          "tag": "x"
+        },
+        {
+          "id": 283,
+          "tag": "x"
+        },
+        {
+          "id": 284,
+          "tag": "x"
+        },
+        {
+          "id": 285,
+          "tag": "x"
+        },
+        {
+          "id": 286,
+          "tag": "x"
+        },
+        {
+          "id": 287,
+          "tag": "x"
+        },
+        {
+          "id": 288,
+          "tag": "x"
+        },
+        {
+          "id": 289,
+          "tag": "x"
+        },
+        {
+          "id": 290,
+          "tag": "x"
+        },
+        {
+          "id": 291,
+          "tag": "x"
+        },
+        {
+          "id": 292,
+          "tag": "x"
+        },
+        {
+          "id": 293,
+          "tag": "x"
+        },
+        {
+          "id": 294,
+          "tag": "x"
+        },
+        {
+          "id": 295,
+          "tag": "x"
+        },
+        {
+          "id": 296,
+          "tag": "x"
+        },
+        {
+          "id": 297,
+          "tag": "x"
+        },
+        {
+          "id": 298,
+          "tag": "x"
+        },
+        {
+          "id": 299,
+          "tag": "x"
+        },
+        {
+          "id": 300,
+          "tag": "x"
+        },
+        {
+          "id": 301,
+          "tag": "x"
+        },
+        {
+          "id": 302,
+          "tag": "x"
+        },
+        {
+          "id": 303,
+          "tag": "x"
+        },
+        {
+          "id": 304,
+          "tag": "x"
+        },
+        {
+          "id": 305,
+          "tag": "x"
+        },
+        {
+          "id": 306,
+          "tag": "x"
+        },
+        {
+          "id": 307,
+          "tag": "x"
+        },
+        {
+          "id": 308,
+          "tag": "x"
+        },
+        {
+          "id": 309,
+          "tag": "x"
+        },
+        {
+          "id": 310,
+          "tag": "x"
+        },
+        {
+          "id": 311,
+          "tag": "x"
+        },
+        {
+          "id": 312,
+          "tag": "x"
+        },
+        {
+          "id": 313,
+          "tag": "x"
+        },
+        {
+          "id": 314,
+          "tag": "x"
+        },
+        {
+          "id": 315,
+          "tag": "x"
+        },
+        {
+          "id": 316,
+          "tag": "x"
+        },
+        {
+          "id": 317,
+          "tag": "x"
+        },
+        {
+          "id": 318,
+          "tag": "x"
+        },
+        {
+          "id": 319,
+          "tag": "x"
+        },
+        {
+          "id": 320,
+          "tag": "x"
+        },
+        {
+          "id": 321,
+          "tag": "x"
+        },
+        {
+          "id": 322,
+          "tag": "x"
+        },
+        {
+          "id": 323,
+          "tag": "x"
+        },
+        {
+          "id": 324,
+          "tag": "x"
+        },
+        {
+          "id": 325,
+          "tag": "x"
+        },
+        {
+          "id": 326,
+          "tag": "x"
+        },
+        {
+          "id": 327,
+          "tag": "x"
+        },
+        {
+          "id": 328,
+          "tag": "x"
+        },
+        {
+          "id": 329,
+          "tag": "x"
+        },
+        {
+          "id": 330,
+          "tag": "x"
+        },
+        {
+          "id": 331,
+          "tag": "x"
+        },
+        {
+          "id": 332,
+          "tag": "x"
+        },
+        {
+          "id": 333,
+          "tag": "x"
+        },
+        {
+          "id": 334,
+          "tag": "x"
+        },
+        {
+          "id": 335,
+          "tag": "x"
+        },
+        {
+          "id": 336,
+          "tag": "x"
+        },
+        {
+          "id": 337,
+          "tag": "x"
+        },
+        {
+          "id": 338,
+          "tag": "x"
+        },
+        {
+          "id": 339,
+          "tag": "x"
+        },
+        {
+          "id": 340,
+          "tag": "x"
+        },
+        {
+          "id": 341,
+          "tag": "x"
+        },
+        {
+          "id": 342,
+          "tag": "x"
+        },
+        {
+          "id": 343,
+          "tag": "x"
+        },
+        {
+          "id": 344,
+          "tag": "x"
+        },
+        {
+          "id": 345,
+          "tag": "x"
+        },
+        {
+          "id": 346,
+          "tag": "x"
+        },
+        {
+          "id": 347,
+          "tag": "x"
+        },
+        {
+          "id": 348,
+          "tag": "x"
+        },
+        {
+          "id": 349,
+          "tag": "x"
+        },
+        {
+          "id": 350,
+          "tag": "x"
+        },
+        {
+          "id": 351,
+          "tag": "x"
+        },
+        {
+          "id": 352,
+          "tag": "x"
+        },
+        {
+          "id": 353,
+          "tag": "x"
+        },
+        {
+          "id": 354,
+          "tag": "x"
+        },
+        {
+          "id": 355,
+          "tag": "x"
+        },
+        {
+          "id": 356,
+          "tag": "x"
+        },
+        {
+          "id": 357,
+          "tag": "x"
+        },
+        {
+          "id": 358,
+          "tag": "x"
+        },
+        {
+          "id": 359,
+          "tag": "x"
+        },
+        {
+          "id": 360,
+          "tag": "x"
+        },
+        {
+          "id": 361,
+          "tag": "x"
+        },
+        {
+          "id": 362,
+          "tag": "x"
+        },
+        {
+          "id": 363,
+          "tag": "x"
+        },
+        {
+          "id": 364,
+          "tag": "x"
+        },
+        {
+          "id": 365,
+          "tag": "x"
+        },
+        {
+          "id": 366,
+          "tag": "x"
+        },
+        {
+          "id": 367,
+          "tag": "x"
+        },
+        {
+          "id": 368,
+          "tag": "x"
+        },
+        {
+          "id": 369,
+          "tag": "x"
+        },
+        {
+          "id": 370,
+          "tag": "x"
+        },
+        {
+          "id": 371,
+          "tag": "x"
+        },
+        {
+          "id": 372,
+          "tag": "x"
+        },
+        {
+          "id": 373,
+          "tag": "x"
+        },
+        {
+          "id": 374,
+          "tag": "x"
+        },
+        {
+          "id": 375,
+          "tag": "x"
+        },
+        {
+          "id": 376,
+          "tag": "x"
+        },
+        {
+          "id": 377,
+          "tag": "x"
+        },
+        {
+          "id": 378,
+          "tag": "x"
+        },
+        {
+          "id": 379,
+          "tag": "x"
+        },
+        {
+          "id": 380,
+          "tag": "x"
+        },
+        {
+          "id": 381,
+          "tag": "x"
+        },
+        {
+          "id": 382,
+          "tag": "x"
+        },
+        {
+          "id": 383,
+          "tag": "x"
+        },
+        {
+          "id": 384,
+          "tag": "x"
+        },
+        {
+          "id": 385,
+          "tag": "x"
+        },
+        {
+          "id": 386,
+          "tag": "x"
+        },
+        {
+          "id": 387,
+          "tag": "x"
+        },
+        {
+          "id": 388,
+          "tag": "x"
+        },
+        {
+          "id": 389,
+          "tag": "x"
+        },
+        {
+          "id": 390,
+          "tag": "x"
+        },
+        {
+          "id": 391,
+          "tag": "x"
+        },
+        {
+          "id": 392,
+          "tag": "x"
+        },
+        {
+          "id": 393,
+          "tag": "x"
+        },
+        {
+          "id": 394,
+          "tag": "x"
         }
+      ],
+      "small": {
+        "count": 3,
+        "ok": true
       },
-      "str": {
-        "result": "<head lines=\"6\">\nNAMESPACE     APIVERSION   KIND   NAME                                                             READY   STATUS    RESTARTS   AGE    IP             NODE                                                  NOMINATED NODE   READINESS GATES   LABELS\nkube-system   v1           Pod    calico-node-kxw8s                                                1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-qjjtd                                                1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-v5nmp                                                1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-vertical-autoscaler-bbb8bfb74-r76x7                  1/1     Running   0          21h    192.168.1.5    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=calico-node-autoscaler,pod-template-hash=bbb8bfb74\nkube-system   v1           Pod    calico-typha-5d84858687-2zhk7                                    1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=calico-typha,pod-template-hash=5d84858687\n</head>\n<bulk-elided lines=\"28\">\n28 lines elided\n</bulk-elided>\n<tail lines=\"7\">\nkube-system   v1           Pod    netd-k9w4z                                                       3/3     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    netd-vgs2g                                                       3/3     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    netd-xxd4r                                                       3/3     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    pdcsi-node-5tr4q                                                 2/2     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    pdcsi-node-7z9zs                                                 2/2     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    pdcsi-node-lcxtr                                                 2/2     Running   0          21h    10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    runsc-metric-server-qr24t                                        1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=6b657887d,k8s-app=runsc-metric-server,pod-template-generation=2\n</tail>"
-      }
+      "str": "<head lines=\"6\">\nNAMESPACE     APIVERSION   KIND   NAME                                                             READY   STATUS    RESTARTS   AGE    IP             NODE                                                  NOMINATED NODE   READINESS GATES   LABELS\nkube-system   v1           Pod    calico-node-kxw8s                                                1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-qjjtd                                                1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-v5nmp                                                1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-vertical-autoscaler-bbb8bfb74-r76x7                  1/1     Running   0          21h    192.168.1.5    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=calico-node-autoscaler,pod-template-hash=bbb8bfb74\nkube-system   v1           Pod    calico-typha-5d84858687-2zhk7                                    1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=calico-typha,pod-template-hash=5d84858687\n</head>\n<bulk-elided lines=\"28\">\n28 lines elided\n</bulk-elided>\n<tail lines=\"7\">\nkube-system   v1           Pod    netd-k9w4z                                                       3/3     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    netd-vgs2g                                                       3/3     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    netd-xxd4r                                                       3/3     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    pdcsi-node-5tr4q                                                 2/2     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    pdcsi-node-7z9zs                                                 2/2     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    pdcsi-node-lcxtr                                                 2/2     Running   0          21h    10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    runsc-metric-server-qr24t                                        1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=6b657887d,k8s-app=runsc-metric-server,pod-template-generation=2\n</tail>"
     },
     "sub_invocations": [
       {

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -18,8 +18,11 @@ use crate::repo::StoredInvocation;
 #[derive(Debug, Clone, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum FetchQuery {
-    /// Byte range on a string-typed value at `path`. `offset` may be
-    /// negative to count from the end of the string.
+    /// UTF-8 safe byte window on a string-typed value at `path`. `offset`
+    /// may be negative to count from the end of the string. If the
+    /// requested byte boundaries land inside a UTF-8 codepoint, they are
+    /// moved inward to the nearest valid character boundaries instead of
+    /// failing the recovery request.
     Range { offset: i64, len: usize },
     /// Line range on a string-typed value at `path`. `offset` is the
     /// zero-indexed first line to return; `len` is the line count.
@@ -61,11 +64,8 @@ impl FetchQuery {
                         "range query requires a string at the resolved path".into(),
                     )
                 })?;
-                let start = resolve_offset(*offset, s.len());
-                let end = start.saturating_add(*len).min(s.len());
-                let slice = s.get(start..end).ok_or_else(|| {
-                    ToolCachingError::InvalidPath("range cuts a non-char-boundary".into())
-                })?;
+                let (start, end) = resolve_utf8_byte_window(s, *offset, *len);
+                let slice = &s[start..end];
                 Ok(Value::String(slice.to_string()))
             }
             FetchQuery::Lines { offset, len } => {
@@ -96,6 +96,30 @@ impl FetchQuery {
             )),
         }
     }
+}
+
+fn resolve_utf8_byte_window(s: &str, offset: i64, len: usize) -> (usize, usize) {
+    let requested_start = resolve_offset(offset, s.len());
+    let requested_end = requested_start.saturating_add(len).min(s.len());
+    let start = ceil_char_boundary(s, requested_start);
+    let end = floor_char_boundary(s, requested_end).max(start);
+    (start, end)
+}
+
+fn floor_char_boundary(s: &str, idx: usize) -> usize {
+    let mut i = idx.min(s.len());
+    while i > 0 && !s.is_char_boundary(i) {
+        i -= 1;
+    }
+    i
+}
+
+fn ceil_char_boundary(s: &str, idx: usize) -> usize {
+    let mut i = idx.min(s.len());
+    while i < s.len() && !s.is_char_boundary(i) {
+        i += 1;
+    }
+    i
 }
 
 /// What `ToolCaching::fetch` hands back to the caller. `result` is the
@@ -416,6 +440,24 @@ mod tests {
         assert_eq!(
             q.apply(Value::String("0123456789".into())).unwrap(),
             Value::String("6789".into()),
+        );
+    }
+
+    #[test]
+    fn fetch_query_range_snaps_to_utf8_boundaries() {
+        let q = FetchQuery::Range { offset: 1, len: 3 };
+        assert_eq!(
+            q.apply(Value::String("a▲b".into())).unwrap(),
+            Value::String("▲".into()),
+        );
+    }
+
+    #[test]
+    fn fetch_query_range_inside_one_codepoint_returns_empty_string() {
+        let q = FetchQuery::Range { offset: 2, len: 1 };
+        assert_eq!(
+            q.apply(Value::String("a▲b".into())).unwrap(),
+            Value::String(String::new()),
         );
     }
 

--- a/core/crates/tool-caching/src/lib.rs
+++ b/core/crates/tool-caching/src/lib.rs
@@ -115,10 +115,10 @@ impl ToolCaching {
     }
 
     /// Compose sub-dispatch call path. The JS engine has its own size
-    /// cap and scripts use the sub-tool's return directly — pre-elided
-    /// data would force every script to recover through
-    /// `tool_output_fetch`. So the wire shape is `{result: T verbatim}`
-    /// even when the value is over threshold.
+    /// cap and scripts use the sub-tool's return directly as upstream `T`
+    /// — pre-elided data would force every script to recover through
+    /// `tool_output_fetch`. So the wire shape is `T verbatim` even when
+    /// the value is over threshold.
     ///
     /// Walker still runs, summary is still persisted: the agent (out of
     /// the JS sandbox, reading `compose_response.sub_invocations[i].invocation_id`)
@@ -145,9 +145,7 @@ impl ToolCaching {
         // For compose JS engine: always emit T verbatim, regardless of
         // whether the walker found anything elision-worthy.
         let mut wrapped = result;
-        wrapped.structured_content = Some(serde_json::json!({
-            "result": processed.upstream_t,
-        }));
+        wrapped.structured_content = Some(processed.upstream_t);
 
         if !processed.persisted {
             return Ok(ToolCacheResponse {

--- a/core/crates/tool-caching/src/lib.rs
+++ b/core/crates/tool-caching/src/lib.rs
@@ -260,7 +260,7 @@ fn build_elide_ctr(summary: ToolCallSummary, invocation_id: ToolInvocationId) ->
     summary.build_wire(invocation_id).0
 }
 
-fn extract_text(result: &CallToolResult) -> String {
+pub fn extract_text(result: &CallToolResult) -> String {
     result
         .content
         .iter()

--- a/core/crates/tool-caching/src/primitives.rs
+++ b/core/crates/tool-caching/src/primitives.rs
@@ -87,7 +87,11 @@ impl ToolCallSummary {
     pub fn build_wire(&self, invocation_id: ToolInvocationId) -> (CallToolResult, Value) {
         let envelope = self.build_envelope_text();
         let mut obj = serde_json::Map::new();
-        obj.insert("result".to_string(), self.wire_result.clone());
+        let recovery = self.recovery_manifest(invocation_id);
+        obj.insert(
+            "_recovery".to_string(),
+            serde_json::to_value(&recovery).unwrap(),
+        );
         if !self.elided_paths.is_empty() {
             obj.insert(
                 "_elided".to_string(),
@@ -97,10 +101,28 @@ impl ToolCallSummary {
                 }),
             );
         }
+        obj.insert("result".to_string(), self.wire_result.clone());
         let structured = Value::Object(obj);
         let mut result = CallToolResult::success(vec![Content::text(envelope)]);
         result.structured_content = Some(structured.clone());
         (result, structured)
+    }
+
+    fn recovery_manifest(&self, invocation_id: ToolInvocationId) -> RecoveryManifest {
+        RecoveryManifest {
+            invocation_id: invocation_id.to_string(),
+            root_kind: value_kind(&self.wire_result).to_string(),
+            root_path: self.root_path.clone(),
+            persisted_root: "upstream T directly; not the outer {result: ...} wire wrapper"
+                .to_string(),
+            paths: self.elided_paths.clone(),
+            recommended_queries: self
+                .elided_paths
+                .iter()
+                .map(|p| p.recover.clone())
+                .collect(),
+            sub_invocations: extract_sub_invocations(&self.wire_result),
+        }
     }
 
     /// Build the `<summary>…</summary><recovery>…</recovery>` text-channel
@@ -161,6 +183,18 @@ pub struct ElidedPath {
     pub recover: Value,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecoveryManifest {
+    pub invocation_id: String,
+    pub root_kind: String,
+    pub root_path: String,
+    pub persisted_root: String,
+    pub paths: Vec<ElidedPath>,
+    pub recommended_queries: Vec<Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub sub_invocations: Vec<Value>,
+}
+
 impl ElidedPath {
     pub(crate) fn render(&self) -> String {
         let mut attrs = format!(
@@ -194,6 +228,24 @@ fn render_recover_call(recover: &Value) -> String {
         .collect::<Vec<_>>()
         .join(", ");
     format!("{tool}({kwargs})")
+}
+
+fn value_kind(value: &Value) -> &'static str {
+    match value {
+        Value::Null => "null",
+        Value::Bool(_) => "bool",
+        Value::Number(_) => "number",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+    }
+}
+
+fn extract_sub_invocations(root: &Value) -> Vec<Value> {
+    root.get("sub_invocations")
+        .and_then(Value::as_array)
+        .map(|arr| arr.to_vec())
+        .unwrap_or_default()
 }
 
 /// Returned by `ToolCaching::cache`. `elided_paths`

--- a/core/crates/tool-caching/tests/envelope.rs
+++ b/core/crates/tool-caching/tests/envelope.rs
@@ -128,6 +128,28 @@ async fn root_string_over_threshold_yields_envelope_with_recovery_section() {
         .and_then(|v| v.as_array())
         .expect("`_elided.paths` is an array");
     assert_eq!(paths.len(), 1, "one elided path: {paths:?}");
+
+    let recovery = structured
+        .get("_recovery")
+        .expect("typed `_recovery` manifest present when something was elided");
+    assert_eq!(
+        recovery.get("invocation_id").and_then(|v| v.as_str()),
+        Some(inv_id),
+        "manifest and _elided share invocation id",
+    );
+    assert_eq!(
+        recovery.get("root_kind").and_then(|v| v.as_str()),
+        Some("string")
+    );
+    assert_eq!(
+        recovery.get("persisted_root").and_then(|v| v.as_str()),
+        Some("upstream T directly; not the outer {result: ...} wire wrapper")
+    );
+    let recommended = recovery
+        .get("recommended_queries")
+        .and_then(|v| v.as_array())
+        .expect("manifest exposes typed fetch templates");
+    assert_eq!(recommended.len(), 1);
 }
 
 #[tokio::test]

--- a/core/crates/tool-caching/tests/envelope.rs
+++ b/core/crates/tool-caching/tests/envelope.rs
@@ -247,8 +247,8 @@ async fn persist_mode_emits_verbatim_t_without_elided_block() {
     let caching = ToolCaching::new(&pool().await, config);
 
     // Pick a value the walker WOULD elide so we hit the persist path —
-    // Persist mode persists to DB but emits {result: T verbatim} on the
-    // wire (no `_elided`); the JS engine in compose has its own size cap.
+    // Persist mode persists to DB but emits T verbatim on the wire (no
+    // wrapper and no `_elided`); the JS engine in compose has its own size cap.
     let big = "x".repeat(1024);
     let upstream = CallToolResult::success(vec![Content::text(big.clone())]);
 
@@ -272,17 +272,72 @@ async fn persist_mode_emits_verbatim_t_without_elided_block() {
         .structured_content
         .as_ref()
         .expect("Persist mode emits structuredContent");
-    let result_field = structured
-        .get("result")
-        .expect("Persist wire shape is {result: T}");
     assert_eq!(
-        result_field,
+        structured,
         &serde_json::Value::String(big.clone()),
         "Persist mode emits T verbatim on the wire",
     );
+}
+
+#[tokio::test]
+async fn direct_and_compose_persistence_share_fetch_root_but_not_wire_wrapper() {
+    let config = ToolCachingConfig {
+        generic_threshold_bytes: 512,
+        ..ToolCachingConfig::default()
+    };
+    let caching = ToolCaching::new(&pool().await, config);
+    let owner = ToolCallOwnerId::new();
+    let upstream_t = serde_json::json!({
+        "items": (0..200).map(|i| format!("item-{i}")).collect::<Vec<_>>()
+    });
+    let mut upstream = CallToolResult::success(Vec::new());
+    upstream.structured_content = Some(upstream_t.clone());
+
+    let direct = caching
+        .cache(owner, "contract", &serde_json::json!({}), upstream.clone())
+        .await
+        .expect("direct cache succeeds");
+    let compose = caching
+        .persist_for_compose(owner, "contract", &serde_json::json!({}), upstream)
+        .await
+        .expect("compose persist succeeds");
+
+    let direct_structured = direct
+        .result
+        .structured_content
+        .as_ref()
+        .expect("direct cache has structured wrapper");
     assert!(
-        structured.get("_elided").is_none(),
-        "Persist mode never emits `_elided`",
+        direct_structured.get("result").is_some(),
+        "direct MCP wire keeps DruaToolResult wrapper",
+    );
+    assert!(
+        direct_structured.get("_recovery").is_some(),
+        "direct MCP wire has typed recovery manifest",
+    );
+
+    let compose_structured = compose
+        .result
+        .structured_content
+        .as_ref()
+        .expect("compose persist has structured content");
+    assert_eq!(
+        compose_structured, &upstream_t,
+        "compose persistence emits upstream T directly",
+    );
+
+    let fetched = caching
+        .fetch(
+            owner,
+            compose.invocation_id.expect("compose persisted invocation"),
+            "$.items",
+            Some(&drua_tool_caching::FetchQuery::JsonArraySlice { offset: -2, len: 2 }),
+        )
+        .await
+        .expect("compose persisted root is upstream T");
+    assert_eq!(
+        fetched.structured,
+        serde_json::json!({"items": ["item-198", "item-199"]})
     );
 }
 

--- a/core/src/toolset/searchable/upstream.rs
+++ b/core/src/toolset/searchable/upstream.rs
@@ -245,11 +245,8 @@ fn looks_like_textual_upstream_error(result: &CallToolResult) -> bool {
     if result.structured_content.is_some() || result.content.len() != 1 {
         return false;
     }
-    let text = extract_text(result);
-    let lower = text.to_ascii_lowercase();
-    lower.starts_with("failed to ")
-        || lower.starts_with("error: ")
-        || lower.contains(" resource not accessible by integration")
+    let lower = extract_text(result).to_ascii_lowercase();
+    lower.contains("resource not accessible by integration")
 }
 
 fn extract_text(result: &CallToolResult) -> String {
@@ -333,6 +330,26 @@ mod tests {
             structured["error"]["tool"],
             serde_json::json!("actions_list")
         );
+    }
+
+    #[test]
+    fn benign_failed_to_text_is_not_reclassified() {
+        let result = CallToolResult::success(vec![Content::text(
+            "Failed to find any matching results for query",
+        )]);
+
+        let normalized = normalize_upstream_result("demo", "search", result);
+
+        assert_ne!(normalized.is_error, Some(true));
+    }
+
+    #[test]
+    fn benign_error_prefix_text_is_not_reclassified() {
+        let result = CallToolResult::success(vec![Content::text("Error: 0 issues remaining")]);
+
+        let normalized = normalize_upstream_result("demo", "count", result);
+
+        assert_ne!(normalized.is_error, Some(true));
     }
 
     #[test]

--- a/core/src/toolset/searchable/upstream.rs
+++ b/core/src/toolset/searchable/upstream.rs
@@ -5,7 +5,7 @@ use std::time::Duration;
 use github_app::GitHubAppTokenProvider;
 use http::{HeaderName, HeaderValue};
 use rmcp::{
-    model::{CallToolRequestParams, CallToolResult, JsonObject},
+    model::{CallToolRequestParams, CallToolResult, JsonObject, RawContent},
     service::RunningService,
     transport::streamable_http_client::{
         StreamableHttpClientTransportConfig, StreamableHttpClientWorker,
@@ -212,7 +212,7 @@ impl SearchableToolSet for UpstreamToolSet {
         }
         let client = self.client.read().await;
         let result = client.peer().call_tool(params).await?;
-        Ok(result)
+        Ok(normalize_upstream_result(&self.name, tool_name, result))
     }
 }
 
@@ -220,10 +220,55 @@ fn has_required_scopes(required: &[AuthScope], subject: &AuthSubject) -> bool {
     required.iter().all(|scope| subject.has_scope(scope))
 }
 
+fn normalize_upstream_result(
+    upstream_name: &str,
+    tool_name: &str,
+    result: CallToolResult,
+) -> CallToolResult {
+    if result.is_error == Some(true) || looks_like_textual_upstream_error(&result) {
+        let message = extract_text(&result);
+        let mut out = CallToolResult::error(result.content);
+        out.structured_content = Some(serde_json::json!({
+            "ok": false,
+            "error": {
+                "upstream": upstream_name,
+                "tool": tool_name,
+                "message": message,
+            }
+        }));
+        return out;
+    }
+    result
+}
+
+fn looks_like_textual_upstream_error(result: &CallToolResult) -> bool {
+    if result.structured_content.is_some() || result.content.len() != 1 {
+        return false;
+    }
+    let text = extract_text(result);
+    let lower = text.to_ascii_lowercase();
+    lower.starts_with("failed to ")
+        || lower.starts_with("error: ")
+        || lower.contains(" resource not accessible by integration")
+}
+
+fn extract_text(result: &CallToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|c| match &c.raw {
+            RawContent::Text(t) => Some(t.text.as_str()),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::primitives::{AgentId, McpCredsId, ProjectId, UserId};
+    use rmcp::model::Content;
 
     fn user_subject() -> AuthSubject {
         AuthSubject::User(UserId::new())
@@ -266,5 +311,37 @@ mod tests {
     #[test]
     fn internal_only_unset_visible_to_user() {
         assert!(visible(false, &user_subject()));
+    }
+
+    #[test]
+    fn textual_upstream_failure_becomes_structured_tool_error() {
+        let result = CallToolResult::success(vec![Content::text(
+            "failed to list workflow runs: 403 Resource not accessible by integration",
+        )]);
+
+        let normalized = normalize_upstream_result("github_actions", "actions_list", result);
+
+        assert_eq!(normalized.is_error, Some(true));
+        let structured = normalized
+            .structured_content
+            .expect("normalized errors carry structured metadata");
+        assert_eq!(
+            structured["error"]["upstream"],
+            serde_json::json!("github_actions")
+        );
+        assert_eq!(
+            structured["error"]["tool"],
+            serde_json::json!("actions_list")
+        );
+    }
+
+    #[test]
+    fn structured_success_is_not_reclassified_by_text() {
+        let mut result = CallToolResult::success(vec![Content::text("failed to parse: example")]);
+        result.structured_content = Some(serde_json::json!({"value": "failed to parse: example"}));
+
+        let normalized = normalize_upstream_result("demo", "tool", result);
+
+        assert_ne!(normalized.is_error, Some(true));
     }
 }

--- a/core/src/toolset/searchable/upstream.rs
+++ b/core/src/toolset/searchable/upstream.rs
@@ -2,10 +2,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
+use drua_tool_caching::extract_text;
 use github_app::GitHubAppTokenProvider;
 use http::{HeaderName, HeaderValue};
 use rmcp::{
-    model::{CallToolRequestParams, CallToolResult, JsonObject, RawContent},
+    model::{CallToolRequestParams, CallToolResult, JsonObject},
     service::RunningService,
     transport::streamable_http_client::{
         StreamableHttpClientTransportConfig, StreamableHttpClientWorker,
@@ -247,18 +248,6 @@ fn looks_like_textual_upstream_error(result: &CallToolResult) -> bool {
     }
     let lower = extract_text(result).to_ascii_lowercase();
     lower.contains("resource not accessible by integration")
-}
-
-fn extract_text(result: &CallToolResult) -> String {
-    result
-        .content
-        .iter()
-        .filter_map(|c| match &c.raw {
-            RawContent::Text(t) => Some(t.text.as_str()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
 }
 
 #[cfg(test)]

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -20,7 +20,7 @@ use crate::auth::AuthSubject;
 
 use super::super::error::ToolSetsError;
 use super::super::traits::{SearchableToolSet, TopLevelTool};
-use super::super::wrap::{wrap_output_schema, wrap_output_ts};
+use super::super::wrap::wrap_output_schema;
 use super::schema_for;
 
 pub struct CatalogEntry {
@@ -278,11 +278,8 @@ impl DescribeCatalogTool {
                 json_schema_ts::schema_to_ts(&v)
             })
             .unwrap_or_else(|| "any".to_string());
-        // Catalog tools always go through tool-caching, so the wire shape
-        // is `DruaToolResult<UpstreamT>` — compose scripts unwrap `.result`.
-        let output_ts = wrap_output_ts(&inner_ts);
         let ts_signature = format!(
-            "\n\n### TypeScript signature (for use in `compose`)\n```ts\nfunction {tool}(args: {{ {input_ts} }}): Promise<{output_ts}>;\n```",
+            "\n\n### TypeScript signature (for use in `compose`)\n```ts\nfunction {tool}(args: {{ {input_ts} }}): Promise<{inner_ts}>;\n```",
             tool = entry.tool_name,
         );
 

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -284,10 +284,7 @@ impl js_engine::ToolDispatcher for CatalogDispatcher {
                             )
                             .await;
                         Audit::record_success();
-                        // Catalog tools always go through tool-caching, so
-                        // wrap into the `DruaToolResult<T>` shape the JS
-                        // engine should see for every cached tool.
-                        Ok(wrap_compose_value(value))
+                        Ok(value)
                     }
                     Err(msg) => {
                         Audit::record_error(msg.clone());
@@ -339,7 +336,7 @@ impl CatalogDispatcher {
         let parent_seed = EventContext::current().data();
         let started_at = chrono::Utc::now();
         let dispatcher = self.clone_for_persistence();
-        let bypass = !tool.default_tool_caching();
+        let should_persist = tool.default_tool_caching();
 
         async move {
             Audit::record_action(action);
@@ -359,7 +356,7 @@ impl CatalogDispatcher {
             let result = match dispatch_result {
                 Ok((raw, value)) => {
                     Audit::record_tokens(super::super::estimate_tokens(&raw));
-                    if !bypass {
+                    if should_persist {
                         dispatcher
                             .maybe_persist_sub_invocation(
                                 &name_owned,
@@ -371,16 +368,6 @@ impl CatalogDispatcher {
                             .await;
                     }
                     Audit::record_success();
-                    // Top-level tools opt in to caching via
-                    // `default_tool_caching`; only wrap into
-                    // `DruaToolResult<T>` for the ones that opt in, so
-                    // bypass tools (bash, read, etc.) keep their native
-                    // shape in JS.
-                    let value = if bypass {
-                        value
-                    } else {
-                        wrap_compose_value(value)
-                    };
                     Ok(value)
                 }
                 Err(msg) => {
@@ -561,7 +548,14 @@ fn result_to_value(result: &CallToolResult) -> serde_json::Value {
     }
 }
 
-use super::super::wrap::wrap_value as wrap_compose_value;
+fn format_tool_error(tool_name: &str, result: &CallToolResult) -> String {
+    let text = extract_text(result);
+    if text.is_empty() {
+        format!("{tool_name} returned an error")
+    } else {
+        format!("{tool_name} returned an error: {text}")
+    }
+}
 
 fn extract_text(result: &CallToolResult) -> String {
     result
@@ -583,16 +577,15 @@ fn extract_text(result: &CallToolResult) -> String {
 ///   function bash(args: { command: string; ... }): Promise<any>;
 ///   function read(args: { file_path: string; ... }): Promise<any>;
 ///   namespace honeycomb {
-///     function list_environments(args: { ... }): Promise<{ result: { env_id: string } }>;
+///     function list_environments(args: { ... }): Promise<{ env_id: string }>;
 ///   }
 /// }
 /// ```
 ///
 /// When a tool has an `output_schema`, the return type is derived from that
-/// schema instead of the default `any`. Cached tools (catalog tools and
-/// top-level tools with `default_tool_caching() == true`) wrap the return
-/// type in `{ result: … }`; bypass tools (bash, read, …) keep their native
-/// shape.
+/// schema instead of the default `any`. Compose scripts see upstream `T`
+/// directly; recovery metadata for cached sub-calls is exposed through
+/// `ComposeOutput.sub_invocations`, not by wrapping each JS return value.
 pub(crate) fn generate_dts(
     subject: &AuthSubject,
     sets: &[Arc<dyn SearchableToolSet>],
@@ -608,12 +601,7 @@ pub(crate) fn generate_dts(
             .inner_output_schema()
             .map(json_schema_ts::schema_to_ts)
             .unwrap_or_else(|| "any".to_string());
-        let return_ts = if tool.default_tool_caching() {
-            super::super::wrap::wrap_output_ts(&inner_ts)
-        } else {
-            inner_ts
-        };
-        top_fns.push((name.clone(), params_ts, return_ts));
+        top_fns.push((name.clone(), params_ts, inner_ts));
     }
     top_fns.sort_by(|a, b| a.0.cmp(&b.0));
 
@@ -637,12 +625,7 @@ pub(crate) fn generate_dts(
                     json_schema_ts::schema_to_ts(&schema_val)
                 })
                 .unwrap_or_else(|| "any".to_string());
-            // Catalog tools always go through tool-caching → always wrap.
-            tools_in_ns.push((
-                entry.name.clone(),
-                params_ts,
-                super::super::wrap::wrap_output_ts(&inner_ts),
-            ));
+            tools_in_ns.push((entry.name.clone(), params_ts, inner_ts));
         }
     }
 

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, LazyLock, Mutex, RwLock};
 use std::time::Duration;
 
-use drua_tool_caching::ToolCaching;
+use drua_tool_caching::{extract_text, ToolCaching};
 use es_entity::context::{EventContext, WithEventContext};
 use rmcp::model::{CallToolResult, JsonObject};
 use serde::Deserialize;
@@ -562,18 +562,6 @@ fn format_tool_error(tool_name: &str, result: &CallToolResult) -> String {
         format!("{tool_name} returned an error: {text}")
     }
 }
-fn extract_text(result: &CallToolResult) -> String {
-    result
-        .content
-        .iter()
-        .filter_map(|c| match &c.raw {
-            rmcp::model::RawContent::Text(t) => Some(t.text.as_str()),
-            _ => None,
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
 /// Generate TypeScript declarations from the visible catalog entries and
 /// top-level tools, grouped by server prefix. Output looks like:
 ///

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -498,6 +498,9 @@ async fn run_searchable_call(
         .call(subject, tool_name, inner_args)
         .await
         .map_err(|e| e.to_string())?;
+    if result.is_error == Some(true) {
+        return Err(format_tool_error(tool_name, &result));
+    }
 
     let value = result_to_value(&result);
     Ok((result, value))
@@ -527,6 +530,9 @@ async fn run_top_level_call(
         .call(subject, inner_args)
         .await
         .map_err(|e| e.to_string())?;
+    if result.is_error == Some(true) {
+        return Err(format_tool_error(tool.name(), &result));
+    }
 
     let value = result_to_value(&result);
     Ok((result, value))
@@ -556,7 +562,6 @@ fn format_tool_error(tool_name: &str, result: &CallToolResult) -> String {
         format!("{tool_name} returned an error: {text}")
     }
 }
-
 fn extract_text(result: &CallToolResult) -> String {
     result
         .content

--- a/core/src/toolset/top_level/compose_types.rs
+++ b/core/src/toolset/top_level/compose_types.rs
@@ -112,12 +112,7 @@ impl TopLevelTool for ComposeTypes {
                 .inner_output_schema()
                 .map(json_schema_ts::schema_to_ts)
                 .unwrap_or_else(|| "any".to_string());
-            let return_ts = if tool.default_tool_caching() {
-                super::super::wrap::wrap_output_ts(&inner_ts)
-            } else {
-                inner_ts
-            };
-            top_fns.push((name.clone(), params_ts, return_ts));
+            top_fns.push((name.clone(), params_ts, inner_ts));
             matched.push(name.clone());
         }
         top_fns.sort_by(|a, b| a.0.cmp(&b.0));
@@ -147,13 +142,10 @@ impl TopLevelTool for ComposeTypes {
                         json_schema_ts::schema_to_ts(&schema_val)
                     })
                     .unwrap_or_else(|| "any".to_string());
-                // Catalog tools always go through tool-caching → always wrap.
-                let return_ts = super::super::wrap::wrap_output_ts(&inner_ts);
-
                 namespaces.entry(prefix.clone()).or_default().push((
                     entry.name.clone(),
                     params_ts,
-                    return_ts,
+                    inner_ts,
                 ));
                 matched.push(prefixed_name);
             }

--- a/core/src/toolset/top_level/tool_output_fetch.rs
+++ b/core/src/toolset/top_level/tool_output_fetch.rs
@@ -39,7 +39,8 @@ const DESCRIPTION: &str = "Recover a slice of a previously-summarised tool outpu
     holds the JS return). When in doubt, copy `path` verbatim from the response's \
     `<recovery>` block. \
     `query` (optional) further slices the resolved value: \
-    `{mode:\"range\", offset, len}` returns bytes `[offset..offset+len]` of a string at the path; \
+    `{mode:\"range\", offset, len}` returns a UTF-8 safe byte window of a string at the path \
+    (boundaries inside a codepoint are moved inward to valid character boundaries); \
     `{mode:\"lines\", offset, len}` returns line range `[offset..offset+len]` of a string at the path; \
     `{mode:\"json_array_slice\", offset, len}` returns item range `arr[offset..offset+len]` of an array at the path; \
     `offset` accepts negatives — `-N` counts from the end (Python/JS slice semantics), \

--- a/core/src/toolset/wrap.rs
+++ b/core/src/toolset/wrap.rs
@@ -6,7 +6,7 @@
 //! own their own envelope shape and opt out of the wrapper. Everything
 //! else, including every catalog tool, is wrapped. The text envelope is
 //! built by `ToolCaching::cache`; this module covers the structured
-//! channel, outputSchema advertising, and the inline JS-engine wrap.
+//! channel and outputSchema advertising.
 //!
 //! See clat memory `019e1dbf` for the design write-up.
 
@@ -53,17 +53,4 @@ pub fn wrap_output_schema(upstream: &Value) -> Value {
         },
         "required": ["result"]
     })
-}
-
-/// Wrap a TS type into `{ result: T }` — the compose-script-visible shape.
-/// Compose sub-dispatch uses `persist_for_compose`, so `_elided` is always
-/// absent; the TS signature stays a single field.
-pub fn wrap_output_ts(inner_ts: &str) -> String {
-    format!("{{ result: {inner_ts} }}")
-}
-
-/// Wrap a `serde_json::Value` for the JS engine's view of a cached
-/// sub-call result.
-pub fn wrap_value(value: Value) -> Value {
-    json!({ "result": value })
 }

--- a/core/src/toolset/wrap.rs
+++ b/core/src/toolset/wrap.rs
@@ -49,6 +49,20 @@ pub fn wrap_output_schema(upstream: &Value) -> Value {
                     }
                 },
                 "required": ["invocation_id", "paths"]
+            },
+            "_recovery": {
+                "type": "object",
+                "description": "Typed recovery manifest for this cached invocation. Includes persisted-root semantics, recoverable paths, and compose sub-invocation handles when present.",
+                "properties": {
+                    "invocation_id": { "type": "string" },
+                    "root_kind": { "type": "string" },
+                    "root_path": { "type": "string" },
+                    "persisted_root": { "type": "string" },
+                    "paths": { "type": "array" },
+                    "recommended_queries": { "type": "array" },
+                    "sub_invocations": { "type": "array" }
+                },
+                "required": ["invocation_id", "root_kind", "root_path", "persisted_root", "paths", "recommended_queries"]
             }
         },
         "required": ["result"]

--- a/core/tests/compose_audit.rs
+++ b/core/tests/compose_audit.rs
@@ -221,8 +221,7 @@ async fn all_success_path_records_success_on_both_rows() {
     let mut args = JsonObject::new();
     args.insert(
         "script".to_string(),
-        // Catalog tools always wrap in `DruaToolResult<T>` — unwrap `.result`.
-        json!("const r = await tools.stub.list_items({}); return r.result.items.length;"),
+        json!("const r = await tools.stub.list_items({}); return r.items.length;"),
     );
 
     let result = toolsets


### PR DESCRIPTION
## Summary

Follow-up to the prod E2E recovery audit and PR #356. This keeps one commit per issue bucket:

1. make range recovery UTF-8 safe instead of failing on codepoint boundaries
2. expose upstream values directly inside compose scripts so paths avoid accidental nested result.result recovery
3. add a typed recovery manifest with persisted-root semantics and recovery templates
4. normalize upstream text failures into structured tool errors and make compose throw on tool errors
5. add direct-vs-compose recovery contract coverage

## Test plan

- [x] cargo fmt
- [x] cargo test -p drua-tool-caching
- [x] cargo test -p drua-core toolset::searchable::upstream::tests
- [x] cargo test -p drua-core --test compose_audit

Opened before broader local verification so GitHub Actions can run in parallel.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes tool output wire/structured shapes for `compose` and adds new error reclassification/propagation behavior, which can break downstream scripts or integrations relying on previous wrappers and error handling.
> 
> **Overview**
> **Tightens tool-caching recovery + compose contracts.** `persist_for_compose` now exposes upstream results as raw `T` in `structured_content` (no `{result: ...}` wrapper), and `compose` TypeScript declarations/tests are updated to match (scripts no longer unwrap `.result`).
> 
> **Improves recovery metadata and robustness.** The cached-tool wire format adds a typed `_recovery` manifest (persisted-root semantics, elided paths, recommended `tool_output_fetch` templates, and optional `sub_invocations`), and `tool_output_fetch`’s `range` slicing is now UTF-8 boundary-safe instead of erroring.
> 
> **Normalizes and propagates tool errors.** Some textual upstream failures are reclassified into structured tool errors in `UpstreamToolSet`, and `compose` now throws when a sub-call returns `is_error`, producing clearer error messages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d9d2eab8aded960af747d7d3f6f65d459edfc76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->