### PR TITLE
feat(deploy): GitHub App webhook secret + issue comments upstream

### DIFF
--- a/charts/drua/templates/deployment.yaml
+++ b/charts/drua/templates/deployment.yaml
@@ -191,6 +191,12 @@ spec:
         {{- if .Values.galoyAgents.config.githubApp.enabled }}
         - name: GITHUB_APP_PRIVATE_KEY_PATH
           value: "/secrets/github-app/private-key.pem"
+        - name: WEBHOOK_SECRET_GITHUB_APP
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "galoyAgents.fullname" . }}
+              key: "github-app-webhook-secret"
+              optional: true
         {{- end }}
         - name: KUBE_NODE_NAME
           valueFrom:

--- a/charts/drua/templates/secret.yaml
+++ b/charts/drua/templates/secret.yaml
@@ -37,6 +37,9 @@ data:
   {{- if .Values.galoyAgents.secrets.openaiApiKey }}
   openai-api-key: {{ .Values.galoyAgents.secrets.openaiApiKey | trim | b64enc | trim }}
   {{- end }}
+  {{- if .Values.galoyAgents.secrets.githubAppWebhookSecret }}
+  github-app-webhook-secret: {{ .Values.galoyAgents.secrets.githubAppWebhookSecret | trim | b64enc | trim }}
+  {{- end }}
   {{- if .Values.galoyAgents.secrets.tunnelInternalSecret }}
   tunnel-internal-secret: {{ .Values.galoyAgents.secrets.tunnelInternalSecret | trim | b64enc | trim }}
   {{- end }}

--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -94,6 +94,11 @@ resource "random_password" "tunnel_internal_secret" {
   special = false
 }
 
+resource "random_password" "github_app_webhook_secret" {
+  length  = 48
+  special = false
+}
+
 resource "kubernetes_secret" "galoy_agents" {
   metadata {
     name      = "galoy-agents"
@@ -118,6 +123,7 @@ resource "kubernetes_secret" "galoy_agents" {
     "openai-api-key"                   = var.openrouter_api_key
     "zenduty-api-token"                = var.zenduty_api_token
     "github-app-private-key"           = local.github_app_private_key
+    "github-app-webhook-secret"        = random_password.github_app_webhook_secret.result
     "tunnel-internal-secret"           = random_password.tunnel_internal_secret.result
   }
 
@@ -304,4 +310,9 @@ provider "helm" {
     token                  = data.google_client_config.default.access_token
     cluster_ca_certificate = base64decode(data.google_container_cluster.primary.master_auth.0.cluster_ca_certificate)
   }
+}
+
+output "github_app_webhook_secret" {
+  value     = random_password.github_app_webhook_secret.result
+  sensitive = true
 }


### PR DESCRIPTION
## Summary
- Generates GitHub App webhook secret via `random_password` in terraform, wires it through k8s secret → `WEBHOOK_SECRET_GITHUB_APP` env var
- Exposes the secret as a sensitive terraform output: `terraform output -raw github_app_webhook_secret`
- Adds `github_issues` MCP upstream (`add_issue_comment`) so workflow steps can post issue comments

## Test plan
- [ ] Deploy and verify the `github_issues` upstream is discovered (tool: `github_issues_add_issue_comment`)
- [ ] Create a test workflow triggered by GitHub App webhook that posts an issue comment
- [ ] Verify HMAC-authenticated webhook delivery from GitHub gets 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)