### PR TITLE
fix(deploy): pin kubectl provider

### DIFF
--- a/ci/deploy/drua/versions.tf
+++ b/ci/deploy/drua/versions.tf
@@ -37,7 +37,8 @@ terraform {
     }
     kubectl = {
       source  = "alekc/kubectl"
-      version = "~> 2.0"
+      # 2.3.0 has a broken combined provider schema under OpenTofu.
+      version = "2.3.1"
     }
   }
 }


### PR DESCRIPTION
## Summary
- Pin the prod deploy `alekc/kubectl` provider to `2.3.1`.
- Add context that `2.3.0` has a broken combined provider schema under OpenTofu.

## Why
`deploy-to-prod` build 682 failed during OpenTofu apply while loading the `registry.opentofu.org/alekc/kubectl` provider schema. The deploy config used `~> 2.0`, so CI could float to the newly discovered `2.3.0` release.

Local reproduction:
- `alekc/kubectl 2.3.0`: reproduces the same `Invalid Provider Server Combination` schema error.
- `alekc/kubectl 2.3.1`: `tofu providers schema -json` succeeds in an isolated provider config.

## Verification
- `git diff --check`
- isolated OpenTofu schema checks for `alekc/kubectl` versions `2.1.6`, `2.2.0`, `2.3.0`, and `2.3.1`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change only pins the `alekc/kubectl` Terraform provider version to avoid a known OpenTofu schema breakage, with no functional logic changes beyond dependency selection.
> 
> **Overview**
> Pins the prod deploy Terraform `alekc/kubectl` provider from a floating `~> 2.0` constraint to **exactly `2.3.1`** to prevent CI/OpenTofu from picking up the broken `2.3.0` release.
> 
> Adds an inline comment documenting the OpenTofu combined provider schema issue in `2.3.0` so future upgrades don’t reintroduce the failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66bb6a800960612dd0a1d6892b086589d1eced04. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->