### PR TITLE
fix(infra): raise prod postgres max connections

### DIFF
--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -66,6 +66,7 @@ module "postgresql" {
   destroyable      = true
   highly_available = false
   tier             = "db-f1-micro"
+  max_connections  = 50
   replication      = false
   readonly_users   = ["mcp"]
 }

--- a/ci/deploy/drua/versions.tf
+++ b/ci/deploy/drua/versions.tf
@@ -36,7 +36,7 @@ terraform {
       version = "1.24.0"
     }
     kubectl = {
-      source  = "alekc/kubectl"
+      source = "alekc/kubectl"
       # 2.3.0 has a broken combined provider schema under OpenTofu.
       version = "2.3.1"
     }


### PR DESCRIPTION
## What changed

- Set prod Cloud SQL Postgres `max_connections` to `50` through the existing `galoy-infra` Postgres module input.
- Applied the OpenTofu formatter normalization in the deploy provider block.

## Why

Prod now runs two `galoyAgents` pods. On `db-f1-micro`, Cloud SQL Postgres defaults `max_connections` to a tiny-instance value, so the two app pools plus listener/sidecar/admin connections can exhaust normal slots and block Terraform PostgreSQL provider operations with:

```
pq: remaining connection slots are reserved for roles with privileges of the "pg_use_reserved_connections" role
```

## Impact

The next deploy will configure a larger Postgres connection budget for the existing tiny Cloud SQL instance. Updating `max_connections` is a database flag change and may require a Cloud SQL Postgres restart during apply.

## Validation

- `tofu -chdir=ci/deploy/drua fmt -check`
- Temp-staged `tofu validate` with `charts/drua` copied to `ci/deploy/drua/chart` and dummy `gcs-creds.json`
