### PR TITLE
revert: "Use PAT auth for GitHub mutation MCP upstreams"

### DIFF
--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -135,11 +135,11 @@ galoyAgents:
       # PR-mutation upstream — gated to internal agents (project_lead /
       # agent / workflow_step_agent) only. Users and ExportedAgents
       # don't see it. `merge_pull_request` deliberately excluded — the
-      # heal-flow guardrail forbids merges. Mutation upstreams use static
-      # PAT auth from the provisioned *_AUTH_HEADER secrets.
+      # heal-flow guardrail forbids merges.
       - name: github_pull_requests
         url: https://api.githubcopilot.com/mcp/
         toolPrefix: github_pr
+        authMode: github_app
         category: source-control-write
         categoryDescription: "GitHub PR mutations — create"
         internalOnly: true
@@ -148,6 +148,7 @@ galoyAgents:
       - name: github_issues
         url: https://api.githubcopilot.com/mcp/
         toolPrefix: github_issues
+        authMode: github_app
         category: source-control-write
         categoryDescription: "GitHub issue mutations — comments"
         internalOnly: true


### PR DESCRIPTION
Reverts GaloyMoney/drua#379

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production MCP upstream authentication for PR/issue mutation tools, which could break internal automation if App permissions/installation are misconfigured. Deployment-only config change but impacts source-control write operations.
> 
> **Overview**
> Reverts the prod Helm values so the internal-only GitHub mutation MCP upstreams (`github_pull_requests`, `github_issues`) authenticate via `authMode: github_app` again (matching read-only upstreams), and removes the prior PAT-auth commentary.
> 
> This affects how PR creation and issue comment mutations are authorized in production, without changing tool allowlists or internal-only gating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ec11a59ce787ba6b1b7a848ae7239d60b4382d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->