### PR TITLE
[codex] Set drua replicas to 2

### DIFF
--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -22,7 +22,7 @@ galoyAgents:
     repository: us.gcr.io/galoyorg/galoy-agents
     digest: "sha256:69a3157b6ad60c04e5514e1c6fcad69cf234fff2a644b42fc3e1f3df24525fcd"
     tag: edge
-  replicas: 1
+  replicas: 2
   annotations:
   config:
     server:


### PR DESCRIPTION
## Summary

- Set the default Helm replica count for the drua deployment from 1 to 2.
- The rendered Kubernetes Deployment now uses `replicas: 2` via `.Values.galoyAgents.replicas`.

## Validation

- `helm template drua charts/drua --set global.security.allowInsecureImages=true --show-only templates/deployment.yaml`
