### PR TITLE
feat(tui): Miller Columns layout for workflows

### DIFF
--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1560,6 +1560,8 @@ async fn run_event_loop(
     let mut event_stream = EventStream::new();
     let mut persisted_project_id: Option<String> = state.selected_project().map(|p| p.id.clone());
     let mut last_workflow_poll = Instant::now();
+    let mut fetched_def_id: Option<String> = None;
+    let mut fetched_run_id: Option<String> = None;
     loop {
         terminal.draw(|frame| ui::draw(frame, state))?;
 
@@ -1645,6 +1647,8 @@ async fn run_event_loop(
                             handlers::Action::OpenWorkflows => {
                                 state.enter_workflows();
                                 state.workflows.loading = true;
+                                fetched_def_id = None;
+                                fetched_run_id = None;
                                 if let Some(project_id) = state.selected_project().map(|p| p.id.clone()) {
                                     match fetch_workflow_definitions(client, &project_id).await {
                                         Ok(definitions) => state.replace_workflow_definitions(definitions),
@@ -1656,32 +1660,13 @@ async fn run_event_loop(
                             }
                             handlers::Action::RefreshWorkflows => {
                                 state.workflows.loading = true;
+                                fetched_def_id = None;
+                                fetched_run_id = None;
                                 if let Some(project_id) = state.selected_project().map(|p| p.id.clone()) {
                                     match fetch_workflow_definitions(client, &project_id).await {
                                         Ok(definitions) => state.replace_workflow_definitions(definitions),
                                         Err(e) => state.set_workflow_error(format!("Failed to refresh workflows: {e}")),
                                     }
-                                }
-                            }
-                            handlers::Action::FetchWorkflowDefinition { definition_id } => {
-                                state.workflows.loading = true;
-                                match fetch_workflow_definition(client, &definition_id).await {
-                                    Ok(definition) => state.replace_workflow_definition_detail(definition),
-                                    Err(e) => state.set_workflow_error(format!("Failed to load workflow: {e}")),
-                                }
-                            }
-                            handlers::Action::FetchWorkflowRuns { definition_id } => {
-                                state.workflows.loading = true;
-                                match fetch_workflow_runs(client, &definition_id).await {
-                                    Ok(runs) => state.replace_workflow_runs(runs),
-                                    Err(e) => state.set_workflow_error(format!("Failed to load runs: {e}")),
-                                }
-                            }
-                            handlers::Action::FetchWorkflowRun { run_id } => {
-                                state.workflows.loading = true;
-                                match fetch_workflow_run(client, &run_id).await {
-                                    Ok(run) => state.replace_workflow_run_detail(run),
-                                    Err(e) => state.set_workflow_error(format!("Failed to load run: {e}")),
                                 }
                             }
                             handlers::Action::TriggerWorkflow { definition_id, payload } => {
@@ -1694,11 +1679,19 @@ async fn run_event_loop(
                                         if let Some(run) = payload.run {
                                             let run_id = run.id.clone();
                                             state.status_message = Some(format!("Workflow run {run_id} created"));
-                                            state.open_workflow_run_detail(run_id.clone());
+                                            state.workflows.run_cursor = 0;
+                                            state.workflows.focus = crate::tui::state::MillerFocus::Runs;
                                             match fetch_workflow_run(client, &run_id).await {
                                                 Ok(detail) => state.replace_workflow_run_detail(detail),
                                                 Err(_) => state.replace_workflow_run_detail(workflow_run_node_to_detail(run)),
                                             }
+                                            // Re-fetch runs to include the new run
+                                            if let Some(def_id) = state.selected_workflow_definition_id() {
+                                                if let Ok(runs) = fetch_workflow_runs(client, &def_id).await {
+                                                    state.replace_workflow_runs(runs);
+                                                }
+                                            }
+                                            fetched_run_id = None;
                                         } else {
                                             state.status_message = Some("Workflow trigger returned no run".to_string());
                                         }
@@ -1725,6 +1718,47 @@ async fn run_event_loop(
                 let _ = Config::save_last_project(id);
             }
             persisted_project_id = current_project_id;
+        }
+
+        // Reactive auto-fetch: when the selected workflow or run changes, load details.
+        if state.focus == Focus::Workflows {
+            let cur_def = state.selected_workflow_definition_id();
+            if cur_def != fetched_def_id {
+                fetched_def_id = cur_def.clone();
+                if let Some(def_id) = &cur_def {
+                    let (def_result, runs_result) = tokio::join!(
+                        fetch_workflow_definition(client, def_id),
+                        fetch_workflow_runs(client, def_id),
+                    );
+                    match def_result {
+                        Ok(detail) => state.replace_workflow_definition_detail(detail),
+                        Err(e) => {
+                            state.set_workflow_error(format!("Failed to load definition: {e}"))
+                        }
+                    }
+                    match runs_result {
+                        Ok(runs) => state.replace_workflow_runs(runs),
+                        Err(e) => state.set_workflow_error(format!("Failed to load runs: {e}")),
+                    }
+                } else {
+                    state.workflows.selected_definition = None;
+                    state.workflows.runs.clear();
+                }
+                fetched_run_id = None;
+            }
+
+            let cur_run = state.selected_workflow_run_id();
+            if cur_run != fetched_run_id {
+                fetched_run_id = cur_run.clone();
+                if let Some(run_id) = &cur_run {
+                    match fetch_workflow_run(client, run_id).await {
+                        Ok(run) => state.replace_workflow_run_detail(run),
+                        Err(e) => state.set_workflow_error(format!("Failed to load run: {e}")),
+                    }
+                } else {
+                    state.workflows.selected_run = None;
+                }
+            }
         }
 
         if last_workflow_poll.elapsed() >= Duration::from_secs(1) {

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1693,7 +1693,7 @@ async fn run_event_loop(
                                                     state.replace_workflow_runs(runs);
                                                 }
                                             }
-                                            fetched_run_id = None;
+                                            fetched_run_id = Some(run_id);
                                         } else {
                                             state.status_message = Some("Workflow trigger returned no run".to_string());
                                         }

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -611,6 +611,32 @@ impl TaggedEvent {
     }
 }
 
+enum WorkflowEvent {
+    DefinitionsLoaded(Vec<WorkflowDefinitionItem>),
+    DefinitionsError(String),
+    DefDetailAndRuns {
+        def_id: String,
+        definition: Option<WorkflowDefinitionDetail>,
+        runs: Option<Vec<WorkflowRunItem>>,
+        error: Option<String>,
+    },
+    RunDetail {
+        run_id: String,
+        detail: Option<WorkflowRunDetail>,
+        error: Option<String>,
+        is_poll: bool,
+    },
+    TriggerComplete(Box<WorkflowTriggerOutcome>),
+}
+
+struct WorkflowTriggerOutcome {
+    filtered: bool,
+    run_id: Option<String>,
+    run_detail: Option<WorkflowRunDetail>,
+    updated_runs: Option<Vec<WorkflowRunItem>>,
+    error: Option<String>,
+}
+
 fn spawn_chat_stream(
     base_url: String,
     token: String,
@@ -1418,6 +1444,230 @@ fn spawn_threads_fetch(
     });
 }
 
+fn spawn_workflow_definitions_fetch(
+    base_url: String,
+    token: String,
+    project_id: String,
+    tx: mpsc::UnboundedSender<WorkflowEvent>,
+) {
+    tokio::spawn(async move {
+        let client = GraphqlClient::new(&base_url, &token);
+        match fetch_workflow_definitions(&client, &project_id).await {
+            Ok(defs) => {
+                let _ = tx.send(WorkflowEvent::DefinitionsLoaded(defs));
+            }
+            Err(e) => {
+                let _ = tx.send(WorkflowEvent::DefinitionsError(format!(
+                    "Failed to load workflows: {e}"
+                )));
+            }
+        }
+    });
+}
+
+fn spawn_workflow_def_detail_fetch(
+    base_url: String,
+    token: String,
+    def_id: String,
+    tx: mpsc::UnboundedSender<WorkflowEvent>,
+) {
+    tokio::spawn(async move {
+        let client = GraphqlClient::new(&base_url, &token);
+        let (def_result, runs_result) = tokio::join!(
+            fetch_workflow_definition(&client, &def_id),
+            fetch_workflow_runs(&client, &def_id),
+        );
+        let mut error = None;
+        let definition = match def_result {
+            Ok(d) => Some(d),
+            Err(e) => {
+                error = Some(format!("Failed to load definition: {e}"));
+                None
+            }
+        };
+        let runs = match runs_result {
+            Ok(r) => Some(r),
+            Err(e) => {
+                error = Some(format!("Failed to load runs: {e}"));
+                None
+            }
+        };
+        let _ = tx.send(WorkflowEvent::DefDetailAndRuns {
+            def_id,
+            definition,
+            runs,
+            error,
+        });
+    });
+}
+
+fn spawn_workflow_run_fetch(
+    base_url: String,
+    token: String,
+    run_id: String,
+    is_poll: bool,
+    tx: mpsc::UnboundedSender<WorkflowEvent>,
+) {
+    tokio::spawn(async move {
+        let client = GraphqlClient::new(&base_url, &token);
+        let (detail, error) = match fetch_workflow_run(&client, &run_id).await {
+            Ok(d) => (Some(d), None),
+            Err(e) => (None, Some(format!("Failed to load run: {e}"))),
+        };
+        let _ = tx.send(WorkflowEvent::RunDetail {
+            run_id,
+            detail,
+            error,
+            is_poll,
+        });
+    });
+}
+
+fn spawn_workflow_trigger(
+    base_url: String,
+    token: String,
+    definition_id: String,
+    payload: serde_json::Value,
+    tx: mpsc::UnboundedSender<WorkflowEvent>,
+) {
+    tokio::spawn(async move {
+        let client = GraphqlClient::new(&base_url, &token);
+        match trigger_workflow(&client, &definition_id, payload).await {
+            Ok(result) if result.filtered => {
+                let _ = tx.send(WorkflowEvent::TriggerComplete(Box::new(
+                    WorkflowTriggerOutcome {
+                        filtered: true,
+                        run_id: None,
+                        run_detail: None,
+                        updated_runs: None,
+                        error: None,
+                    },
+                )));
+            }
+            Ok(result) => {
+                if let Some(run) = result.run {
+                    let run_id = run.id.clone();
+                    let run_detail = match fetch_workflow_run(&client, &run_id).await {
+                        Ok(detail) => detail,
+                        Err(_) => workflow_run_node_to_detail(run),
+                    };
+                    let updated_runs = fetch_workflow_runs(&client, &definition_id).await.ok();
+                    let _ = tx.send(WorkflowEvent::TriggerComplete(Box::new(
+                        WorkflowTriggerOutcome {
+                            filtered: false,
+                            run_id: Some(run_id),
+                            run_detail: Some(run_detail),
+                            updated_runs,
+                            error: None,
+                        },
+                    )));
+                } else {
+                    let _ = tx.send(WorkflowEvent::TriggerComplete(Box::new(
+                        WorkflowTriggerOutcome {
+                            filtered: false,
+                            run_id: None,
+                            run_detail: None,
+                            updated_runs: None,
+                            error: None,
+                        },
+                    )));
+                }
+            }
+            Err(e) => {
+                let _ = tx.send(WorkflowEvent::TriggerComplete(Box::new(
+                    WorkflowTriggerOutcome {
+                        filtered: false,
+                        run_id: None,
+                        run_detail: None,
+                        updated_runs: None,
+                        error: Some(format!("Trigger failed: {e}")),
+                    },
+                )));
+            }
+        }
+    });
+}
+
+fn handle_workflow_event(
+    state: &mut ScreenState,
+    event: WorkflowEvent,
+    fetched_def_id: &mut Option<String>,
+    fetched_run_id: &mut Option<String>,
+    poll_in_flight: &mut bool,
+) {
+    match event {
+        WorkflowEvent::DefinitionsLoaded(defs) => {
+            state.replace_workflow_definitions(defs);
+        }
+        WorkflowEvent::DefinitionsError(e) => {
+            state.set_workflow_error(e);
+        }
+        WorkflowEvent::DefDetailAndRuns {
+            def_id,
+            definition,
+            runs,
+            error,
+        } => {
+            if fetched_def_id.as_deref() != Some(&def_id) {
+                return;
+            }
+            if let Some(detail) = definition {
+                state.replace_workflow_definition_detail(detail);
+            }
+            if let Some(runs) = runs {
+                state.replace_workflow_runs(runs);
+            }
+            if let Some(e) = error {
+                state.set_workflow_error(e);
+            }
+        }
+        WorkflowEvent::RunDetail {
+            run_id,
+            detail,
+            error,
+            is_poll,
+        } => {
+            if is_poll {
+                *poll_in_flight = false;
+            }
+            if fetched_run_id.as_deref() != Some(&run_id) {
+                return;
+            }
+            if let Some(detail) = detail {
+                state.replace_workflow_run_detail(detail);
+            }
+            if let Some(e) = error {
+                state.set_workflow_error(e);
+            }
+        }
+        WorkflowEvent::TriggerComplete(outcome) => {
+            if let Some(error) = outcome.error {
+                state.set_workflow_error(error);
+                return;
+            }
+            if outcome.filtered {
+                state.status_message =
+                    Some("Trigger condition filtered; no run created".to_string());
+                return;
+            }
+            if let Some(ref run_id) = outcome.run_id {
+                state.status_message = Some(format!("Workflow run {run_id} created"));
+                state.workflows.run_cursor = 0;
+                state.workflows.focus = crate::tui::state::MillerFocus::Runs;
+                if let Some(detail) = outcome.run_detail {
+                    state.replace_workflow_run_detail(detail);
+                }
+                if let Some(runs) = outcome.updated_runs {
+                    state.replace_workflow_runs(runs);
+                }
+                *fetched_run_id = outcome.run_id;
+            } else {
+                state.status_message = Some("Workflow trigger returned no run".to_string());
+            }
+        }
+    }
+}
+
 fn dispatch_stream_event(state: &mut ScreenState, tagged: TaggedEvent) {
     // Drop tagged events whose originating agent no longer matches the
     // user's selection — e.g. in-flight deltas from a chat stream
@@ -1540,9 +1790,11 @@ async fn run_event_loop(
     config: &Config,
 ) -> Result<()> {
     let (stream_tx, mut stream_rx) = mpsc::unbounded_channel::<TaggedEvent>();
+    let (workflow_tx, mut workflow_rx) = mpsc::unbounded_channel::<WorkflowEvent>();
     let mut event_stream = EventStream::new();
     let mut persisted_project_id: Option<String> = state.selected_project().map(|p| p.id.clone());
     let mut last_workflow_poll = Instant::now();
+    let mut workflow_poll_in_flight = false;
     let mut fetched_def_id: Option<String> = None;
     let mut fetched_run_id: Option<String> = None;
     loop {
@@ -1633,10 +1885,12 @@ async fn run_event_loop(
                                 fetched_def_id = None;
                                 fetched_run_id = None;
                                 if let Some(project_id) = state.selected_project().map(|p| p.id.clone()) {
-                                    match fetch_workflow_definitions(client, &project_id).await {
-                                        Ok(definitions) => state.replace_workflow_definitions(definitions),
-                                        Err(e) => state.set_workflow_error(format!("Failed to load workflows: {e}")),
-                                    }
+                                    spawn_workflow_definitions_fetch(
+                                        config.server_url.clone(),
+                                        config.auth_token.clone(),
+                                        project_id,
+                                        workflow_tx.clone(),
+                                    );
                                 } else {
                                     state.set_workflow_error("No project selected".to_string());
                                 }
@@ -1646,43 +1900,25 @@ async fn run_event_loop(
                                 fetched_def_id = None;
                                 fetched_run_id = None;
                                 if let Some(project_id) = state.selected_project().map(|p| p.id.clone()) {
-                                    match fetch_workflow_definitions(client, &project_id).await {
-                                        Ok(definitions) => state.replace_workflow_definitions(definitions),
-                                        Err(e) => state.set_workflow_error(format!("Failed to refresh workflows: {e}")),
-                                    }
+                                    spawn_workflow_definitions_fetch(
+                                        config.server_url.clone(),
+                                        config.auth_token.clone(),
+                                        project_id,
+                                        workflow_tx.clone(),
+                                    );
                                 } else {
                                     state.workflows.loading = false;
                                 }
                             }
                             handlers::Action::TriggerWorkflow { definition_id, payload } => {
                                 state.status_message = Some("Triggering workflow...".to_string());
-                                match trigger_workflow(client, &definition_id, payload).await {
-                                    Ok(payload) if payload.filtered => {
-                                        state.status_message = Some("Trigger condition filtered; no run created".to_string());
-                                    }
-                                    Ok(payload) => {
-                                        if let Some(run) = payload.run {
-                                            let run_id = run.id.clone();
-                                            state.status_message = Some(format!("Workflow run {run_id} created"));
-                                            state.workflows.run_cursor = 0;
-                                            state.workflows.focus = crate::tui::state::MillerFocus::Runs;
-                                            match fetch_workflow_run(client, &run_id).await {
-                                                Ok(detail) => state.replace_workflow_run_detail(detail),
-                                                Err(_) => state.replace_workflow_run_detail(workflow_run_node_to_detail(run)),
-                                            }
-                                            // Re-fetch runs to include the new run
-                                            if let Some(def_id) = state.selected_workflow_definition_id() {
-                                                if let Ok(runs) = fetch_workflow_runs(client, &def_id).await {
-                                                    state.replace_workflow_runs(runs);
-                                                }
-                                            }
-                                            fetched_run_id = Some(run_id);
-                                        } else {
-                                            state.status_message = Some("Workflow trigger returned no run".to_string());
-                                        }
-                                    }
-                                    Err(e) => state.set_workflow_error(format!("Trigger failed: {e}")),
-                                }
+                                spawn_workflow_trigger(
+                                    config.server_url.clone(),
+                                    config.auth_token.clone(),
+                                    definition_id,
+                                    payload,
+                                    workflow_tx.clone(),
+                                );
                             }
                             handlers::Action::None => {}
                         }
@@ -1692,6 +1928,15 @@ async fn run_event_loop(
             event = stream_rx.recv() => {
                 if let Some(evt) = event {
                     dispatch_stream_event(state, evt);
+                }
+            }
+            event = workflow_rx.recv() => {
+                if let Some(evt) = event {
+                    handle_workflow_event(
+                        state, evt,
+                        &mut fetched_def_id, &mut fetched_run_id,
+                        &mut workflow_poll_in_flight,
+                    );
                 }
             }
             _ = tokio::time::sleep(timeout) => {}
@@ -1705,27 +1950,18 @@ async fn run_event_loop(
             persisted_project_id = current_project_id;
         }
 
-        // Reactive auto-fetch: when the selected workflow or run changes, load details.
         if state.focus == Focus::Workflows {
             let cur_def = state.selected_workflow_definition_id();
             if cur_def != fetched_def_id {
                 fetched_def_id = cur_def.clone();
                 state.workflows.error = None;
                 if let Some(def_id) = &cur_def {
-                    let (def_result, runs_result) = tokio::join!(
-                        fetch_workflow_definition(client, def_id),
-                        fetch_workflow_runs(client, def_id),
+                    spawn_workflow_def_detail_fetch(
+                        config.server_url.clone(),
+                        config.auth_token.clone(),
+                        def_id.clone(),
+                        workflow_tx.clone(),
                     );
-                    match def_result {
-                        Ok(detail) => state.replace_workflow_definition_detail(detail),
-                        Err(e) => {
-                            state.set_workflow_error(format!("Failed to load definition: {e}"))
-                        }
-                    }
-                    match runs_result {
-                        Ok(runs) => state.replace_workflow_runs(runs),
-                        Err(e) => state.set_workflow_error(format!("Failed to load runs: {e}")),
-                    }
                 } else {
                     state.workflows.selected_definition = None;
                     state.workflows.runs.clear();
@@ -1739,10 +1975,13 @@ async fn run_event_loop(
                 fetched_run_id = cur_run.clone();
                 state.workflows.error = None;
                 if let Some(run_id) = &cur_run {
-                    match fetch_workflow_run(client, run_id).await {
-                        Ok(run) => state.replace_workflow_run_detail(run),
-                        Err(e) => state.set_workflow_error(format!("Failed to load run: {e}")),
-                    }
+                    spawn_workflow_run_fetch(
+                        config.server_url.clone(),
+                        config.auth_token.clone(),
+                        run_id.clone(),
+                        false,
+                        workflow_tx.clone(),
+                    );
                 } else {
                     state.workflows.selected_run = None;
                 }
@@ -1751,10 +1990,16 @@ async fn run_event_loop(
 
         if last_workflow_poll.elapsed() >= Duration::from_secs(1) {
             last_workflow_poll = Instant::now();
-            if let Some(run_id) = state.workflow_poll_run_id() {
-                match fetch_workflow_run(client, &run_id).await {
-                    Ok(run) => state.replace_workflow_run_detail(run),
-                    Err(e) => state.set_workflow_error(format!("Failed to poll run: {e}")),
+            if !workflow_poll_in_flight {
+                if let Some(run_id) = state.workflow_poll_run_id() {
+                    workflow_poll_in_flight = true;
+                    spawn_workflow_run_fetch(
+                        config.server_url.clone(),
+                        config.auth_token.clone(),
+                        run_id,
+                        true,
+                        workflow_tx.clone(),
+                    );
                 }
             }
         }

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -18,8 +18,8 @@ use crate::graphql::GraphqlClient;
 use crate::tui::chat::{ChatMessage, ChatRole, ContentBlock};
 use crate::tui::state::{
     AgentItem, BlockDetail, CellKind, Focus, GridSection, ProjectItem, SandboxInfo, ScreenState,
-    SystemBlockDetail, ThreadGridState, ThreadInfo, UsageDetail, WorkflowAgentItem,
-    WorkflowDefinitionDetail, WorkflowDefinitionItem, WorkflowRunDetail, WorkflowRunItem,
+    SystemBlockDetail, ThreadGridState, ThreadInfo, UsageDetail, WorkflowDefinitionDetail,
+    WorkflowDefinitionItem, WorkflowRunDetail, WorkflowRunItem,
     WorkflowSandboxItem, WorkflowStepItem, WorkflowStepResultItem, WorkflowTriggerInfo,
 };
 use crate::tui::{handlers, ui};
@@ -723,19 +723,6 @@ fn agent_node_to_item(a: AgentNode) -> AgentItem {
     }
 }
 
-fn agent_node_to_workflow_item(a: AgentNode) -> WorkflowAgentItem {
-    WorkflowAgentItem {
-        id: a.id,
-        name: a.name,
-        role: a.role,
-        model: a.session.model,
-        sandbox: a.attached_sandbox.map(|s| SandboxInfo {
-            name: s.name,
-            mode: s.mode,
-        }),
-    }
-}
-
 fn workflow_trigger_node_to_info(t: WorkflowTriggerNode) -> WorkflowTriggerInfo {
     WorkflowTriggerInfo {
         kind: t.kind,
@@ -816,7 +803,7 @@ fn workflow_run_node_to_detail(r: WorkflowRunNode) -> WorkflowRunDetail {
         agents: r
             .agents
             .into_iter()
-            .map(agent_node_to_workflow_item)
+            .map(agent_node_to_item)
             .collect(),
     }
 }

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1955,6 +1955,7 @@ async fn run_event_loop(
             if cur_def != fetched_def_id {
                 fetched_def_id = cur_def.clone();
                 state.workflows.error = None;
+                state.workflows.runs.clear();
                 if let Some(def_id) = &cur_def {
                     spawn_workflow_def_detail_fetch(
                         config.server_url.clone(),
@@ -1964,7 +1965,6 @@ async fn run_event_loop(
                     );
                 } else {
                     state.workflows.selected_definition = None;
-                    state.workflows.runs.clear();
                 }
                 state.workflows.selected_run = None;
                 fetched_run_id = None;

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1667,6 +1667,8 @@ async fn run_event_loop(
                                         Ok(definitions) => state.replace_workflow_definitions(definitions),
                                         Err(e) => state.set_workflow_error(format!("Failed to refresh workflows: {e}")),
                                     }
+                                } else {
+                                    state.workflows.loading = false;
                                 }
                             }
                             handlers::Action::TriggerWorkflow { definition_id, payload } => {

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1730,6 +1730,7 @@ async fn run_event_loop(
                     state.workflows.selected_definition = None;
                     state.workflows.runs.clear();
                 }
+                state.workflows.selected_run = None;
                 fetched_run_id = None;
             }
 

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1725,6 +1725,7 @@ async fn run_event_loop(
             let cur_def = state.selected_workflow_definition_id();
             if cur_def != fetched_def_id {
                 fetched_def_id = cur_def.clone();
+                state.workflows.error = None;
                 if let Some(def_id) = &cur_def {
                     let (def_result, runs_result) = tokio::join!(
                         fetch_workflow_definition(client, def_id),
@@ -1750,6 +1751,7 @@ async fn run_event_loop(
             let cur_run = state.selected_workflow_run_id();
             if cur_run != fetched_run_id {
                 fetched_run_id = cur_run.clone();
+                state.workflows.error = None;
                 if let Some(run_id) = &cur_run {
                     match fetch_workflow_run(client, run_id).await {
                         Ok(run) => state.replace_workflow_run_detail(run),

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -19,8 +19,8 @@ use crate::tui::chat::{ChatMessage, ChatRole, ContentBlock};
 use crate::tui::state::{
     AgentItem, BlockDetail, CellKind, Focus, GridSection, ProjectItem, SandboxInfo, ScreenState,
     SystemBlockDetail, ThreadGridState, ThreadInfo, UsageDetail, WorkflowDefinitionDetail,
-    WorkflowDefinitionItem, WorkflowRunDetail, WorkflowRunItem,
-    WorkflowSandboxItem, WorkflowStepItem, WorkflowStepResultItem, WorkflowTriggerInfo,
+    WorkflowDefinitionItem, WorkflowRunDetail, WorkflowRunItem, WorkflowSandboxItem,
+    WorkflowStepItem, WorkflowStepResultItem, WorkflowTriggerInfo,
 };
 use crate::tui::{handlers, ui};
 
@@ -800,11 +800,7 @@ fn workflow_run_node_to_detail(r: WorkflowRunNode) -> WorkflowRunDetail {
             .into_iter()
             .map(workflow_step_result_node_to_item)
             .collect(),
-        agents: r
-            .agents
-            .into_iter()
-            .map(agent_node_to_item)
-            .collect(),
+        agents: r.agents.into_iter().map(agent_node_to_item).collect(),
     }
 }
 

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1,6 +1,6 @@
 use std::collections::{BTreeSet, HashMap};
 use std::io;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use anyhow::Result;
 use crossterm::{
@@ -18,7 +18,9 @@ use crate::graphql::GraphqlClient;
 use crate::tui::chat::{ChatMessage, ChatRole, ContentBlock};
 use crate::tui::state::{
     AgentItem, BlockDetail, CellKind, Focus, GridSection, ProjectItem, SandboxInfo, ScreenState,
-    SystemBlockDetail, ThreadGridState, ThreadInfo, UsageDetail,
+    SystemBlockDetail, ThreadGridState, ThreadInfo, UsageDetail, WorkflowAgentItem,
+    WorkflowDefinitionDetail, WorkflowDefinitionItem, WorkflowRunDetail, WorkflowRunItem,
+    WorkflowSandboxItem, WorkflowStepItem, WorkflowStepResultItem, WorkflowTriggerInfo,
 };
 use crate::tui::{handlers, ui};
 
@@ -81,6 +83,204 @@ struct AgentSessionNode {
 struct SandboxAttachmentNode {
     name: String,
     mode: String,
+}
+
+const WORKFLOW_DEFINITIONS_QUERY: &str = r#"
+    query WorkflowDefinitions($projectId: ProjectId!) {
+        workflowDefinitions(projectId: $projectId) {
+            id
+            name
+            description
+            trigger { kind provider cronSchedule cronTimezone nextRunAt condition webhookUrl }
+            steps { name stepType skill tool sandbox sandboxMode condition }
+            recentRuns(first: 1) {
+                id
+                state
+                startedAt
+                completedAt
+                stepResults { name state output error skipped completedAt }
+            }
+        }
+    }
+"#;
+
+const WORKFLOW_DEFINITION_QUERY: &str = r#"
+    query WorkflowDefinition($id: WorkflowDefinitionId!) {
+        workflowDefinition(id: $id) {
+            id
+            name
+            description
+            yaml
+            trigger { kind provider cronSchedule cronTimezone nextRunAt condition webhookUrl }
+            steps { name stepType skill tool sandbox sandboxMode condition }
+            sandboxes { name kind branch repoUrl }
+            recentRuns(first: 10) { id state startedAt completedAt stepResults { name state output error skipped completedAt } }
+        }
+    }
+"#;
+
+const WORKFLOW_RUNS_QUERY: &str = r#"
+    query WorkflowRuns($definitionId: WorkflowDefinitionId!, $first: Int!) {
+        workflowRuns(definitionId: $definitionId, first: $first) {
+            id
+            state
+            startedAt
+            completedAt
+            stepResults { name state output error skipped completedAt }
+        }
+    }
+"#;
+
+const WORKFLOW_RUN_QUERY: &str = r#"
+    query WorkflowRun($id: WorkflowRunId!) {
+        workflowRun(id: $id) {
+            id
+            definitionId
+            projectId
+            state
+            startedAt
+            completedAt
+            triggerContext
+            stepsSnapshot { name stepType skill tool sandbox sandboxMode condition }
+            stepResults { name state output error skipped completedAt }
+            agents { id name role session { model } attachedSandbox { name mode } }
+        }
+    }
+"#;
+
+const WORKFLOW_TRIGGER_MUTATION: &str = r#"
+    mutation WorkflowTrigger($input: WorkflowTriggerInput!) {
+        workflowTrigger(input: $input) {
+            filtered
+            run {
+                id
+                definitionId
+                projectId
+                state
+                startedAt
+                completedAt
+                stepResults { name state output error skipped completedAt }
+            }
+        }
+    }
+"#;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowDefinitionsResponse {
+    workflow_definitions: Vec<WorkflowDefinitionNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowDefinitionResponse {
+    workflow_definition: Option<WorkflowDefinitionNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRunsResponse {
+    workflow_runs: Vec<WorkflowRunNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRunResponse {
+    workflow_run: Option<WorkflowRunNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowTriggerResponse {
+    workflow_trigger: WorkflowTriggerPayloadNode,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkflowTriggerPayloadNode {
+    filtered: bool,
+    run: Option<WorkflowRunNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowDefinitionNode {
+    id: String,
+    name: String,
+    description: Option<String>,
+    #[serde(default)]
+    yaml: String,
+    trigger: WorkflowTriggerNode,
+    #[serde(default)]
+    steps: Vec<WorkflowStepNode>,
+    #[serde(default)]
+    sandboxes: Vec<WorkflowSandboxNode>,
+    #[serde(default)]
+    recent_runs: Vec<WorkflowRunNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowTriggerNode {
+    kind: String,
+    provider: Option<String>,
+    cron_schedule: Option<String>,
+    cron_timezone: Option<String>,
+    next_run_at: Option<String>,
+    condition: Option<String>,
+    webhook_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowStepNode {
+    name: String,
+    step_type: String,
+    skill: Option<String>,
+    tool: Option<String>,
+    sandbox: Option<String>,
+    sandbox_mode: Option<String>,
+    condition: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowSandboxNode {
+    name: String,
+    kind: String,
+    branch: Option<String>,
+    repo_url: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowRunNode {
+    id: String,
+    #[serde(default)]
+    definition_id: String,
+    #[serde(default)]
+    project_id: String,
+    state: String,
+    started_at: String,
+    completed_at: Option<String>,
+    #[serde(default)]
+    trigger_context: serde_json::Value,
+    #[serde(default)]
+    steps_snapshot: Vec<WorkflowStepNode>,
+    #[serde(default)]
+    step_results: Vec<WorkflowStepResultNode>,
+    #[serde(default)]
+    agents: Vec<AgentNode>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct WorkflowStepResultNode {
+    name: String,
+    state: String,
+    output: Option<serde_json::Value>,
+    error: Option<String>,
+    skipped: Option<String>,
+    completed_at: Option<String>,
 }
 
 const PROJECTS_QUERY: &str = r#"
@@ -523,6 +723,148 @@ fn agent_node_to_item(a: AgentNode) -> AgentItem {
     }
 }
 
+fn agent_node_to_workflow_item(a: AgentNode) -> WorkflowAgentItem {
+    WorkflowAgentItem {
+        id: a.id,
+        name: a.name,
+        role: a.role,
+        model: a.session.model,
+        sandbox: a.attached_sandbox.map(|s| SandboxInfo {
+            name: s.name,
+            mode: s.mode,
+        }),
+    }
+}
+
+fn workflow_trigger_node_to_info(t: WorkflowTriggerNode) -> WorkflowTriggerInfo {
+    WorkflowTriggerInfo {
+        kind: t.kind,
+        provider: t.provider,
+        cron_schedule: t.cron_schedule,
+        cron_timezone: t.cron_timezone,
+        next_run_at: t.next_run_at,
+        condition: t.condition,
+        webhook_url: t.webhook_url,
+    }
+}
+
+fn workflow_step_node_to_item(s: WorkflowStepNode) -> WorkflowStepItem {
+    WorkflowStepItem {
+        name: s.name,
+        step_type: s.step_type,
+        skill: s.skill,
+        tool: s.tool,
+        sandbox: s.sandbox,
+        sandbox_mode: s.sandbox_mode,
+        condition: s.condition,
+    }
+}
+
+fn workflow_sandbox_node_to_item(s: WorkflowSandboxNode) -> WorkflowSandboxItem {
+    WorkflowSandboxItem {
+        name: s.name,
+        kind: s.kind,
+        branch: s.branch,
+        repo_url: s.repo_url,
+    }
+}
+
+fn workflow_step_result_node_to_item(r: WorkflowStepResultNode) -> WorkflowStepResultItem {
+    WorkflowStepResultItem {
+        name: r.name,
+        state: r.state,
+        output: r.output,
+        error: r.error,
+        skipped: r.skipped,
+        completed_at: r.completed_at,
+    }
+}
+
+fn workflow_run_node_to_item(r: WorkflowRunNode) -> WorkflowRunItem {
+    WorkflowRunItem {
+        id: r.id,
+        state: r.state,
+        started_at: r.started_at,
+        completed_at: r.completed_at,
+        step_results: r
+            .step_results
+            .into_iter()
+            .map(workflow_step_result_node_to_item)
+            .collect(),
+    }
+}
+
+fn workflow_run_node_to_detail(r: WorkflowRunNode) -> WorkflowRunDetail {
+    WorkflowRunDetail {
+        id: r.id,
+        definition_id: r.definition_id,
+        project_id: r.project_id,
+        state: r.state,
+        started_at: r.started_at,
+        completed_at: r.completed_at,
+        trigger_context: r.trigger_context,
+        steps_snapshot: r
+            .steps_snapshot
+            .into_iter()
+            .map(workflow_step_node_to_item)
+            .collect(),
+        step_results: r
+            .step_results
+            .into_iter()
+            .map(workflow_step_result_node_to_item)
+            .collect(),
+        agents: r
+            .agents
+            .into_iter()
+            .map(agent_node_to_workflow_item)
+            .collect(),
+    }
+}
+
+fn workflow_definition_node_to_item(d: WorkflowDefinitionNode) -> WorkflowDefinitionItem {
+    WorkflowDefinitionItem {
+        id: d.id,
+        name: d.name,
+        description: d.description,
+        trigger: workflow_trigger_node_to_info(d.trigger),
+        steps: d
+            .steps
+            .into_iter()
+            .map(workflow_step_node_to_item)
+            .collect(),
+        recent_runs: d
+            .recent_runs
+            .into_iter()
+            .map(workflow_run_node_to_item)
+            .collect(),
+    }
+}
+
+fn workflow_definition_node_to_detail(d: WorkflowDefinitionNode) -> WorkflowDefinitionDetail {
+    WorkflowDefinitionDetail {
+        id: d.id,
+        name: d.name,
+        description: d.description,
+        yaml: d.yaml,
+        trigger: workflow_trigger_node_to_info(d.trigger),
+        steps: d
+            .steps
+            .into_iter()
+            .map(workflow_step_node_to_item)
+            .collect(),
+        sandboxes: d
+            .sandboxes
+            .into_iter()
+            .map(workflow_sandbox_node_to_item)
+            .collect(),
+        recent_runs: d
+            .recent_runs
+            .into_iter()
+            .map(workflow_run_node_to_item)
+            .collect(),
+    }
+}
+
 async fn fetch_projects(client: &GraphqlClient) -> Result<Vec<ProjectItem>> {
     let resp: ProjectsResponse = client.query(PROJECTS_QUERY, serde_json::json!({})).await?;
 
@@ -544,6 +886,87 @@ async fn fetch_projects(client: &GraphqlClient) -> Result<Vec<ProjectItem>> {
         .collect();
 
     Ok(items)
+}
+
+async fn fetch_workflow_definitions(
+    client: &GraphqlClient,
+    project_id: &str,
+) -> Result<Vec<WorkflowDefinitionItem>> {
+    let resp: WorkflowDefinitionsResponse = client
+        .query(
+            WORKFLOW_DEFINITIONS_QUERY,
+            serde_json::json!({ "projectId": project_id }),
+        )
+        .await?;
+
+    Ok(resp
+        .workflow_definitions
+        .into_iter()
+        .map(workflow_definition_node_to_item)
+        .collect())
+}
+
+async fn fetch_workflow_definition(
+    client: &GraphqlClient,
+    definition_id: &str,
+) -> Result<WorkflowDefinitionDetail> {
+    let resp: WorkflowDefinitionResponse = client
+        .query(
+            WORKFLOW_DEFINITION_QUERY,
+            serde_json::json!({ "id": definition_id }),
+        )
+        .await?;
+
+    resp.workflow_definition
+        .map(workflow_definition_node_to_detail)
+        .ok_or_else(|| anyhow::anyhow!("workflow definition not found"))
+}
+
+async fn fetch_workflow_runs(
+    client: &GraphqlClient,
+    definition_id: &str,
+) -> Result<Vec<WorkflowRunItem>> {
+    let resp: WorkflowRunsResponse = client
+        .query(
+            WORKFLOW_RUNS_QUERY,
+            serde_json::json!({ "definitionId": definition_id, "first": 50 }),
+        )
+        .await?;
+
+    Ok(resp
+        .workflow_runs
+        .into_iter()
+        .map(workflow_run_node_to_item)
+        .collect())
+}
+
+async fn fetch_workflow_run(client: &GraphqlClient, run_id: &str) -> Result<WorkflowRunDetail> {
+    let resp: WorkflowRunResponse = client
+        .query(WORKFLOW_RUN_QUERY, serde_json::json!({ "id": run_id }))
+        .await?;
+
+    resp.workflow_run
+        .map(workflow_run_node_to_detail)
+        .ok_or_else(|| anyhow::anyhow!("workflow run not found"))
+}
+
+async fn trigger_workflow(
+    client: &GraphqlClient,
+    definition_id: &str,
+    payload: serde_json::Value,
+) -> Result<WorkflowTriggerPayloadNode> {
+    let resp: WorkflowTriggerResponse = client
+        .query(
+            WORKFLOW_TRIGGER_MUTATION,
+            serde_json::json!({
+                "input": {
+                    "definitionId": definition_id,
+                    "payload": payload,
+                }
+            }),
+        )
+        .await?;
+    Ok(resp.workflow_trigger)
 }
 
 async fn fetch_user_name(client: &GraphqlClient) -> Result<String> {
@@ -1136,6 +1559,7 @@ async fn run_event_loop(
     let (stream_tx, mut stream_rx) = mpsc::unbounded_channel::<TaggedEvent>();
     let mut event_stream = EventStream::new();
     let mut persisted_project_id: Option<String> = state.selected_project().map(|p| p.id.clone());
+    let mut last_workflow_poll = Instant::now();
     loop {
         terminal.draw(|frame| ui::draw(frame, state))?;
 
@@ -1218,6 +1642,70 @@ async fn run_event_loop(
                                     );
                                 }
                             }
+                            handlers::Action::OpenWorkflows => {
+                                state.enter_workflows();
+                                state.workflows.loading = true;
+                                if let Some(project_id) = state.selected_project().map(|p| p.id.clone()) {
+                                    match fetch_workflow_definitions(client, &project_id).await {
+                                        Ok(definitions) => state.replace_workflow_definitions(definitions),
+                                        Err(e) => state.set_workflow_error(format!("Failed to load workflows: {e}")),
+                                    }
+                                } else {
+                                    state.set_workflow_error("No project selected".to_string());
+                                }
+                            }
+                            handlers::Action::RefreshWorkflows => {
+                                state.workflows.loading = true;
+                                if let Some(project_id) = state.selected_project().map(|p| p.id.clone()) {
+                                    match fetch_workflow_definitions(client, &project_id).await {
+                                        Ok(definitions) => state.replace_workflow_definitions(definitions),
+                                        Err(e) => state.set_workflow_error(format!("Failed to refresh workflows: {e}")),
+                                    }
+                                }
+                            }
+                            handlers::Action::FetchWorkflowDefinition { definition_id } => {
+                                state.workflows.loading = true;
+                                match fetch_workflow_definition(client, &definition_id).await {
+                                    Ok(definition) => state.replace_workflow_definition_detail(definition),
+                                    Err(e) => state.set_workflow_error(format!("Failed to load workflow: {e}")),
+                                }
+                            }
+                            handlers::Action::FetchWorkflowRuns { definition_id } => {
+                                state.workflows.loading = true;
+                                match fetch_workflow_runs(client, &definition_id).await {
+                                    Ok(runs) => state.replace_workflow_runs(runs),
+                                    Err(e) => state.set_workflow_error(format!("Failed to load runs: {e}")),
+                                }
+                            }
+                            handlers::Action::FetchWorkflowRun { run_id } => {
+                                state.workflows.loading = true;
+                                match fetch_workflow_run(client, &run_id).await {
+                                    Ok(run) => state.replace_workflow_run_detail(run),
+                                    Err(e) => state.set_workflow_error(format!("Failed to load run: {e}")),
+                                }
+                            }
+                            handlers::Action::TriggerWorkflow { definition_id, payload } => {
+                                state.status_message = Some("Triggering workflow...".to_string());
+                                match trigger_workflow(client, &definition_id, payload).await {
+                                    Ok(payload) if payload.filtered => {
+                                        state.status_message = Some("Trigger condition filtered; no run created".to_string());
+                                    }
+                                    Ok(payload) => {
+                                        if let Some(run) = payload.run {
+                                            let run_id = run.id.clone();
+                                            state.status_message = Some(format!("Workflow run {run_id} created"));
+                                            state.open_workflow_run_detail(run_id.clone());
+                                            match fetch_workflow_run(client, &run_id).await {
+                                                Ok(detail) => state.replace_workflow_run_detail(detail),
+                                                Err(_) => state.replace_workflow_run_detail(workflow_run_node_to_detail(run)),
+                                            }
+                                        } else {
+                                            state.status_message = Some("Workflow trigger returned no run".to_string());
+                                        }
+                                    }
+                                    Err(e) => state.set_workflow_error(format!("Trigger failed: {e}")),
+                                }
+                            }
                             handlers::Action::None => {}
                         }
                     }
@@ -1237,6 +1725,16 @@ async fn run_event_loop(
                 let _ = Config::save_last_project(id);
             }
             persisted_project_id = current_project_id;
+        }
+
+        if last_workflow_poll.elapsed() >= Duration::from_secs(1) {
+            last_workflow_poll = Instant::now();
+            if let Some(run_id) = state.workflow_poll_run_id() {
+                match fetch_workflow_run(client, &run_id).await {
+                    Ok(run) => state.replace_workflow_run_detail(run),
+                    Err(e) => state.set_workflow_error(format!("Failed to poll run: {e}")),
+                }
+            }
         }
 
         // Fetch history when the selected agent changes (and we're not streaming).

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use super::state::{Focus, Mode, RunDetailPanel, ScreenState, WorkflowView};
+use super::state::{Focus, MillerFocus, Mode, ScreenState};
 
 /// Async side-effects returned from key handlers for the event loop to execute.
 pub enum Action {
@@ -19,15 +19,6 @@ pub enum Action {
     ToggleThreads,
     OpenWorkflows,
     RefreshWorkflows,
-    FetchWorkflowDefinition {
-        definition_id: String,
-    },
-    FetchWorkflowRuns {
-        definition_id: String,
-    },
-    FetchWorkflowRun {
-        run_id: String,
-    },
     TriggerWorkflow {
         definition_id: String,
         payload: serde_json::Value,
@@ -99,15 +90,14 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
 
 fn handle_workflows_key(state: &mut ScreenState, key: KeyEvent) -> Action {
     state.status_message = None;
-    match &state.workflows.view {
-        WorkflowView::Catalog => handle_workflow_catalog_key(state, key),
-        WorkflowView::Definition { .. } => handle_workflow_definition_key(state, key),
-        WorkflowView::Runs { .. } => handle_workflow_runs_key(state, key),
-        WorkflowView::RunDetail { .. } => handle_workflow_run_detail_key(state, key),
+    match state.workflows.focus {
+        MillerFocus::Definitions => handle_workflow_definitions_key(state, key),
+        MillerFocus::Runs => handle_workflow_runs_key(state, key),
+        MillerFocus::StepDetail => handle_workflow_step_detail_key(state, key),
     }
 }
 
-fn handle_workflow_catalog_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+fn handle_workflow_definitions_key(state: &mut ScreenState, key: KeyEvent) -> Action {
     match key.code {
         KeyCode::Char('j') | KeyCode::Down => {
             state.workflow_cursor_down();
@@ -117,47 +107,14 @@ fn handle_workflow_catalog_key(state: &mut ScreenState, key: KeyEvent) -> Action
             state.workflow_cursor_up();
             Action::None
         }
-        KeyCode::Enter => match state.selected_workflow_definition_id() {
-            Some(definition_id) => {
-                state.open_workflow_definition(definition_id.clone());
-                Action::FetchWorkflowDefinition { definition_id }
-            }
-            None => Action::None,
-        },
+        KeyCode::Right | KeyCode::Char('l') | KeyCode::Enter => {
+            state.workflow_focus_right();
+            Action::None
+        }
         KeyCode::Char('T') => enter_trigger_for_selected_workflow(state),
         KeyCode::Char('r') => Action::RefreshWorkflows,
         KeyCode::Esc => {
-            state.workflow_back();
-            Action::None
-        }
-        _ => Action::None,
-    }
-}
-
-fn handle_workflow_definition_key(state: &mut ScreenState, key: KeyEvent) -> Action {
-    match key.code {
-        KeyCode::Char('j') | KeyCode::Down => {
-            state.workflow_scroll_yaml_down();
-            Action::None
-        }
-        KeyCode::Char('k') | KeyCode::Up => {
-            state.workflow_scroll_yaml_up();
-            Action::None
-        }
-        KeyCode::Char('T') => enter_trigger_for_selected_workflow(state),
-        KeyCode::Char('R') => match state.selected_workflow_definition_id() {
-            Some(definition_id) => {
-                state.open_workflow_runs(definition_id.clone());
-                Action::FetchWorkflowRuns { definition_id }
-            }
-            None => Action::None,
-        },
-        KeyCode::Char('r') => match state.selected_workflow_definition_id() {
-            Some(definition_id) => Action::FetchWorkflowDefinition { definition_id },
-            None => Action::None,
-        },
-        KeyCode::Esc => {
-            state.workflow_back();
+            state.focus = Focus::Chat;
             Action::None
         }
         _ => Action::None,
@@ -174,26 +131,24 @@ fn handle_workflow_runs_key(state: &mut ScreenState, key: KeyEvent) -> Action {
             state.workflow_runs_cursor_up();
             Action::None
         }
-        KeyCode::Enter => match state.selected_workflow_run_id() {
-            Some(run_id) => {
-                state.open_workflow_run_detail(run_id.clone());
-                Action::FetchWorkflowRun { run_id }
-            }
-            None => Action::None,
-        },
-        KeyCode::Char('r') => match state.selected_workflow_definition_id() {
-            Some(definition_id) => Action::FetchWorkflowRuns { definition_id },
-            None => Action::None,
-        },
+        KeyCode::Left | KeyCode::Char('h') => {
+            state.workflow_focus_left();
+            Action::None
+        }
+        KeyCode::Right | KeyCode::Char('l') | KeyCode::Enter => {
+            state.workflow_focus_right();
+            Action::None
+        }
+        KeyCode::Char('r') => Action::RefreshWorkflows,
         KeyCode::Esc => {
-            state.workflow_back();
+            state.focus = Focus::Chat;
             Action::None
         }
         _ => Action::None,
     }
 }
 
-fn handle_workflow_run_detail_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+fn handle_workflow_step_detail_key(state: &mut ScreenState, key: KeyEvent) -> Action {
     match key.code {
         KeyCode::Char('j') | KeyCode::Down => {
             state.workflow_step_cursor_down();
@@ -203,32 +158,17 @@ fn handle_workflow_run_detail_key(state: &mut ScreenState, key: KeyEvent) -> Act
             state.workflow_step_cursor_up();
             Action::None
         }
+        KeyCode::Left | KeyCode::Char('h') => {
+            state.workflow_focus_left();
+            Action::None
+        }
         KeyCode::Enter => {
             state.workflow_toggle_expanded();
             Action::None
         }
-        KeyCode::Char('p') => {
-            state.workflow_set_panel(RunDetailPanel::Trigger);
-            Action::None
-        }
-        KeyCode::Char('a') => {
-            state.workflow_set_panel(RunDetailPanel::Agents);
-            Action::None
-        }
-        KeyCode::Char('s') => {
-            state.workflow_set_panel(RunDetailPanel::Sandboxes);
-            Action::None
-        }
-        KeyCode::Char('d') => {
-            state.workflow_set_panel(RunDetailPanel::Step);
-            Action::None
-        }
-        KeyCode::Char('r') => match state.selected_workflow_run_id() {
-            Some(run_id) => Action::FetchWorkflowRun { run_id },
-            None => Action::None,
-        },
+        KeyCode::Char('r') => Action::RefreshWorkflows,
         KeyCode::Esc => {
-            state.workflow_back();
+            state.focus = Focus::Chat;
             Action::None
         }
         _ => Action::None,
@@ -559,7 +499,7 @@ mod tests {
     use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
     use super::*;
-    use crate::tui::state::{AgentItem, ProjectItem};
+    use crate::tui::state::{AgentItem, MillerFocus, ProjectItem};
 
     fn project() -> ProjectItem {
         ProjectItem {
@@ -600,7 +540,7 @@ mod tests {
     fn ctrl_w_is_noop_when_already_focused_on_workflows() {
         let mut state = state();
         state.enter_workflows();
-        state.open_workflow_run_detail("run-1".into());
+        state.workflows.focus = MillerFocus::Runs;
 
         let action = handle_key(
             &mut state,
@@ -608,10 +548,7 @@ mod tests {
         );
 
         assert!(matches!(action, Action::None));
-        assert!(matches!(
-            state.workflows.view,
-            crate::tui::state::WorkflowView::RunDetail { .. }
-        ));
+        assert_eq!(state.workflows.focus, MillerFocus::Runs);
     }
 
     #[test]
@@ -666,5 +603,53 @@ mod tests {
             state.mode,
             Mode::TriggerWorkflow { error: Some(_), .. }
         ));
+    }
+
+    #[test]
+    fn arrow_right_moves_focus_from_definitions_to_runs() {
+        let mut state = state();
+        state.enter_workflows();
+        state.workflows.runs = vec![crate::tui::state::WorkflowRunItem {
+            id: "r-1".into(),
+            state: "SUCCEEDED".into(),
+            started_at: "now".into(),
+            completed_at: None,
+            step_results: vec![],
+        }];
+
+        let action = handle_key(&mut state, key(KeyCode::Right));
+
+        assert!(matches!(action, Action::None));
+        assert_eq!(state.workflows.focus, MillerFocus::Runs);
+    }
+
+    #[test]
+    fn arrow_left_moves_focus_from_runs_to_definitions() {
+        let mut state = state();
+        state.enter_workflows();
+        state.workflows.focus = MillerFocus::Runs;
+
+        let action = handle_key(&mut state, key(KeyCode::Left));
+
+        assert!(matches!(action, Action::None));
+        assert_eq!(state.workflows.focus, MillerFocus::Definitions);
+    }
+
+    #[test]
+    fn esc_exits_workflows_from_any_focus() {
+        for focus in [
+            MillerFocus::Definitions,
+            MillerFocus::Runs,
+            MillerFocus::StepDetail,
+        ] {
+            let mut state = state();
+            state.enter_workflows();
+            state.workflows.focus = focus;
+
+            let action = handle_key(&mut state, key(KeyCode::Esc));
+
+            assert!(matches!(action, Action::None));
+            assert_eq!(state.focus, Focus::Chat);
+        }
     }
 }

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -72,7 +72,10 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
                     return Action::None;
                 }
                 KeyCode::Char('t') => return Action::ToggleThreads,
-                KeyCode::Char('w') if state.focus != Focus::Chat || state.chat_input.is_empty() => {
+                KeyCode::Char('w')
+                    if state.focus != Focus::Workflows
+                        && (state.focus != Focus::Chat || state.chat_input.is_empty()) =>
+                {
                     return Action::OpenWorkflows;
                 }
                 _ => {}
@@ -591,6 +594,24 @@ mod tests {
             KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
         );
         assert!(matches!(action, Action::OpenWorkflows));
+    }
+
+    #[test]
+    fn ctrl_w_is_noop_when_already_focused_on_workflows() {
+        let mut state = state();
+        state.enter_workflows();
+        state.open_workflow_run_detail("run-1".into());
+
+        let action = handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
+        );
+
+        assert!(matches!(action, Action::None));
+        assert!(matches!(
+            state.workflows.view,
+            crate::tui::state::WorkflowView::RunDetail { .. }
+        ));
     }
 
     #[test]

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -107,6 +107,14 @@ fn handle_workflow_definitions_key(state: &mut ScreenState, key: KeyEvent) -> Ac
             state.workflow_cursor_up();
             Action::None
         }
+        KeyCode::Char('J') | KeyCode::PageDown => {
+            state.workflow_detail_scroll_down();
+            Action::None
+        }
+        KeyCode::Char('K') | KeyCode::PageUp => {
+            state.workflow_detail_scroll_up();
+            Action::None
+        }
         KeyCode::Right | KeyCode::Char('l') | KeyCode::Enter => {
             state.workflow_focus_right();
             Action::None
@@ -129,6 +137,14 @@ fn handle_workflow_runs_key(state: &mut ScreenState, key: KeyEvent) -> Action {
         }
         KeyCode::Char('k') | KeyCode::Up => {
             state.workflow_runs_cursor_up();
+            Action::None
+        }
+        KeyCode::Char('J') | KeyCode::PageDown => {
+            state.workflow_detail_scroll_down();
+            Action::None
+        }
+        KeyCode::Char('K') | KeyCode::PageUp => {
+            state.workflow_detail_scroll_up();
             Action::None
         }
         KeyCode::Left | KeyCode::Char('h') => {

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
-use super::state::{Focus, Mode, ScreenState};
+use super::state::{Focus, Mode, RunDetailPanel, ScreenState, WorkflowView};
 
 /// Async side-effects returned from key handlers for the event loop to execute.
 pub enum Action {
@@ -8,10 +8,34 @@ pub enum Action {
     Quit,
     Suspend,
     Refresh,
-    CreateProject { name: String, description: String },
-    SendChat { agent_id: String, prompt: String },
+    CreateProject {
+        name: String,
+        description: String,
+    },
+    SendChat {
+        agent_id: String,
+        prompt: String,
+    },
     ToggleThreads,
-    ExportThread { agent_id: String, path: String },
+    OpenWorkflows,
+    RefreshWorkflows,
+    FetchWorkflowDefinition {
+        definition_id: String,
+    },
+    FetchWorkflowRuns {
+        definition_id: String,
+    },
+    FetchWorkflowRun {
+        run_id: String,
+    },
+    TriggerWorkflow {
+        definition_id: String,
+        payload: serde_json::Value,
+    },
+    ExportThread {
+        agent_id: String,
+        path: String,
+    },
 }
 
 pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
@@ -48,6 +72,9 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
                     return Action::None;
                 }
                 KeyCode::Char('t') => return Action::ToggleThreads,
+                KeyCode::Char('w') if state.focus != Focus::Chat || state.chat_input.is_empty() => {
+                    return Action::OpenWorkflows;
+                }
                 _ => {}
             }
         }
@@ -58,10 +85,161 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
             Focus::Agents => handle_agents_key(state, key),
             Focus::Chat => handle_chat_key(state, key),
             Focus::Threads => handle_threads_key(state, key),
+            Focus::Workflows => handle_workflows_key(state, key),
         },
         Mode::CreateProject => handle_create_key(state, key),
         Mode::ExportThread => handle_export_key(state, key),
         Mode::ProjectPicker { .. } => handle_picker_key(state, key),
+        Mode::TriggerWorkflow { .. } => handle_trigger_workflow_key(state, key),
+    }
+}
+
+fn handle_workflows_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    state.status_message = None;
+    match &state.workflows.view {
+        WorkflowView::Catalog => handle_workflow_catalog_key(state, key),
+        WorkflowView::Definition { .. } => handle_workflow_definition_key(state, key),
+        WorkflowView::Runs { .. } => handle_workflow_runs_key(state, key),
+        WorkflowView::RunDetail { .. } => handle_workflow_run_detail_key(state, key),
+    }
+}
+
+fn handle_workflow_catalog_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.workflow_cursor_down();
+            Action::None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.workflow_cursor_up();
+            Action::None
+        }
+        KeyCode::Enter => match state.selected_workflow_definition_id() {
+            Some(definition_id) => {
+                state.open_workflow_definition(definition_id.clone());
+                Action::FetchWorkflowDefinition { definition_id }
+            }
+            None => Action::None,
+        },
+        KeyCode::Char('T') => enter_trigger_for_selected_workflow(state),
+        KeyCode::Char('r') => Action::RefreshWorkflows,
+        KeyCode::Esc => {
+            state.workflow_back();
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn handle_workflow_definition_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.workflow_scroll_yaml_down();
+            Action::None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.workflow_scroll_yaml_up();
+            Action::None
+        }
+        KeyCode::Char('T') => enter_trigger_for_selected_workflow(state),
+        KeyCode::Char('R') => match state.selected_workflow_definition_id() {
+            Some(definition_id) => {
+                state.open_workflow_runs(definition_id.clone());
+                Action::FetchWorkflowRuns { definition_id }
+            }
+            None => Action::None,
+        },
+        KeyCode::Char('r') => match state.selected_workflow_definition_id() {
+            Some(definition_id) => Action::FetchWorkflowDefinition { definition_id },
+            None => Action::None,
+        },
+        KeyCode::Esc => {
+            state.workflow_back();
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn handle_workflow_runs_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.workflow_runs_cursor_down();
+            Action::None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.workflow_runs_cursor_up();
+            Action::None
+        }
+        KeyCode::Enter => match state.selected_workflow_run_id() {
+            Some(run_id) => {
+                state.open_workflow_run_detail(run_id.clone());
+                Action::FetchWorkflowRun { run_id }
+            }
+            None => Action::None,
+        },
+        KeyCode::Char('r') => match state.selected_workflow_definition_id() {
+            Some(definition_id) => Action::FetchWorkflowRuns { definition_id },
+            None => Action::None,
+        },
+        KeyCode::Esc => {
+            state.workflow_back();
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn handle_workflow_run_detail_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.workflow_step_cursor_down();
+            Action::None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.workflow_step_cursor_up();
+            Action::None
+        }
+        KeyCode::Enter => {
+            state.workflow_toggle_expanded();
+            Action::None
+        }
+        KeyCode::Char('p') => {
+            state.workflow_set_panel(RunDetailPanel::Trigger);
+            Action::None
+        }
+        KeyCode::Char('a') => {
+            state.workflow_set_panel(RunDetailPanel::Agents);
+            Action::None
+        }
+        KeyCode::Char('s') => {
+            state.workflow_set_panel(RunDetailPanel::Sandboxes);
+            Action::None
+        }
+        KeyCode::Char('d') => {
+            state.workflow_set_panel(RunDetailPanel::Step);
+            Action::None
+        }
+        KeyCode::Char('r') => match state.selected_workflow_run_id() {
+            Some(run_id) => Action::FetchWorkflowRun { run_id },
+            None => Action::None,
+        },
+        KeyCode::Esc => {
+            state.workflow_back();
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn enter_trigger_for_selected_workflow(state: &mut ScreenState) -> Action {
+    match state.selected_workflow_definition_id() {
+        Some(definition_id) => {
+            let name = state.selected_workflow_name();
+            state.enter_trigger_workflow(definition_id, name);
+            Action::None
+        }
+        None => Action::None,
     }
 }
 
@@ -293,6 +471,68 @@ fn handle_export_key(state: &mut ScreenState, key: KeyEvent) -> Action {
     }
 }
 
+fn handle_trigger_workflow_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    match key.code {
+        KeyCode::Esc => {
+            state.exit_trigger_workflow();
+            Action::None
+        }
+        KeyCode::Backspace => {
+            if let Mode::TriggerWorkflow { payload, error, .. } = &mut state.mode {
+                payload.pop();
+                *error = None;
+            }
+            Action::None
+        }
+        KeyCode::Char('u') if ctrl => {
+            if let Mode::TriggerWorkflow { payload, error, .. } = &mut state.mode {
+                payload.clear();
+                *error = None;
+            }
+            Action::None
+        }
+        KeyCode::Char(c) if !ctrl => {
+            if let Mode::TriggerWorkflow { payload, error, .. } = &mut state.mode {
+                payload.push(c);
+                *error = None;
+            }
+            Action::None
+        }
+        KeyCode::Enter => {
+            let (definition_id, payload_text) = match &state.mode {
+                Mode::TriggerWorkflow {
+                    definition_id,
+                    payload,
+                    ..
+                } => (definition_id.clone(), payload.trim().to_string()),
+                _ => return Action::None,
+            };
+            let payload_text = if payload_text.is_empty() {
+                "{}".to_string()
+            } else {
+                payload_text
+            };
+            match serde_json::from_str(&payload_text) {
+                Ok(payload) => {
+                    state.exit_trigger_workflow();
+                    Action::TriggerWorkflow {
+                        definition_id,
+                        payload,
+                    }
+                }
+                Err(e) => {
+                    if let Mode::TriggerWorkflow { error, .. } = &mut state.mode {
+                        *error = Some(format!("Invalid JSON: {e}"));
+                    }
+                    Action::None
+                }
+            }
+        }
+        _ => Action::None,
+    }
+}
+
 fn send_chat_to_selected_agent(state: &mut ScreenState, input: String) -> Action {
     match state.selected_agent_id() {
         Some(agent_id) => {
@@ -308,5 +548,102 @@ fn send_chat_to_selected_agent(state: &mut ScreenState, input: String) -> Action
             state.status_message = Some("No agent selected".to_string());
             Action::None
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+    use super::*;
+    use crate::tui::state::{AgentItem, ProjectItem};
+
+    fn project() -> ProjectItem {
+        ProjectItem {
+            id: "p-1".into(),
+            name: "Project".into(),
+            description: None,
+            created_at: None,
+            lead: None,
+            agents: vec![AgentItem {
+                id: "a-1".into(),
+                name: "lead".into(),
+                role: "PROJECT_LEAD".into(),
+                model: "test".into(),
+                sandbox: None,
+            }],
+        }
+    }
+
+    fn state() -> ScreenState {
+        ScreenState::new(vec![project()], "http://s".into(), "u".into(), None)
+    }
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::empty())
+    }
+
+    #[test]
+    fn ctrl_w_opens_workflows() {
+        let mut state = state();
+        let action = handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
+        );
+        assert!(matches!(action, Action::OpenWorkflows));
+    }
+
+    #[test]
+    fn ctrl_w_still_deletes_chat_word_when_input_has_text() {
+        let mut state = state();
+        state.chat_input = "hello world".into();
+        state.input_cursor = state.chat_input.len();
+
+        let action = handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Char('w'), KeyModifiers::CONTROL),
+        );
+
+        assert!(matches!(action, Action::None));
+        assert_eq!(state.chat_input, "hello ");
+    }
+
+    #[test]
+    fn trigger_modal_empty_payload_submits_empty_object() {
+        let mut state = state();
+        state.enter_trigger_workflow("wf-1".into(), "wf".into());
+        if let Mode::TriggerWorkflow { payload, .. } = &mut state.mode {
+            payload.clear();
+        }
+
+        let action = handle_key(&mut state, key(KeyCode::Enter));
+
+        match action {
+            Action::TriggerWorkflow {
+                definition_id,
+                payload,
+            } => {
+                assert_eq!(definition_id, "wf-1");
+                assert_eq!(payload, serde_json::json!({}));
+            }
+            _ => panic!("expected trigger action"),
+        }
+    }
+
+    #[test]
+    fn trigger_modal_invalid_json_stays_open_with_error() {
+        let mut state = state();
+        state.enter_trigger_workflow("wf-1".into(), "wf".into());
+        if let Mode::TriggerWorkflow { payload, .. } = &mut state.mode {
+            *payload = "{".into();
+        }
+
+        let action = handle_key(&mut state, key(KeyCode::Enter));
+
+        assert!(matches!(action, Action::None));
+        assert!(matches!(
+            state.mode,
+            Mode::TriggerWorkflow { error: Some(_), .. }
+        ));
     }
 }

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -53,6 +53,9 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
                     state.select_lead_and_focus_chat();
                     return Action::None;
                 }
+                KeyCode::Char('r') if state.focus == Focus::Workflows => {
+                    return enter_trigger_for_selected_workflow(state);
+                }
                 KeyCode::Char('r') => return Action::Refresh,
                 KeyCode::Char('h') => {
                     state.focus_left();
@@ -92,6 +95,7 @@ fn handle_workflows_key(state: &mut ScreenState, key: KeyEvent) -> Action {
     state.status_message = None;
     match state.workflows.focus {
         MillerFocus::Definitions => handle_workflow_definitions_key(state, key),
+        MillerFocus::YamlDetail => handle_workflow_yaml_key(state, key),
         MillerFocus::Runs => handle_workflow_runs_key(state, key),
         MillerFocus::StepDetail => handle_workflow_step_detail_key(state, key),
     }
@@ -107,22 +111,39 @@ fn handle_workflow_definitions_key(state: &mut ScreenState, key: KeyEvent) -> Ac
             state.workflow_cursor_up();
             Action::None
         }
-        KeyCode::Char('J') | KeyCode::PageDown => {
-            state.workflow_detail_scroll_down();
+        KeyCode::Enter => {
+            state.workflow_focus_yaml();
             Action::None
         }
-        KeyCode::Char('K') | KeyCode::PageUp => {
-            state.workflow_detail_scroll_up();
-            Action::None
-        }
-        KeyCode::Right | KeyCode::Char('l') | KeyCode::Enter => {
+        KeyCode::Right | KeyCode::Char('l') => {
             state.workflow_focus_right();
             Action::None
         }
-        KeyCode::Char('T') => enter_trigger_for_selected_workflow(state),
         KeyCode::Char('r') => Action::RefreshWorkflows,
         KeyCode::Esc => {
             state.focus = Focus::Chat;
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn handle_workflow_yaml_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.workflow_detail_scroll_down();
+            Action::None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.workflow_detail_scroll_up();
+            Action::None
+        }
+        KeyCode::Right | KeyCode::Char('l') => {
+            state.workflow_focus_right();
+            Action::None
+        }
+        KeyCode::Left | KeyCode::Char('h') | KeyCode::Esc => {
+            state.workflow_focus_left();
             Action::None
         }
         _ => Action::None,

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -2,6 +2,10 @@ use std::collections::HashMap;
 
 use super::chat::{AssistantChat, ChatRole, ContentBlock};
 
+mod workflow;
+
+pub use workflow::*;
+
 #[allow(dead_code)]
 pub struct ProjectItem {
     pub id: String,
@@ -12,6 +16,7 @@ pub struct ProjectItem {
     pub agents: Vec<AgentItem>,
 }
 
+#[derive(Debug, Clone)]
 pub struct SandboxInfo {
     pub name: String,
     pub mode: String,
@@ -39,6 +44,12 @@ pub enum Mode {
         input: String,
         list_cursor: usize,
     },
+    TriggerWorkflow {
+        definition_id: String,
+        name: String,
+        payload: String,
+        error: Option<String>,
+    },
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -54,6 +65,7 @@ pub enum Focus {
     Chat,
     Agents,
     Threads,
+    Workflows,
 }
 
 #[derive(Default)]
@@ -270,6 +282,7 @@ pub struct ScreenState {
     pub loaded_agent_id: Option<String>,
 
     pub thread_view: Option<ThreadGridState>,
+    pub workflows: WorkflowState,
 
     pub mode: Mode,
     pub input_name: String,
@@ -311,6 +324,7 @@ impl ScreenState {
             loaded_agent_id: None,
 
             thread_view: None,
+            workflows: WorkflowState::default(),
 
             mode: Mode::default(),
             input_name: String::new(),
@@ -412,6 +426,19 @@ impl ScreenState {
         self.mode = Mode::Browse;
     }
 
+    pub fn enter_trigger_workflow(&mut self, definition_id: String, name: String) {
+        self.mode = Mode::TriggerWorkflow {
+            definition_id,
+            name,
+            payload: "{}".to_string(),
+            error: None,
+        };
+    }
+
+    pub fn exit_trigger_workflow(&mut self) {
+        self.mode = Mode::Browse;
+    }
+
     /// Case-insensitive substring match in original-order; returns `(idx, name)`.
     pub fn picker_matches(&self, query: &str) -> Vec<(usize, String)> {
         let q = query.to_lowercase();
@@ -454,6 +481,227 @@ impl ScreenState {
         self.focus = Focus::Chat;
     }
 
+    pub fn replace_workflow_definitions(&mut self, definitions: Vec<WorkflowDefinitionItem>) {
+        self.workflows.definitions = definitions;
+        if self.workflows.cursor >= self.workflows.definitions.len() {
+            self.workflows.cursor = self.workflows.definitions.len().saturating_sub(1);
+        }
+        self.workflows.loading = false;
+        self.workflows.error = None;
+    }
+
+    pub fn replace_workflow_definition_detail(&mut self, detail: WorkflowDefinitionDetail) {
+        let id = detail.id.clone();
+        self.workflows.selected_definition = Some(detail);
+        if !matches!(self.workflows.view, WorkflowView::Definition { .. }) {
+            self.open_workflow_definition(id);
+        }
+        self.workflows.loading = false;
+        self.workflows.error = None;
+    }
+
+    pub fn replace_workflow_runs(&mut self, runs: Vec<WorkflowRunItem>) {
+        self.workflows.runs = runs;
+        if let WorkflowView::Runs { cursor, .. } = &mut self.workflows.view {
+            if *cursor >= self.workflows.runs.len() {
+                *cursor = self.workflows.runs.len().saturating_sub(1);
+            }
+        }
+        self.workflows.loading = false;
+        self.workflows.error = None;
+    }
+
+    pub fn replace_workflow_run_detail(&mut self, run: WorkflowRunDetail) {
+        let id = run.id.clone();
+        self.workflows.selected_run = Some(run);
+        if !matches!(self.workflows.view, WorkflowView::RunDetail { .. }) {
+            self.open_workflow_run_detail(id);
+        }
+        self.workflows.loading = false;
+        self.workflows.error = None;
+    }
+
+    pub fn set_workflow_error(&mut self, error: String) {
+        self.workflows.loading = false;
+        self.workflows.error = Some(error);
+    }
+
+    pub fn enter_workflows(&mut self) {
+        self.focus = Focus::Workflows;
+        self.thread_view = None;
+        self.workflows.view = WorkflowView::Catalog;
+        self.workflows.error = None;
+    }
+
+    pub fn selected_workflow_definition(&self) -> Option<&WorkflowDefinitionItem> {
+        self.workflows.definitions.get(self.workflows.cursor)
+    }
+
+    pub fn selected_workflow_definition_id(&self) -> Option<String> {
+        match &self.workflows.view {
+            WorkflowView::Catalog => self.selected_workflow_definition().map(|d| d.id.clone()),
+            WorkflowView::Definition { definition_id, .. }
+            | WorkflowView::Runs { definition_id, .. } => Some(definition_id.clone()),
+            WorkflowView::RunDetail { .. } => self
+                .workflows
+                .selected_run
+                .as_ref()
+                .map(|run| run.definition_id.clone()),
+        }
+    }
+
+    pub fn selected_workflow_name(&self) -> String {
+        self.workflows
+            .selected_definition
+            .as_ref()
+            .map(|d| d.name.clone())
+            .or_else(|| self.selected_workflow_definition().map(|d| d.name.clone()))
+            .unwrap_or_else(|| "workflow".to_string())
+    }
+
+    pub fn workflow_cursor_down(&mut self) {
+        if !self.workflows.definitions.is_empty()
+            && self.workflows.cursor < self.workflows.definitions.len() - 1
+        {
+            self.workflows.cursor += 1;
+        }
+    }
+
+    pub fn workflow_cursor_up(&mut self) {
+        self.workflows.cursor = self.workflows.cursor.saturating_sub(1);
+    }
+
+    pub fn workflow_runs_cursor_down(&mut self) {
+        if let WorkflowView::Runs { cursor, .. } = &mut self.workflows.view {
+            if !self.workflows.runs.is_empty() && *cursor < self.workflows.runs.len() - 1 {
+                *cursor += 1;
+            }
+        }
+    }
+
+    pub fn workflow_runs_cursor_up(&mut self) {
+        if let WorkflowView::Runs { cursor, .. } = &mut self.workflows.view {
+            *cursor = cursor.saturating_sub(1);
+        }
+    }
+
+    pub fn selected_workflow_run_id(&self) -> Option<String> {
+        match &self.workflows.view {
+            WorkflowView::Runs { cursor, .. } => {
+                self.workflows.runs.get(*cursor).map(|r| r.id.clone())
+            }
+            WorkflowView::RunDetail { run_id, .. } => Some(run_id.clone()),
+            _ => None,
+        }
+    }
+
+    pub fn workflow_step_cursor_down(&mut self) {
+        if let WorkflowView::RunDetail { step_cursor, .. } = &mut self.workflows.view {
+            let len = self
+                .workflows
+                .selected_run
+                .as_ref()
+                .map(|r| r.steps_snapshot.len().max(r.step_results.len()))
+                .unwrap_or(0);
+            if len > 0 && *step_cursor < len - 1 {
+                *step_cursor += 1;
+            }
+        }
+    }
+
+    pub fn workflow_step_cursor_up(&mut self) {
+        if let WorkflowView::RunDetail { step_cursor, .. } = &mut self.workflows.view {
+            *step_cursor = step_cursor.saturating_sub(1);
+        }
+    }
+
+    pub fn workflow_scroll_yaml_down(&mut self) {
+        if let WorkflowView::Definition { yaml_scroll, .. } = &mut self.workflows.view {
+            *yaml_scroll = yaml_scroll.saturating_add(1);
+        }
+    }
+
+    pub fn workflow_scroll_yaml_up(&mut self) {
+        if let WorkflowView::Definition { yaml_scroll, .. } = &mut self.workflows.view {
+            *yaml_scroll = yaml_scroll.saturating_sub(1);
+        }
+    }
+
+    pub fn workflow_set_panel(&mut self, next: RunDetailPanel) {
+        if let WorkflowView::RunDetail { panel, .. } = &mut self.workflows.view {
+            *panel = next;
+        }
+    }
+
+    pub fn workflow_toggle_expanded(&mut self) {
+        if let WorkflowView::RunDetail { expanded, .. } = &mut self.workflows.view {
+            *expanded = !*expanded;
+        }
+    }
+
+    pub fn open_workflow_definition(&mut self, definition_id: String) {
+        self.workflows.view = WorkflowView::Definition {
+            definition_id,
+            yaml_scroll: 0,
+        };
+        self.workflows.error = None;
+    }
+
+    pub fn open_workflow_runs(&mut self, definition_id: String) {
+        self.workflows.view = WorkflowView::Runs {
+            definition_id,
+            cursor: 0,
+        };
+        self.workflows.error = None;
+    }
+
+    pub fn open_workflow_run_detail(&mut self, run_id: String) {
+        self.workflows.view = WorkflowView::RunDetail {
+            run_id,
+            step_cursor: 0,
+            panel: RunDetailPanel::Step,
+            expanded: false,
+        };
+        self.workflows.error = None;
+    }
+
+    pub fn workflow_back(&mut self) {
+        self.workflows.error = None;
+        self.workflows.view = match &self.workflows.view {
+            WorkflowView::Catalog => {
+                self.focus = Focus::Chat;
+                WorkflowView::Catalog
+            }
+            WorkflowView::Definition { .. } => WorkflowView::Catalog,
+            WorkflowView::Runs { definition_id, .. } => WorkflowView::Definition {
+                definition_id: definition_id.clone(),
+                yaml_scroll: 0,
+            },
+            WorkflowView::RunDetail { .. } => match self.workflows.selected_run.as_ref() {
+                Some(run) => WorkflowView::Runs {
+                    definition_id: run.definition_id.clone(),
+                    cursor: 0,
+                },
+                None => WorkflowView::Catalog,
+            },
+        };
+    }
+
+    pub fn workflow_poll_run_id(&self) -> Option<String> {
+        if self.focus != Focus::Workflows {
+            return None;
+        }
+        let WorkflowView::RunDetail { run_id, .. } = &self.workflows.view else {
+            return None;
+        };
+        let run = self.workflows.selected_run.as_ref()?;
+        if run.id == *run_id && !run.is_terminal() {
+            Some(run_id.clone())
+        } else {
+            None
+        }
+    }
+
     pub fn active_input_mut(&mut self) -> &mut String {
         if self.input_field == 0 {
             &mut self.input_name
@@ -466,21 +714,21 @@ impl ScreenState {
     pub fn toggle_focus(&mut self) {
         self.focus = match self.focus {
             Focus::Chat => Focus::Agents,
-            Focus::Agents | Focus::Threads => Focus::Chat,
+            Focus::Agents | Focus::Threads | Focus::Workflows => Focus::Chat,
         };
     }
 
     pub fn focus_left(&mut self) {
         self.focus = match self.focus {
             Focus::Agents => Focus::Chat,
-            Focus::Chat | Focus::Threads => Focus::Chat,
+            Focus::Chat | Focus::Threads | Focus::Workflows => Focus::Chat,
         };
     }
 
     pub fn focus_right(&mut self) {
         self.focus = match self.focus {
             Focus::Chat => Focus::Agents,
-            Focus::Agents | Focus::Threads => Focus::Agents,
+            Focus::Agents | Focus::Threads | Focus::Workflows => Focus::Agents,
         };
     }
 
@@ -929,5 +1177,65 @@ mod tests {
 
         assert!(!state.chat_view.assistant.streaming);
         assert!(state.chat_view.assistant.messages.is_empty());
+    }
+
+    #[test]
+    fn enter_workflows_sets_catalog_focus() {
+        let mut state = make_state(vec![proj("a", "Alpha")], None);
+
+        state.enter_workflows();
+
+        assert_eq!(state.focus, Focus::Workflows);
+        assert!(matches!(state.workflows.view, WorkflowView::Catalog));
+    }
+
+    #[test]
+    fn workflow_navigation_preserves_definition_context() {
+        let mut state = make_state(vec![proj("a", "Alpha")], None);
+
+        state.open_workflow_definition("wf-1".into());
+        assert!(matches!(
+            state.workflows.view,
+            WorkflowView::Definition { ref definition_id, .. } if definition_id == "wf-1"
+        ));
+
+        state.open_workflow_runs("wf-1".into());
+        assert!(matches!(
+            state.workflows.view,
+            WorkflowView::Runs { ref definition_id, cursor } if definition_id == "wf-1" && cursor == 0
+        ));
+
+        state.open_workflow_run_detail("run-1".into());
+        assert!(matches!(
+            state.workflows.view,
+            WorkflowView::RunDetail { ref run_id, step_cursor, .. } if run_id == "run-1" && step_cursor == 0
+        ));
+    }
+
+    #[test]
+    fn workflow_polling_only_for_non_terminal_selected_run() {
+        let mut state = make_state(vec![proj("a", "Alpha")], None);
+        state.enter_workflows();
+        state.open_workflow_run_detail("run-1".into());
+        state.replace_workflow_run_detail(WorkflowRunDetail {
+            id: "run-1".into(),
+            definition_id: "wf-1".into(),
+            project_id: "p-1".into(),
+            state: "RUNNING".into(),
+            started_at: "now".into(),
+            completed_at: None,
+            trigger_context: serde_json::json!({}),
+            steps_snapshot: vec![],
+            step_results: vec![],
+            agents: vec![],
+        });
+        assert_eq!(state.workflow_poll_run_id().as_deref(), Some("run-1"));
+
+        state.focus = Focus::Chat;
+        assert_eq!(state.workflow_poll_run_id(), None);
+
+        state.focus = Focus::Workflows;
+        state.workflows.selected_run.as_mut().unwrap().state = "SUCCEEDED".into();
+        assert_eq!(state.workflow_poll_run_id(), None);
     }
 }

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -624,7 +624,7 @@ impl ScreenState {
 
     pub fn workflow_focus_right(&mut self) {
         self.workflows.focus = match self.workflows.focus {
-            MillerFocus::Definitions => {
+            MillerFocus::Definitions | MillerFocus::YamlDetail => {
                 if self.workflows.runs.is_empty() {
                     return;
                 }
@@ -642,9 +642,15 @@ impl ScreenState {
         self.workflows.error = None;
     }
 
+    pub fn workflow_focus_yaml(&mut self) {
+        self.workflows.focus = MillerFocus::YamlDetail;
+        self.workflows.detail_scroll = 0;
+    }
+
     pub fn workflow_focus_left(&mut self) {
         self.workflows.focus = match self.workflows.focus {
             MillerFocus::Definitions => return,
+            MillerFocus::YamlDetail => MillerFocus::Definitions,
             MillerFocus::Runs => MillerFocus::Definitions,
             MillerFocus::StepDetail => MillerFocus::Runs,
         };

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -506,9 +506,16 @@ impl ScreenState {
     }
 
     pub fn replace_workflow_run_detail(&mut self, run: WorkflowRunDetail) {
+        let is_new_run = self
+            .workflows
+            .selected_run
+            .as_ref()
+            .is_none_or(|prev| prev.id != run.id);
         self.workflows.selected_run = Some(run);
-        self.workflows.step_cursor = 0;
-        self.workflows.expanded = false;
+        if is_new_run {
+            self.workflows.step_cursor = 0;
+            self.workflows.expanded = false;
+        }
         self.workflows.loading = false;
         self.workflows.error = None;
     }

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -22,6 +22,7 @@ pub struct SandboxInfo {
     pub mode: String,
 }
 
+#[derive(Debug, Clone)]
 #[allow(dead_code)]
 pub struct AgentItem {
     pub id: String,

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -493,7 +493,6 @@ impl ScreenState {
     pub fn replace_workflow_definition_detail(&mut self, detail: WorkflowDefinitionDetail) {
         self.workflows.selected_definition = Some(detail);
         self.workflows.loading = false;
-        self.workflows.error = None;
     }
 
     pub fn replace_workflow_runs(&mut self, runs: Vec<WorkflowRunItem>) {
@@ -502,7 +501,6 @@ impl ScreenState {
             self.workflows.run_cursor = self.workflows.runs.len().saturating_sub(1);
         }
         self.workflows.loading = false;
-        self.workflows.error = None;
     }
 
     pub fn replace_workflow_run_detail(&mut self, run: WorkflowRunDetail) {
@@ -517,7 +515,6 @@ impl ScreenState {
             self.workflows.expanded = false;
         }
         self.workflows.loading = false;
-        self.workflows.error = None;
     }
 
     pub fn set_workflow_error(&mut self, error: String) {

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -677,11 +677,19 @@ impl ScreenState {
                 definition_id: definition_id.clone(),
                 yaml_scroll: 0,
             },
-            WorkflowView::RunDetail { .. } => match self.workflows.selected_run.as_ref() {
-                Some(run) => WorkflowView::Runs {
-                    definition_id: run.definition_id.clone(),
-                    cursor: 0,
-                },
+            WorkflowView::RunDetail { run_id, .. } => match self.workflows.selected_run.as_ref() {
+                Some(run) => {
+                    let cursor = self
+                        .workflows
+                        .runs
+                        .iter()
+                        .position(|r| r.id == *run_id)
+                        .unwrap_or(0);
+                    WorkflowView::Runs {
+                        definition_id: run.definition_id.clone(),
+                        cursor,
+                    }
+                }
                 None => WorkflowView::Catalog,
             },
         };

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -483,40 +483,32 @@ impl ScreenState {
 
     pub fn replace_workflow_definitions(&mut self, definitions: Vec<WorkflowDefinitionItem>) {
         self.workflows.definitions = definitions;
-        if self.workflows.cursor >= self.workflows.definitions.len() {
-            self.workflows.cursor = self.workflows.definitions.len().saturating_sub(1);
+        if self.workflows.def_cursor >= self.workflows.definitions.len() {
+            self.workflows.def_cursor = self.workflows.definitions.len().saturating_sub(1);
         }
         self.workflows.loading = false;
         self.workflows.error = None;
     }
 
     pub fn replace_workflow_definition_detail(&mut self, detail: WorkflowDefinitionDetail) {
-        let id = detail.id.clone();
         self.workflows.selected_definition = Some(detail);
-        if !matches!(self.workflows.view, WorkflowView::Definition { .. }) {
-            self.open_workflow_definition(id);
-        }
         self.workflows.loading = false;
         self.workflows.error = None;
     }
 
     pub fn replace_workflow_runs(&mut self, runs: Vec<WorkflowRunItem>) {
         self.workflows.runs = runs;
-        if let WorkflowView::Runs { cursor, .. } = &mut self.workflows.view {
-            if *cursor >= self.workflows.runs.len() {
-                *cursor = self.workflows.runs.len().saturating_sub(1);
-            }
+        if self.workflows.run_cursor >= self.workflows.runs.len() {
+            self.workflows.run_cursor = self.workflows.runs.len().saturating_sub(1);
         }
         self.workflows.loading = false;
         self.workflows.error = None;
     }
 
     pub fn replace_workflow_run_detail(&mut self, run: WorkflowRunDetail) {
-        let id = run.id.clone();
         self.workflows.selected_run = Some(run);
-        if !matches!(self.workflows.view, WorkflowView::RunDetail { .. }) {
-            self.open_workflow_run_detail(id);
-        }
+        self.workflows.step_cursor = 0;
+        self.workflows.expanded = false;
         self.workflows.loading = false;
         self.workflows.error = None;
     }
@@ -529,25 +521,16 @@ impl ScreenState {
     pub fn enter_workflows(&mut self) {
         self.focus = Focus::Workflows;
         self.thread_view = None;
-        self.workflows.view = WorkflowView::Catalog;
+        self.workflows.focus = MillerFocus::Definitions;
         self.workflows.error = None;
     }
 
     pub fn selected_workflow_definition(&self) -> Option<&WorkflowDefinitionItem> {
-        self.workflows.definitions.get(self.workflows.cursor)
+        self.workflows.definitions.get(self.workflows.def_cursor)
     }
 
     pub fn selected_workflow_definition_id(&self) -> Option<String> {
-        match &self.workflows.view {
-            WorkflowView::Catalog => self.selected_workflow_definition().map(|d| d.id.clone()),
-            WorkflowView::Definition { definition_id, .. }
-            | WorkflowView::Runs { definition_id, .. } => Some(definition_id.clone()),
-            WorkflowView::RunDetail { .. } => self
-                .workflows
-                .selected_run
-                .as_ref()
-                .map(|run| run.definition_id.clone()),
-        }
+        self.selected_workflow_definition().map(|d| d.id.clone())
     }
 
     pub fn selected_workflow_name(&self) -> String {
@@ -561,150 +544,114 @@ impl ScreenState {
 
     pub fn workflow_cursor_down(&mut self) {
         if !self.workflows.definitions.is_empty()
-            && self.workflows.cursor < self.workflows.definitions.len() - 1
+            && self.workflows.def_cursor < self.workflows.definitions.len() - 1
         {
-            self.workflows.cursor += 1;
+            self.workflows.def_cursor += 1;
+            self.workflows.run_cursor = 0;
+            self.workflows.detail_scroll = 0;
         }
     }
 
     pub fn workflow_cursor_up(&mut self) {
-        self.workflows.cursor = self.workflows.cursor.saturating_sub(1);
+        if self.workflows.def_cursor > 0 {
+            self.workflows.def_cursor = self.workflows.def_cursor.saturating_sub(1);
+            self.workflows.run_cursor = 0;
+            self.workflows.detail_scroll = 0;
+        }
     }
 
     pub fn workflow_runs_cursor_down(&mut self) {
-        if let WorkflowView::Runs { cursor, .. } = &mut self.workflows.view {
-            if !self.workflows.runs.is_empty() && *cursor < self.workflows.runs.len() - 1 {
-                *cursor += 1;
-            }
+        if !self.workflows.runs.is_empty()
+            && self.workflows.run_cursor < self.workflows.runs.len() - 1
+        {
+            self.workflows.run_cursor += 1;
+            self.workflows.detail_scroll = 0;
         }
     }
 
     pub fn workflow_runs_cursor_up(&mut self) {
-        if let WorkflowView::Runs { cursor, .. } = &mut self.workflows.view {
-            *cursor = cursor.saturating_sub(1);
+        if self.workflows.run_cursor > 0 {
+            self.workflows.run_cursor = self.workflows.run_cursor.saturating_sub(1);
+            self.workflows.detail_scroll = 0;
         }
     }
 
     pub fn selected_workflow_run_id(&self) -> Option<String> {
-        match &self.workflows.view {
-            WorkflowView::Runs { cursor, .. } => {
-                self.workflows.runs.get(*cursor).map(|r| r.id.clone())
-            }
-            WorkflowView::RunDetail { run_id, .. } => Some(run_id.clone()),
-            _ => None,
-        }
+        self.workflows
+            .runs
+            .get(self.workflows.run_cursor)
+            .map(|r| r.id.clone())
     }
 
     pub fn workflow_step_cursor_down(&mut self) {
-        if let WorkflowView::RunDetail { step_cursor, .. } = &mut self.workflows.view {
-            let len = self
-                .workflows
-                .selected_run
-                .as_ref()
-                .map(|r| r.steps_snapshot.len().max(r.step_results.len()))
-                .unwrap_or(0);
-            if len > 0 && *step_cursor < len - 1 {
-                *step_cursor += 1;
-            }
+        let len = self
+            .workflows
+            .selected_run
+            .as_ref()
+            .map(|r| r.steps_snapshot.len().max(r.step_results.len()))
+            .unwrap_or(0);
+        if len > 0 && self.workflows.step_cursor < len - 1 {
+            self.workflows.step_cursor += 1;
+            self.workflows.expanded = false;
         }
     }
 
     pub fn workflow_step_cursor_up(&mut self) {
-        if let WorkflowView::RunDetail { step_cursor, .. } = &mut self.workflows.view {
-            *step_cursor = step_cursor.saturating_sub(1);
+        if self.workflows.step_cursor > 0 {
+            self.workflows.step_cursor = self.workflows.step_cursor.saturating_sub(1);
+            self.workflows.expanded = false;
         }
     }
 
-    pub fn workflow_scroll_yaml_down(&mut self) {
-        if let WorkflowView::Definition { yaml_scroll, .. } = &mut self.workflows.view {
-            *yaml_scroll = yaml_scroll.saturating_add(1);
-        }
+    pub fn workflow_detail_scroll_down(&mut self) {
+        self.workflows.detail_scroll = self.workflows.detail_scroll.saturating_add(1);
     }
 
-    pub fn workflow_scroll_yaml_up(&mut self) {
-        if let WorkflowView::Definition { yaml_scroll, .. } = &mut self.workflows.view {
-            *yaml_scroll = yaml_scroll.saturating_sub(1);
-        }
-    }
-
-    pub fn workflow_set_panel(&mut self, next: RunDetailPanel) {
-        if let WorkflowView::RunDetail { panel, .. } = &mut self.workflows.view {
-            *panel = next;
-        }
+    pub fn workflow_detail_scroll_up(&mut self) {
+        self.workflows.detail_scroll = self.workflows.detail_scroll.saturating_sub(1);
     }
 
     pub fn workflow_toggle_expanded(&mut self) {
-        if let WorkflowView::RunDetail { expanded, .. } = &mut self.workflows.view {
-            *expanded = !*expanded;
-        }
+        self.workflows.expanded = !self.workflows.expanded;
     }
 
-    pub fn open_workflow_definition(&mut self, definition_id: String) {
-        self.workflows.view = WorkflowView::Definition {
-            definition_id,
-            yaml_scroll: 0,
-        };
-        self.workflows.error = None;
-    }
-
-    pub fn open_workflow_runs(&mut self, definition_id: String) {
-        self.workflows.view = WorkflowView::Runs {
-            definition_id,
-            cursor: 0,
-        };
-        self.workflows.error = None;
-    }
-
-    pub fn open_workflow_run_detail(&mut self, run_id: String) {
-        self.workflows.view = WorkflowView::RunDetail {
-            run_id,
-            step_cursor: 0,
-            panel: RunDetailPanel::Step,
-            expanded: false,
-        };
-        self.workflows.error = None;
-    }
-
-    pub fn workflow_back(&mut self) {
-        self.workflows.error = None;
-        self.workflows.view = match &self.workflows.view {
-            WorkflowView::Catalog => {
-                self.focus = Focus::Chat;
-                WorkflowView::Catalog
-            }
-            WorkflowView::Definition { .. } => WorkflowView::Catalog,
-            WorkflowView::Runs { definition_id, .. } => WorkflowView::Definition {
-                definition_id: definition_id.clone(),
-                yaml_scroll: 0,
-            },
-            WorkflowView::RunDetail { run_id, .. } => match self.workflows.selected_run.as_ref() {
-                Some(run) => {
-                    let cursor = self
-                        .workflows
-                        .runs
-                        .iter()
-                        .position(|r| r.id == *run_id)
-                        .unwrap_or(0);
-                    WorkflowView::Runs {
-                        definition_id: run.definition_id.clone(),
-                        cursor,
-                    }
+    pub fn workflow_focus_right(&mut self) {
+        self.workflows.focus = match self.workflows.focus {
+            MillerFocus::Definitions => {
+                if self.workflows.runs.is_empty() {
+                    return;
                 }
-                None => WorkflowView::Catalog,
-            },
+                MillerFocus::Runs
+            }
+            MillerFocus::Runs => {
+                if self.workflows.selected_run.is_none() {
+                    return;
+                }
+                MillerFocus::StepDetail
+            }
+            MillerFocus::StepDetail => return,
         };
+        self.workflows.detail_scroll = 0;
+        self.workflows.error = None;
+    }
+
+    pub fn workflow_focus_left(&mut self) {
+        self.workflows.focus = match self.workflows.focus {
+            MillerFocus::Definitions => return,
+            MillerFocus::Runs => MillerFocus::Definitions,
+            MillerFocus::StepDetail => MillerFocus::Runs,
+        };
+        self.workflows.detail_scroll = 0;
+        self.workflows.error = None;
     }
 
     pub fn workflow_poll_run_id(&self) -> Option<String> {
         if self.focus != Focus::Workflows {
             return None;
         }
-        let WorkflowView::RunDetail { run_id, .. } = &self.workflows.view else {
-            return None;
-        };
         let run = self.workflows.selected_run.as_ref()?;
-        if run.id == *run_id && !run.is_terminal() {
-            Some(run_id.clone())
+        if !run.is_terminal() {
+            Some(run.id.clone())
         } else {
             None
         }
@@ -1188,43 +1135,70 @@ mod tests {
     }
 
     #[test]
-    fn enter_workflows_sets_catalog_focus() {
+    fn enter_workflows_sets_definitions_focus() {
         let mut state = make_state(vec![proj("a", "Alpha")], None);
 
         state.enter_workflows();
 
         assert_eq!(state.focus, Focus::Workflows);
-        assert!(matches!(state.workflows.view, WorkflowView::Catalog));
+        assert_eq!(state.workflows.focus, MillerFocus::Definitions);
     }
 
     #[test]
-    fn workflow_navigation_preserves_definition_context() {
+    fn workflow_focus_right_left_navigation() {
         let mut state = make_state(vec![proj("a", "Alpha")], None);
+        state.enter_workflows();
 
-        state.open_workflow_definition("wf-1".into());
-        assert!(matches!(
-            state.workflows.view,
-            WorkflowView::Definition { ref definition_id, .. } if definition_id == "wf-1"
-        ));
+        // Can't move right with empty runs
+        state.workflow_focus_right();
+        assert_eq!(state.workflows.focus, MillerFocus::Definitions);
 
-        state.open_workflow_runs("wf-1".into());
-        assert!(matches!(
-            state.workflows.view,
-            WorkflowView::Runs { ref definition_id, cursor } if definition_id == "wf-1" && cursor == 0
-        ));
+        // Add a run so we can move right
+        state.workflows.runs = vec![WorkflowRunItem {
+            id: "run-1".into(),
+            state: "SUCCEEDED".into(),
+            started_at: "now".into(),
+            completed_at: None,
+            step_results: vec![],
+        }];
+        state.replace_workflow_run_detail(WorkflowRunDetail {
+            id: "run-1".into(),
+            definition_id: "wf-1".into(),
+            project_id: "p-1".into(),
+            state: "SUCCEEDED".into(),
+            started_at: "now".into(),
+            completed_at: None,
+            trigger_context: serde_json::json!({}),
+            steps_snapshot: vec![],
+            step_results: vec![],
+            agents: vec![],
+        });
 
-        state.open_workflow_run_detail("run-1".into());
-        assert!(matches!(
-            state.workflows.view,
-            WorkflowView::RunDetail { ref run_id, step_cursor, .. } if run_id == "run-1" && step_cursor == 0
-        ));
+        state.workflow_focus_right();
+        assert_eq!(state.workflows.focus, MillerFocus::Runs);
+
+        state.workflow_focus_right();
+        assert_eq!(state.workflows.focus, MillerFocus::StepDetail);
+
+        // Can't go further right
+        state.workflow_focus_right();
+        assert_eq!(state.workflows.focus, MillerFocus::StepDetail);
+
+        state.workflow_focus_left();
+        assert_eq!(state.workflows.focus, MillerFocus::Runs);
+
+        state.workflow_focus_left();
+        assert_eq!(state.workflows.focus, MillerFocus::Definitions);
+
+        // Can't go further left
+        state.workflow_focus_left();
+        assert_eq!(state.workflows.focus, MillerFocus::Definitions);
     }
 
     #[test]
     fn workflow_polling_only_for_non_terminal_selected_run() {
         let mut state = make_state(vec![proj("a", "Alpha")], None);
         state.enter_workflows();
-        state.open_workflow_run_detail("run-1".into());
         state.replace_workflow_run_detail(WorkflowRunDetail {
             id: "run-1".into(),
             definition_id: "wf-1".into(),
@@ -1245,5 +1219,34 @@ mod tests {
         state.focus = Focus::Workflows;
         state.workflows.selected_run.as_mut().unwrap().state = "SUCCEEDED".into();
         assert_eq!(state.workflow_poll_run_id(), None);
+    }
+
+    #[test]
+    fn workflow_def_cursor_resets_run_cursor() {
+        let mut state = make_state(vec![proj("a", "Alpha")], None);
+        state.enter_workflows();
+        state.workflows.definitions = vec![
+            WorkflowDefinitionItem {
+                id: "wf-1".into(),
+                name: "first".into(),
+                description: None,
+                trigger: WorkflowTriggerInfo::default(),
+                steps: vec![],
+                recent_runs: vec![],
+            },
+            WorkflowDefinitionItem {
+                id: "wf-2".into(),
+                name: "second".into(),
+                description: None,
+                trigger: WorkflowTriggerInfo::default(),
+                steps: vec![],
+                recent_runs: vec![],
+            },
+        ];
+        state.workflows.run_cursor = 3;
+
+        state.workflow_cursor_down();
+        assert_eq!(state.workflows.def_cursor, 1);
+        assert_eq!(state.workflows.run_cursor, 0);
     }
 }

--- a/client/src/tui/state/workflow.rs
+++ b/client/src/tui/state/workflow.rs
@@ -117,4 +117,3 @@ pub struct WorkflowStepResultItem {
     pub skipped: Option<String>,
     pub completed_at: Option<String>,
 }
-

--- a/client/src/tui/state/workflow.rs
+++ b/client/src/tui/state/workflow.rs
@@ -1,7 +1,5 @@
 use serde_json::Value;
 
-use super::SandboxInfo;
-
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum MillerFocus {
     #[default]
@@ -99,7 +97,7 @@ pub struct WorkflowRunDetail {
     pub trigger_context: Value,
     pub steps_snapshot: Vec<WorkflowStepItem>,
     pub step_results: Vec<WorkflowStepResultItem>,
-    pub agents: Vec<WorkflowAgentItem>,
+    pub agents: Vec<super::AgentItem>,
 }
 
 impl WorkflowRunDetail {
@@ -120,11 +118,3 @@ pub struct WorkflowStepResultItem {
     pub completed_at: Option<String>,
 }
 
-#[derive(Debug, Clone)]
-pub struct WorkflowAgentItem {
-    pub id: String,
-    pub name: String,
-    pub role: String,
-    pub model: String,
-    pub sandbox: Option<SandboxInfo>,
-}

--- a/client/src/tui/state/workflow.rs
+++ b/client/src/tui/state/workflow.rs
@@ -2,43 +2,26 @@ use serde_json::Value;
 
 use super::SandboxInfo;
 
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub enum WorkflowView {
-    #[default]
-    Catalog,
-    Definition {
-        definition_id: String,
-        yaml_scroll: u16,
-    },
-    Runs {
-        definition_id: String,
-        cursor: usize,
-    },
-    RunDetail {
-        run_id: String,
-        step_cursor: usize,
-        panel: RunDetailPanel,
-        expanded: bool,
-    },
-}
-
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum RunDetailPanel {
+pub enum MillerFocus {
     #[default]
-    Step,
-    Trigger,
-    Agents,
-    Sandboxes,
+    Definitions,
+    Runs,
+    StepDetail,
 }
 
 #[derive(Debug, Clone, Default)]
 pub struct WorkflowState {
-    pub view: WorkflowView,
+    pub focus: MillerFocus,
     pub definitions: Vec<WorkflowDefinitionItem>,
+    pub def_cursor: usize,
     pub selected_definition: Option<WorkflowDefinitionDetail>,
     pub runs: Vec<WorkflowRunItem>,
+    pub run_cursor: usize,
     pub selected_run: Option<WorkflowRunDetail>,
-    pub cursor: usize,
+    pub step_cursor: usize,
+    pub expanded: bool,
+    pub detail_scroll: u16,
     pub loading: bool,
     pub error: Option<String>,
 }

--- a/client/src/tui/state/workflow.rs
+++ b/client/src/tui/state/workflow.rs
@@ -6,6 +6,7 @@ use super::SandboxInfo;
 pub enum MillerFocus {
     #[default]
     Definitions,
+    YamlDetail,
     Runs,
     StepDetail,
 }

--- a/client/src/tui/state/workflow.rs
+++ b/client/src/tui/state/workflow.rs
@@ -1,0 +1,144 @@
+use serde_json::Value;
+
+use super::SandboxInfo;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub enum WorkflowView {
+    #[default]
+    Catalog,
+    Definition {
+        definition_id: String,
+        yaml_scroll: u16,
+    },
+    Runs {
+        definition_id: String,
+        cursor: usize,
+    },
+    RunDetail {
+        run_id: String,
+        step_cursor: usize,
+        panel: RunDetailPanel,
+        expanded: bool,
+    },
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum RunDetailPanel {
+    #[default]
+    Step,
+    Trigger,
+    Agents,
+    Sandboxes,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WorkflowState {
+    pub view: WorkflowView,
+    pub definitions: Vec<WorkflowDefinitionItem>,
+    pub selected_definition: Option<WorkflowDefinitionDetail>,
+    pub runs: Vec<WorkflowRunItem>,
+    pub selected_run: Option<WorkflowRunDetail>,
+    pub cursor: usize,
+    pub loading: bool,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowDefinitionItem {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub trigger: WorkflowTriggerInfo,
+    pub steps: Vec<WorkflowStepItem>,
+    pub recent_runs: Vec<WorkflowRunItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowDefinitionDetail {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub yaml: String,
+    pub trigger: WorkflowTriggerInfo,
+    pub steps: Vec<WorkflowStepItem>,
+    pub sandboxes: Vec<WorkflowSandboxItem>,
+    pub recent_runs: Vec<WorkflowRunItem>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct WorkflowTriggerInfo {
+    pub kind: String,
+    pub provider: Option<String>,
+    pub cron_schedule: Option<String>,
+    pub cron_timezone: Option<String>,
+    pub next_run_at: Option<String>,
+    pub condition: Option<String>,
+    pub webhook_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowStepItem {
+    pub name: String,
+    pub step_type: String,
+    pub skill: Option<String>,
+    pub tool: Option<String>,
+    pub sandbox: Option<String>,
+    pub sandbox_mode: Option<String>,
+    pub condition: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowSandboxItem {
+    pub name: String,
+    pub kind: String,
+    pub branch: Option<String>,
+    pub repo_url: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowRunItem {
+    pub id: String,
+    pub state: String,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    pub step_results: Vec<WorkflowStepResultItem>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowRunDetail {
+    pub id: String,
+    pub definition_id: String,
+    pub project_id: String,
+    pub state: String,
+    pub started_at: String,
+    pub completed_at: Option<String>,
+    pub trigger_context: Value,
+    pub steps_snapshot: Vec<WorkflowStepItem>,
+    pub step_results: Vec<WorkflowStepResultItem>,
+    pub agents: Vec<WorkflowAgentItem>,
+}
+
+impl WorkflowRunDetail {
+    pub fn is_terminal(&self) -> bool {
+        matches!(self.state.as_str(), "SUCCEEDED" | "FAILED" | "ERRORED")
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowStepResultItem {
+    pub name: String,
+    pub state: String,
+    pub output: Option<Value>,
+    pub error: Option<String>,
+    pub skipped: Option<String>,
+    pub completed_at: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WorkflowAgentItem {
+    pub id: String,
+    pub name: String,
+    pub role: String,
+    pub model: String,
+    pub sandbox: Option<SandboxInfo>,
+}

--- a/client/src/tui/state/workflow.rs
+++ b/client/src/tui/state/workflow.rs
@@ -119,8 +119,10 @@ pub struct WorkflowRunDetail {
 }
 
 impl WorkflowRunDetail {
+    // Treat any non-pending/non-running state as terminal so unknown
+    // future states (e.g. CANCELLED) stop polling instead of looping.
     pub fn is_terminal(&self) -> bool {
-        matches!(self.state.as_str(), "SUCCEEDED" | "FAILED" | "ERRORED")
+        !matches!(self.state.as_str(), "PENDING" | "RUNNING")
     }
 }
 

--- a/client/src/tui/ui/mod.rs
+++ b/client/src/tui/ui/mod.rs
@@ -2,12 +2,13 @@ mod agents;
 mod chat_pane;
 mod grid;
 mod project_picker;
+mod workflows;
 
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Style},
     text::{Line, Span},
-    widgets::{Block, Borders, Clear, Paragraph},
+    widgets::{Block, Borders, Clear, Paragraph, Wrap},
     Frame,
 };
 
@@ -22,25 +23,30 @@ pub fn draw(frame: &mut Frame, state: &mut ScreenState) {
     let main_area = chunks[0];
     let status_area = chunks[1];
 
-    let panels = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(1), Constraint::Length(44)])
-        .split(main_area);
+    if state.focus == Focus::Workflows {
+        workflows::draw_workflows(frame, state, main_area);
+    } else {
+        let panels = Layout::default()
+            .direction(Direction::Horizontal)
+            .constraints([Constraint::Min(1), Constraint::Length(44)])
+            .split(main_area);
 
-    let right_col = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
-        .split(panels[1]);
+        let right_col = Layout::default()
+            .direction(Direction::Vertical)
+            .constraints([Constraint::Percentage(50), Constraint::Percentage(50)])
+            .split(panels[1]);
 
-    chat_pane::draw_chat_pane(frame, state, panels[0]);
-    agents::draw_agents_list(frame, state, right_col[0]);
-    agents::draw_agent_details(frame, state, right_col[1]);
+        chat_pane::draw_chat_pane(frame, state, panels[0]);
+        agents::draw_agents_list(frame, state, right_col[0]);
+        agents::draw_agent_details(frame, state, right_col[1]);
+    }
     draw_status_bar(frame, state, status_area);
 
     match &state.mode {
         Mode::CreateProject => draw_create_modal(frame, state),
         Mode::ExportThread => draw_export_modal(frame, state),
         Mode::ProjectPicker { .. } => project_picker::draw_project_picker(frame, state),
+        Mode::TriggerWorkflow { .. } => draw_trigger_workflow_modal(frame, state),
         Mode::Browse => {}
     }
 }
@@ -73,8 +79,9 @@ fn draw_status_bar(frame: &mut Frame, state: &ScreenState, area: Rect) {
 
     let keys = match state.focus {
         Focus::Agents => " │ ↑/↓:nav  Enter:chat  Tab:chat  ^P:project  Esc:chat ",
-        Focus::Chat => " │ Enter:send  ↑/↓:scroll  ^P:project  ^T:threads  ^C:quit ",
+        Focus::Chat => " │ Enter:send  ↑/↓:scroll  ^P:project  ^W:workflows  ^T:threads  ^C:quit ",
         Focus::Threads => " │ ←→:pos  ↑↓:thread  Tab:next  g/G:jump  e:export  ^T:close  Esc:chat ",
+        Focus::Workflows => workflows::status_keys(state),
     };
     spans.push(Span::styled(keys, Style::default().fg(Color::DarkGray)));
 
@@ -160,6 +167,62 @@ fn draw_export_modal(frame: &mut Frame, state: &ScreenState) {
 
     let paragraph = Paragraph::new(lines).block(block);
     frame.render_widget(paragraph, area);
+}
+
+fn draw_trigger_workflow_modal(frame: &mut Frame, state: &ScreenState) {
+    let area = centered_rect(72, 11, frame.area());
+    frame.render_widget(Clear, area);
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(" Trigger Workflow ")
+        .border_style(Style::default().fg(Color::Yellow));
+
+    let (name, payload, error) = match &state.mode {
+        Mode::TriggerWorkflow {
+            name,
+            payload,
+            error,
+            ..
+        } => (name.as_str(), payload.as_str(), error.as_deref()),
+        _ => ("workflow", "{}", None),
+    };
+
+    let mut lines = vec![
+        Line::from(""),
+        Line::from(vec![
+            Span::styled("  Workflow: ", Style::default().fg(Color::DarkGray)),
+            Span::styled(name, Style::default().fg(Color::White)),
+        ]),
+        Line::from(""),
+        Line::from(Span::styled(
+            "  Payload JSON (optional):",
+            Style::default().fg(Color::DarkGray),
+        )),
+        Line::from(vec![
+            Span::raw("  "),
+            Span::styled(format!("{payload}▎"), Style::default().fg(Color::Yellow)),
+        ]),
+    ];
+    if let Some(error) = error {
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(error, Style::default().fg(Color::Red)),
+        ]));
+    }
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "  Enter:trigger  Esc:cancel  ^U:clear",
+        Style::default().fg(Color::DarkGray),
+    )));
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .wrap(Wrap { trim: false }),
+        area,
+    );
 }
 
 pub(super) fn centered_rect(width: u16, height: u16, area: Rect) -> Rect {

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -257,7 +257,7 @@ fn draw_run_overview(frame: &mut Frame, run: &WorkflowRunDetail, scroll: u16, ar
 
     // Trigger context
     let trigger_json = pretty_json(&run.trigger_context);
-    if trigger_json != "{}" {
+    if trigger_json != "{}" && trigger_json != "null" {
         lines.push(Line::from(""));
         lines.push(Line::from(Span::styled(
             "Trigger Payload",

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -1,0 +1,513 @@
+use std::collections::BTreeSet;
+
+use ratatui::{
+    layout::{Constraint, Direction, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, List, ListItem, Paragraph, Wrap},
+    Frame,
+};
+
+use super::super::state::{
+    RunDetailPanel, ScreenState, WorkflowRunDetail, WorkflowStepItem, WorkflowStepResultItem,
+    WorkflowView,
+};
+
+pub fn draw_workflows(frame: &mut Frame, state: &ScreenState, area: Rect) {
+    match &state.workflows.view {
+        WorkflowView::Catalog => draw_catalog(frame, state, area),
+        WorkflowView::Definition { yaml_scroll, .. } => {
+            draw_definition(frame, state, area, *yaml_scroll)
+        }
+        WorkflowView::Runs { cursor, .. } => draw_runs(frame, state, area, *cursor),
+        WorkflowView::RunDetail {
+            step_cursor,
+            panel,
+            expanded,
+            ..
+        } => draw_run_detail(frame, state, area, *step_cursor, *panel, *expanded),
+    }
+}
+
+pub fn status_keys(state: &ScreenState) -> &'static str {
+    match state.workflows.view {
+        WorkflowView::Catalog => " │ ↑/↓:nav  Enter:detail  T:trigger  r:refresh  Esc:chat ",
+        WorkflowView::Definition { .. } => " │ ↑/↓:scroll  T:trigger  R:runs  r:refresh  Esc:list ",
+        WorkflowView::Runs { .. } => " │ ↑/↓:nav  Enter:inspect  r:refresh  Esc:workflow ",
+        WorkflowView::RunDetail { .. } => {
+            " │ ↑/↓:step  Enter:expand  d/p/a/s:panel  r:refresh  Esc:runs "
+        }
+    }
+}
+
+fn draw_catalog(frame: &mut Frame, state: &ScreenState, area: Rect) {
+    let project = state
+        .selected_project()
+        .map(|p| p.name.as_str())
+        .unwrap_or("-");
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Workflows - project: {project} "));
+
+    let mut items = Vec::new();
+    if state.workflows.loading {
+        items.push(ListItem::new(Line::from("Loading workflows...")));
+    } else if state.workflows.definitions.is_empty() {
+        items.push(ListItem::new(Line::from("No workflows in this project")));
+    } else {
+        for (idx, definition) in state.workflows.definitions.iter().enumerate() {
+            let selected = idx == state.workflows.cursor;
+            let marker = if selected { ">" } else { " " };
+            let run = definition
+                .recent_runs
+                .first()
+                .map(|r| {
+                    (
+                        format!(
+                            "last: {} {}",
+                            state_label(&r.state),
+                            short_time(&r.started_at)
+                        ),
+                        state_color(&r.state),
+                    )
+                })
+                .unwrap_or_else(|| ("no runs".to_string(), Color::DarkGray));
+            let trigger = trigger_label(
+                &definition.trigger.kind,
+                definition.trigger.provider.as_deref(),
+            );
+            let next = definition
+                .trigger
+                .next_run_at
+                .as_deref()
+                .map(|t| format!(" next: {}", short_time(t)))
+                .unwrap_or_default();
+            let line = Line::from(vec![
+                Span::styled(marker, Style::default().fg(Color::Yellow)),
+                Span::raw(" "),
+                Span::styled(
+                    truncate(&definition.name, 30),
+                    if selected {
+                        Style::default().add_modifier(Modifier::BOLD)
+                    } else {
+                        Style::default()
+                    },
+                ),
+                Span::styled(format!("  {trigger:<18}"), Style::default().fg(Color::Cyan)),
+                Span::styled(format!("  {:<24}", run.0), Style::default().fg(run.1)),
+                Span::styled(
+                    format!("  steps: {}{next}", definition.steps.len()),
+                    Style::default().fg(Color::DarkGray),
+                ),
+            ]);
+            items.push(ListItem::new(line));
+        }
+    }
+
+    if let Some(error) = &state.workflows.error {
+        items.push(ListItem::new(Line::from("")));
+        items.push(ListItem::new(Line::from(Span::styled(
+            error,
+            Style::default().fg(Color::Red),
+        ))));
+    }
+
+    frame.render_widget(List::new(items).block(block), area);
+}
+
+fn draw_definition(frame: &mut Frame, state: &ScreenState, area: Rect, yaml_scroll: u16) {
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Min(1), Constraint::Length(34)])
+        .split(area);
+
+    let title = state
+        .workflows
+        .selected_definition
+        .as_ref()
+        .map(|d| format!(" {} ", d.name))
+        .unwrap_or_else(|| " Workflow ".to_string());
+    let yaml = state
+        .workflows
+        .selected_definition
+        .as_ref()
+        .map(|d| d.yaml.as_str())
+        .unwrap_or("Loading workflow YAML...");
+
+    frame.render_widget(
+        Paragraph::new(yaml)
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .scroll((yaml_scroll, 0))
+            .wrap(Wrap { trim: false }),
+        chunks[0],
+    );
+
+    let lines = if let Some(definition) = &state.workflows.selected_definition {
+        let mut lines = vec![
+            Line::from(vec![
+                Span::styled("Trigger ", Style::default().fg(Color::DarkGray)),
+                Span::raw(trigger_label(
+                    &definition.trigger.kind,
+                    definition.trigger.provider.as_deref(),
+                )),
+            ]),
+            Line::from(vec![
+                Span::styled("Steps   ", Style::default().fg(Color::DarkGray)),
+                Span::raw(definition.steps.len().to_string()),
+            ]),
+        ];
+        if let Some(condition) = &definition.trigger.condition {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "Condition",
+                Style::default().fg(Color::DarkGray),
+            )));
+            lines.push(Line::from(condition.as_str()));
+        }
+        if let Some(next) = &definition.trigger.next_run_at {
+            lines.push(Line::from(""));
+            lines.push(Line::from(vec![
+                Span::styled("Next run ", Style::default().fg(Color::DarkGray)),
+                Span::raw(short_time(next)),
+            ]));
+        }
+        if !definition.recent_runs.is_empty() {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                "Recent runs",
+                Style::default().fg(Color::DarkGray),
+            )));
+            for run in &definition.recent_runs {
+                lines.push(Line::from(vec![
+                    Span::styled(
+                        state_label(&run.state),
+                        Style::default().fg(state_color(&run.state)),
+                    ),
+                    Span::raw(format!(" {}", short_time(&run.started_at))),
+                ]));
+            }
+        }
+        if let Some(error) = &state.workflows.error {
+            lines.push(Line::from(""));
+            lines.push(Line::from(Span::styled(
+                error,
+                Style::default().fg(Color::Red),
+            )));
+        }
+        lines
+    } else {
+        vec![Line::from("Loading...")]
+    };
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(Block::default().borders(Borders::ALL).title(" Metadata "))
+            .wrap(Wrap { trim: true }),
+        chunks[1],
+    );
+}
+
+fn draw_runs(frame: &mut Frame, state: &ScreenState, area: Rect, cursor: usize) {
+    let name = state.selected_workflow_name();
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .title(format!(" Runs - {name} "));
+    let mut items = Vec::new();
+    if state.workflows.loading {
+        items.push(ListItem::new(Line::from("Loading runs...")));
+    } else if state.workflows.runs.is_empty() {
+        items.push(ListItem::new(Line::from("No workflow runs")));
+    } else {
+        for (idx, run) in state.workflows.runs.iter().enumerate() {
+            let selected = idx == cursor;
+            let marker = if selected { ">" } else { " " };
+            let summary = run_summary(run);
+            items.push(ListItem::new(Line::from(vec![
+                Span::styled(marker, Style::default().fg(Color::Yellow)),
+                Span::raw(" "),
+                Span::styled(short_id(&run.id), Style::default().fg(Color::White)),
+                Span::raw("  "),
+                Span::styled(
+                    state_label(&run.state),
+                    Style::default().fg(state_color(&run.state)),
+                ),
+                Span::raw(format!("  {}  ", short_time(&run.started_at))),
+                Span::styled(summary, Style::default().fg(Color::DarkGray)),
+            ])));
+        }
+    }
+    if let Some(error) = &state.workflows.error {
+        items.push(ListItem::new(Line::from("")));
+        items.push(ListItem::new(Line::from(Span::styled(
+            error,
+            Style::default().fg(Color::Red),
+        ))));
+    }
+    frame.render_widget(List::new(items).block(block), area);
+}
+
+fn draw_run_detail(
+    frame: &mut Frame,
+    state: &ScreenState,
+    area: Rect,
+    step_cursor: usize,
+    panel: RunDetailPanel,
+    expanded: bool,
+) {
+    let Some(run) = &state.workflows.selected_run else {
+        frame.render_widget(
+            Paragraph::new("Loading run...")
+                .block(Block::default().borders(Borders::ALL).title(" Run ")),
+            area,
+        );
+        return;
+    };
+
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([Constraint::Length(34), Constraint::Min(1)])
+        .split(area);
+    draw_step_list(frame, run, chunks[0], step_cursor);
+    draw_run_panel(frame, run, chunks[1], step_cursor, panel, expanded);
+}
+
+fn draw_step_list(frame: &mut Frame, run: &WorkflowRunDetail, area: Rect, cursor: usize) {
+    let mut items = Vec::new();
+    let count = run.steps_snapshot.len().max(run.step_results.len());
+    for idx in 0..count {
+        let step = run.steps_snapshot.get(idx);
+        let result = result_for_step(run, idx, step);
+        let selected = idx == cursor;
+        let marker = if selected { ">" } else { " " };
+        let name = step
+            .map(|s| s.name.as_str())
+            .or_else(|| result.map(|r| r.name.as_str()))
+            .unwrap_or("step");
+        let state = result.map(|r| r.state.as_str()).unwrap_or("PENDING");
+        items.push(ListItem::new(Line::from(vec![
+            Span::styled(marker, Style::default().fg(Color::Yellow)),
+            Span::raw(" "),
+            Span::styled(truncate(name, 18), Style::default()),
+            Span::raw(" "),
+            Span::styled(state_label(state), Style::default().fg(state_color(state))),
+        ])));
+    }
+    frame.render_widget(
+        List::new(items).block(Block::default().borders(Borders::ALL).title(format!(
+            " Run {} - {} ",
+            short_id(&run.id),
+            state_label(&run.state)
+        ))),
+        area,
+    );
+}
+
+fn draw_run_panel(
+    frame: &mut Frame,
+    run: &WorkflowRunDetail,
+    area: Rect,
+    step_cursor: usize,
+    panel: RunDetailPanel,
+    expanded: bool,
+) {
+    let (title, body) = match panel {
+        RunDetailPanel::Step => (" Step ", selected_step_body(run, step_cursor, expanded)),
+        RunDetailPanel::Trigger => (" Trigger Payload ", pretty_json(&run.trigger_context)),
+        RunDetailPanel::Agents => (" Related Agents ", agents_body(run)),
+        RunDetailPanel::Sandboxes => (" Related Sandboxes ", sandboxes_body(run)),
+    };
+    frame.render_widget(
+        Paragraph::new(body)
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn selected_step_body(run: &WorkflowRunDetail, cursor: usize, expanded: bool) -> String {
+    let step = run.steps_snapshot.get(cursor);
+    let result = result_for_step(run, cursor, step);
+    let mut lines = Vec::new();
+    if let Some(step) = step {
+        lines.push(format!("name: {}", step.name));
+        lines.push(format!("type: {}", step.step_type));
+        if let Some(skill) = &step.skill {
+            lines.push(format!("skill: {skill}"));
+        }
+        if let Some(tool) = &step.tool {
+            lines.push(format!("tool: {tool}"));
+        }
+        if let Some(sandbox) = &step.sandbox {
+            let mode = step.sandbox_mode.as_deref().unwrap_or("default");
+            lines.push(format!("sandbox: {sandbox} ({mode})"));
+        }
+        if let Some(condition) = &step.condition {
+            lines.push(format!("condition: {condition}"));
+        }
+    }
+    if let Some(result) = result {
+        lines.push(format!("state: {}", state_label(&result.state)));
+        if let Some(at) = &result.completed_at {
+            lines.push(format!("completed: {at}"));
+        }
+        if let Some(skipped) = &result.skipped {
+            lines.push(String::new());
+            lines.push(format!("skipped: {skipped}"));
+        }
+        if let Some(error) = &result.error {
+            lines.push(String::new());
+            lines.push(format!("error:\n{error}"));
+        }
+        if let Some(output) = &result.output {
+            lines.push(String::new());
+            lines.push("output:".to_string());
+            let output = pretty_json(output);
+            if expanded {
+                lines.push(output);
+            } else {
+                lines.extend(output.lines().take(18).map(str::to_string));
+                if output.lines().count() > 18 {
+                    lines.push("...".to_string());
+                }
+            }
+        }
+    } else {
+        lines.push("state: pending".to_string());
+    }
+    lines.join("\n")
+}
+
+fn agents_body(run: &WorkflowRunDetail) -> String {
+    if run.agents.is_empty() {
+        return "No related agents reported for this run".to_string();
+    }
+    run.agents
+        .iter()
+        .map(|agent| {
+            let sandbox = agent
+                .sandbox
+                .as_ref()
+                .map(|s| format!(" sandbox={}({})", s.name, s.mode))
+                .unwrap_or_default();
+            format!(
+                "{}  {}  {}  model={}{}",
+                short_id(&agent.id),
+                agent.name,
+                agent.role,
+                agent.model,
+                sandbox
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn sandboxes_body(run: &WorkflowRunDetail) -> String {
+    let mut sandboxes = BTreeSet::new();
+    for step in &run.steps_snapshot {
+        if let Some(name) = &step.sandbox {
+            let mode = step.sandbox_mode.as_deref().unwrap_or("default");
+            sandboxes.insert(format!("{name}  mode={mode}"));
+        }
+    }
+    for agent in &run.agents {
+        if let Some(sandbox) = &agent.sandbox {
+            sandboxes.insert(format!(
+                "{}  mode={}  agent={}",
+                sandbox.name, sandbox.mode, agent.name
+            ));
+        }
+    }
+    if sandboxes.is_empty() {
+        "No related sandboxes reported for this run".to_string()
+    } else {
+        sandboxes.into_iter().collect::<Vec<_>>().join("\n")
+    }
+}
+
+fn result_for_step<'a>(
+    run: &'a WorkflowRunDetail,
+    idx: usize,
+    step: Option<&WorkflowStepItem>,
+) -> Option<&'a WorkflowStepResultItem> {
+    step.and_then(|s| run.step_results.iter().find(|r| r.name == s.name))
+        .or_else(|| run.step_results.get(idx))
+}
+
+fn run_summary(run: &super::super::state::WorkflowRunItem) -> String {
+    if let Some(failed) = run
+        .step_results
+        .iter()
+        .find(|r| matches!(r.state.as_str(), "FAILED" | "ERRORED"))
+    {
+        if let Some(error) = &failed.error {
+            return format!("step: {}  {}", failed.name, truncate(error, 48));
+        }
+        if let Some(output) = &failed.output {
+            return format!(
+                "step: {}  {}",
+                failed.name,
+                truncate(&pretty_json(output), 48)
+            );
+        }
+        return format!("step: {}", failed.name);
+    }
+    format!("{} steps", run.step_results.len())
+}
+
+fn trigger_label(kind: &str, provider: Option<&str>) -> String {
+    match provider {
+        Some(provider) if !provider.is_empty() => format!("{}:{provider}", kind.to_lowercase()),
+        _ => kind.to_lowercase(),
+    }
+}
+
+fn state_label(state: &str) -> &'static str {
+    match state {
+        "SUCCEEDED" => "ok",
+        "FAILED" => "failed",
+        "ERRORED" => "errored",
+        "RUNNING" => "running",
+        "PENDING" => "pending",
+        "SKIPPED" => "skipped",
+        _ => "unknown",
+    }
+}
+
+fn state_color(state: &str) -> Color {
+    match state {
+        "SUCCEEDED" | "ok" => Color::Green,
+        "FAILED" | "failed" | "ERRORED" | "errored" => Color::Red,
+        "RUNNING" | "running" => Color::Yellow,
+        "SKIPPED" | "skipped" => Color::DarkGray,
+        _ => Color::White,
+    }
+}
+
+fn short_time(value: &str) -> String {
+    value
+        .split('T')
+        .nth(1)
+        .map(|t| t.trim_end_matches('Z').chars().take(8).collect())
+        .unwrap_or_else(|| truncate(value, 16))
+}
+
+fn short_id(id: &str) -> String {
+    id.chars().take(8).collect()
+}
+
+fn truncate(value: &str, max: usize) -> String {
+    let mut out = String::new();
+    for (idx, ch) in value.chars().enumerate() {
+        if idx >= max {
+            out.push_str("...");
+            return out;
+        }
+        out.push(ch);
+    }
+    out
+}
+
+fn pretty_json(value: &serde_json::Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -125,106 +125,37 @@ fn draw_col_runs(frame: &mut Frame, state: &ScreenState, area: Rect) {
 fn draw_col_detail(frame: &mut Frame, state: &ScreenState, area: Rect) {
     match state.workflows.focus {
         MillerFocus::Definitions => draw_definition_detail(frame, state, area),
-        MillerFocus::Runs => draw_run_overview(frame, state, area),
-        MillerFocus::StepDetail => draw_step_detail_view(frame, state, area),
+        MillerFocus::Runs | MillerFocus::StepDetail => draw_run_split(frame, state, area),
     }
 }
 
 fn draw_definition_detail(frame: &mut Frame, state: &ScreenState, area: Rect) {
+    let title = state
+        .workflows
+        .selected_definition
+        .as_ref()
+        .map(|d| format!(" {} ", d.name))
+        .unwrap_or_else(|| " Definition ".to_string());
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::DarkGray))
-        .title(" Definition ");
+        .title(title);
 
-    let Some(definition) = &state.workflows.selected_definition else {
-        let msg = if state.workflows.definitions.is_empty() {
-            "No workflow selected"
-        } else {
-            "Loading..."
-        };
-        frame.render_widget(Paragraph::new(msg).block(block), area);
-        return;
-    };
-
-    let mut lines: Vec<Line> = Vec::new();
-
-    lines.push(Line::from(vec![
-        Span::styled("Trigger  ", Style::default().fg(Color::DarkGray)),
-        Span::raw(trigger_label(
-            &definition.trigger.kind,
-            definition.trigger.provider.as_deref(),
-        )),
-    ]));
-
-    lines.push(Line::from(vec![
-        Span::styled("Steps    ", Style::default().fg(Color::DarkGray)),
-        Span::raw(definition.steps.len().to_string()),
-    ]));
-
-    if let Some(condition) = &definition.trigger.condition {
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            "Condition",
-            Style::default().fg(Color::DarkGray),
-        )));
-        lines.push(Line::from(condition.as_str()));
-    }
-
-    if let Some(next) = &definition.trigger.next_run_at {
-        lines.push(Line::from(vec![
-            Span::styled("Next run ", Style::default().fg(Color::DarkGray)),
-            Span::raw(short_time(next)),
-        ]));
-    }
-
-    // Step summary
-    lines.push(Line::from(""));
-    for step in &definition.steps {
-        let skill_or_tool = step
-            .skill
-            .as_deref()
-            .or(step.tool.as_deref())
-            .unwrap_or("—");
-        lines.push(Line::from(vec![
-            Span::styled("  • ", Style::default().fg(Color::DarkGray)),
-            Span::raw(&step.name),
-            Span::styled(
-                format!("  ({skill_or_tool})"),
-                Style::default().fg(Color::Cyan),
-            ),
-        ]));
-    }
-
-    // Recent runs
-    if !definition.recent_runs.is_empty() {
-        lines.push(Line::from(""));
-        lines.push(Line::from(Span::styled(
-            "Recent runs",
-            Style::default().fg(Color::DarkGray),
-        )));
-        for run in &definition.recent_runs {
-            lines.push(Line::from(vec![
-                Span::styled(
-                    format!("  {}", state_label(&run.state)),
-                    Style::default().fg(state_color(&run.state)),
-                ),
-                Span::raw(format!("  {}", short_time(&run.started_at))),
-            ]));
-        }
-    }
-
-    // YAML
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        "─── YAML ───",
-        Style::default().fg(Color::DarkGray),
-    )));
-    for yaml_line in definition.yaml.lines() {
-        lines.push(Line::from(yaml_line.to_string()));
-    }
+    let yaml = state
+        .workflows
+        .selected_definition
+        .as_ref()
+        .map(|d| d.yaml.as_str())
+        .unwrap_or_else(|| {
+            if state.workflows.definitions.is_empty() {
+                "No workflow selected"
+            } else {
+                "Loading..."
+            }
+        });
 
     frame.render_widget(
-        Paragraph::new(lines)
+        Paragraph::new(yaml)
             .block(block)
             .scroll((state.workflows.detail_scroll, 0))
             .wrap(Wrap { trim: false }),
@@ -232,27 +163,55 @@ fn draw_definition_detail(frame: &mut Frame, state: &ScreenState, area: Rect) {
     );
 }
 
-fn draw_run_overview(frame: &mut Frame, state: &ScreenState, area: Rect) {
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::DarkGray))
-        .title(" Run Detail ");
-
+fn draw_run_split(frame: &mut Frame, state: &ScreenState, area: Rect) {
     let Some(run) = &state.workflows.selected_run else {
         let msg = if state.workflows.runs.is_empty() {
             "No run selected"
         } else {
             "Loading..."
         };
-        frame.render_widget(Paragraph::new(msg).block(block), area);
+        frame.render_widget(
+            Paragraph::new(msg).block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::DarkGray)),
+            ),
+            area,
+        );
         return;
     };
 
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(35), Constraint::Percentage(65)])
+        .split(area);
+
+    let step_focused = state.workflows.focus == MillerFocus::StepDetail;
+    draw_step_list(frame, state, run, chunks[0], step_focused);
+
+    if step_focused {
+        draw_step_body(
+            frame,
+            run,
+            state.workflows.step_cursor,
+            state.workflows.expanded,
+            chunks[1],
+        );
+    } else {
+        draw_run_overview(frame, run, state.workflows.detail_scroll, chunks[1]);
+    }
+}
+
+fn draw_run_overview(frame: &mut Frame, run: &WorkflowRunDetail, scroll: u16, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .title(" Run Detail ");
+
     let mut lines: Vec<Line> = Vec::new();
 
-    // Header
     lines.push(Line::from(vec![
-        Span::styled("Run  ", Style::default().fg(Color::DarkGray)),
+        Span::styled("Run      ", Style::default().fg(Color::DarkGray)),
         Span::raw(short_id(&run.id)),
         Span::raw("  "),
         Span::styled(
@@ -268,28 +227,6 @@ fn draw_run_overview(frame: &mut Frame, state: &ScreenState, area: Rect) {
         lines.push(Line::from(vec![
             Span::styled("Ended    ", Style::default().fg(Color::DarkGray)),
             Span::raw(short_time(completed)),
-        ]));
-    }
-
-    // Steps
-    lines.push(Line::from(""));
-    lines.push(Line::from(Span::styled(
-        "Steps",
-        Style::default().fg(Color::DarkGray),
-    )));
-    let count = run.steps_snapshot.len().max(run.step_results.len());
-    for idx in 0..count {
-        let step = run.steps_snapshot.get(idx);
-        let result = result_for_step(run, idx, step);
-        let name = step
-            .map(|s| s.name.as_str())
-            .or_else(|| result.map(|r| r.name.as_str()))
-            .unwrap_or("step");
-        let st = result.map(|r| r.state.as_str()).unwrap_or("PENDING");
-        lines.push(Line::from(vec![
-            Span::raw("  "),
-            Span::styled(format!("{:<20}", truncate(name, 20)), Style::default()),
-            Span::styled(state_label(st), Style::default().fg(state_color(st))),
         ]));
     }
 
@@ -332,48 +269,30 @@ fn draw_run_overview(frame: &mut Frame, state: &ScreenState, area: Rect) {
     frame.render_widget(
         Paragraph::new(lines)
             .block(block)
-            .scroll((state.workflows.detail_scroll, 0))
+            .scroll((scroll, 0))
             .wrap(Wrap { trim: false }),
         area,
     );
 }
 
-fn draw_step_detail_view(frame: &mut Frame, state: &ScreenState, area: Rect) {
-    let Some(run) = &state.workflows.selected_run else {
-        frame.render_widget(
-            Paragraph::new("No run selected").block(
-                Block::default()
-                    .borders(Borders::ALL)
-                    .border_style(Style::default().fg(Color::Yellow))
-                    .title(" Steps "),
-            ),
-            area,
-        );
-        return;
+fn draw_step_list(
+    frame: &mut Frame,
+    state: &ScreenState,
+    run: &WorkflowRunDetail,
+    area: Rect,
+    focused: bool,
+) {
+    let border_color = if focused {
+        Color::Yellow
+    } else {
+        Color::DarkGray
     };
-
-    let chunks = Layout::default()
-        .direction(Direction::Vertical)
-        .constraints([Constraint::Percentage(35), Constraint::Percentage(65)])
-        .split(area);
-
-    draw_step_list(frame, state, run, chunks[0]);
-    draw_step_body(
-        frame,
-        run,
-        state.workflows.step_cursor,
-        state.workflows.expanded,
-        chunks[1],
-    );
-}
-
-fn draw_step_list(frame: &mut Frame, state: &ScreenState, run: &WorkflowRunDetail, area: Rect) {
     let mut items = Vec::new();
     let count = run.steps_snapshot.len().max(run.step_results.len());
     for idx in 0..count {
         let step = run.steps_snapshot.get(idx);
         let result = result_for_step(run, idx, step);
-        let selected = idx == state.workflows.step_cursor;
+        let selected = focused && idx == state.workflows.step_cursor;
         let marker = if selected { ">" } else { " " };
         let name = step
             .map(|s| s.name.as_str())
@@ -392,7 +311,7 @@ fn draw_step_list(frame: &mut Frame, state: &ScreenState, run: &WorkflowRunDetai
         List::new(items).block(
             Block::default()
                 .borders(Borders::ALL)
-                .border_style(Style::default().fg(Color::Yellow))
+                .border_style(Style::default().fg(border_color))
                 .title(format!(
                     " Run {} - {} ",
                     short_id(&run.id),
@@ -484,13 +403,6 @@ fn result_for_step<'a>(
 ) -> Option<&'a WorkflowStepResultItem> {
     step.and_then(|s| run.step_results.iter().find(|r| r.name == s.name))
         .or_else(|| run.step_results.get(idx))
-}
-
-fn trigger_label(kind: &str, provider: Option<&str>) -> String {
-    match provider {
-        Some(provider) if !provider.is_empty() => format!("{}:{provider}", kind.to_lowercase()),
-        _ => kind.to_lowercase(),
-    }
 }
 
 fn state_label(state: &str) -> &'static str {

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -409,8 +409,10 @@ fn selected_step_body(run: &WorkflowRunDetail, cursor: usize, expanded: bool) ->
             if expanded {
                 lines.push(output);
             } else {
-                lines.extend(output.lines().take(18).map(str::to_string));
-                if output.lines().count() > 18 {
+                let preview: Vec<String> = output.lines().take(19).map(str::to_string).collect();
+                let truncated = preview.len() > 18;
+                lines.extend(preview.into_iter().take(18));
+                if truncated {
                     lines.push("...".to_string());
                 }
             }

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -1,5 +1,3 @@
-use std::collections::BTreeSet;
-
 use ratatui::{
     layout::{Constraint, Direction, Layout, Rect},
     style::{Color, Modifier, Style},
@@ -9,316 +7,418 @@ use ratatui::{
 };
 
 use super::super::state::{
-    RunDetailPanel, ScreenState, WorkflowRunDetail, WorkflowStepItem, WorkflowStepResultItem,
-    WorkflowView,
+    MillerFocus, ScreenState, WorkflowRunDetail, WorkflowStepItem, WorkflowStepResultItem,
 };
 
 pub fn draw_workflows(frame: &mut Frame, state: &ScreenState, area: Rect) {
-    match &state.workflows.view {
-        WorkflowView::Catalog => draw_catalog(frame, state, area),
-        WorkflowView::Definition { yaml_scroll, .. } => {
-            draw_definition(frame, state, area, *yaml_scroll)
-        }
-        WorkflowView::Runs { cursor, .. } => draw_runs(frame, state, area, *cursor),
-        WorkflowView::RunDetail {
-            step_cursor,
-            panel,
-            expanded,
-            ..
-        } => draw_run_detail(frame, state, area, *step_cursor, *panel, *expanded),
-    }
+    let chunks = Layout::default()
+        .direction(Direction::Horizontal)
+        .constraints([
+            Constraint::Percentage(25),
+            Constraint::Percentage(25),
+            Constraint::Percentage(50),
+        ])
+        .split(area);
+
+    draw_col_definitions(frame, state, chunks[0]);
+    draw_col_runs(frame, state, chunks[1]);
+    draw_col_detail(frame, state, chunks[2]);
 }
 
 pub fn status_keys(state: &ScreenState) -> &'static str {
-    match state.workflows.view {
-        WorkflowView::Catalog => " │ ↑/↓:nav  Enter:detail  T:trigger  r:refresh  Esc:chat ",
-        WorkflowView::Definition { .. } => " │ ↑/↓:scroll  T:trigger  R:runs  r:refresh  Esc:list ",
-        WorkflowView::Runs { .. } => " │ ↑/↓:nav  Enter:inspect  r:refresh  Esc:workflow ",
-        WorkflowView::RunDetail { .. } => {
-            " │ ↑/↓:step  Enter:expand  d/p/a/s:panel  r:refresh  Esc:runs "
-        }
+    match state.workflows.focus {
+        MillerFocus::Definitions => " │ ↑/↓:nav  →:runs  T:trigger  r:refresh  Esc:chat ",
+        MillerFocus::Runs => " │ ↑/↓:nav  ←:defs  →:steps  r:refresh  Esc:chat ",
+        MillerFocus::StepDetail => " │ ↑/↓:step  ←:runs  Enter:expand  r:refresh  Esc:chat ",
     }
 }
 
-fn draw_catalog(frame: &mut Frame, state: &ScreenState, area: Rect) {
+fn col_border(state: &ScreenState, col: MillerFocus) -> Color {
+    if state.workflows.focus == col {
+        Color::Yellow
+    } else {
+        Color::DarkGray
+    }
+}
+
+fn draw_col_definitions(frame: &mut Frame, state: &ScreenState, area: Rect) {
     let project = state
         .selected_project()
         .map(|p| p.name.as_str())
         .unwrap_or("-");
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(format!(" Workflows - project: {project} "));
+        .border_style(Style::default().fg(col_border(state, MillerFocus::Definitions)))
+        .title(format!(" Workflows ({project}) "));
 
     let mut items = Vec::new();
-    if state.workflows.loading {
-        items.push(ListItem::new(Line::from("Loading workflows...")));
+    if state.workflows.loading && state.workflows.definitions.is_empty() {
+        items.push(ListItem::new(Line::from("Loading...")));
     } else if state.workflows.definitions.is_empty() {
-        items.push(ListItem::new(Line::from("No workflows in this project")));
+        items.push(ListItem::new(Line::from("No workflows")));
     } else {
         for (idx, definition) in state.workflows.definitions.iter().enumerate() {
-            let selected = idx == state.workflows.cursor;
+            let selected = idx == state.workflows.def_cursor;
             let marker = if selected { ">" } else { " " };
-            let run = definition
+            let run_indicator = definition
                 .recent_runs
                 .first()
-                .map(|r| {
-                    (
-                        format!(
-                            "last: {} {}",
-                            state_label(&r.state),
-                            short_time(&r.started_at)
-                        ),
-                        state_color(&r.state),
-                    )
-                })
-                .unwrap_or_else(|| ("no runs".to_string(), Color::DarkGray));
-            let trigger = trigger_label(
-                &definition.trigger.kind,
-                definition.trigger.provider.as_deref(),
-            );
-            let next = definition
-                .trigger
-                .next_run_at
-                .as_deref()
-                .map(|t| format!(" next: {}", short_time(t)))
-                .unwrap_or_default();
+                .map(|r| (state_label(&r.state), state_color(&r.state)))
+                .unwrap_or(("—", Color::DarkGray));
             let line = Line::from(vec![
                 Span::styled(marker, Style::default().fg(Color::Yellow)),
                 Span::raw(" "),
                 Span::styled(
-                    truncate(&definition.name, 30),
+                    truncate(&definition.name, 20),
                     if selected {
                         Style::default().add_modifier(Modifier::BOLD)
                     } else {
                         Style::default()
                     },
                 ),
-                Span::styled(format!("  {trigger:<18}"), Style::default().fg(Color::Cyan)),
-                Span::styled(format!("  {:<24}", run.0), Style::default().fg(run.1)),
-                Span::styled(
-                    format!("  steps: {}{next}", definition.steps.len()),
-                    Style::default().fg(Color::DarkGray),
-                ),
+                Span::raw(" "),
+                Span::styled(run_indicator.0, Style::default().fg(run_indicator.1)),
             ]);
             items.push(ListItem::new(line));
         }
     }
 
-    if let Some(error) = &state.workflows.error {
-        items.push(ListItem::new(Line::from("")));
-        items.push(ListItem::new(Line::from(Span::styled(
-            error,
-            Style::default().fg(Color::Red),
-        ))));
-    }
-
     frame.render_widget(List::new(items).block(block), area);
 }
 
-fn draw_definition(frame: &mut Frame, state: &ScreenState, area: Rect, yaml_scroll: u16) {
-    let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Min(1), Constraint::Length(34)])
-        .split(area);
-
-    let title = state
-        .workflows
-        .selected_definition
-        .as_ref()
-        .map(|d| format!(" {} ", d.name))
-        .unwrap_or_else(|| " Workflow ".to_string());
-    let yaml = state
-        .workflows
-        .selected_definition
-        .as_ref()
-        .map(|d| d.yaml.as_str())
-        .unwrap_or("Loading workflow YAML...");
-
-    frame.render_widget(
-        Paragraph::new(yaml)
-            .block(Block::default().borders(Borders::ALL).title(title))
-            .scroll((yaml_scroll, 0))
-            .wrap(Wrap { trim: false }),
-        chunks[0],
-    );
-
-    let lines = if let Some(definition) = &state.workflows.selected_definition {
-        let mut lines = vec![
-            Line::from(vec![
-                Span::styled("Trigger ", Style::default().fg(Color::DarkGray)),
-                Span::raw(trigger_label(
-                    &definition.trigger.kind,
-                    definition.trigger.provider.as_deref(),
-                )),
-            ]),
-            Line::from(vec![
-                Span::styled("Steps   ", Style::default().fg(Color::DarkGray)),
-                Span::raw(definition.steps.len().to_string()),
-            ]),
-        ];
-        if let Some(condition) = &definition.trigger.condition {
-            lines.push(Line::from(""));
-            lines.push(Line::from(Span::styled(
-                "Condition",
-                Style::default().fg(Color::DarkGray),
-            )));
-            lines.push(Line::from(condition.as_str()));
-        }
-        if let Some(next) = &definition.trigger.next_run_at {
-            lines.push(Line::from(""));
-            lines.push(Line::from(vec![
-                Span::styled("Next run ", Style::default().fg(Color::DarkGray)),
-                Span::raw(short_time(next)),
-            ]));
-        }
-        if !definition.recent_runs.is_empty() {
-            lines.push(Line::from(""));
-            lines.push(Line::from(Span::styled(
-                "Recent runs",
-                Style::default().fg(Color::DarkGray),
-            )));
-            for run in &definition.recent_runs {
-                lines.push(Line::from(vec![
-                    Span::styled(
-                        state_label(&run.state),
-                        Style::default().fg(state_color(&run.state)),
-                    ),
-                    Span::raw(format!(" {}", short_time(&run.started_at))),
-                ]));
-            }
-        }
-        if let Some(error) = &state.workflows.error {
-            lines.push(Line::from(""));
-            lines.push(Line::from(Span::styled(
-                error,
-                Style::default().fg(Color::Red),
-            )));
-        }
-        lines
-    } else {
-        vec![Line::from("Loading...")]
-    };
-
-    frame.render_widget(
-        Paragraph::new(lines)
-            .block(Block::default().borders(Borders::ALL).title(" Metadata "))
-            .wrap(Wrap { trim: true }),
-        chunks[1],
-    );
-}
-
-fn draw_runs(frame: &mut Frame, state: &ScreenState, area: Rect, cursor: usize) {
-    let name = state.selected_workflow_name();
+fn draw_col_runs(frame: &mut Frame, state: &ScreenState, area: Rect) {
     let block = Block::default()
         .borders(Borders::ALL)
-        .title(format!(" Runs - {name} "));
+        .border_style(Style::default().fg(col_border(state, MillerFocus::Runs)))
+        .title(" Runs ");
+
+    let show_cursor = state.workflows.focus == MillerFocus::Runs
+        || state.workflows.focus == MillerFocus::StepDetail;
+
     let mut items = Vec::new();
-    if state.workflows.loading {
-        items.push(ListItem::new(Line::from("Loading runs...")));
-    } else if state.workflows.runs.is_empty() {
-        items.push(ListItem::new(Line::from("No workflow runs")));
+    if state.workflows.runs.is_empty() {
+        items.push(ListItem::new(Line::from(Span::styled(
+            "No runs",
+            Style::default().fg(Color::DarkGray),
+        ))));
     } else {
         for (idx, run) in state.workflows.runs.iter().enumerate() {
-            let selected = idx == cursor;
+            let selected = show_cursor && idx == state.workflows.run_cursor;
             let marker = if selected { ">" } else { " " };
-            let summary = run_summary(run);
             items.push(ListItem::new(Line::from(vec![
                 Span::styled(marker, Style::default().fg(Color::Yellow)),
                 Span::raw(" "),
                 Span::styled(short_id(&run.id), Style::default().fg(Color::White)),
-                Span::raw("  "),
+                Span::raw(" "),
                 Span::styled(
                     state_label(&run.state),
                     Style::default().fg(state_color(&run.state)),
                 ),
-                Span::raw(format!("  {}  ", short_time(&run.started_at))),
-                Span::styled(summary, Style::default().fg(Color::DarkGray)),
+                Span::raw(format!(" {}", short_time(&run.started_at))),
             ])));
         }
     }
-    if let Some(error) = &state.workflows.error {
-        items.push(ListItem::new(Line::from("")));
-        items.push(ListItem::new(Line::from(Span::styled(
-            error,
-            Style::default().fg(Color::Red),
-        ))));
-    }
+
     frame.render_widget(List::new(items).block(block), area);
 }
 
-fn draw_run_detail(
-    frame: &mut Frame,
-    state: &ScreenState,
-    area: Rect,
-    step_cursor: usize,
-    panel: RunDetailPanel,
-    expanded: bool,
-) {
+fn draw_col_detail(frame: &mut Frame, state: &ScreenState, area: Rect) {
+    match state.workflows.focus {
+        MillerFocus::Definitions => draw_definition_detail(frame, state, area),
+        MillerFocus::Runs => draw_run_overview(frame, state, area),
+        MillerFocus::StepDetail => draw_step_detail_view(frame, state, area),
+    }
+}
+
+fn draw_definition_detail(frame: &mut Frame, state: &ScreenState, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .title(" Definition ");
+
+    let Some(definition) = &state.workflows.selected_definition else {
+        let msg = if state.workflows.definitions.is_empty() {
+            "No workflow selected"
+        } else {
+            "Loading..."
+        };
+        frame.render_widget(Paragraph::new(msg).block(block), area);
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    lines.push(Line::from(vec![
+        Span::styled("Trigger  ", Style::default().fg(Color::DarkGray)),
+        Span::raw(trigger_label(
+            &definition.trigger.kind,
+            definition.trigger.provider.as_deref(),
+        )),
+    ]));
+
+    lines.push(Line::from(vec![
+        Span::styled("Steps    ", Style::default().fg(Color::DarkGray)),
+        Span::raw(definition.steps.len().to_string()),
+    ]));
+
+    if let Some(condition) = &definition.trigger.condition {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Condition",
+            Style::default().fg(Color::DarkGray),
+        )));
+        lines.push(Line::from(condition.as_str()));
+    }
+
+    if let Some(next) = &definition.trigger.next_run_at {
+        lines.push(Line::from(vec![
+            Span::styled("Next run ", Style::default().fg(Color::DarkGray)),
+            Span::raw(short_time(next)),
+        ]));
+    }
+
+    // Step summary
+    lines.push(Line::from(""));
+    for step in &definition.steps {
+        let skill_or_tool = step
+            .skill
+            .as_deref()
+            .or(step.tool.as_deref())
+            .unwrap_or("—");
+        lines.push(Line::from(vec![
+            Span::styled("  • ", Style::default().fg(Color::DarkGray)),
+            Span::raw(&step.name),
+            Span::styled(
+                format!("  ({skill_or_tool})"),
+                Style::default().fg(Color::Cyan),
+            ),
+        ]));
+    }
+
+    // Recent runs
+    if !definition.recent_runs.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Recent runs",
+            Style::default().fg(Color::DarkGray),
+        )));
+        for run in &definition.recent_runs {
+            lines.push(Line::from(vec![
+                Span::styled(
+                    format!("  {}", state_label(&run.state)),
+                    Style::default().fg(state_color(&run.state)),
+                ),
+                Span::raw(format!("  {}", short_time(&run.started_at))),
+            ]));
+        }
+    }
+
+    // YAML
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "─── YAML ───",
+        Style::default().fg(Color::DarkGray),
+    )));
+    for yaml_line in definition.yaml.lines() {
+        lines.push(Line::from(yaml_line.to_string()));
+    }
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .scroll((state.workflows.detail_scroll, 0))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn draw_run_overview(frame: &mut Frame, state: &ScreenState, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .title(" Run Detail ");
+
+    let Some(run) = &state.workflows.selected_run else {
+        let msg = if state.workflows.runs.is_empty() {
+            "No run selected"
+        } else {
+            "Loading..."
+        };
+        frame.render_widget(Paragraph::new(msg).block(block), area);
+        return;
+    };
+
+    let mut lines: Vec<Line> = Vec::new();
+
+    // Header
+    lines.push(Line::from(vec![
+        Span::styled("Run  ", Style::default().fg(Color::DarkGray)),
+        Span::raw(short_id(&run.id)),
+        Span::raw("  "),
+        Span::styled(
+            state_label(&run.state),
+            Style::default().fg(state_color(&run.state)),
+        ),
+    ]));
+    lines.push(Line::from(vec![
+        Span::styled("Started  ", Style::default().fg(Color::DarkGray)),
+        Span::raw(short_time(&run.started_at)),
+    ]));
+    if let Some(completed) = &run.completed_at {
+        lines.push(Line::from(vec![
+            Span::styled("Ended    ", Style::default().fg(Color::DarkGray)),
+            Span::raw(short_time(completed)),
+        ]));
+    }
+
+    // Steps
+    lines.push(Line::from(""));
+    lines.push(Line::from(Span::styled(
+        "Steps",
+        Style::default().fg(Color::DarkGray),
+    )));
+    let count = run.steps_snapshot.len().max(run.step_results.len());
+    for idx in 0..count {
+        let step = run.steps_snapshot.get(idx);
+        let result = result_for_step(run, idx, step);
+        let name = step
+            .map(|s| s.name.as_str())
+            .or_else(|| result.map(|r| r.name.as_str()))
+            .unwrap_or("step");
+        let st = result.map(|r| r.state.as_str()).unwrap_or("PENDING");
+        lines.push(Line::from(vec![
+            Span::raw("  "),
+            Span::styled(format!("{:<20}", truncate(name, 20)), Style::default()),
+            Span::styled(state_label(st), Style::default().fg(state_color(st))),
+        ]));
+    }
+
+    // Trigger context
+    let trigger_json = pretty_json(&run.trigger_context);
+    if trigger_json != "{}" {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Trigger Payload",
+            Style::default().fg(Color::DarkGray),
+        )));
+        for l in trigger_json.lines() {
+            lines.push(Line::from(format!("  {l}")));
+        }
+    }
+
+    // Agents
+    if !run.agents.is_empty() {
+        lines.push(Line::from(""));
+        lines.push(Line::from(Span::styled(
+            "Agents",
+            Style::default().fg(Color::DarkGray),
+        )));
+        for agent in &run.agents {
+            let sandbox = agent
+                .sandbox
+                .as_ref()
+                .map(|s| format!(" sandbox={}({})", s.name, s.mode))
+                .unwrap_or_default();
+            lines.push(Line::from(format!(
+                "  {} {} model={}{}",
+                short_id(&agent.id),
+                agent.name,
+                agent.model,
+                sandbox
+            )));
+        }
+    }
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .scroll((state.workflows.detail_scroll, 0))
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn draw_step_detail_view(frame: &mut Frame, state: &ScreenState, area: Rect) {
     let Some(run) = &state.workflows.selected_run else {
         frame.render_widget(
-            Paragraph::new("Loading run...")
-                .block(Block::default().borders(Borders::ALL).title(" Run ")),
+            Paragraph::new("No run selected").block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Yellow))
+                    .title(" Steps "),
+            ),
             area,
         );
         return;
     };
 
     let chunks = Layout::default()
-        .direction(Direction::Horizontal)
-        .constraints([Constraint::Length(34), Constraint::Min(1)])
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Percentage(35), Constraint::Percentage(65)])
         .split(area);
-    draw_step_list(frame, run, chunks[0], step_cursor);
-    draw_run_panel(frame, run, chunks[1], step_cursor, panel, expanded);
+
+    draw_step_list(frame, state, run, chunks[0]);
+    draw_step_body(
+        frame,
+        run,
+        state.workflows.step_cursor,
+        state.workflows.expanded,
+        chunks[1],
+    );
 }
 
-fn draw_step_list(frame: &mut Frame, run: &WorkflowRunDetail, area: Rect, cursor: usize) {
+fn draw_step_list(frame: &mut Frame, state: &ScreenState, run: &WorkflowRunDetail, area: Rect) {
     let mut items = Vec::new();
     let count = run.steps_snapshot.len().max(run.step_results.len());
     for idx in 0..count {
         let step = run.steps_snapshot.get(idx);
         let result = result_for_step(run, idx, step);
-        let selected = idx == cursor;
+        let selected = idx == state.workflows.step_cursor;
         let marker = if selected { ">" } else { " " };
         let name = step
             .map(|s| s.name.as_str())
             .or_else(|| result.map(|r| r.name.as_str()))
             .unwrap_or("step");
-        let state = result.map(|r| r.state.as_str()).unwrap_or("PENDING");
+        let st = result.map(|r| r.state.as_str()).unwrap_or("PENDING");
         items.push(ListItem::new(Line::from(vec![
             Span::styled(marker, Style::default().fg(Color::Yellow)),
             Span::raw(" "),
             Span::styled(truncate(name, 18), Style::default()),
             Span::raw(" "),
-            Span::styled(state_label(state), Style::default().fg(state_color(state))),
+            Span::styled(state_label(st), Style::default().fg(state_color(st))),
         ])));
     }
     frame.render_widget(
-        List::new(items).block(Block::default().borders(Borders::ALL).title(format!(
-            " Run {} - {} ",
-            short_id(&run.id),
-            state_label(&run.state)
-        ))),
+        List::new(items).block(
+            Block::default()
+                .borders(Borders::ALL)
+                .border_style(Style::default().fg(Color::Yellow))
+                .title(format!(
+                    " Run {} - {} ",
+                    short_id(&run.id),
+                    state_label(&run.state)
+                )),
+        ),
         area,
     );
 }
 
-fn draw_run_panel(
+fn draw_step_body(
     frame: &mut Frame,
     run: &WorkflowRunDetail,
-    area: Rect,
-    step_cursor: usize,
-    panel: RunDetailPanel,
+    cursor: usize,
     expanded: bool,
+    area: Rect,
 ) {
-    let (title, body) = match panel {
-        RunDetailPanel::Step => (" Step ", selected_step_body(run, step_cursor, expanded)),
-        RunDetailPanel::Trigger => (" Trigger Payload ", pretty_json(&run.trigger_context)),
-        RunDetailPanel::Agents => (" Related Agents ", agents_body(run)),
-        RunDetailPanel::Sandboxes => (" Related Sandboxes ", sandboxes_body(run)),
-    };
+    let body = selected_step_body(run, cursor, expanded);
     frame.render_widget(
         Paragraph::new(body)
-            .block(Block::default().borders(Borders::ALL).title(title))
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_style(Style::default().fg(Color::Yellow))
+                    .title(" Step Detail "),
+            )
             .wrap(Wrap { trim: false }),
         area,
     );
@@ -377,54 +477,6 @@ fn selected_step_body(run: &WorkflowRunDetail, cursor: usize, expanded: bool) ->
     lines.join("\n")
 }
 
-fn agents_body(run: &WorkflowRunDetail) -> String {
-    if run.agents.is_empty() {
-        return "No related agents reported for this run".to_string();
-    }
-    run.agents
-        .iter()
-        .map(|agent| {
-            let sandbox = agent
-                .sandbox
-                .as_ref()
-                .map(|s| format!(" sandbox={}({})", s.name, s.mode))
-                .unwrap_or_default();
-            format!(
-                "{}  {}  {}  model={}{}",
-                short_id(&agent.id),
-                agent.name,
-                agent.role,
-                agent.model,
-                sandbox
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n")
-}
-
-fn sandboxes_body(run: &WorkflowRunDetail) -> String {
-    let mut sandboxes = BTreeSet::new();
-    for step in &run.steps_snapshot {
-        if let Some(name) = &step.sandbox {
-            let mode = step.sandbox_mode.as_deref().unwrap_or("default");
-            sandboxes.insert(format!("{name}  mode={mode}"));
-        }
-    }
-    for agent in &run.agents {
-        if let Some(sandbox) = &agent.sandbox {
-            sandboxes.insert(format!(
-                "{}  mode={}  agent={}",
-                sandbox.name, sandbox.mode, agent.name
-            ));
-        }
-    }
-    if sandboxes.is_empty() {
-        "No related sandboxes reported for this run".to_string()
-    } else {
-        sandboxes.into_iter().collect::<Vec<_>>().join("\n")
-    }
-}
-
 fn result_for_step<'a>(
     run: &'a WorkflowRunDetail,
     idx: usize,
@@ -432,27 +484,6 @@ fn result_for_step<'a>(
 ) -> Option<&'a WorkflowStepResultItem> {
     step.and_then(|s| run.step_results.iter().find(|r| r.name == s.name))
         .or_else(|| run.step_results.get(idx))
-}
-
-fn run_summary(run: &super::super::state::WorkflowRunItem) -> String {
-    if let Some(failed) = run
-        .step_results
-        .iter()
-        .find(|r| matches!(r.state.as_str(), "FAILED" | "ERRORED"))
-    {
-        if let Some(error) = &failed.error {
-            return format!("step: {}  {}", failed.name, truncate(error, 48));
-        }
-        if let Some(output) = &failed.output {
-            return format!(
-                "step: {}  {}",
-                failed.name,
-                truncate(&pretty_json(output), 48)
-            );
-        }
-        return format!("step: {}", failed.name);
-    }
-    format!("{} steps", run.step_results.len())
 }
 
 fn trigger_label(kind: &str, provider: Option<&str>) -> String {

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -63,11 +63,17 @@ fn draw_col_definitions(frame: &mut Frame, state: &ScreenState, area: Rect) {
         .title(format!(" Workflows ({project}) "));
 
     let mut items = Vec::new();
-    if state.workflows.loading && state.workflows.definitions.is_empty() {
+    if let Some(err) = &state.workflows.error {
+        items.push(ListItem::new(Line::from(Span::styled(
+            truncate(err, 30),
+            Style::default().fg(Color::Red),
+        ))));
+    } else if state.workflows.loading && state.workflows.definitions.is_empty() {
         items.push(ListItem::new(Line::from("Loading...")));
     } else if state.workflows.definitions.is_empty() {
         items.push(ListItem::new(Line::from("No workflows")));
-    } else {
+    }
+    if !state.workflows.definitions.is_empty() {
         for (idx, definition) in state.workflows.definitions.iter().enumerate() {
             let selected = idx == state.workflows.def_cursor;
             let marker = if selected { ">" } else { " " };

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -28,17 +28,24 @@ pub fn draw_workflows(frame: &mut Frame, state: &ScreenState, area: Rect) {
 pub fn status_keys(state: &ScreenState) -> &'static str {
     match state.workflows.focus {
         MillerFocus::Definitions => {
-            " │ ↑/↓:nav  J/K:scroll  →:runs  T:trigger  r:refresh  Esc:chat "
+            " │ ↑/↓:nav  Enter:yaml  →:runs  ^R:trigger  r:refresh  Esc:chat "
         }
-        MillerFocus::Runs => " │ ↑/↓:nav  J/K:scroll  ←:defs  →:steps  r:refresh  Esc:chat ",
+        MillerFocus::YamlDetail => " │ ↑/↓:scroll  →:runs  ←/Esc:back ",
+        MillerFocus::Runs => {
+            " │ ↑/↓:nav  J/K:scroll  ←:defs  →:steps  ^R:trigger  r:refresh  Esc:chat "
+        }
         MillerFocus::StepDetail => {
-            " │ ↑/↓:step  ←:runs  Enter:expand  r:refresh  Esc:chat "
+            " │ ↑/↓:step  ←:runs  Enter:expand  ^R:trigger  r:refresh  Esc:chat "
         }
     }
 }
 
 fn col_border(state: &ScreenState, col: MillerFocus) -> Color {
-    if state.workflows.focus == col {
+    let focused = match state.workflows.focus {
+        MillerFocus::YamlDetail => col == MillerFocus::Definitions,
+        other => other == col,
+    };
+    if focused {
         Color::Yellow
     } else {
         Color::DarkGray
@@ -128,7 +135,9 @@ fn draw_col_runs(frame: &mut Frame, state: &ScreenState, area: Rect) {
 
 fn draw_col_detail(frame: &mut Frame, state: &ScreenState, area: Rect) {
     match state.workflows.focus {
-        MillerFocus::Definitions => draw_definition_detail(frame, state, area),
+        MillerFocus::Definitions | MillerFocus::YamlDetail => {
+            draw_definition_detail(frame, state, area)
+        }
         MillerFocus::Runs | MillerFocus::StepDetail => draw_run_split(frame, state, area),
     }
 }
@@ -140,9 +149,15 @@ fn draw_definition_detail(frame: &mut Frame, state: &ScreenState, area: Rect) {
         .as_ref()
         .map(|d| format!(" {} ", d.name))
         .unwrap_or_else(|| " Definition ".to_string());
+    let focused = state.workflows.focus == MillerFocus::YamlDetail;
+    let border_color = if focused {
+        Color::Yellow
+    } else {
+        Color::DarkGray
+    };
     let block = Block::default()
         .borders(Borders::ALL)
-        .border_style(Style::default().fg(Color::DarkGray))
+        .border_style(Style::default().fg(border_color))
         .title(title);
 
     let yaml = state

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -27,9 +27,13 @@ pub fn draw_workflows(frame: &mut Frame, state: &ScreenState, area: Rect) {
 
 pub fn status_keys(state: &ScreenState) -> &'static str {
     match state.workflows.focus {
-        MillerFocus::Definitions => " │ ↑/↓:nav  →:runs  T:trigger  r:refresh  Esc:chat ",
-        MillerFocus::Runs => " │ ↑/↓:nav  ←:defs  →:steps  r:refresh  Esc:chat ",
-        MillerFocus::StepDetail => " │ ↑/↓:step  ←:runs  Enter:expand  r:refresh  Esc:chat ",
+        MillerFocus::Definitions => {
+            " │ ↑/↓:nav  J/K:scroll  →:runs  T:trigger  r:refresh  Esc:chat "
+        }
+        MillerFocus::Runs => " │ ↑/↓:nav  J/K:scroll  ←:defs  →:steps  r:refresh  Esc:chat ",
+        MillerFocus::StepDetail => {
+            " │ ↑/↓:step  ←:runs  Enter:expand  r:refresh  Esc:chat "
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace the 4-screen sequential workflow views (Catalog → Definition → Runs → RunDetail) with a 3-column Miller Columns layout where all levels are visible simultaneously
- Navigation is now spatial: ←/→ shifts focus between Definitions, Runs, and Step Detail columns; ↑/↓ navigates within the focused column; Esc exits from any column
- Col 3 is context-sensitive: shows definition detail + YAML when Definitions is focused, run overview (steps + trigger + agents) when Runs is focused, and navigable step list + step output when StepDetail is focused
- Data loading is now reactive — cursor movement auto-fetches definition detail + runs concurrently via `tokio::join!`, modeled on the existing `loaded_agent_id` pattern

## Test plan

- [ ] `cargo test -p drua-client --lib` — 25 tests pass
- [ ] `cargo clippy -p drua-client --all-targets -- -D warnings` — clean
- [ ] Manual: Ctrl+W opens 3-column view, ←/→ shifts focus, ↑/↓ navigates, T triggers, Esc exits
- [ ] Manual: Verify auto-fetch loads definition + runs when moving cursor in col 1
- [ ] Manual: Verify polling still updates non-terminal runs in real-time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new workflow browsing/triggering flows in the TUI, including new GraphQL queries/mutation and periodic polling, which could introduce UI state bugs or increased backend load if mishandled.
> 
> **Overview**
> Adds a new **Workflows** screen to the TUI (opened via `^W`) using a 3-column Miller layout to browse workflow definitions, view YAML/details, inspect runs, and drill into per-step output.
> 
> Introduces new GraphQL queries/mutations and async fetch orchestration in `dashboard.rs` to load definitions, definition detail + runs concurrently, fetch run detail, and *poll non-terminal runs* every second; also adds a trigger modal (`^R`) for submitting optional JSON payloads and updating the runs list/status messages on completion.
> 
> Extends shared TUI state and input handling with `WorkflowState`/`MillerFocus`, navigation bindings for the new screen, and new rendering in `ui/workflows.rs`, plus targeted unit tests for keybindings and workflow-state behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad7ca7d21773673a714dd6d6d613d15014c9eb7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->