### PR TITLE
fix(mcp): recover multipart content and clean catalog output

### DIFF
--- a/bats/summarized-tool-responses/compose-roundtrip-1.json
+++ b/bats/summarized-tool-responses/compose-roundtrip-1.json
@@ -118,7 +118,7 @@
         "args_digest": "fake_upstream_str-large-table({})",
         "invocation_id": "<uuid>",
         "kind": "lines",
-        "raw_size_bytes": 13051,
+        "raw_size_bytes": 13093,
         "summary_envelope_bytes": 8233,
         "tool_name": "fake_upstream_str-large-table"
       },
@@ -1731,7 +1731,7 @@
         "args_digest": "fake_upstream_str-large-table({})",
         "invocation_id": "<uuid>",
         "kind": "lines",
-        "raw_size_bytes": 13051,
+        "raw_size_bytes": 13093,
         "summary_envelope_bytes": 8233,
         "tool_name": "fake_upstream_str-large-table"
       },

--- a/core/crates/tool-caching/src/lib.rs
+++ b/core/crates/tool-caching/src/lib.rs
@@ -84,7 +84,7 @@ impl ToolCaching {
         let Some(owner_id) = owner.into() else {
             return Ok(passthrough_no_owner(result));
         };
-        if result.is_error == Some(true) || !is_simple_text_result(&result) {
+        if result.is_error == Some(true) {
             return Ok(passthrough_no_owner(result));
         }
 
@@ -139,7 +139,7 @@ impl ToolCaching {
         let Some(owner_id) = owner.into() else {
             return Ok(passthrough_no_owner(result));
         };
-        if result.is_error == Some(true) || !is_simple_text_result(&result) {
+        if result.is_error == Some(true) {
             return Ok(passthrough_no_owner(result));
         }
 
@@ -211,25 +211,25 @@ impl ToolCaching {
         result: &CallToolResult,
     ) -> Result<Processed, ToolCachingError> {
         let original_structured = result.structured_content.clone();
-        let original_text = extract_text(result);
+        let upstream_t = tool_result_value(result);
+        let original_text = if is_simple_text_result(result) {
+            extract_text(result)
+        } else {
+            serde_json::to_string_pretty(&upstream_t).unwrap_or_else(|_| extract_text(result))
+        };
 
         // Walk the upstream's structured channel when present — that's
         // the canonical `T` whose shape MCP clients validate against the
-        // advertised outputSchema. Fall back to parsed-text Value for
-        // text-only tools (bash, k8s logs, etc.).
+        // advertised outputSchema. Fall back to a normalized content value
+        // for MCP content-only tools, including multi-part text/resource
+        // responses.
         let query_structure = QueryStructure {
-            root: original_structured
-                .clone()
-                .unwrap_or_else(|| QueryStructure::new(&original_text).root),
+            root: upstream_t.clone(),
         };
         let invocation_id = ToolInvocationId::new();
         let summary = self
             .walker
             .summarize(&query_structure, invocation_id, tool_name);
-
-        let upstream_t = original_structured
-            .clone()
-            .unwrap_or_else(|| query_structure.root.clone());
 
         if summary.elided_paths.is_empty() {
             return Ok(Processed {
@@ -292,6 +292,81 @@ pub fn extract_text(result: &CallToolResult) -> String {
         .join("\n")
 }
 
+/// Canonical JSON view of a tool result used by the recovery walker and
+/// compose. Prefer upstream structured content when present; otherwise parse a
+/// single text block as before, or preserve multi-part MCP content as an
+/// inspectable JSON object.
+pub fn tool_result_value(result: &CallToolResult) -> Value {
+    if let Some(structured) = &result.structured_content {
+        return structured.clone();
+    }
+    if is_simple_text_result(result) {
+        return QueryStructure::new(&extract_text(result)).root;
+    }
+    Value::Object(
+        [(
+            "content".to_string(),
+            Value::Array(result.content.iter().map(content_to_value).collect()),
+        )]
+        .into_iter()
+        .collect(),
+    )
+}
+
+fn content_to_value(content: &Content) -> Value {
+    let mut value = serde_json::to_value(content).unwrap_or(Value::Null);
+    match &content.raw {
+        RawContent::Image(image) => {
+            replace_key(
+                &mut value,
+                "data",
+                Value::String(format!("<base64 image elided; {} bytes>", image.data.len())),
+            );
+        }
+        RawContent::Audio(audio) => {
+            replace_key(
+                &mut value,
+                "data",
+                Value::String(format!("<base64 audio elided; {} bytes>", audio.data.len())),
+            );
+        }
+        RawContent::Resource(resource) => {
+            if let rmcp::model::ResourceContents::BlobResourceContents { blob, .. } =
+                &resource.resource
+            {
+                replace_key(
+                    &mut value,
+                    "blob",
+                    Value::String(format!(
+                        "<base64 resource blob elided; {} bytes>",
+                        blob.len()
+                    )),
+                );
+            }
+        }
+        RawContent::Text(_) | RawContent::ResourceLink(_) => {}
+    }
+    value
+}
+
+fn replace_key(value: &mut Value, key: &str, replacement: Value) -> bool {
+    match value {
+        Value::Object(map) => {
+            if map.contains_key(key) {
+                map.insert(key.to_string(), replacement);
+                true
+            } else {
+                map.values_mut()
+                    .any(|child| replace_key(child, key, replacement.clone()))
+            }
+        }
+        Value::Array(items) => items
+            .iter_mut()
+            .any(|child| replace_key(child, key, replacement.clone())),
+        _ => false,
+    }
+}
+
 fn is_simple_text_result(result: &CallToolResult) -> bool {
     result.content.len() == 1 && matches!(result.content[0].raw, RawContent::Text(_))
 }
@@ -304,9 +379,8 @@ fn is_simple_text_result(result: &CallToolResult) -> bool {
 /// something, replaced in place by the `<summary>+<recovery>` envelope.
 ///
 /// Strictly `is_empty()`, not "no text content present": multi-part
-/// results (e.g. images alongside structured data) must keep their
-/// non-text parts intact and fall through to the
-/// `!is_simple_text_result` passthrough below.
+/// results keep their original content channel while the cache walker
+/// operates on `tool_result_value`.
 fn ensure_text_channel(mut result: CallToolResult) -> CallToolResult {
     if !result.content.is_empty() {
         return result;
@@ -317,4 +391,53 @@ fn ensure_text_channel(mut result: CallToolResult) -> CallToolResult {
     let text = serde_json::to_string_pretty(structured).unwrap_or_default();
     result.content = vec![Content::text(text)];
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tool_result_value_preserves_embedded_text_resources() {
+        let result = CallToolResult::success(vec![
+            Content::text("downloaded"),
+            Content::resource(rmcp::model::ResourceContents::text(
+                "file-body",
+                "repo://owner/repo/file.txt",
+            )),
+        ]);
+
+        let value = tool_result_value(&result);
+
+        assert_eq!(value["content"][0]["type"], "text");
+        assert_eq!(value["content"][0]["text"], "downloaded");
+        assert_eq!(value["content"][1]["type"], "resource");
+        assert_eq!(
+            value["content"][1]["resource"]["uri"],
+            "repo://owner/repo/file.txt"
+        );
+        assert_eq!(value["content"][1]["resource"]["text"], "file-body");
+    }
+
+    #[test]
+    fn tool_result_value_omits_binary_payloads() {
+        let result = CallToolResult::success(vec![
+            Content::image("abcdefgh", "image/png"),
+            Content::resource(rmcp::model::ResourceContents::blob(
+                "0123456789",
+                "repo://owner/repo/image.png",
+            )),
+        ]);
+
+        let value = tool_result_value(&result);
+
+        assert_eq!(
+            value["content"][0]["data"],
+            "<base64 image elided; 8 bytes>"
+        );
+        assert_eq!(
+            value["content"][1]["resource"]["blob"],
+            "<base64 resource blob elided; 10 bytes>"
+        );
+    }
 }

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -568,14 +568,9 @@ impl ToolSets {
 
 /// Estimate tokens from text content (~4 chars per token).
 pub fn estimate_tokens(result: &CallToolResult) -> u64 {
-    let total_chars: usize = result
-        .content
-        .iter()
-        .map(|c| match &c.raw {
-            rmcp::model::RawContent::Text(t) => t.text.len(),
-            _ => 0,
-        })
-        .sum();
+    let total_chars = drua_tool_caching::tool_result_value(result)
+        .to_string()
+        .len();
     (total_chars / 4).max(1) as u64
 }
 

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -541,10 +541,8 @@ fn brief_description(s: &str) -> String {
         .split_whitespace()
         .collect::<Vec<_>>()
         .join(" ");
-    if compact.chars().count() <= MAX_BRIEF_DESCRIPTION_CHARS {
-        return compact;
-    }
-    if compact.chars().count() <= MAX_BRIEF_DESCRIPTION_CHARS + 3 {
+    let compact_chars = compact.chars().count();
+    if compact_chars <= MAX_BRIEF_DESCRIPTION_CHARS + 3 {
         return compact;
     }
 

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -515,7 +515,7 @@ fn visible_entries(
             let brief = desc
                 .description
                 .as_ref()
-                .map(|d| first_sentence(d))
+                .map(|d| brief_description(d))
                 .unwrap_or_default();
             out.push(CatalogEntry {
                 prefixed_name: format!("{}_{}", set.prefix(), desc.name),
@@ -530,11 +530,38 @@ fn visible_entries(
     out
 }
 
-fn first_sentence(s: &str) -> String {
-    s.split_once(". ")
-        .or_else(|| s.split_once(".\n"))
-        .map(|(first, _)| format!("{first}."))
-        .unwrap_or_else(|| s.to_string())
+const MAX_BRIEF_DESCRIPTION_CHARS: usize = 220;
+
+fn brief_description(s: &str) -> String {
+    let first_paragraph = s
+        .split("\n\n")
+        .find(|part| !part.trim().is_empty())
+        .unwrap_or(s);
+    let compact = first_paragraph
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ");
+    if compact.chars().count() <= MAX_BRIEF_DESCRIPTION_CHARS {
+        return compact;
+    }
+
+    let mut end = 0;
+    for (idx, _) in compact.char_indices() {
+        if compact[..idx].chars().count() > MAX_BRIEF_DESCRIPTION_CHARS {
+            break;
+        }
+        if compact[..idx].ends_with(' ') {
+            end = idx;
+        }
+    }
+    if end == 0 {
+        end = compact
+            .char_indices()
+            .nth(MAX_BRIEF_DESCRIPTION_CHARS)
+            .map(|(idx, _)| idx)
+            .unwrap_or(compact.len());
+    }
+    format!("{}...", compact[..end].trim_end())
 }
 
 #[cfg(test)]
@@ -750,6 +777,28 @@ mod tests {
             formatted.contains("id: string"),
             "missing return field in:\n{formatted}"
         );
+    }
+
+    #[test]
+    fn brief_description_preserves_abbreviations() {
+        let brief = brief_description(
+            "Search indexed codebases for code patterns matching a query, e.g. pass `fn main` for Rust functions.\n\nUsage tips:\n- Prefer concrete snippets.",
+        );
+
+        assert_eq!(
+            brief,
+            "Search indexed codebases for code patterns matching a query, e.g. pass `fn main` for Rust functions."
+        );
+    }
+
+    #[test]
+    fn brief_description_compacts_and_truncates_on_word_boundary() {
+        let long = format!("{}tail", "alpha ".repeat(60));
+        let brief = brief_description(&long);
+
+        assert!(brief.ends_with("..."), "{brief}");
+        assert!(brief.chars().count() <= MAX_BRIEF_DESCRIPTION_CHARS + 3);
+        assert!(!brief.contains("tail"));
     }
 
     #[test]

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -544,6 +544,9 @@ fn brief_description(s: &str) -> String {
     if compact.chars().count() <= MAX_BRIEF_DESCRIPTION_CHARS {
         return compact;
     }
+    if compact.chars().count() <= MAX_BRIEF_DESCRIPTION_CHARS + 3 {
+        return compact;
+    }
 
     let mut end = 0;
     for (idx, _) in compact.char_indices() {
@@ -799,6 +802,14 @@ mod tests {
         assert!(brief.ends_with("..."), "{brief}");
         assert!(brief.chars().count() <= MAX_BRIEF_DESCRIPTION_CHARS + 3);
         assert!(!brief.contains("tail"));
+    }
+
+    #[test]
+    fn brief_description_does_not_truncate_to_longer_output() {
+        let input = "x".repeat(MAX_BRIEF_DESCRIPTION_CHARS + 1);
+        let brief = brief_description(&input);
+
+        assert_eq!(brief, input);
     }
 
     #[test]

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::{Arc, LazyLock, Mutex, RwLock};
 use std::time::Duration;
 
-use drua_tool_caching::{extract_text, ToolCaching};
+use drua_tool_caching::{extract_text, tool_result_value, ToolCaching};
 use es_entity::context::{EventContext, WithEventContext};
 use rmcp::model::{CallToolResult, JsonObject};
 use serde::Deserialize;
@@ -427,7 +427,9 @@ impl CatalogDispatcherShared {
         let Some(tc) = self.tool_caching.as_ref() else {
             return;
         };
-        let raw_size = extract_text(raw).len() as u64;
+        let raw_size = serde_json::to_vec(&tool_result_value(raw))
+            .map(|bytes| bytes.len() as u64)
+            .unwrap_or_else(|_| extract_text(raw).len() as u64);
         let Ok(resp) = tc
             .persist_for_compose(&self.subject, tool_name, args, raw.clone())
             .await
@@ -557,19 +559,10 @@ async fn run_top_level_call(
 }
 
 /// JS-engine view of a sub-call's result. Returns the upstream's actual
-/// shape: a record from `structured_content` when set, otherwise the
-/// upstream's text content parsed as JSON (or as a bare `Value::String` if
-/// the text isn't JSON). No `{value|items, _shape}` envelope ever leaks
-/// into JS.
+/// structured shape when present, otherwise the same canonical content value
+/// used by tool caching. No `{value|items, _shape}` envelope ever leaks into JS.
 fn result_to_value(result: &CallToolResult) -> serde_json::Value {
-    if let Some(structured) = &result.structured_content {
-        return structured.clone();
-    }
-    let text = extract_text(result);
-    match serde_json::from_str::<serde_json::Value>(&text) {
-        Ok(v) => v,
-        Err(_) => serde_json::Value::String(text),
-    }
+    tool_result_value(result)
 }
 
 fn format_tool_error(tool_name: &str, result: &CallToolResult) -> String {

--- a/lib/json-schema-ts/src/lib.rs
+++ b/lib/json-schema-ts/src/lib.rs
@@ -32,7 +32,7 @@ pub fn schema_to_ts(schema: &Value) -> String {
 pub fn schema_to_ts_params(schema: &Value) -> String {
     let defs = extract_defs(schema);
     let mut ctx = Ctx::new(defs);
-    emit_object_body(schema, &mut ctx).unwrap_or_else(|| "...args: any".to_string())
+    emit_object_body(schema, &mut ctx).unwrap_or_else(|| "[key: string]: any".to_string())
 }
 
 struct Ctx<'a> {
@@ -234,7 +234,7 @@ fn emit_array(obj: &serde_json::Map<String, Value>, ctx: &mut Ctx<'_>) -> String
             let inner = emit(item, ctx);
             ctx.depth -= 1;
             // Wrap unions/intersections to keep precedence right: `(a | b)[]`.
-            let needs_paren = inner.contains(' ') && !inner.starts_with('{');
+            let needs_paren = inner.contains('|') || inner.contains('&');
             if needs_paren {
                 format!("({inner})[]")
             } else {
@@ -489,6 +489,28 @@ mod tests {
     }
 
     #[test]
+    fn array_of_object_unions_gets_parens() {
+        let s = json!({
+            "type": "array",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "properties": {"type": {"const": "scratch"}},
+                        "required": ["type"]
+                    },
+                    {
+                        "type": "object",
+                        "properties": {"type": {"const": "repo"}},
+                        "required": ["type"]
+                    }
+                ]
+            }
+        });
+        assert_eq!(ts(s), "({ type: \"scratch\" } | { type: \"repo\" })[]");
+    }
+
+    #[test]
     fn optional_field() {
         let s = json!({
             "type": "object",
@@ -693,7 +715,7 @@ mod tests {
 
     #[test]
     fn schema_to_ts_params_no_properties_fallback() {
-        assert_eq!(schema_to_ts_params(&json!({})), "...args: any");
+        assert_eq!(schema_to_ts_params(&json!({})), "[key: string]: any");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- normalize multipart MCP content before tool-caching and compose so embedded text resources are recoverable
- emit valid compose TypeScript declarations for empty/unknown params and arrays of union types
- preserve catalog description previews without splitting on abbreviations like e.g.

## Tests
- cargo test -p drua-tool-caching tool_result_value
- cargo test -p json-schema-ts
- cargo test -p drua-core brief_description
- cargo check -p drua-core

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches tool result normalization used by caching, token estimation, and `compose`, which can affect recoverability and sizing across many tools; changes are contained and covered by focused tests.
> 
> **Overview**
> Fixes recovery for **multi-part MCP tool results** by introducing a canonical `tool_result_value()` JSON view (preserving text/resources while eliding binary payloads) and using it for tool-caching walks, `compose` JS values, sub-invocation sizing, and token estimation.
> 
> Improves **tool catalog output** by generating brief descriptions from the first non-empty paragraph, compacting whitespace, and truncating at word boundaries instead of splitting on the first sentence (avoids breaking on abbreviations like `e.g.`).
> 
> Updates **TypeScript generation from JSON Schema** to emit a safer params fallback (`[key: string]: any`) and to parenthesize array item unions/intersections correctly, with new unit tests and an updated compose golden response fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 533d3c41dd7797a782966f3c9feb8e576bdf8f7f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->