### PR TITLE
feat(tui): add workflow catalog and run inspection

### DIFF
--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, HashMap};
 use std::io;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use crossterm::{
@@ -18,7 +18,9 @@ use crate::graphql::GraphqlClient;
 use crate::tui::chat::{ChatMessage, ChatRole, ContentBlock};
 use crate::tui::state::{
     AgentItem, BlockDetail, CellKind, Focus, GridSection, ProjectItem, SandboxInfo, ScreenState,
-    SystemBlockDetail, ThreadGridState, ThreadInfo, UsageDetail,
+    SystemBlockDetail, ThreadGridState, ThreadInfo, UsageDetail, WorkflowAgentItem,
+    WorkflowDefinitionDetail, WorkflowDefinitionItem, WorkflowRunDetail, WorkflowRunItem,
+    WorkflowSandboxItem, WorkflowStepItem, WorkflowStepResultItem, WorkflowTriggerInfo,
 };
 use crate::tui::{handlers, ui};
 
@@ -81,6 +83,204 @@ struct AgentSessionNode {
 struct SandboxAttachmentNode {
     name: String,
     mode: String,
+}
+
+const WORKFLOW_DEFINITIONS_QUERY: &str = r#"
+    query WorkflowDefinitions($projectId: ProjectId!) {
+        workflowDefinitions(projectId: $projectId) {
+            id
+            name
+            description
+            trigger { kind provider cronSchedule cronTimezone nextRunAt condition webhookUrl }
+            steps { name stepType skill tool sandbox sandboxMode condition }
+            recentRuns(first: 1) {
+                id
+                state
+                startedAt
+                completedAt
+                stepResults { name state output error skipped completedAt }
+            }
+        }
+    }
+"#;
+
+const WORKFLOW_DEFINITION_QUERY: &str = r#"
+    query WorkflowDefinition($id: WorkflowDefinitionId!) {
+        workflowDefinition(id: $id) {
+            id
+            name
+            description
+            yaml
+            trigger { kind provider cronSchedule cronTimezone nextRunAt condition webhookUrl }
+            steps { name stepType skill tool sandbox sandboxMode condition }
+            sandboxes { name kind branch repoUrl }
+            recentRuns(first: 10) { id state startedAt completedAt stepResults { name state output error skipped completedAt } }
+        }
+    }
+"#;
+
+const WORKFLOW_RUNS_QUERY: &str = r#"
+    query WorkflowRuns($definitionId: WorkflowDefinitionId!, $first: Int!) {
+        workflowRuns(definitionId: $definitionId, first: $first) {
+            id
+            state
+            startedAt
+            completedAt
+            stepResults { name state output error skipped completedAt }
+        }
+    }
+"#;
+
+const WORKFLOW_RUN_QUERY: &str = r#"
+    query WorkflowRun($id: WorkflowRunId!) {
+        workflowRun(id: $id) {
+            id
+            definitionId
+            projectId
+            state
+            startedAt
+            completedAt
+            triggerContext
+            stepsSnapshot { name stepType skill tool sandbox sandboxMode condition }
+            stepResults { name state output error skipped completedAt }
+            agents { id name role session { model } attachedSandbox { name mode } }
+        }
+    }
+"#;
+
+const WORKFLOW_TRIGGER_MUTATION: &str = r#"
+    mutation WorkflowTrigger($input: WorkflowTriggerInput!) {
+        workflowTrigger(input: $input) {
+            filtered
+            run {
+                id
+                definitionId
+                projectId
+                state
+                startedAt
+                completedAt
+                stepResults { name state output error skipped completedAt }
+            }
+        }
+    }
+"#;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowDefinitionsResponse {
+    workflow_definitions: Vec<WorkflowDefinitionNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowDefinitionResponse {
+    workflow_definition: Option<WorkflowDefinitionNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRunsResponse {
+    workflow_runs: Vec<WorkflowRunNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRunResponse {
+    workflow_run: Option<WorkflowRunNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowTriggerResponse {
+    workflow_trigger: WorkflowTriggerPayloadNode,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkflowTriggerPayloadNode {
+    filtered: bool,
+    run: Option<WorkflowRunNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowDefinitionNode {
+    id: String,
+    name: String,
+    description: Option<String>,
+    #[serde(default)]
+    yaml: String,
+    trigger: WorkflowTriggerNode,
+    #[serde(default)]
+    steps: Vec<WorkflowStepNode>,
+    #[serde(default)]
+    sandboxes: Vec<WorkflowSandboxNode>,
+    #[serde(default)]
+    recent_runs: Vec<WorkflowRunNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowTriggerNode {
+    kind: String,
+    provider: Option<String>,
+    cron_schedule: Option<String>,
+    cron_timezone: Option<String>,
+    next_run_at: Option<String>,
+    condition: Option<String>,
+    webhook_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowStepNode {
+    name: String,
+    step_type: String,
+    skill: Option<String>,
+    tool: Option<String>,
+    sandbox: Option<String>,
+    sandbox_mode: Option<String>,
+    condition: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowSandboxNode {
+    name: String,
+    kind: String,
+    branch: Option<String>,
+    repo_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRunNode {
+    id: String,
+    #[serde(default)]
+    definition_id: String,
+    #[serde(default)]
+    project_id: String,
+    state: String,
+    started_at: String,
+    completed_at: Option<String>,
+    #[serde(default)]
+    trigger_context: serde_json::Value,
+    #[serde(default)]
+    steps_snapshot: Vec<WorkflowStepNode>,
+    #[serde(default)]
+    step_results: Vec<WorkflowStepResultNode>,
+    #[serde(default)]
+    agents: Vec<AgentNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowStepResultNode {
+    name: String,
+    state: String,
+    output: Option<serde_json::Value>,
+    error: Option<String>,
+    skipped: Option<String>,
+    completed_at: Option<String>,
 }
 
 const PROJECTS_QUERY: &str = r#"
@@ -523,6 +723,148 @@ fn agent_node_to_item(a: AgentNode) -> AgentItem {
     }
 }
 
+fn agent_node_to_workflow_item(a: AgentNode) -> WorkflowAgentItem {
+    WorkflowAgentItem {
+        id: a.id,
+        name: a.name,
+        role: a.role,
+        model: a.session.model,
+        sandbox: a.attached_sandbox.map(|s| SandboxInfo {
+            name: s.name,
+            mode: s.mode,
+        }),
+    }
+}
+
+fn workflow_trigger_node_to_info(t: WorkflowTriggerNode) -> WorkflowTriggerInfo {
+    WorkflowTriggerInfo {
+        kind: t.kind,
+        provider: t.provider,
+        cron_schedule: t.cron_schedule,
+        cron_timezone: t.cron_timezone,
+        next_run_at: t.next_run_at,
+        condition: t.condition,
+        webhook_url: t.webhook_url,
+    }
+}
+
+fn workflow_step_node_to_item(s: WorkflowStepNode) -> WorkflowStepItem {
+    WorkflowStepItem {
+        name: s.name,
+        step_type: s.step_type,
+        skill: s.skill,
+        tool: s.tool,
+        sandbox: s.sandbox,
+        sandbox_mode: s.sandbox_mode,
+        condition: s.condition,
+    }
+}
+
+fn workflow_sandbox_node_to_item(s: WorkflowSandboxNode) -> WorkflowSandboxItem {
+    WorkflowSandboxItem {
+        name: s.name,
+        kind: s.kind,
+        branch: s.branch,
+        repo_url: s.repo_url,
+    }
+}
+
+fn workflow_step_result_node_to_item(r: WorkflowStepResultNode) -> WorkflowStepResultItem {
+    WorkflowStepResultItem {
+        name: r.name,
+        state: r.state,
+        output: r.output,
+        error: r.error,
+        skipped: r.skipped,
+        completed_at: r.completed_at,
+    }
+}
+
+fn workflow_run_node_to_item(r: WorkflowRunNode) -> WorkflowRunItem {
+    WorkflowRunItem {
+        id: r.id,
+        state: r.state,
+        started_at: r.started_at,
+        completed_at: r.completed_at,
+        step_results: r
+            .step_results
+            .into_iter()
+            .map(workflow_step_result_node_to_item)
+            .collect(),
+    }
+}
+
+fn workflow_run_node_to_detail(r: WorkflowRunNode) -> WorkflowRunDetail {
+    WorkflowRunDetail {
+        id: r.id,
+        definition_id: r.definition_id,
+        project_id: r.project_id,
+        state: r.state,
+        started_at: r.started_at,
+        completed_at: r.completed_at,
+        trigger_context: r.trigger_context,
+        steps_snapshot: r
+            .steps_snapshot
+            .into_iter()
+            .map(workflow_step_node_to_item)
+            .collect(),
+        step_results: r
+            .step_results
+            .into_iter()
+            .map(workflow_step_result_node_to_item)
+            .collect(),
+        agents: r
+            .agents
+            .into_iter()
+            .map(agent_node_to_workflow_item)
+            .collect(),
+    }
+}
+
+fn workflow_definition_node_to_item(d: WorkflowDefinitionNode) -> WorkflowDefinitionItem {
+    WorkflowDefinitionItem {
+        id: d.id,
+        name: d.name,
+        description: d.description,
+        trigger: workflow_trigger_node_to_info(d.trigger),
+        steps: d
+            .steps
+            .into_iter()
+            .map(workflow_step_node_to_item)
+            .collect(),
+        recent_runs: d
+            .recent_runs
+            .into_iter()
+            .map(workflow_run_node_to_item)
+            .collect(),
+    }
+}
+
+fn workflow_definition_node_to_detail(d: WorkflowDefinitionNode) -> WorkflowDefinitionDetail {
+    WorkflowDefinitionDetail {
+        id: d.id,
+        name: d.name,
+        description: d.description,
+        yaml: d.yaml,
+        trigger: workflow_trigger_node_to_info(d.trigger),
+        steps: d
+            .steps
+            .into_iter()
+            .map(workflow_step_node_to_item)
+            .collect(),
+        sandboxes: d
+            .sandboxes
+            .into_iter()
+            .map(workflow_sandbox_node_to_item)
+            .collect(),
+        recent_runs: d
+            .recent_runs
+            .into_iter()
+            .map(workflow_run_node_to_item)
+            .collect(),
+    }
+}
+
 async fn fetch_projects(client: &GraphqlClient) -> Result<Vec<ProjectItem>> {
     let resp: ProjectsResponse = client.query(PROJECTS_QUERY, serde_json::json!({})).await?;
 
@@ -544,6 +886,87 @@ async fn fetch_projects(client: &GraphqlClient) -> Result<Vec<ProjectItem>> {
         .collect();
 
     Ok(items)
+}
+
+async fn fetch_workflow_definitions(
+    client: &GraphqlClient,
+    project_id: &str,
+) -> Result<Vec<WorkflowDefinitionItem>> {
+    let resp: WorkflowDefinitionsResponse = client
+        .query(
+            WORKFLOW_DEFINITIONS_QUERY,
+            serde_json::json!({ "projectId": project_id }),
+        )
+        .await?;
+
+    Ok(resp
+        .workflow_definitions
+        .into_iter()
+        .map(workflow_definition_node_to_item)
+        .collect())
+}
+
+async fn fetch_workflow_definition(
+    client: &GraphqlClient,
+    definition_id: &str,
+) -> Result<WorkflowDefinitionDetail> {
+    let resp: WorkflowDefinitionResponse = client
+        .query(
+            WORKFLOW_DEFINITION_QUERY,
+            serde_json::json!({ "id": definition_id }),
+        )
+        .await?;
+
+    resp.workflow_definition
+        .map(workflow_definition_node_to_detail)
+        .ok_or_else(|| anyhow::anyhow!("workflow definition not found"))
+}
+
+async fn fetch_workflow_runs(
+    client: &GraphqlClient,
+    definition_id: &str,
+) -> Result<Vec<WorkflowRunItem>> {
+    let resp: WorkflowRunsResponse = client
+        .query(
+            WORKFLOW_RUNS_QUERY,
+            serde_json::json!({ "definitionId": definition_id, "first": 50 }),
+        )
+        .await?;
+
+    Ok(resp
+        .workflow_runs
+        .into_iter()
+        .map(workflow_run_node_to_item)
+        .collect())
+}
+
+async fn fetch_workflow_run(client: &GraphqlClient, run_id: &str) -> Result<WorkflowRunDetail> {
+    let resp: WorkflowRunResponse = client
+        .query(WORKFLOW_RUN_QUERY, serde_json::json!({ "id": run_id }))
+        .await?;
+
+    resp.workflow_run
+        .map(workflow_run_node_to_detail)
+        .ok_or_else(|| anyhow::anyhow!("workflow run not found"))
+}
+
+async fn trigger_workflow(
+    client: &GraphqlClient,
+    definition_id: &str,
+    payload: serde_json::Value,
+) -> Result<WorkflowTriggerPayloadNode> {
+    let resp: WorkflowTriggerResponse = client
+        .query(
+            WORKFLOW_TRIGGER_MUTATION,
+            serde_json::json!({
+                "input": {
+                    "definitionId": definition_id,
+                    "payload": payload,
+                }
+            }),
+        )
+        .await?;
+    Ok(resp.workflow_trigger)
 }
 
 async fn fetch_user_name(client: &GraphqlClient) -> Result<String> {
@@ -1136,6 +1559,7 @@ async fn run_event_loop(
     let (stream_tx, mut stream_rx) = mpsc::unbounded_channel::<TaggedEvent>();
     let mut event_stream = EventStream::new();
     let mut persisted_project_id: Option<String> = state.selected_project().map(|p| p.id.clone());
+    let mut last_workflow_poll = Instant::now();
     loop {
         terminal.draw(|frame| ui::draw(frame, state))?;
 
@@ -1218,6 +1642,70 @@ async fn run_event_loop(
                                     );
                                 }
                             }
+                            handlers::Action::OpenWorkflows => {
+                                state.enter_workflows();
+                                state.workflows.loading = true;
+                                if let Some(project_id) = state.selected_project().map(|p| p.id.clone()) {
+                                    match fetch_workflow_definitions(client, &project_id).await {
+                                        Ok(definitions) => state.replace_workflow_definitions(definitions),
+                                        Err(e) => state.set_workflow_error(format!("Failed to load workflows: {e}")),
+                                    }
+                                } else {
+                                    state.set_workflow_error("No project selected".to_string());
+                                }
+                            }
+                            handlers::Action::RefreshWorkflows => {
+                                state.workflows.loading = true;
+                                if let Some(project_id) = state.selected_project().map(|p| p.id.clone()) {
+                                    match fetch_workflow_definitions(client, &project_id).await {
+                                        Ok(definitions) => state.replace_workflow_definitions(definitions),
+                                        Err(e) => state.set_workflow_error(format!("Failed to refresh workflows: {e}")),
+                                    }
+                                }
+                            }
+                            handlers::Action::FetchWorkflowDefinition { definition_id } => {
+                                state.workflows.loading = true;
+                                match fetch_workflow_definition(client, &definition_id).await {
+                                    Ok(definition) => state.replace_workflow_definition_detail(definition),
+                                    Err(e) => state.set_workflow_error(format!("Failed to load workflow: {e}")),
+                                }
+                            }
+                            handlers::Action::FetchWorkflowRuns { definition_id } => {
+                                state.workflows.loading = true;
+                                match fetch_workflow_runs(client, &definition_id).await {
+                                    Ok(runs) => state.replace_workflow_runs(runs),
+                                    Err(e) => state.set_workflow_error(format!("Failed to load runs: {e}")),
+                                }
+                            }
+                            handlers::Action::FetchWorkflowRun { run_id } => {
+                                state.workflows.loading = true;
+                                match fetch_workflow_run(client, &run_id).await {
+                                    Ok(run) => state.replace_workflow_run_detail(run),
+                                    Err(e) => state.set_workflow_error(format!("Failed to load run: {e}")),
+                                }
+                            }
+                            handlers::Action::TriggerWorkflow { definition_id, payload } => {
+                                state.status_message = Some("Triggering workflow...".to_string());
+                                match trigger_workflow(client, &definition_id, payload).await {
+                                    Ok(payload) if payload.filtered => {
+                                        state.status_message = Some("Trigger condition filtered; no run created".to_string());
+                                    }
+                                    Ok(payload) => {
+                                        if let Some(run) = payload.run {
+                                            let run_id = run.id.clone();
+                                            state.status_message = Some(format!("Workflow run {run_id} created"));
+                                            state.open_workflow_run_detail(run_id.clone());
+                                            match fetch_workflow_run(client, &run_id).await {
+                                                Ok(detail) => state.replace_workflow_run_detail(detail),
+                                                Err(_) => state.replace_workflow_run_detail(workflow_run_node_to_detail(run)),
+                                            }
+                                        } else {
+                                            state.status_message = Some("Workflow trigger returned no run".to_string());
+                                        }
+                                    }
+                                    Err(e) => state.set_workflow_error(format!("Trigger failed: {e}")),
+                                }
+                            }
                             handlers::Action::None => {}
                         }
                     }
@@ -1237,6 +1725,16 @@ async fn run_event_loop(
                 let _ = Config::save_last_project(id);
             }
             persisted_project_id = current_project_id;
+        }
+
+        if last_workflow_poll.elapsed() >= Duration::from_secs(1) {
+            last_workflow_poll = Instant::now();
+            if let Some(run_id) = state.workflow_poll_run_id() {
+                match fetch_workflow_run(client, &run_id).await {
+                    Ok(run) => state.replace_workflow_run_detail(run),
+                    Err(e) => state.set_workflow_error(format!("Failed to poll run: {e}")),
+                }
+            }
         }
 
         // Fetch history when the selected agent changes (and we're not streaming).

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -72,7 +72,10 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
                     return Action::None;
                 }
                 KeyCode::Char('t') => return Action::ToggleThreads,
-                KeyCode::Char('w') if state.focus != Focus::Chat || state.chat_input.is_empty() => {
+                KeyCode::Char('w')
+                    if state.focus != Focus::Workflows
+                        && (state.focus != Focus::Chat || state.chat_input.is_empty()) =>
+                {
                     return Action::OpenWorkflows;
                 }
                 _ => {}
@@ -591,6 +594,24 @@ mod tests {
             KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
         );
         assert!(matches!(action, Action::OpenWorkflows));
+    }
+
+    #[test]
+    fn ctrl_w_is_noop_when_already_focused_on_workflows() {
+        let mut state = state();
+        state.enter_workflows();
+        state.open_workflow_run_detail("run-1".into());
+
+        let action = handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
+        );
+
+        assert!(matches!(action, Action::None));
+        assert!(matches!(
+            state.workflows.view,
+            crate::tui::state::WorkflowView::RunDetail { .. }
+        ));
     }
 
     #[test]

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use super::state::{Focus, Mode, ScreenState};
+use super::state::{Focus, Mode, RunDetailPanel, ScreenState, WorkflowView};
 
 /// Async side-effects returned from key handlers for the event loop to execute.
 pub enum Action {
@@ -8,10 +8,34 @@ pub enum Action {
     Quit,
     Suspend,
     Refresh,
-    CreateProject { name: String, description: String },
-    SendChat { agent_id: String, prompt: String },
+    CreateProject {
+        name: String,
+        description: String,
+    },
+    SendChat {
+        agent_id: String,
+        prompt: String,
+    },
     ToggleThreads,
-    ExportThread { agent_id: String, path: String },
+    OpenWorkflows,
+    RefreshWorkflows,
+    FetchWorkflowDefinition {
+        definition_id: String,
+    },
+    FetchWorkflowRuns {
+        definition_id: String,
+    },
+    FetchWorkflowRun {
+        run_id: String,
+    },
+    TriggerWorkflow {
+        definition_id: String,
+        payload: serde_json::Value,
+    },
+    ExportThread {
+        agent_id: String,
+        path: String,
+    },
 }
 
 pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
@@ -48,6 +72,9 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
                     return Action::None;
                 }
                 KeyCode::Char('t') => return Action::ToggleThreads,
+                KeyCode::Char('w') if state.focus != Focus::Chat || state.chat_input.is_empty() => {
+                    return Action::OpenWorkflows;
+                }
                 _ => {}
             }
         }
@@ -58,10 +85,161 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
             Focus::Agents => handle_agents_key(state, key),
             Focus::Chat => handle_chat_key(state, key),
             Focus::Threads => handle_threads_key(state, key),
+            Focus::Workflows => handle_workflows_key(state, key),
         },
         Mode::CreateProject => handle_create_key(state, key),
         Mode::ExportThread => handle_export_key(state, key),
         Mode::ProjectPicker { .. } => handle_picker_key(state, key),
+        Mode::TriggerWorkflow { .. } => handle_trigger_workflow_key(state, key),
+    }
+}
+
+fn handle_workflows_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    state.status_message = None;
+    match &state.workflows.view {
+        WorkflowView::Catalog => handle_workflow_catalog_key(state, key),
+        WorkflowView::Definition { .. } => handle_workflow_definition_key(state, key),
+        WorkflowView::Runs { .. } => handle_workflow_runs_key(state, key),
+        WorkflowView::RunDetail { .. } => handle_workflow_run_detail_key(state, key),
+    }
+}
+
+fn handle_workflow_catalog_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.workflow_cursor_down();
+            Action::None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.workflow_cursor_up();
+            Action::None
+        }
+        KeyCode::Enter => match state.selected_workflow_definition_id() {
+            Some(definition_id) => {
+                state.open_workflow_definition(definition_id.clone());
+                Action::FetchWorkflowDefinition { definition_id }
+            }
+            None => Action::None,
+        },
+        KeyCode::Char('T') => enter_trigger_for_selected_workflow(state),
+        KeyCode::Char('r') => Action::RefreshWorkflows,
+        KeyCode::Esc => {
+            state.workflow_back();
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn handle_workflow_definition_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.workflow_scroll_yaml_down();
+            Action::None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.workflow_scroll_yaml_up();
+            Action::None
+        }
+        KeyCode::Char('T') => enter_trigger_for_selected_workflow(state),
+        KeyCode::Char('R') => match state.selected_workflow_definition_id() {
+            Some(definition_id) => {
+                state.open_workflow_runs(definition_id.clone());
+                Action::FetchWorkflowRuns { definition_id }
+            }
+            None => Action::None,
+        },
+        KeyCode::Char('r') => match state.selected_workflow_definition_id() {
+            Some(definition_id) => Action::FetchWorkflowDefinition { definition_id },
+            None => Action::None,
+        },
+        KeyCode::Esc => {
+            state.workflow_back();
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn handle_workflow_runs_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.workflow_runs_cursor_down();
+            Action::None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.workflow_runs_cursor_up();
+            Action::None
+        }
+        KeyCode::Enter => match state.selected_workflow_run_id() {
+            Some(run_id) => {
+                state.open_workflow_run_detail(run_id.clone());
+                Action::FetchWorkflowRun { run_id }
+            }
+            None => Action::None,
+        },
+        KeyCode::Char('r') => match state.selected_workflow_definition_id() {
+            Some(definition_id) => Action::FetchWorkflowRuns { definition_id },
+            None => Action::None,
+        },
+        KeyCode::Esc => {
+            state.workflow_back();
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn handle_workflow_run_detail_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.workflow_step_cursor_down();
+            Action::None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.workflow_step_cursor_up();
+            Action::None
+        }
+        KeyCode::Enter => {
+            state.workflow_toggle_expanded();
+            Action::None
+        }
+        KeyCode::Char('p') => {
+            state.workflow_set_panel(RunDetailPanel::Trigger);
+            Action::None
+        }
+        KeyCode::Char('a') => {
+            state.workflow_set_panel(RunDetailPanel::Agents);
+            Action::None
+        }
+        KeyCode::Char('s') => {
+            state.workflow_set_panel(RunDetailPanel::Sandboxes);
+            Action::None
+        }
+        KeyCode::Char('d') => {
+            state.workflow_set_panel(RunDetailPanel::Step);
+            Action::None
+        }
+        KeyCode::Char('r') => match state.selected_workflow_run_id() {
+            Some(run_id) => Action::FetchWorkflowRun { run_id },
+            None => Action::None,
+        },
+        KeyCode::Esc => {
+            state.workflow_back();
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn enter_trigger_for_selected_workflow(state: &mut ScreenState) -> Action {
+    match state.selected_workflow_definition_id() {
+        Some(definition_id) => {
+            let name = state.selected_workflow_name();
+            state.enter_trigger_workflow(definition_id, name);
+            Action::None
+        }
+        None => Action::None,
     }
 }
 
@@ -293,6 +471,68 @@ fn handle_export_key(state: &mut ScreenState, key: KeyEvent) -> Action {
     }
 }
 
+fn handle_trigger_workflow_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    match key.code {
+        KeyCode::Esc => {
+            state.exit_trigger_workflow();
+            Action::None
+        }
+        KeyCode::Backspace => {
+            if let Mode::TriggerWorkflow { payload, error, .. } = &mut state.mode {
+                payload.pop();
+                *error = None;
+            }
+            Action::None
+        }
+        KeyCode::Char('u') if ctrl => {
+            if let Mode::TriggerWorkflow { payload, error, .. } = &mut state.mode {
+                payload.clear();
+                *error = None;
+            }
+            Action::None
+        }
+        KeyCode::Char(c) if !ctrl => {
+            if let Mode::TriggerWorkflow { payload, error, .. } = &mut state.mode {
+                payload.push(c);
+                *error = None;
+            }
+            Action::None
+        }
+        KeyCode::Enter => {
+            let (definition_id, payload_text) = match &state.mode {
+                Mode::TriggerWorkflow {
+                    definition_id,
+                    payload,
+                    ..
+                } => (definition_id.clone(), payload.trim().to_string()),
+                _ => return Action::None,
+            };
+            let payload_text = if payload_text.is_empty() {
+                "{}".to_string()
+            } else {
+                payload_text
+            };
+            match serde_json::from_str(&payload_text) {
+                Ok(payload) => {
+                    state.exit_trigger_workflow();
+                    Action::TriggerWorkflow {
+                        definition_id,
+                        payload,
+                    }
+                }
+                Err(e) => {
+                    if let Mode::TriggerWorkflow { error, .. } = &mut state.mode {
+                        *error = Some(format!("Invalid JSON: {e}"));
+                    }
+                    Action::None
+                }
+            }
+        }
+        _ => Action::None,
+    }
+}
+
 fn send_chat_to_selected_agent(state: &mut ScreenState, input: String) -> Action {
     match state.selected_agent_id() {
         Some(agent_id) => {
@@ -308,5 +548,102 @@ fn send_chat_to_selected_agent(state: &mut ScreenState, input: String) -> Action
             state.status_message = Some("No agent selected".to_string());
             Action::None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    use super::*;
+    use crate::tui::state::{AgentItem, ProjectItem};
+
+    fn project() -> ProjectItem {
+        ProjectItem {
+            id: "p-1".into(),
+            name: "Project".into(),
+            description: None,
+            created_at: None,
+            lead: None,
+            agents: vec![AgentItem {
+                id: "a-1".into(),
+                name: "lead".into(),
+                role: "PROJECT_LEAD".into(),
+                model: "test".into(),
+                sandbox: None,
+            }],
+        }
+    }
+
+    fn state() -> ScreenState {
+        ScreenState::new(vec![project()], "http://s".into(), "u".into(), None)
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn ctrl_w_opens_workflows() {
+        let mut state = state();
+        let action = handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
+        );
+        assert!(matches!(action, Action::OpenWorkflows));
+    }
+
+    #[test]
+    fn ctrl_w_still_deletes_chat_word_when_input_has_text() {
+        let mut state = state();
+        state.chat_input = "hello world".into();
+        state.input_cursor = state.chat_input.len();
+
+        let action = handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
+        );
+
+        assert!(matches!(action, Action::None));
+        assert_eq!(state.chat_input, "hello ");
+    }
+
+    #[test]
+    fn trigger_modal_empty_payload_submits_empty_object() {
+        let mut state = state();
+        state.enter_trigger_workflow("wf-1".into(), "wf".into());
+        if let Mode::TriggerWorkflow { payload, .. } = &mut state.mode {
+            payload.clear();
+        }
+
+        let action = handle_key(&mut state, key(KeyCode::Enter));
+
+        match action {
+            Action::TriggerWorkflow {
+                definition_id,
+                payload,
+            } => {
+                assert_eq!(definition_id, "wf-1");
+                assert_eq!(payload, serde_json::json!({}));
+            }
+            _ => panic!("expected trigger action"),
+        }
+    }
+
+    #[test]
+    fn trigger_modal_invalid_json_stays_open_with_error() {
+        let mut state = state();
+        state.enter_trigger_workflow("wf-1".into(), "wf".into());
+        if let Mode::TriggerWorkflow { payload, .. } = &mut state.mode {
+            *payload = "{".into();
+        }
+
+        let action = handle_key(&mut state, key(KeyCode::Enter));
+
+        assert!(matches!(action, Action::None));
+        assert!(matches!(
+            state.mode,
+            Mode::TriggerWorkflow { error: Some(_), .. }
+        ));
     }
 }

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -2,6 +2,10 @@ use std::collections::HashMap;
 
 use super::chat::{AssistantChat, ChatRole, ContentBlock};
 
+mod workflow;
+
+pub use workflow::*;
+
 #[allow(dead_code)]
 pub struct ProjectItem {
     pub id: String,
@@ -12,6 +16,7 @@ pub struct ProjectItem {
     pub agents: Vec<AgentItem>,
 }
 
+#[derive(Debug, Clone)]
 pub struct SandboxInfo {
     pub name: String,
     pub mode: String,
@@ -39,6 +44,12 @@ pub enum Mode {
         input: String,
         list_cursor: usize,
     },
+    TriggerWorkflow {
+        definition_id: String,
+        name: String,
+        payload: String,
+        error: Option<String>,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -54,6 +65,7 @@ pub enum Focus {
     Chat,
     Agents,
     Threads,
+    Workflows,
 }
 
 #[derive(Default)]
@@ -270,6 +282,7 @@ pub struct ScreenState {
     pub loaded_agent_id: Option<String>,
 
     pub thread_view: Option<ThreadGridState>,
+    pub workflows: WorkflowState,
 
     pub mode: Mode,
     pub input_name: String,
@@ -311,6 +324,7 @@ impl ScreenState {
             loaded_agent_id: None,
 
             thread_view: None,
+            workflows: WorkflowState::default(),
 
             mode: Mode::default(),
             input_name: String::new(),
@@ -412,6 +426,19 @@ impl ScreenState {
         self.mode = Mode::Browse;
     }
 
+    pub fn enter_trigger_workflow(&mut self, definition_id: String, name: String) {
+        self.mode = Mode::TriggerWorkflow {
+            definition_id,
+            name,
+            payload: "{}".to_string(),
+            error: None,
+        };
+    }
+
+    pub fn exit_trigger_workflow(&mut self) {
+        self.mode = Mode::Browse;
+    }
+
     /// Case-insensitive substring match in original-order; returns `(idx, name)`.
     pub fn picker_matches(&self, query: &str) -> Vec<(usize, String)> {
         let q = query.to_lowercase();
@@ -454,6 +481,227 @@ impl ScreenState {
         self.focus = Focus::Chat;
     }
 
+    pub fn replace_workflow_definitions(&mut self, definitions: Vec<WorkflowDefinitionItem>) {
+        self.workflows.definitions = definitions;
+        if self.workflows.cursor >= self.workflows.definitions.len() {
+            self.workflows.cursor = self.workflows.definitions.len().saturating_sub(1);
+        }
+        self.workflows.loading = false;
+        self.workflows.error = None;
+    }
+
+    pub fn replace_workflow_definition_detail(&mut self, detail: WorkflowDefinitionDetail) {
+        let id = detail.id.clone();
+        self.workflows.selected_definition = Some(detail);
+        if !matches!(self.workflows.view, WorkflowView::Definition { .. }) {
+            self.open_workflow_definition(id);
+        }
+        self.workflows.loading = false;
+        self.workflows.error = None;
+    }
+
+    pub fn replace_workflow_runs(&mut self, runs: Vec<WorkflowRunItem>) {
+        self.workflows.runs = runs;
+        if let WorkflowView::Runs { cursor, .. } = &mut self.workflows.view {
+            if *cursor >= self.workflows.runs.len() {
+                *cursor = self.workflows.runs.len().saturating_sub(1);
+            }
+        }
+        self.workflows.loading = false;
+        self.workflows.error = None;
+    }
+
+    pub fn replace_workflow_run_detail(&mut self, run: WorkflowRunDetail) {
+        let id = run.id.clone();
+        self.workflows.selected_run = Some(run);
+        if !matches!(self.workflows.view, WorkflowView::RunDetail { .. }) {
+            self.open_workflow_run_detail(id);
+        }
+        self.workflows.loading = false;
+        self.workflows.error = None;
+    }
+
+    pub fn set_workflow_error(&mut self, error: String) {
+        self.workflows.loading = false;
+        self.workflows.error = Some(error);
+    }
+
+    pub fn enter_workflows(&mut self) {
+        self.focus = Focus::Workflows;
+        self.thread_view = None;
+        self.workflows.view = WorkflowView::Catalog;
+        self.workflows.error = None;
+    }
+
+    pub fn selected_workflow_definition(&self) -> Option<&WorkflowDefinitionItem> {
+        self.workflows.definitions.get(self.workflows.cursor)
+    }
+
+    pub fn selected_workflow_definition_id(&self) -> Option<String> {
+        match &self.workflows.view {
+            WorkflowView::Catalog => self.selected_workflow_definition().map(|d| d.id.clone()),
+            WorkflowView::Definition { definition_id, .. }
+            | WorkflowView::Runs { definition_id, .. } => Some(definition_id.clone()),
+            WorkflowView::RunDetail { .. } => self
+                .workflows
+                .selected_run
+                .as_ref()
+                .map(|run| run.definition_id.clone()),
+        }
+    }
+
+    pub fn selected_workflow_name(&self) -> String {
+        self.workflows
+            .selected_definition
+            .as_ref()
+            .map(|d| d.name.clone())
+            .or_else(|| self.selected_workflow_definition().map(|d| d.name.clone()))
+            .unwrap_or_else(|| "workflow".to_string())
+    }
+
+    pub fn workflow_cursor_down(&mut self) {
+        if !self.workflows.definitions.is_empty()
+            && self.workflows.cursor < self.workflows.definitions.len() - 1
+        {
+            self.workflows.cursor += 1;
+        }
+    }
+
+    pub fn workflow_cursor_up(&mut self) {
+        self.workflows.cursor = self.workflows.cursor.saturating_sub(1);
+    }
+
+    pub fn workflow_runs_cursor_down(&mut self) {
+        if let WorkflowView::Runs { cursor, .. } = &mut self.workflows.view {
+            if !self.workflows.runs.is_empty() && *cursor < self.workflows.runs.len() - 1 {
+                *cursor += 1;
+            }
+        }
+    }
+
+    pub fn workflow_runs_cursor_up(&mut self) {
+        if let WorkflowView::Runs { cursor, .. } = &mut self.workflows.view {
+            *cursor = cursor.saturating_sub(1);
+        }
+    }
+
+    pub fn selected_workflow_run_id(&self) -> Option<String> {
+        match &self.workflows.view {
+            WorkflowView::Runs { cursor, .. } => {
+                self.workflows.runs.get(*cursor).map(|r| r.id.clone())
+            }
+            WorkflowView::RunDetail { run_id, .. } => Some(run_id.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn workflow_step_cursor_down(&mut self) {
+        if let WorkflowView::RunDetail { step_cursor, .. } = &mut self.workflows.view {
+            let len = self
+                .workflows
+                .selected_run
+                .as_ref()
+                .map(|r| r.steps_snapshot.len().max(r.step_results.len()))
+                .unwrap_or(0);
+            if len > 0 && *step_cursor < len - 1 {
+                *step_cursor += 1;
+            }
+        }
+    }
+
+    pub fn workflow_step_cursor_up(&mut self) {
+        if let WorkflowView::RunDetail { step_cursor, .. } = &mut self.workflows.view {
+            *step_cursor = step_cursor.saturating_sub(1);
+        }
+    }
+
+    pub fn workflow_scroll_yaml_down(&mut self) {
+        if let WorkflowView::Definition { yaml_scroll, .. } = &mut self.workflows.view {
+            *yaml_scroll = yaml_scroll.saturating_add(1);
+        }
+    }
+
+    pub fn workflow_scroll_yaml_up(&mut self) {
+        if let WorkflowView::Definition { yaml_scroll, .. } = &mut self.workflows.view {
+            *yaml_scroll = yaml_scroll.saturating_sub(1);
+        }
+    }
+
+    pub fn workflow_set_panel(&mut self, next: RunDetailPanel) {
+        if let WorkflowView::RunDetail { panel, .. } = &mut self.workflows.view {
+            *panel = next;
+        }
+    }
+
+    pub fn workflow_toggle_expanded(&mut self) {
+        if let WorkflowView::RunDetail { expanded, .. } = &mut self.workflows.view {
+            *expanded = !*expanded;
+        }
+    }
+
+    pub fn open_workflow_definition(&mut self, definition_id: String) {
+        self.workflows.view = WorkflowView::Definition {
+            definition_id,
+            yaml_scroll: 0,
+        };
+        self.workflows.error = None;
+    }
+
+    pub fn open_workflow_runs(&mut self, definition_id: String) {
+        self.workflows.view = WorkflowView::Runs {
+            definition_id,
+            cursor: 0,
+        };
+        self.workflows.error = None;
+    }
+
+    pub fn open_workflow_run_detail(&mut self, run_id: String) {
+        self.workflows.view = WorkflowView::RunDetail {
+            run_id,
+            step_cursor: 0,
+            panel: RunDetailPanel::Step,
+            expanded: false,
+        };
+        self.workflows.error = None;
+    }
+
+    pub fn workflow_back(&mut self) {
+        self.workflows.error = None;
+        self.workflows.view = match &self.workflows.view {
+            WorkflowView::Catalog => {
+                self.focus = Focus::Chat;
+                WorkflowView::Catalog
+            }
+            WorkflowView::Definition { .. } => WorkflowView::Catalog,
+            WorkflowView::Runs { definition_id, .. } => WorkflowView::Definition {
+                definition_id: definition_id.clone(),
+                yaml_scroll: 0,
+            },
+            WorkflowView::RunDetail { .. } => match self.workflows.selected_run.as_ref() {
+                Some(run) => WorkflowView::Runs {
+                    definition_id: run.definition_id.clone(),
+                    cursor: 0,
+                },
+                None => WorkflowView::Catalog,
+            },
+        };
+    }
+
+    pub fn workflow_poll_run_id(&self) -> Option<String> {
+        if self.focus != Focus::Workflows {
+            return None;
+        }
+        let WorkflowView::RunDetail { run_id, .. } = &self.workflows.view else {
+            return None;
+        };
+        let run = self.workflows.selected_run.as_ref()?;
+        if run.id == *run_id && !run.is_terminal() {
+            Some(run_id.clone())
+        } else {
+            None
+        }
+    }
+
     pub fn active_input_mut(&mut self) -> &mut String {
         if self.input_field == 0 {
             &mut self.input_name
@@ -466,21 +714,21 @@ impl ScreenState {
     pub fn toggle_focus(&mut self) {
         self.focus = match self.focus {
             Focus::Chat => Focus::Agents,
-            Focus::Agents | Focus::Threads => Focus::Chat,
+            Focus::Agents | Focus::Threads | Focus::Workflows => Focus::Chat,
         };
     }
 
     pub fn focus_left(&mut self) {
         self.focus = match self.focus {
             Focus::Agents => Focus::Chat,
-            Focus::Chat | Focus::Threads => Focus::Chat,
+            Focus::Chat | Focus::Threads | Focus::Workflows => Focus::Chat,
         };
     }
 
     pub fn focus_right(&mut self) {
         self.focus = match self.focus {
             Focus::Chat => Focus::Agents,
-            Focus::Agents | Focus::Threads => Focus::Agents,
+            Focus::Agents | Focus::Threads | Focus::Workflows => Focus::Agents,
         };
     }
 
@@ -929,5 +1177,65 @@ mod tests {
 
         assert!(!state.chat_view.assistant.streaming);
         assert!(state.chat_view.assistant.messages.is_empty());
+    }
+
+    #[test]
+    fn enter_workflows_sets_catalog_focus() {
+        let mut state = make_state(vec![proj("a", "Alpha")], None);
+
+        state.enter_workflows();
+
+        assert_eq!(state.focus, Focus::Workflows);
+        assert!(matches!(state.workflows.view, WorkflowView::Catalog));
+    }
+
+    #[test]
+    fn workflow_navigation_preserves_definition_context() {
+        let mut state = make_state(vec![proj("a", "Alpha")], None);
+
+        state.open_workflow_definition("wf-1".into());
+        assert!(matches!(
+            state.workflows.view,
+            WorkflowView::Definition { ref definition_id, .. } if definition_id == "wf-1"
+        ));
+
+        state.open_workflow_runs("wf-1".into());
+        assert!(matches!(
+            state.workflows.view,
+            WorkflowView::Runs { ref definition_id, cursor } if definition_id == "wf-1" && cursor == 0
+        ));
+
+        state.open_workflow_run_detail("run-1".into());
+        assert!(matches!(
+            state.workflows.view,
+            WorkflowView::RunDetail { ref run_id, step_cursor, .. } if run_id == "run-1" && step_cursor == 0
+        ));
+    }
+
+    #[test]
+    fn workflow_polling_only_for_non_terminal_selected_run() {
+        let mut state = make_state(vec![proj("a", "Alpha")], None);
+        state.enter_workflows();
+        state.open_workflow_run_detail("run-1".into());
+        state.replace_workflow_run_detail(WorkflowRunDetail {
+            id: "run-1".into(),
+            definition_id: "wf-1".into(),
+            project_id: "p-1".into(),
+            state: "RUNNING".into(),
+            started_at: "now".into(),
+            completed_at: None,
+            trigger_context: serde_json::json!({}),
+            steps_snapshot: vec![],
+            step_results: vec![],
+            agents: vec![],
+        });
+        assert_eq!(state.workflow_poll_run_id().as_deref(), Some("run-1"));
+
+        state.focus = Focus::Chat;
+        assert_eq!(state.workflow_poll_run_id(), None);
+
+        state.focus = Focus::Workflows;
+        state.workflows.selected_run.as_mut().unwrap().state = "SUCCEEDED".into();
+        assert_eq!(state.workflow_poll_run_id(), None);
     }
 }

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -677,11 +677,19 @@ impl ScreenState {
                 definition_id: definition_id.clone(),
                 yaml_scroll: 0,
             },
-            WorkflowView::RunDetail { .. } => match self.workflows.selected_run.as_ref() {
-                Some(run) => WorkflowView::Runs {
-                    definition_id: run.definition_id.clone(),
-                    cursor: 0,
-                },
+            WorkflowView::RunDetail { run_id, .. } => match self.workflows.selected_run.as_ref() {
+                Some(run) => {
+                    let cursor = self
+                        .workflows
+                        .runs
+                        .iter()
+                        .position(|r| r.id == *run_id)
+                        .unwrap_or(0);
+                    WorkflowView::Runs {
+                        definition_id: run.definition_id.clone(),
+                        cursor,
+                    }
+                }
                 None => WorkflowView::Catalog,
             },
         };

--- a/client/src/tui/state/workflow.rs
+++ b/client/src/tui/state/workflow.rs
@@ -1,0 +1,144 @@
+use serde_json::Value;
+
+use super::SandboxInfo;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum WorkflowView {
+    #[default]
+    Catalog,
+    Definition {
+        definition_id: String,
+        yaml_scroll: u16,
+    },
+    Runs {
+        definition_id: String,
+        cursor: usize,
+    },
+    RunDetail {
+        run_id: String,
+        step_cursor: usize,
+        panel: RunDetailPanel,
+        expanded: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RunDetailPanel {
+    #[default]
+    Step,
+    Trigger,
+    Agents,
+    Sandboxes,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WorkflowState {
+    pub view: WorkflowView,
+    pub definitions: Vec<WorkflowDefinitionItem>,
+    pub selected_definition: Option<WorkflowDefinitionDetail>,
+    pub runs: Vec<WorkflowRunItem>,
+    pub selected_run: Option<WorkflowRunDetail>,
+    pub cursor: usize,
+    pub loading: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowDefinitionItem {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub trigger: WorkflowTriggerInfo,
+    pub steps: Vec<WorkflowStepItem>,
+    pub recent_runs: Vec<WorkflowRunItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowDefinitionDetail {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub yaml: String,
+    pub trigger: WorkflowTriggerInfo,
+    pub steps: Vec<WorkflowStepItem>,
+    pub sandboxes: Vec<WorkflowSandboxItem>,
+    pub recent_runs: Vec<WorkflowRunItem>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WorkflowTriggerInfo {
+    pub kind: String,
+    pub provider: Option<String>,
+    pub cron_schedule: Option<String>,
+    pub cron_timezone: Option<String>,
+    pub next_run_at: Option<String>,
+    pub condition: Option<String>,
+    pub webhook_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowStepItem {
+    pub name: String,
+    pub step_type: String,
+    pub skill: Option<String>,
+    pub tool: Option<String>,
+    pub sandbox: Option<String>,
+    pub sandbox_mode: Option<String>,
+    pub condition: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowSandboxItem {
+    pub name: String,
+    pub kind: String,
+    pub branch: Option<String>,
+    pub repo_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowRunItem {
+    pub id: String,
+    pub state: String,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    pub step_results: Vec<WorkflowStepResultItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowRunDetail {
+    pub id: String,
+    pub definition_id: String,
+    pub project_id: String,
+    pub state: String,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    pub trigger_context: Value,
+    pub steps_snapshot: Vec<WorkflowStepItem>,
+    pub step_results: Vec<WorkflowStepResultItem>,
+    pub agents: Vec<WorkflowAgentItem>,
+}
+
+impl WorkflowRunDetail {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self.state.as_str(), "SUCCEEDED" | "FAILED" | "ERRORED")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowStepResultItem {
+    pub name: String,
+    pub state: String,
+    pub output: Option<Value>,
+    pub error: Option<String>,
+    pub skipped: Option<String>,
+    pub completed_at: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowAgentItem {
+    pub id: String,
+    pub name: String,
+    pub role: String,
+    pub model: String,
+    pub sandbox: Option<SandboxInfo>,
+}

--- a/client/src/tui/state/workflow.rs
+++ b/client/src/tui/state/workflow.rs
@@ -119,8 +119,10 @@ pub struct WorkflowRunDetail {
 }
 
 impl WorkflowRunDetail {
+    // Treat any non-pending/non-running state as terminal so unknown
+    // future states (e.g. CANCELLED) stop polling instead of looping.
     pub fn is_terminal(&self) -> bool {
-        matches!(self.state.as_str(), "SUCCEEDED" | "FAILED" | "ERRORED")
+        !matches!(self.state.as_str(), "PENDING" | "RUNNING")
     }
 }
 

--- a/client/src/tui/ui/mod.rs
+++ b/client/src/tui/ui/mod.rs
@@ -2,12 +2,13 @@ mod agents;
 mod chat_pane;
 mod grid;
 mod project_picker;
+mod workflows;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
     Frame,
 };
 
@@ -22,25 +23,30 @@ pub fn draw(frame: &mut Frame, state: &mut ScreenState) {
     let main_area = chunks[0];
     let status_area = chunks[1];
 
-    let panels = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(1), Constraint::Length(44)])
-        .split(main_area);
+    if state.focus == Focus::Workflows {
+        workflows::draw_workflows(frame, state, main_area);
+    } else {
+        let panels = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Min(1), Constraint::Length(44)])
+            .split(main_area);
 
-    let right_col = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(panels[1]);
+        let right_col = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(panels[1]);
 
-    chat_pane::draw_chat_pane(frame, state, panels[0]);
-    agents::draw_agents_list(frame, state, right_col[0]);
-    agents::draw_agent_details(frame, state, right_col[1]);
+        chat_pane::draw_chat_pane(frame, state, panels[0]);
+        agents::draw_agents_list(frame, state, right_col[0]);
+        agents::draw_agent_details(frame, state, right_col[1]);
+    }
     draw_status_bar(frame, state, status_area);
 
     match &state.mode {
         Mode::CreateProject => draw_create_modal(frame, state),
         Mode::ExportThread => draw_export_modal(frame, state),
         Mode::ProjectPicker { .. } => project_picker::draw_project_picker(frame, state),
+        Mode::TriggerWorkflow { .. } => draw_trigger_workflow_modal(frame, state),
         Mode::Browse => {}
     }
 }
@@ -73,8 +79,9 @@ fn draw_status_bar(frame: &mut Frame, state: &ScreenState, area: Rect) {
 
     let keys = match state.focus {
         Focus::Agents => " │ ↑/↓:nav  Enter:chat  Tab:chat  ^P:project  Esc:chat ",
-        Focus::Chat => " │ Enter:send  ↑/↓:scroll  ^P:project  ^T:threads  ^C:quit ",
+        Focus::Chat => " │ Enter:send  ↑/↓:scroll  ^P:project  ^W:workflows  ^T:threads  ^C:quit ",
         Focus::Threads => " │ ←→:pos  ↑↓:thread  Tab:next  g/G:jump  e:export  ^T:close  Esc:chat ",
+        Focus::Workflows => workflows::status_keys(state),
     };
     spans.push(Span::styled(keys, Style::default().fg(Color::DarkGray)));
 
@@ -160,6 +167,62 @@ fn draw_export_modal(frame: &mut Frame, state: &ScreenState) {
 
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
+}
+
+fn draw_trigger_workflow_modal(frame: &mut Frame, state: &ScreenState) {
+    let area = centered_rect(72, 11, frame.area());
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Trigger Workflow ")
+        .border_style(Style::default().fg(Color::Yellow));
+
+    let (name, payload, error) = match &state.mode {
+        Mode::TriggerWorkflow {
+            name,
+            payload,
+            error,
+            ..
+        } => (name.as_str(), payload.as_str(), error.as_deref()),
+        _ => ("workflow", "{}", None),
+    };
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Workflow: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(name, Style::default().fg(Color::White)),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Payload JSON (optional):",
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled(format!("{payload}▎"), Style::default().fg(Color::Yellow)),
+        ]),
+    ];
+    if let Some(error) = error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(error, Style::default().fg(Color::Red)),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  Enter:trigger  Esc:cancel  ^U:clear",
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        area,
+    );
 }
 
 pub(super) fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -1,0 +1,513 @@
+use std::collections::BTreeSet;
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
+    Frame,
+};
+
+use super::super::state::{
+    RunDetailPanel, ScreenState, WorkflowRunDetail, WorkflowStepItem, WorkflowStepResultItem,
+    WorkflowView,
+};
+
+pub fn draw_workflows(frame: &mut Frame, state: &ScreenState, area: Rect) {
+    match &state.workflows.view {
+        WorkflowView::Catalog => draw_catalog(frame, state, area),
+        WorkflowView::Definition { yaml_scroll, .. } => {
+            draw_definition(frame, state, area, *yaml_scroll)
+        }
+        WorkflowView::Runs { cursor, .. } => draw_runs(frame, state, area, *cursor),
+        WorkflowView::RunDetail {
+            step_cursor,
+            panel,
+            expanded,
+            ..
+        } => draw_run_detail(frame, state, area, *step_cursor, *panel, *expanded),
+    }
+}
+
+pub fn status_keys(state: &ScreenState) -> &'static str {
+    match state.workflows.view {
+        WorkflowView::Catalog => " │ ↑/↓:nav  Enter:detail  T:trigger  r:refresh  Esc:chat ",
+        WorkflowView::Definition { .. } => " │ ↑/↓:scroll  T:trigger  R:runs  r:refresh  Esc:list ",
+        WorkflowView::Runs { .. } => " │ ↑/↓:nav  Enter:inspect  r:refresh  Esc:workflow ",
+        WorkflowView::RunDetail { .. } => {
+            " │ ↑/↓:step  Enter:expand  d/p/a/s:panel  r:refresh  Esc:runs "
+        }
+    }
+}
+
+fn draw_catalog(frame: &mut Frame, state: &ScreenState, area: Rect) {
+    let project = state
+        .selected_project()
+        .map(|p| p.name.as_str())
+        .unwrap_or("-");
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Workflows - project: {project} "));
+
+    let mut items = Vec::new();
+    if state.workflows.loading {
+        items.push(ListItem::new(Line::from("Loading workflows...")));
+    } else if state.workflows.definitions.is_empty() {
+        items.push(ListItem::new(Line::from("No workflows in this project")));
+    } else {
+        for (idx, definition) in state.workflows.definitions.iter().enumerate() {
+            let selected = idx == state.workflows.cursor;
+            let marker = if selected { ">" } else { " " };
+            let run = definition
+                .recent_runs
+                .first()
+                .map(|r| {
+                    (
+                        format!(
+                            "last: {} {}",
+                            state_label(&r.state),
+                            short_time(&r.started_at)
+                        ),
+                        state_color(&r.state),
+                    )
+                })
+                .unwrap_or_else(|| ("no runs".to_string(), Color::DarkGray));
+            let trigger = trigger_label(
+                &definition.trigger.kind,
+                definition.trigger.provider.as_deref(),
+            );
+            let next = definition
+                .trigger
+                .next_run_at
+                .as_deref()
+                .map(|t| format!(" next: {}", short_time(t)))
+                .unwrap_or_default();
+            let line = Line::from(vec![
+                Span::styled(marker, Style::default().fg(Color::Yellow)),
+                Span::raw(" "),
+                Span::styled(
+                    truncate(&definition.name, 30),
+                    if selected {
+                        Style::default().add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default()
+                    },
+                ),
+                Span::styled(format!("  {trigger:<18}"), Style::default().fg(Color::Cyan)),
+                Span::styled(format!("  {:<24}", run.0), Style::default().fg(run.1)),
+                Span::styled(
+                    format!("  steps: {}{next}", definition.steps.len()),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]);
+            items.push(ListItem::new(line));
+        }
+    }
+
+    if let Some(error) = &state.workflows.error {
+        items.push(ListItem::new(Line::from("")));
+        items.push(ListItem::new(Line::from(Span::styled(
+            error,
+            Style::default().fg(Color::Red),
+        ))));
+    }
+
+    frame.render_widget(List::new(items).block(block), area);
+}
+
+fn draw_definition(frame: &mut Frame, state: &ScreenState, area: Rect, yaml_scroll: u16) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(1), Constraint::Length(34)])
+        .split(area);
+
+    let title = state
+        .workflows
+        .selected_definition
+        .as_ref()
+        .map(|d| format!(" {} ", d.name))
+        .unwrap_or_else(|| " Workflow ".to_string());
+    let yaml = state
+        .workflows
+        .selected_definition
+        .as_ref()
+        .map(|d| d.yaml.as_str())
+        .unwrap_or("Loading workflow YAML...");
+
+    frame.render_widget(
+        Paragraph::new(yaml)
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .scroll((yaml_scroll, 0))
+            .wrap(Wrap { trim: false }),
+        chunks[0],
+    );
+
+    let lines = if let Some(definition) = &state.workflows.selected_definition {
+        let mut lines = vec![
+            Line::from(vec![
+                Span::styled("Trigger ", Style::default().fg(Color::DarkGray)),
+                Span::raw(trigger_label(
+                    &definition.trigger.kind,
+                    definition.trigger.provider.as_deref(),
+                )),
+            ]),
+            Line::from(vec![
+                Span::styled("Steps   ", Style::default().fg(Color::DarkGray)),
+                Span::raw(definition.steps.len().to_string()),
+            ]),
+        ];
+        if let Some(condition) = &definition.trigger.condition {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "Condition",
+                Style::default().fg(Color::DarkGray),
+            )));
+            lines.push(Line::from(condition.as_str()));
+        }
+        if let Some(next) = &definition.trigger.next_run_at {
+            lines.push(Line::from(""));
+            lines.push(Line::from(vec![
+                Span::styled("Next run ", Style::default().fg(Color::DarkGray)),
+                Span::raw(short_time(next)),
+            ]));
+        }
+        if !definition.recent_runs.is_empty() {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "Recent runs",
+                Style::default().fg(Color::DarkGray),
+            )));
+            for run in &definition.recent_runs {
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        state_label(&run.state),
+                        Style::default().fg(state_color(&run.state)),
+                    ),
+                    Span::raw(format!(" {}", short_time(&run.started_at))),
+                ]));
+            }
+        }
+        if let Some(error) = &state.workflows.error {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                error,
+                Style::default().fg(Color::Red),
+            )));
+        }
+        lines
+    } else {
+        vec![Line::from("Loading...")]
+    };
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(Block::default().borders(Borders::ALL).title(" Metadata "))
+            .wrap(Wrap { trim: true }),
+        chunks[1],
+    );
+}
+
+fn draw_runs(frame: &mut Frame, state: &ScreenState, area: Rect, cursor: usize) {
+    let name = state.selected_workflow_name();
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Runs - {name} "));
+    let mut items = Vec::new();
+    if state.workflows.loading {
+        items.push(ListItem::new(Line::from("Loading runs...")));
+    } else if state.workflows.runs.is_empty() {
+        items.push(ListItem::new(Line::from("No workflow runs")));
+    } else {
+        for (idx, run) in state.workflows.runs.iter().enumerate() {
+            let selected = idx == cursor;
+            let marker = if selected { ">" } else { " " };
+            let summary = run_summary(run);
+            items.push(ListItem::new(Line::from(vec![
+                Span::styled(marker, Style::default().fg(Color::Yellow)),
+                Span::raw(" "),
+                Span::styled(short_id(&run.id), Style::default().fg(Color::White)),
+                Span::raw("  "),
+                Span::styled(
+                    state_label(&run.state),
+                    Style::default().fg(state_color(&run.state)),
+                ),
+                Span::raw(format!("  {}  ", short_time(&run.started_at))),
+                Span::styled(summary, Style::default().fg(Color::DarkGray)),
+            ])));
+        }
+    }
+    if let Some(error) = &state.workflows.error {
+        items.push(ListItem::new(Line::from("")));
+        items.push(ListItem::new(Line::from(Span::styled(
+            error,
+            Style::default().fg(Color::Red),
+        ))));
+    }
+    frame.render_widget(List::new(items).block(block), area);
+}
+
+fn draw_run_detail(
+    frame: &mut Frame,
+    state: &ScreenState,
+    area: Rect,
+    step_cursor: usize,
+    panel: RunDetailPanel,
+    expanded: bool,
+) {
+    let Some(run) = &state.workflows.selected_run else {
+        frame.render_widget(
+            Paragraph::new("Loading run...")
+                .block(Block::default().borders(Borders::ALL).title(" Run ")),
+            area,
+        );
+        return;
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(34), Constraint::Min(1)])
+        .split(area);
+    draw_step_list(frame, run, chunks[0], step_cursor);
+    draw_run_panel(frame, run, chunks[1], step_cursor, panel, expanded);
+}
+
+fn draw_step_list(frame: &mut Frame, run: &WorkflowRunDetail, area: Rect, cursor: usize) {
+    let mut items = Vec::new();
+    let count = run.steps_snapshot.len().max(run.step_results.len());
+    for idx in 0..count {
+        let step = run.steps_snapshot.get(idx);
+        let result = result_for_step(run, idx, step);
+        let selected = idx == cursor;
+        let marker = if selected { ">" } else { " " };
+        let name = step
+            .map(|s| s.name.as_str())
+            .or_else(|| result.map(|r| r.name.as_str()))
+            .unwrap_or("step");
+        let state = result.map(|r| r.state.as_str()).unwrap_or("PENDING");
+        items.push(ListItem::new(Line::from(vec![
+            Span::styled(marker, Style::default().fg(Color::Yellow)),
+            Span::raw(" "),
+            Span::styled(truncate(name, 18), Style::default()),
+            Span::raw(" "),
+            Span::styled(state_label(state), Style::default().fg(state_color(state))),
+        ])));
+    }
+    frame.render_widget(
+        List::new(items).block(Block::default().borders(Borders::ALL).title(format!(
+            " Run {} - {} ",
+            short_id(&run.id),
+            state_label(&run.state)
+        ))),
+        area,
+    );
+}
+
+fn draw_run_panel(
+    frame: &mut Frame,
+    run: &WorkflowRunDetail,
+    area: Rect,
+    step_cursor: usize,
+    panel: RunDetailPanel,
+    expanded: bool,
+) {
+    let (title, body) = match panel {
+        RunDetailPanel::Step => (" Step ", selected_step_body(run, step_cursor, expanded)),
+        RunDetailPanel::Trigger => (" Trigger Payload ", pretty_json(&run.trigger_context)),
+        RunDetailPanel::Agents => (" Related Agents ", agents_body(run)),
+        RunDetailPanel::Sandboxes => (" Related Sandboxes ", sandboxes_body(run)),
+    };
+    frame.render_widget(
+        Paragraph::new(body)
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn selected_step_body(run: &WorkflowRunDetail, cursor: usize, expanded: bool) -> String {
+    let step = run.steps_snapshot.get(cursor);
+    let result = result_for_step(run, cursor, step);
+    let mut lines = Vec::new();
+    if let Some(step) = step {
+        lines.push(format!("name: {}", step.name));
+        lines.push(format!("type: {}", step.step_type));
+        if let Some(skill) = &step.skill {
+            lines.push(format!("skill: {skill}"));
+        }
+        if let Some(tool) = &step.tool {
+            lines.push(format!("tool: {tool}"));
+        }
+        if let Some(sandbox) = &step.sandbox {
+            let mode = step.sandbox_mode.as_deref().unwrap_or("default");
+            lines.push(format!("sandbox: {sandbox} ({mode})"));
+        }
+        if let Some(condition) = &step.condition {
+            lines.push(format!("condition: {condition}"));
+        }
+    }
+    if let Some(result) = result {
+        lines.push(format!("state: {}", state_label(&result.state)));
+        if let Some(at) = &result.completed_at {
+            lines.push(format!("completed: {at}"));
+        }
+        if let Some(skipped) = &result.skipped {
+            lines.push(String::new());
+            lines.push(format!("skipped: {skipped}"));
+        }
+        if let Some(error) = &result.error {
+            lines.push(String::new());
+            lines.push(format!("error:\n{error}"));
+        }
+        if let Some(output) = &result.output {
+            lines.push(String::new());
+            lines.push("output:".to_string());
+            let output = pretty_json(output);
+            if expanded {
+                lines.push(output);
+            } else {
+                lines.extend(output.lines().take(18).map(str::to_string));
+                if output.lines().count() > 18 {
+                    lines.push("...".to_string());
+                }
+            }
+        }
+    } else {
+        lines.push("state: pending".to_string());
+    }
+    lines.join("\n")
+}
+
+fn agents_body(run: &WorkflowRunDetail) -> String {
+    if run.agents.is_empty() {
+        return "No related agents reported for this run".to_string();
+    }
+    run.agents
+        .iter()
+        .map(|agent| {
+            let sandbox = agent
+                .sandbox
+                .as_ref()
+                .map(|s| format!(" sandbox={}({})", s.name, s.mode))
+                .unwrap_or_default();
+            format!(
+                "{}  {}  {}  model={}{}",
+                short_id(&agent.id),
+                agent.name,
+                agent.role,
+                agent.model,
+                sandbox
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn sandboxes_body(run: &WorkflowRunDetail) -> String {
+    let mut sandboxes = BTreeSet::new();
+    for step in &run.steps_snapshot {
+        if let Some(name) = &step.sandbox {
+            let mode = step.sandbox_mode.as_deref().unwrap_or("default");
+            sandboxes.insert(format!("{name}  mode={mode}"));
+        }
+    }
+    for agent in &run.agents {
+        if let Some(sandbox) = &agent.sandbox {
+            sandboxes.insert(format!(
+                "{}  mode={}  agent={}",
+                sandbox.name, sandbox.mode, agent.name
+            ));
+        }
+    }
+    if sandboxes.is_empty() {
+        "No related sandboxes reported for this run".to_string()
+    } else {
+        sandboxes.into_iter().collect::<Vec<_>>().join("\n")
+    }
+}
+
+fn result_for_step<'a>(
+    run: &'a WorkflowRunDetail,
+    idx: usize,
+    step: Option<&WorkflowStepItem>,
+) -> Option<&'a WorkflowStepResultItem> {
+    step.and_then(|s| run.step_results.iter().find(|r| r.name == s.name))
+        .or_else(|| run.step_results.get(idx))
+}
+
+fn run_summary(run: &super::super::state::WorkflowRunItem) -> String {
+    if let Some(failed) = run
+        .step_results
+        .iter()
+        .find(|r| matches!(r.state.as_str(), "FAILED" | "ERRORED"))
+    {
+        if let Some(error) = &failed.error {
+            return format!("step: {}  {}", failed.name, truncate(error, 48));
+        }
+        if let Some(output) = &failed.output {
+            return format!(
+                "step: {}  {}",
+                failed.name,
+                truncate(&pretty_json(output), 48)
+            );
+        }
+        return format!("step: {}", failed.name);
+    }
+    format!("{} steps", run.step_results.len())
+}
+
+fn trigger_label(kind: &str, provider: Option<&str>) -> String {
+    match provider {
+        Some(provider) if !provider.is_empty() => format!("{}:{provider}", kind.to_lowercase()),
+        _ => kind.to_lowercase(),
+    }
+}
+
+fn state_label(state: &str) -> &'static str {
+    match state {
+        "SUCCEEDED" => "ok",
+        "FAILED" => "failed",
+        "ERRORED" => "errored",
+        "RUNNING" => "running",
+        "PENDING" => "pending",
+        "SKIPPED" => "skipped",
+        _ => "unknown",
+    }
+}
+
+fn state_color(state: &str) -> Color {
+    match state {
+        "SUCCEEDED" | "ok" => Color::Green,
+        "FAILED" | "failed" | "ERRORED" | "errored" => Color::Red,
+        "RUNNING" | "running" => Color::Yellow,
+        "SKIPPED" | "skipped" => Color::DarkGray,
+        _ => Color::White,
+    }
+}
+
+fn short_time(value: &str) -> String {
+    value
+        .split('T')
+        .nth(1)
+        .map(|t| t.trim_end_matches('Z').chars().take(8).collect())
+        .unwrap_or_else(|| truncate(value, 16))
+}
+
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
+fn truncate(value: &str, max: usize) -> String {
+    let mut out = String::new();
+    for (idx, ch) in value.chars().enumerate() {
+        if idx >= max {
+            out.push_str("...");
+            return out;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn pretty_json(value: &serde_json::Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}


### PR DESCRIPTION
## Summary
- add a project-scoped workflow catalog to the TUI
- render workflow definitions with YAML as the primary detail view
- add recent run listing, run detail inspection, manual trigger modal, and polling for active runs
- split workflow-specific TUI state into client/src/tui/state/workflow.rs

## Validation
- cargo fmt
- git diff --check
- nix develop -c cargo check -p drua-client
- nix develop -c cargo test -p drua-client

Phase 2 only: no workflow create/update/delete/disable/replay.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new GraphQL queries/mutation and a 1s polling loop in the TUI event loop, which could impact responsiveness/load and introduces more stateful navigation paths to maintain.
> 
> **Overview**
> Adds a new **Workflows** area to the TUI (opened via `^W`) that lets users browse project-scoped workflow definitions, view definition YAML/metadata, list recent and historical runs, and inspect run details (step results, trigger payload, related agents/sandboxes).
> 
> Introduces workflow-specific state (`WorkflowState`, `WorkflowView`, run/definition models) in `client/src/tui/state/workflow.rs`, plus new key handling and UI rendering (`ui/workflows.rs`) and a trigger modal that validates JSON payloads.
> 
> Extends the dashboard command to call new GraphQL queries/mutation for workflow definitions/runs and to **poll non-terminal run details every second** while viewing a run detail page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc5cdbff1e2e9ac52f4d1f42cd9af34427d4f4b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->