### PR TITLE
fix(tunnel): keep websocket connections alive

### DIFF
--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -155,6 +155,8 @@ galoyAgents:
     ingressClassName: nginx
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-issuer
+      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     tls:
       - hosts:
           - dashboard.agents.galoy.io

--- a/server/src/tunnel.rs
+++ b/server/src/tunnel.rs
@@ -2,7 +2,7 @@
 //! through `auth_middleware`; identity is a `deployment_id` verified
 //! via [`verify_handshake`] against `config.server.tunnel.deployments`.
 
-use std::collections::HashMap;
+use std::{collections::HashMap, time::Duration};
 
 use axum::{
     extract::{
@@ -27,6 +27,7 @@ use crate::AppState;
 
 /// Replay-window for the handshake timestamp, in either direction.
 const HANDSHAKE_MAX_SKEW_MS: i64 = 60_000;
+const TUNNEL_WS_HEARTBEAT_INTERVAL: Duration = Duration::from_secs(30);
 
 /// Decode every config entry to a [`VerifyingKey`] at boot; fail loudly
 /// on any bad entry rather than silently rejecting its handshakes.
@@ -268,6 +269,12 @@ async fn handle_tunnel(mut socket: WebSocket, state: AppState, deployment_id: St
         None => (None, None),
     };
 
+    let mut ws_heartbeat = tokio::time::interval_at(
+        tokio::time::Instant::now() + TUNNEL_WS_HEARTBEAT_INTERVAL,
+        TUNNEL_WS_HEARTBEAT_INTERVAL,
+    );
+    ws_heartbeat.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
     loop {
         let displaced_fut = async {
             match displaced_rx.as_mut() {
@@ -329,6 +336,12 @@ async fn handle_tunnel(mut socket: WebSocket, state: AppState, deployment_id: St
                         }
                     }
                     None => break, // all senders dropped
+                }
+            }
+            _ = ws_heartbeat.tick() => {
+                if socket.send(Message::Ping(Vec::new().into())).await.is_err() {
+                    tracing::error!(deployment_id = %deployment_id, "tunnel heartbeat write error");
+                    break;
                 }
             }
         }


### PR DESCRIPTION
## What changed

- Adds NGINX ingress WebSocket timeout annotations for the production Drua ingress.
- Sends a WebSocket ping from the tunnel server every 30 seconds while a connector is registered.

## Why

After HA tunnel deployment, `galoy-staging` tunnel sessions were being reset around the 60 second idle mark with `Connection reset without closing handshake`. The ingress had no long-lived WebSocket timeout annotations, and the tunnel had no application heartbeat while idle between tool calls.

## Impact

The tunnel connection should remain stable across idle periods and avoid catalog churn from repeated unregister/register cycles. The existing tunnel connector already responds to WebSocket ping frames with pong frames.

## Validation

- `cargo fmt --check`
- `cargo check -p drua-server`
- `cargo test -p drua-server --lib tunnel`
- `git diff --cached --check`
- `helm lint charts/drua` (passes; existing Bitnami legacy image warning only)
