### PR TITLE
feat(tui): read-only conversation view for workflow step agents

### DIFF
--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1702,7 +1702,14 @@ fn handle_workflow_event(
             agent_name,
             messages,
         } => {
-            state.show_step_conversation(agent_id, agent_name, messages);
+            let still_selected = state
+                .selected_step_agent_id()
+                .map(|(id, _)| id == agent_id)
+                .unwrap_or(false);
+            if still_selected {
+                state.status_message = None;
+                state.show_step_conversation(agent_id, agent_name, messages);
+            }
         }
         WorkflowEvent::ConversationError(e) => {
             state.status_message = Some(e);

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -632,7 +632,10 @@ enum WorkflowEvent {
         agent_name: String,
         messages: Vec<ChatMessage>,
     },
-    ConversationError(String),
+    ConversationError {
+        agent_id: String,
+        error: String,
+    },
 }
 
 struct WorkflowTriggerOutcome {
@@ -1612,9 +1615,10 @@ fn spawn_step_conversation_fetch(
                 });
             }
             Err(e) => {
-                let _ = tx.send(WorkflowEvent::ConversationError(format!(
-                    "Failed to load conversation: {e}"
-                )));
+                let _ = tx.send(WorkflowEvent::ConversationError {
+                    agent_id,
+                    error: format!("Failed to load conversation: {e}"),
+                });
             }
         }
     });
@@ -1702,17 +1706,25 @@ fn handle_workflow_event(
             agent_name,
             messages,
         } => {
+            state.status_message = None;
             let still_selected = state
                 .selected_step_agent_id()
                 .map(|(id, _)| id == agent_id)
                 .unwrap_or(false);
             if still_selected {
-                state.status_message = None;
                 state.show_step_conversation(agent_id, agent_name, messages);
             }
         }
-        WorkflowEvent::ConversationError(e) => {
-            state.status_message = Some(e);
+        WorkflowEvent::ConversationError { agent_id, error } => {
+            let still_selected = state
+                .selected_step_agent_id()
+                .map(|(id, _)| id == agent_id)
+                .unwrap_or(false);
+            if still_selected {
+                state.status_message = Some(error);
+            } else {
+                state.status_message = None;
+            }
         }
     }
 }

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -627,6 +627,12 @@ enum WorkflowEvent {
         is_poll: bool,
     },
     TriggerComplete(Box<WorkflowTriggerOutcome>),
+    ConversationLoaded {
+        agent_id: String,
+        agent_name: String,
+        messages: Vec<ChatMessage>,
+    },
+    ConversationError(String),
 }
 
 struct WorkflowTriggerOutcome {
@@ -1588,6 +1594,32 @@ fn spawn_workflow_trigger(
     });
 }
 
+fn spawn_step_conversation_fetch(
+    base_url: String,
+    token: String,
+    agent_id: String,
+    agent_name: String,
+    tx: mpsc::UnboundedSender<WorkflowEvent>,
+) {
+    tokio::spawn(async move {
+        let client = GraphqlClient::new(&base_url, &token);
+        match fetch_chat_history(&client, &agent_id).await {
+            Ok(messages) => {
+                let _ = tx.send(WorkflowEvent::ConversationLoaded {
+                    agent_id,
+                    agent_name,
+                    messages,
+                });
+            }
+            Err(e) => {
+                let _ = tx.send(WorkflowEvent::ConversationError(format!(
+                    "Failed to load conversation: {e}"
+                )));
+            }
+        }
+    });
+}
+
 fn handle_workflow_event(
     state: &mut ScreenState,
     event: WorkflowEvent,
@@ -1664,6 +1696,16 @@ fn handle_workflow_event(
             } else {
                 state.status_message = Some("Workflow trigger returned no run".to_string());
             }
+        }
+        WorkflowEvent::ConversationLoaded {
+            agent_id,
+            agent_name,
+            messages,
+        } => {
+            state.show_step_conversation(agent_id, agent_name, messages);
+        }
+        WorkflowEvent::ConversationError(e) => {
+            state.status_message = Some(e);
         }
     }
 }
@@ -1917,6 +1959,16 @@ async fn run_event_loop(
                                     config.auth_token.clone(),
                                     definition_id,
                                     payload,
+                                    workflow_tx.clone(),
+                                );
+                            }
+                            handlers::Action::FetchStepConversation { agent_id, agent_name } => {
+                                state.status_message = Some("Loading conversation…".to_string());
+                                spawn_step_conversation_fetch(
+                                    config.server_url.clone(),
+                                    config.auth_token.clone(),
+                                    agent_id,
+                                    agent_name,
                                     workflow_tx.clone(),
                                 );
                             }

--- a/client/src/tui/chat.rs
+++ b/client/src/tui/chat.rs
@@ -1,4 +1,4 @@
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ContentBlock {
     Text(String),
     ToolUse {
@@ -15,14 +15,14 @@ pub enum ContentBlock {
     },
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ChatRole {
     User,
     Assistant,
     System,
 }
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct ChatMessage {
     pub role: ChatRole,
     pub blocks: Vec<ContentBlock>,

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -27,6 +27,10 @@ pub enum Action {
         agent_id: String,
         path: String,
     },
+    FetchStepConversation {
+        agent_id: String,
+        agent_name: String,
+    },
 }
 
 pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
@@ -186,6 +190,9 @@ fn handle_workflow_runs_key(state: &mut ScreenState, key: KeyEvent) -> Action {
 }
 
 fn handle_workflow_step_detail_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    if state.workflows.conversation.is_some() {
+        return handle_workflow_conversation_key(state, key);
+    }
     match key.code {
         KeyCode::Char('j') | KeyCode::Down => {
             state.workflow_step_cursor_down();
@@ -203,9 +210,42 @@ fn handle_workflow_step_detail_key(state: &mut ScreenState, key: KeyEvent) -> Ac
             state.workflow_toggle_expanded();
             Action::None
         }
+        KeyCode::Char('c') => {
+            if let Some((agent_id, agent_name)) = state.selected_step_agent_id() {
+                Action::FetchStepConversation {
+                    agent_id,
+                    agent_name,
+                }
+            } else {
+                state.status_message = Some("No agent for this step".to_string());
+                Action::None
+            }
+        }
         KeyCode::Char('r') => Action::RefreshWorkflows,
         KeyCode::Esc => {
             state.focus = Focus::Chat;
+            Action::None
+        }
+        _ => Action::None,
+    }
+}
+
+fn handle_workflow_conversation_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    match key.code {
+        KeyCode::Char('j') | KeyCode::Down => {
+            state.conversation_scroll_down();
+            Action::None
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            state.conversation_scroll_up();
+            Action::None
+        }
+        KeyCode::Char('c') | KeyCode::Left | KeyCode::Char('h') => {
+            state.hide_step_conversation();
+            Action::None
+        }
+        KeyCode::Esc => {
+            state.hide_step_conversation();
             Action::None
         }
         _ => Action::None,

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -514,6 +514,7 @@ impl ScreenState {
         if is_new_run {
             self.workflows.step_cursor = 0;
             self.workflows.expanded = false;
+            self.workflows.conversation = None;
         }
         self.workflows.loading = false;
     }

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use super::chat::{AssistantChat, ChatRole, ContentBlock};
+use super::chat::{AssistantChat, ChatMessage, ChatRole, ContentBlock};
 
 mod workflow;
 
@@ -598,6 +598,7 @@ impl ScreenState {
         if len > 0 && self.workflows.step_cursor < len - 1 {
             self.workflows.step_cursor += 1;
             self.workflows.expanded = false;
+            self.workflows.conversation = None;
         }
     }
 
@@ -605,6 +606,7 @@ impl ScreenState {
         if self.workflows.step_cursor > 0 {
             self.workflows.step_cursor = self.workflows.step_cursor.saturating_sub(1);
             self.workflows.expanded = false;
+            self.workflows.conversation = None;
         }
     }
 
@@ -618,6 +620,43 @@ impl ScreenState {
 
     pub fn workflow_toggle_expanded(&mut self) {
         self.workflows.expanded = !self.workflows.expanded;
+    }
+
+    pub fn selected_step_agent_id(&self) -> Option<(String, String)> {
+        let run = self.workflows.selected_run.as_ref()?;
+        let step = run.steps_snapshot.get(self.workflows.step_cursor)?;
+        let agent = run.agent_for_step(&step.name)?;
+        Some((agent.id.clone(), agent.name.clone()))
+    }
+
+    pub fn show_step_conversation(
+        &mut self,
+        agent_id: String,
+        agent_name: String,
+        messages: Vec<ChatMessage>,
+    ) {
+        self.workflows.conversation = Some(StepConversation {
+            agent_id,
+            agent_name,
+            messages,
+            scroll: 0,
+        });
+    }
+
+    pub fn hide_step_conversation(&mut self) {
+        self.workflows.conversation = None;
+    }
+
+    pub fn conversation_scroll_down(&mut self) {
+        if let Some(conv) = &mut self.workflows.conversation {
+            conv.scroll = conv.scroll.saturating_add(1);
+        }
+    }
+
+    pub fn conversation_scroll_up(&mut self) {
+        if let Some(conv) = &mut self.workflows.conversation {
+            conv.scroll = conv.scroll.saturating_sub(1);
+        }
     }
 
     pub fn workflow_focus_right(&mut self) {

--- a/client/src/tui/state/workflow.rs
+++ b/client/src/tui/state/workflow.rs
@@ -1,5 +1,7 @@
 use serde_json::Value;
 
+use super::super::chat::ChatMessage;
+
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum MillerFocus {
     #[default]
@@ -23,6 +25,15 @@ pub struct WorkflowState {
     pub detail_scroll: u16,
     pub loading: bool,
     pub error: Option<String>,
+    pub conversation: Option<StepConversation>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StepConversation {
+    pub agent_id: String,
+    pub agent_name: String,
+    pub messages: Vec<ChatMessage>,
+    pub scroll: u16,
 }
 
 #[derive(Debug, Clone)]
@@ -101,10 +112,14 @@ pub struct WorkflowRunDetail {
 }
 
 impl WorkflowRunDetail {
-    // Treat any non-pending/non-running state as terminal so unknown
-    // future states (e.g. CANCELLED) stop polling instead of looping.
     pub fn is_terminal(&self) -> bool {
         !matches!(self.state.as_str(), "PENDING" | "RUNNING")
+    }
+
+    pub fn agent_for_step(&self, step_name: &str) -> Option<&super::AgentItem> {
+        let run_short: String = self.id.chars().take(8).collect();
+        let expected = format!("workflow-{run_short}-{step_name}");
+        self.agents.iter().find(|a| a.name == expected)
     }
 }
 

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -6,8 +6,10 @@ use ratatui::{
     Frame,
 };
 
+use super::super::chat::{ChatRole, ContentBlock};
 use super::super::state::{
-    MillerFocus, ScreenState, WorkflowRunDetail, WorkflowStepItem, WorkflowStepResultItem,
+    MillerFocus, ScreenState, StepConversation, WorkflowRunDetail, WorkflowStepItem,
+    WorkflowStepResultItem,
 };
 
 pub fn draw_workflows(frame: &mut Frame, state: &ScreenState, area: Rect) {
@@ -34,9 +36,10 @@ pub fn status_keys(state: &ScreenState) -> &'static str {
         MillerFocus::Runs => {
             " │ ↑/↓:nav  J/K:scroll  ←:defs  →:steps  ^R:trigger  r:refresh  Esc:chat "
         }
-        MillerFocus::StepDetail => {
-            " │ ↑/↓:step  ←:runs  Enter:expand  ^R:trigger  r:refresh  Esc:chat "
+        MillerFocus::StepDetail if state.workflows.conversation.is_some() => {
+            " │ ↑/↓:scroll  c/←/Esc:back "
         }
+        MillerFocus::StepDetail => " │ ↑/↓:step  ←:runs  Enter:expand  c:conversation  Esc:chat ",
     }
 }
 
@@ -217,6 +220,7 @@ fn draw_run_split(frame: &mut Frame, state: &ScreenState, area: Rect) {
     if step_focused {
         draw_step_body(
             frame,
+            state,
             run,
             state.workflows.step_cursor,
             state.workflows.expanded,
@@ -349,11 +353,16 @@ fn draw_step_list(
 
 fn draw_step_body(
     frame: &mut Frame,
+    state: &ScreenState,
     run: &WorkflowRunDetail,
     cursor: usize,
     expanded: bool,
     area: Rect,
 ) {
+    if let Some(conv) = &state.workflows.conversation {
+        draw_conversation(frame, conv, area);
+        return;
+    }
     let body = selected_step_body(run, cursor, expanded);
     frame.render_widget(
         Paragraph::new(body)
@@ -363,6 +372,90 @@ fn draw_step_body(
                     .border_style(Style::default().fg(Color::Yellow))
                     .title(" Step Detail "),
             )
+            .wrap(Wrap { trim: false }),
+        area,
+    );
+}
+
+fn draw_conversation(frame: &mut Frame, conv: &StepConversation, area: Rect) {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Yellow))
+        .title(format!(" {} — Conversation ", conv.agent_name));
+
+    if conv.messages.is_empty() {
+        frame.render_widget(
+            Paragraph::new("No messages")
+                .block(block)
+                .style(Style::default().fg(Color::DarkGray)),
+            area,
+        );
+        return;
+    }
+
+    let mut lines: Vec<Line> = Vec::new();
+    for msg in &conv.messages {
+        let (role_label, role_color) = match msg.role {
+            ChatRole::User => ("▶ user", Color::Cyan),
+            ChatRole::Assistant => ("◀ assistant", Color::Green),
+            ChatRole::System => ("● system", Color::Red),
+        };
+        lines.push(Line::from(Span::styled(
+            role_label,
+            Style::default().fg(role_color).add_modifier(Modifier::BOLD),
+        )));
+
+        for block_item in &msg.blocks {
+            match block_item {
+                ContentBlock::Text(text) => {
+                    for l in text.lines() {
+                        lines.push(Line::from(format!("  {l}")));
+                    }
+                }
+                ContentBlock::ToolUse { name, .. } => {
+                    lines.push(Line::from(Span::styled(
+                        format!("  ⚙ {name}"),
+                        Style::default().fg(Color::Yellow),
+                    )));
+                }
+                ContentBlock::ToolResult(result) => {
+                    let preview: String = result
+                        .lines()
+                        .next()
+                        .unwrap_or("")
+                        .chars()
+                        .take(80)
+                        .collect();
+                    lines.push(Line::from(Span::styled(
+                        format!("  ← {preview}"),
+                        Style::default().fg(Color::DarkGray),
+                    )));
+                }
+                ContentBlock::Thinking(_) => {
+                    lines.push(Line::from(Span::styled(
+                        "  (thinking…)",
+                        Style::default().fg(Color::DarkGray),
+                    )));
+                }
+                ContentBlock::Sandbox {
+                    sandbox_name,
+                    operation,
+                    ..
+                } => {
+                    lines.push(Line::from(Span::styled(
+                        format!("  ⊞ {operation} {sandbox_name}"),
+                        Style::default().fg(Color::Magenta),
+                    )));
+                }
+            }
+        }
+        lines.push(Line::from(""));
+    }
+
+    frame.render_widget(
+        Paragraph::new(lines)
+            .block(block)
+            .scroll((conv.scroll, 0))
             .wrap(Wrap { trim: false }),
         area,
     );

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -412,24 +412,33 @@ fn draw_conversation(frame: &mut Frame, conv: &StepConversation, area: Rect) {
                         lines.push(Line::from(format!("  {l}")));
                     }
                 }
-                ContentBlock::ToolUse { name, .. } => {
+                ContentBlock::ToolUse { name, input } => {
                     lines.push(Line::from(Span::styled(
                         format!("  ⚙ {name}"),
                         Style::default().fg(Color::Yellow),
                     )));
+                    if !input.is_empty() {
+                        let pretty = try_pretty_json(input);
+                        for l in pretty.lines() {
+                            lines.push(Line::from(Span::styled(
+                                format!("    {l}"),
+                                Style::default().fg(Color::DarkGray),
+                            )));
+                        }
+                    }
                 }
                 ContentBlock::ToolResult(result) => {
-                    let preview: String = result
-                        .lines()
-                        .next()
-                        .unwrap_or("")
-                        .chars()
-                        .take(80)
-                        .collect();
                     lines.push(Line::from(Span::styled(
-                        format!("  ← {preview}"),
+                        "  ← result",
                         Style::default().fg(Color::DarkGray),
                     )));
+                    let pretty = try_pretty_json(result);
+                    for l in pretty.lines() {
+                        lines.push(Line::from(Span::styled(
+                            format!("    {l}"),
+                            Style::default().fg(Color::DarkGray),
+                        )));
+                    }
                 }
                 ContentBlock::Thinking(_) => {
                     lines.push(Line::from(Span::styled(
@@ -573,4 +582,11 @@ fn truncate(value: &str, max: usize) -> String {
 
 fn pretty_json(value: &serde_json::Value) -> String {
     serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}
+
+fn try_pretty_json(s: &str) -> String {
+    serde_json::from_str::<serde_json::Value>(s)
+        .ok()
+        .and_then(|v| serde_json::to_string_pretty(&v).ok())
+        .unwrap_or_else(|| s.to_string())
 }


### PR DESCRIPTION
## Summary

- Adds a read-only conversation history view for workflow step agents in the TUI
- When viewing a step in StepDetail focus, press `c` to load and display the agent's chat history
- Messages rendered with role indicators (▶ user, ◀ assistant, ● system) and content type formatting (text, ⚙ tool use, ← tool result, thinking, ⊞ sandbox ops)
- Scrollable with `j/k`, dismiss with `c`/`←`/`Esc`
- Reuses existing `chatHistory` GraphQL query — no server-side changes needed
- Agent matched to step via naming convention: `workflow-{run_id_short}-{step_name}`

## Approach

**Polling via GraphQL** — simplest viable approach. When the user presses `c`, the TUI fetches the agent's chat history once via the existing `chatHistory(last: 50)` query. No subscriptions or streaming needed since this is a read-only view of completed (or in-progress) agent work.

**Trade-offs considered:**
- Subscriptions would give real-time updates but add complexity; polling on re-press is sufficient for inspection
- Direct log/file reads would be brittle and not portable
- 50-message limit matches existing chat history pattern; enough for most workflow steps

## Files changed

| File | Change |
|------|--------|
| `client/src/tui/state/workflow.rs` | `StepConversation` struct, `agent_for_step()` helper |
| `client/src/tui/state/mod.rs` | Conversation state management methods |
| `client/src/tui/handlers.rs` | `FetchStepConversation` action, `c` keybinding, conversation scroll/dismiss handlers |
| `client/src/commands/dashboard.rs` | `ConversationLoaded`/`ConversationError` events, async fetch spawn |
| `client/src/tui/ui/workflows.rs` | `draw_conversation()` renderer, updated status keys |
| `client/src/tui/chat.rs` | Added `Debug` derives to `ChatMessage`, `ChatRole`, `ContentBlock` |

## Test plan

- [ ] Open TUI, navigate to Workflows (^W), select a workflow with completed runs
- [ ] Navigate to a run (→), then to steps (→)
- [ ] Press `c` on an agent step — conversation should load and display
- [ ] Verify j/k scrolls, c/←/Esc returns to step detail
- [ ] Press `c` on a tool step or step with no agent — should show "No agent for this step"
- [ ] Verify step cursor navigation clears the conversation view

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new async GraphQL fetch + UI/state paths in the workflows TUI; main risk is incorrect agent-to-step matching or stale in-flight responses causing confusing UI/state, but no server-side or write-path changes.
> 
> **Overview**
> Adds a **read-only conversation history view** for workflow step agents in the TUI: from workflow `StepDetail`, pressing `c` fetches the step’s agent chat history and renders it in a scrollable panel, with `j/k` scrolling and `c`/`←`/`Esc` to exit.
> 
> This introduces new workflow events/actions (`FetchStepConversation`, `ConversationLoaded`/`ConversationError`), conversation state (`StepConversation`) that is cleared on run/step changes, and a helper to map a step to its agent via the `workflow-{run_id_short}-{step_name}` naming convention. UI rendering formats different message block types and best-effort pretty-prints JSON tool inputs/results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0172e7814aaa3d7aa818d6335692ee7e24ea4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->