### PR TITLE
fix(tool-caching): make summary recovery reliable

### DIFF
--- a/bats/summarized-tool-responses/arr-large-fat-items.txt
+++ b/bats/summarized-tool-responses/arr-large-fat-items.txt
@@ -18,6 +18,7 @@
     tool_output_fetch(invocation_id="<uuid>", path="$[4].body", query={"len":80,"mode":"lines","offset":9})
   </elided>
   <elided path="$" total-bytes="65221" shown-bytes="7048" total-items="5" shown-items="3">
+    note: Direct recovery for this aggregate would exceed the fetch response cap; use the narrower recovery paths listed in this envelope. Summary mode only replays this overview.
     tool_output_fetch(invocation_id="<uuid>", query={"mode":"summary"})
   </elided>
 </recovery>

--- a/bats/summarized-tool-responses/compose-roundtrip-1.json
+++ b/bats/summarized-tool-responses/compose-roundtrip-1.json
@@ -119,6 +119,7 @@
         "invocation_id": "<uuid>",
         "kind": "lines",
         "raw_size_bytes": 13051,
+        "summary_envelope_bytes": 8233,
         "tool_name": "fake_upstream_str-large-table"
       },
       {
@@ -126,6 +127,7 @@
         "invocation_id": "<uuid>",
         "kind": "json_array_slice",
         "raw_size_bytes": 10391,
+        "summary_envelope_bytes": 8566,
         "tool_name": "fake_upstream_arr-large-passthrough-items"
       }
     ]
@@ -133,7 +135,8 @@
   "result": {
     "console": [],
     "execution_time_ms": "<ms>",
-    "fetch_hint": "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated `<summary>+<recovery>` envelope you'd have seen calling that tool directly.",
+    "fetch_hint": "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated `<summary>+<recovery>` envelope you'd have seen calling that tool directly. Compose includes `normal_fetch_limit_bytes`, and each sub_invocation includes `summary_envelope_bytes`, so you can size summary fetches before calling them.",
+    "normal_fetch_limit_bytes": 16384,
     "result": {
       "arr": [
         {
@@ -1729,6 +1732,7 @@
         "invocation_id": "<uuid>",
         "kind": "lines",
         "raw_size_bytes": 13051,
+        "summary_envelope_bytes": 8233,
         "tool_name": "fake_upstream_str-large-table"
       },
       {
@@ -1736,6 +1740,7 @@
         "invocation_id": "<uuid>",
         "kind": "json_array_slice",
         "raw_size_bytes": 10391,
+        "summary_envelope_bytes": 8566,
         "tool_name": "fake_upstream_arr-large-passthrough-items"
       }
     ],

--- a/bats/summarized-tool-responses/compose-roundtrip-2.json
+++ b/bats/summarized-tool-responses/compose-roundtrip-2.json
@@ -2,7 +2,8 @@
   "result": {
     "console": [],
     "execution_time_ms": "<ms>",
-    "fetch_hint": "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated `<summary>+<recovery>` envelope you'd have seen calling that tool directly.",
+    "fetch_hint": "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated `<summary>+<recovery>` envelope you'd have seen calling that tool directly. Compose includes `normal_fetch_limit_bytes`, and each sub_invocation includes `summary_envelope_bytes`, so you can size summary fetches before calling them.",
+    "normal_fetch_limit_bytes": 16384,
     "result": {
       "arr_slice": [
         {

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -39,7 +39,9 @@ pub enum FetchQuery {
     /// sub-invocation's curated form (JS scripts see verbatim T; the
     /// agent reading `sub_invocations[i].invocation_id` post-hoc can
     /// fetch the summary view here). `path` is ignored — the summary
-    /// is always the root view.
+    /// is always the root view. Summary recovery bypasses the normal
+    /// fetch response cap; callers that advertise summary recovery
+    /// should expose the envelope size before this fetch is attempted.
     Summary,
 }
 
@@ -162,7 +164,7 @@ impl StoredInvocation {
             return Err(ToolCachingError::FetchResponseTooLarge {
                 size: text.len(),
                 max: max_bytes,
-                hint: self.too_large_hint(path),
+                hint: self.too_large_hint(path, max_bytes),
             });
         }
         Ok(FetchResult {
@@ -172,22 +174,10 @@ impl StoredInvocation {
     }
 
     /// Replay the curated `<summary>+<recovery>` envelope from the
-    /// persisted `ToolCallSummary`. Output is byte-identical to what
-    /// `cache()` originally returned — both share
-    /// `ToolCallSummary::build_wire`.
-    fn summary_view(&self, max_bytes: usize) -> Result<FetchResult, ToolCachingError> {
+    /// persisted `ToolCallSummary`. Summary mode is the recovery escape
+    /// hatch, so it bypasses the normal fetch-size cap.
+    fn summary_view(&self, _max_bytes: usize) -> Result<FetchResult, ToolCachingError> {
         let (result, structured) = self.summary.build_wire(self.id);
-        let envelope_len = match result.content.first().map(|c| &c.raw) {
-            Some(rmcp::model::RawContent::Text(t)) => t.text.len(),
-            _ => 0,
-        };
-        if envelope_len > max_bytes {
-            return Err(ToolCachingError::FetchResponseTooLarge {
-                size: envelope_len,
-                max: max_bytes,
-                hint: String::new(),
-            });
-        }
         Ok(FetchResult { result, structured })
     }
 
@@ -195,9 +185,13 @@ impl StoredInvocation {
     /// `mode:'summary'`; on a compose root (`sub_invocations` array at
     /// `$`), names up to three drill-down invocation_ids the agent can
     /// fetch directly instead of re-slicing the aggregate body.
-    fn too_large_hint(&self, path: &str) -> String {
-        let mut parts =
-            vec![". Try `query: {mode: \"summary\"}` for the curated envelope".to_string()];
+    fn too_large_hint(&self, path: &str, max_bytes: usize) -> String {
+        let summary_envelope_bytes = self.summary.build_envelope_text().len();
+        let mut parts = vec![format!(
+            ". Try `query: {{mode: \"summary\"}}` for the curated envelope \
+             (summary_envelope_bytes: {summary_envelope_bytes}, \
+             normal_fetch_limit_bytes: {max_bytes}; summary mode bypasses that cap)"
+        )];
         let touches_result = path == "$" || path == "$.result" || path.starts_with("$.result.");
         if touches_result {
             if let Some(arr) = self
@@ -528,8 +522,42 @@ mod tests {
     #[test]
     fn too_large_hint_always_suggests_summary_mode() {
         let inv = stored(serde_json::json!({"result": "x"}));
-        let hint = inv.too_large_hint("$.result");
+        let hint = inv.too_large_hint("$.result", 64);
         assert!(hint.contains("mode: \"summary\""), "got: {hint}");
+        assert!(hint.contains("summary_envelope_bytes:"), "got: {hint}");
+        assert!(hint.contains("normal_fetch_limit_bytes: 64"), "got: {hint}");
+    }
+
+    #[test]
+    fn summary_query_bypasses_fetch_cap_without_late_annotation() {
+        let mut inv = stored(serde_json::json!("full"));
+        inv.summary = ToolCallSummary {
+            summary: Value::String("x".repeat(200)),
+            wire_result: Value::String("<summary>".into()),
+            elided_paths: Vec::new(),
+            root_path: "$".to_string(),
+            total_bytes: 200,
+            shown_bytes: 200,
+            total_items: None,
+            shown_items: None,
+            total_lines: None,
+            shown_lines: None,
+        };
+
+        let fetched = inv
+            .query("$", Some(&FetchQuery::Summary), 64)
+            .expect("summary mode bypasses the normal fetch cap");
+        let text = match fetched.result.content.first().map(|c| &c.raw) {
+            Some(rmcp::model::RawContent::Text(t)) => t.text.as_str(),
+            _ => "",
+        };
+        assert!(!text.contains("<summary-fetch"), "got: {text}");
+        assert!(fetched.structured.get("_fetch").is_none());
+        assert_eq!(
+            fetched.result.structured_content.as_ref(),
+            Some(&fetched.structured),
+            "FetchResult result.structured_content must stay in sync with structured"
+        );
     }
 
     #[test]
@@ -541,7 +569,7 @@ mod tests {
                 {"invocation_id": "bbb", "tool_name": "honeycomb_query"},
             ],
         }));
-        let hint = inv.too_large_hint("$.result");
+        let hint = inv.too_large_hint("$.result", 1024);
         assert!(hint.contains("github_list_prs=aaa"), "got: {hint}");
         assert!(hint.contains("honeycomb_query=bbb"), "got: {hint}");
     }
@@ -558,7 +586,7 @@ mod tests {
                 {"invocation_id": "i4", "tool_name": "t4"},
             ],
         }));
-        let hint = inv.too_large_hint("$.result");
+        let hint = inv.too_large_hint("$.result", 1024);
         assert!(hint.contains("t0=i0"), "got: {hint}");
         assert!(hint.contains("t2=i2"), "got: {hint}");
         assert!(!hint.contains("t3=i3"), "should cap at 3; got: {hint}");
@@ -573,7 +601,7 @@ mod tests {
                 {"invocation_id": "aaa", "tool_name": "github_list_prs"},
             ],
         }));
-        let hint = inv.too_large_hint("$.sub_invocations");
+        let hint = inv.too_large_hint("$.sub_invocations", 1024);
         assert!(!hint.contains("github_list_prs"), "got: {hint}");
         assert!(hint.contains("mode: \"summary\""), "got: {hint}");
     }

--- a/core/crates/tool-caching/src/lib.rs
+++ b/core/crates/tool-caching/src/lib.rs
@@ -12,8 +12,8 @@ pub use config::ToolCachingConfig;
 pub use error::ToolCachingError;
 pub use fetch::{FetchQuery, FetchResult};
 pub use primitives::{
-    ElidedPath, QueryStructure, ToolCacheResponse, ToolCallOwnerId, ToolCallSummary,
-    ToolInvocationId,
+    ElidedPath, QueryStructure, SummaryFetchInfo, ToolCacheResponse, ToolCallOwnerId,
+    ToolCallSummary, ToolInvocationId,
 };
 pub use repo::StoredInvocation;
 pub use string_summarizer::StringSummarizerChain;
@@ -102,15 +102,18 @@ impl ToolCaching {
                 result: passthrough,
                 elided_paths: Vec::new(),
                 invocation_id: None,
+                summary_fetch_info: None,
             });
         }
 
         let elided_paths = processed.summary.elided_paths.clone();
+        let summary_fetch_info = self.summary_fetch_info(&processed.summary);
         let wrapped = build_elide_ctr(processed.summary, processed.invocation_id);
         Ok(ToolCacheResponse {
             result: wrapped,
             elided_paths,
             invocation_id: Some(processed.invocation_id),
+            summary_fetch_info: Some(summary_fetch_info),
         })
     }
 
@@ -152,13 +155,16 @@ impl ToolCaching {
                 result: wrapped,
                 elided_paths: Vec::new(),
                 invocation_id: None,
+                summary_fetch_info: None,
             });
         }
 
+        let summary_fetch_info = self.summary_fetch_info(&processed.summary);
         Ok(ToolCacheResponse {
             result: wrapped,
             elided_paths: processed.summary.elided_paths,
             invocation_id: Some(processed.invocation_id),
+            summary_fetch_info: Some(summary_fetch_info),
         })
     }
 
@@ -177,6 +183,19 @@ impl ToolCaching {
     ) -> Result<FetchResult, ToolCachingError> {
         let stored = self.repo.find_by_id(id, owner_id).await?;
         stored.query(path, query, self.config.max_fetch_response_bytes)
+    }
+
+    pub fn max_fetch_response_bytes(&self) -> u64 {
+        self.config.max_fetch_response_bytes as u64
+    }
+
+    fn summary_fetch_info(&self, summary: &ToolCallSummary) -> SummaryFetchInfo {
+        let summary_envelope_bytes = summary.build_envelope_text().len() as u64;
+        let normal_fetch_limit_bytes = self.max_fetch_response_bytes();
+        SummaryFetchInfo {
+            summary_envelope_bytes,
+            normal_fetch_limit_bytes,
+        }
     }
 
     /// Shared walk + persist. Both public entry points feed into this:
@@ -250,6 +269,7 @@ fn passthrough_no_owner(result: CallToolResult) -> ToolCacheResponse {
         result,
         elided_paths: Vec::new(),
         invocation_id: None,
+        summary_fetch_info: None,
     }
 }
 

--- a/core/crates/tool-caching/src/primitives.rs
+++ b/core/crates/tool-caching/src/primitives.rs
@@ -195,6 +195,12 @@ pub struct RecoveryManifest {
     pub sub_invocations: Vec<Value>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SummaryFetchInfo {
+    pub summary_envelope_bytes: u64,
+    pub normal_fetch_limit_bytes: u64,
+}
+
 impl ElidedPath {
     pub(crate) fn render(&self) -> String {
         let mut attrs = format!(
@@ -207,8 +213,14 @@ impl ElidedPath {
         if let (Some(total), Some(shown)) = (self.total_items, self.shown_items) {
             attrs.push_str(&format!(" total-items=\"{total}\" shown-items=\"{shown}\""));
         }
+        let note = self
+            .recover
+            .get("note")
+            .and_then(Value::as_str)
+            .map(|note| format!("    note: {note}\n"))
+            .unwrap_or_default();
         format!(
-            "{attrs}>\n    {}\n  </elided>\n",
+            "{attrs}>\n{note}    {}\n  </elided>\n",
             render_recover_call(&self.recover),
         )
     }
@@ -258,4 +270,5 @@ pub struct ToolCacheResponse {
     pub result: CallToolResult,
     pub elided_paths: Vec<ElidedPath>,
     pub invocation_id: Option<ToolInvocationId>,
+    pub summary_fetch_info: Option<SummaryFetchInfo>,
 }

--- a/core/crates/tool-caching/src/walker.rs
+++ b/core/crates/tool-caching/src/walker.rs
@@ -421,7 +421,7 @@ impl Walker {
         let recover = if slice_fits_fetch_cap {
             make_array_slice_recover(invocation_id, path, head_count, missing_len)
         } else {
-            make_summary_recover(invocation_id)
+            make_summary_recover(invocation_id, path)
         };
         elided_paths.push(ElidedPath {
             path: path.to_string(),
@@ -781,14 +781,17 @@ fn make_array_slice_recover(
     })
 }
 
-/// Bounded-by-construction fallback recover for elisions whose direct
-/// slice would exceed `max_fetch_response_bytes`. Returns the persisted
-/// `<summary>+<recovery>` envelope (capped by `sentinel_budget`), from
-/// which the agent reads per-index `<elided>` pointers and drills down
-/// individually.
-fn make_summary_recover(invocation_id: ToolInvocationId) -> Value {
+/// Aggregate fallback marker for elisions whose direct slice would
+/// exceed `max_fetch_response_bytes`. This is intentionally not
+/// path-scoped: `mode:"summary"` replays the invocation's root summary
+/// so callers that only have the structured manifest can inspect the
+/// narrower `<elided>` pointers and drill down individually.
+fn make_summary_recover(invocation_id: ToolInvocationId, scope_path: &str) -> Value {
     serde_json::json!({
         "tool": "tool_output_fetch",
+        "kind": "aggregate_summary",
+        "scope_path": scope_path,
+        "note": "Direct recovery for this aggregate would exceed the fetch response cap; use the narrower recovery paths listed in this envelope. Summary mode only replays this overview.",
         "args_template": {
             "invocation_id": invocation_id.to_string(),
             "query": { "mode": "summary" },
@@ -869,6 +872,20 @@ mod tests {
             mode, "summary",
             "fat tail should switch aggregate recover to summary mode; got {mode}"
         );
+        assert_eq!(
+            agg.recover.get("kind").and_then(Value::as_str),
+            Some("aggregate_summary")
+        );
+        assert_eq!(
+            agg.recover.get("scope_path").and_then(Value::as_str),
+            Some("$")
+        );
+        assert!(agg
+            .recover
+            .get("note")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .contains("narrower recovery paths"));
     }
 
     /// When the tail slice does fit the fetch cap, existing slice-mode
@@ -907,6 +924,14 @@ mod tests {
             .and_then(Value::as_str)
             .expect("recover has query.mode");
         assert_eq!(mode, "json_array_slice");
+        assert_eq!(
+            agg.recover
+                .get("args_template")
+                .and_then(|t| t.get("path"))
+                .and_then(Value::as_str),
+            Some("$"),
+            "path-scoped array slice recoveries advertise the elided path"
+        );
     }
 
     fn walker_for_line_split() -> Walker {

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -62,6 +62,8 @@ struct ComposeOutput {
     /// of source order. The drill-down nudge reaches the agent through `fetch_hint`.
     sub_invocations: Vec<SubInvocation>,
     fetch_hint: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    normal_fetch_limit_bytes: Option<u64>,
     tool_calls: usize,
     execution_time_ms: u64,
     console: Vec<String>,
@@ -71,7 +73,8 @@ struct ComposeOutput {
     /// `path: "$.result"` (compose opts out of the `DruaToolResult`
     /// wrap, so there's no outer `result` key — the persisted root IS
     /// `ComposeOutput`) or `query: {mode: "summary"}` for the full
-    /// envelope.
+    /// envelope, which bypasses the normal fetch cap. Per-subcall
+    /// `summary_envelope_bytes` exposes the size before fetching.
     #[schemars(schema_with = "crate::toolset::any_json_schema")]
     result: serde_json::Value,
 }
@@ -179,10 +182,16 @@ impl TopLevelTool for ComposeTool {
         // Compose opts out of the `DruaToolResult` wrap, so the
         // persisted root IS `ComposeOutput`: agents recover via
         // `path: "$.result"` (not `$.result.result`) or
-        // `query: {mode: "summary"}` for the full curated envelope.
+        // `query: {mode: "summary"}` for the full curated envelope,
+        // which bypasses the normal fetch cap. The sub-invocation
+        // metadata exposes summary size before the agent fetches it.
         let out = ComposeOutput {
             sub_invocations: collected_sub_invocations,
             fetch_hint: COMPOSE_FETCH_HINT.to_string(),
+            normal_fetch_limit_bytes: self
+                .tool_caching
+                .as_ref()
+                .map(|tc| tc.max_fetch_response_bytes()),
             tool_calls: result.tool_calls_made,
             execution_time_ms: result.execution_time.as_millis() as u64,
             console: result.console_output.clone(),
@@ -212,7 +221,9 @@ impl TopLevelTool for ComposeTool {
 const COMPOSE_FETCH_HINT: &str =
     "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a \
      sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated \
-     `<summary>+<recovery>` envelope you'd have seen calling that tool directly.";
+     `<summary>+<recovery>` envelope you'd have seen calling that tool directly. \
+     Compose includes `normal_fetch_limit_bytes`, and each sub_invocation includes \
+     `summary_envelope_bytes`, so you can size summary fetches before calling them.";
 
 /// Recovery metadata for one sub-tool dispatch inside a compose script.
 /// Array order is completion order (0-based).
@@ -228,6 +239,9 @@ pub struct SubInvocation {
     /// would naturally slice this sub-call's output.
     pub kind: String,
     pub raw_size_bytes: u64,
+    /// Size of `tool_output_fetch(query:{mode:"summary"})` for this
+    /// sub-call's curated `<summary>+<recovery>` envelope.
+    pub summary_envelope_bytes: u64,
 }
 
 struct CatalogDispatcher {
@@ -426,6 +440,9 @@ impl CatalogDispatcherShared {
         let Some(invocation_id) = resp.invocation_id else {
             return;
         };
+        let Some(summary_fetch_info) = resp.summary_fetch_info else {
+            return;
+        };
         let kind = sub_invocation_kind(&resp.elided_paths);
         if let Ok(mut guard) = self.sub_invocations.lock() {
             guard.push(SubInvocation {
@@ -434,6 +451,7 @@ impl CatalogDispatcherShared {
                 invocation_id: uuid::Uuid::from(invocation_id),
                 kind,
                 raw_size_bytes: raw_size,
+                summary_envelope_bytes: summary_fetch_info.summary_envelope_bytes,
             });
         }
     }

--- a/core/src/toolset/top_level/tool_output_fetch.rs
+++ b/core/src/toolset/top_level/tool_output_fetch.rs
@@ -45,8 +45,11 @@ const DESCRIPTION: &str = "Recover a slice of a previously-summarised tool outpu
     `{mode:\"json_array_slice\", offset, len}` returns item range `arr[offset..offset+len]` of an array at the path; \
     `offset` accepts negatives — `-N` counts from the end (Python/JS slice semantics), \
     so `{mode:\"lines\", offset:-80, len:80}` returns the last 80 lines. Out-of-range offsets clamp. \
-    `{mode:\"summary\"}` replays the original curated `<summary>+<recovery>` envelope (ignores `path`). \
-    The response is the resolved (and optionally sliced) value, wrapped back at `path`.";
+    `{mode:\"summary\"}` returns the curated `<summary>+<recovery>` envelope (ignores `path`), \
+    bypassing the normal fetch response cap; compose advertises `normal_fetch_limit_bytes` \
+    and each sub_invocation's `summary_envelope_bytes` before you fetch. \
+    The response is the resolved (and optionally sliced) value, wrapped back at `path`; \
+    `structuredContent` carries the same dynamic value for clients that consume structured output.";
 
 #[derive(serde::Deserialize, schemars::JsonSchema)]
 struct ToolOutputFetchArgs {
@@ -78,6 +81,13 @@ impl TopLevelTool for ToolOutputFetch {
     fn input_schema(&self) -> &serde_json::Value {
         &SCHEMA
     }
+    fn inner_output_schema(&self) -> Option<&serde_json::Value> {
+        // Intentionally dynamic: recovery can return any JSON shape
+        // depending on `path` and `query`, while MCP outputSchema must be
+        // a single root object schema. The result still populates
+        // structuredContent for clients that consume recovered JSON.
+        None
+    }
     fn default_tool_caching(&self) -> bool {
         // Recovery is the *output* of caching — re-caching it would loop.
         false
@@ -103,6 +113,8 @@ impl TopLevelTool for ToolOutputFetch {
             .tool_caching
             .fetch(owner_id, invocation_id, &args.path, args.query.as_ref())
             .await?;
-        Ok(fetched.result)
+        let mut result = fetched.result;
+        result.structured_content = Some(fetched.structured);
+        Ok(result)
     }
 }


### PR DESCRIPTION
## Summary

- Let tool_output_fetch summary recovery bypass the normal fetch response cap, with text and structured annotations for the summary envelope size.
- Mark oversized array-tail summary fallbacks as aggregate recovery overviews while keeping path-scoped json_array_slice templates on the exact elided path when they fit.
- Populate tool_output_fetch structuredContent from the fetched structured value and update compose/tool docs for the revised recovery behavior.

## Test plan

- [x] cargo fmt
- [x] cargo test -p drua-tool-caching
- [x] cargo test -p drua-core toolset::top_level::compose

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tool-output recovery semantics and compose metadata, so regressions could affect how large tool results are recovered and displayed, but changes are localized and covered by new tests.
> 
> **Overview**
> **Summary recovery is now reliable for oversized outputs.** `tool_output_fetch` with `query:{mode:"summary"}` no longer enforces the normal fetch-size cap, and it always returns the recovered JSON in `structuredContent`.
> 
> **Recovery metadata is expanded to help clients avoid failed fetches.** Fetch-too-large hints now include `summary_envelope_bytes` and `normal_fetch_limit_bytes`, `compose` responses include `normal_fetch_limit_bytes`, and each persisted sub-invocation reports `summary_envelope_bytes`.
> 
> **Oversized array-tail recovery is clarified.** When a tail slice would exceed the fetch cap, array truncation recovery switches to an `aggregate_summary` marker (with `note`/`scope_path`) pointing at summary-mode drill-down, and the rendered `<elided>` block includes this note; golden fixtures and tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0520cc774b00b6b6255e30e28695dd7b9bc95f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->