### PR TITLE
fix(deploy): add tunnel internal secret

### DIFF
--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -88,6 +88,11 @@ resource "kubernetes_namespace" "sandbox_controller" {
   }
 }
 
+resource "random_password" "tunnel_internal_secret" {
+  length  = 48
+  special = false
+}
+
 resource "kubernetes_secret" "galoy_agents" {
   metadata {
     name      = "galoy-agents"
@@ -112,6 +117,7 @@ resource "kubernetes_secret" "galoy_agents" {
     "openai-api-key"                   = var.openrouter_api_key
     "zenduty-api-token"                = var.zenduty_api_token
     "github-app-private-key"           = local.github_app_private_key
+    "tunnel-internal-secret"           = random_password.tunnel_internal_secret.result
   }
 
   depends_on = [kubernetes_namespace.galoy_agents]


### PR DESCRIPTION
## Summary

- generate a Terraform-managed random password for Drua tunnel internal auth
- add the generated value to the existing `galoy-agents` Kubernetes secret as `tunnel-internal-secret`

## Why

Drua tunnel HA falls back to single-replica mode unless `DRUA_TUNNEL_INTERNAL_SECRET` is populated. The deployment already mounts the `tunnel-internal-secret` key when present, so Terraform should create and manage that secret value.

## Validation

- `git diff --check`
- `tofu fmt -check ci/deploy/drua/main.tf`