### PR TITLE
fix(workflow): preserve success+reason in agent step output_schema

### DIFF
--- a/core/src/toolset/top_level/submit_output.rs
+++ b/core/src/toolset/top_level/submit_output.rs
@@ -148,7 +148,7 @@ mod tests {
                 "b": { "type": "boolean" }
             }
         }));
-        let value = serde_json::json!({ "a": "hi", "b": true });
+        let value = serde_json::json!({ "a": "hi", "b": true, "success": true });
         validate_against_schema(&s, &value).unwrap();
     }
 
@@ -171,8 +171,13 @@ mod tests {
     }
 
     #[test]
-    fn skips_when_no_required_array() {
+    fn minimal_schema_still_requires_success() {
         let s = schema(serde_json::json!({ "type": "object" }));
-        validate_against_schema(&s, &serde_json::json!({})).unwrap();
+        let err = validate_against_schema(&s, &serde_json::json!({})).unwrap_err();
+        assert!(
+            err.contains("success"),
+            "success is always injected as required"
+        );
+        validate_against_schema(&s, &serde_json::json!({ "success": true })).unwrap();
     }
 }

--- a/core/src/workflow/definition.rs
+++ b/core/src/workflow/definition.rs
@@ -7,7 +7,7 @@ use std::str::FromStr;
 
 use chrono::{DateTime, Utc};
 use llm::ModelChain;
-use schemars::schema::{InstanceType, RootSchema, SingleOrVec};
+use schemars::schema::{InstanceType, RootSchema, Schema, SingleOrVec};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::sandbox::{SandboxAgentMode, SandboxMode, SandboxSpecs};
@@ -31,14 +31,42 @@ pub enum OutputSchemaError {
 }
 
 impl OutputSchema {
-    pub fn new(schema: RootSchema) -> Result<Self, OutputSchemaError> {
+    pub fn new(mut schema: RootSchema) -> Result<Self, OutputSchemaError> {
         match &schema.schema.instance_type {
             Some(SingleOrVec::Single(t)) if **t == InstanceType::Object => {}
             Some(SingleOrVec::Vec(types))
                 if types.len() == 1 && types[0] == InstanceType::Object => {}
             _ => return Err(OutputSchemaError::NotObjectRoot),
         }
+        Self::ensure_control_flow_fields(&mut schema);
         Ok(Self(schema))
+    }
+
+    /// Injects `success` (boolean, required) and `reason` (string,
+    /// optional) when missing. These fields drive workflow run-state
+    /// classification — without them the executor cannot distinguish
+    /// step success from failure (memo `019e019e`).
+    fn ensure_control_flow_fields(schema: &mut RootSchema) {
+        let obj = schema.schema.object.get_or_insert_with(Default::default);
+
+        if !obj.properties.contains_key("success") {
+            let prop: Schema = serde_json::from_value(serde_json::json!({
+                "type": "boolean",
+                "description": "Did the step achieve its goal?"
+            }))
+            .expect("static schema is valid");
+            obj.properties.insert("success".to_string(), prop);
+        }
+        obj.required.insert("success".to_string());
+
+        if !obj.properties.contains_key("reason") {
+            let prop: Schema = serde_json::from_value(serde_json::json!({
+                "type": "string",
+                "description": "Optional one-paragraph meta-explanation of the outcome — typically used on failure to cite evidence."
+            }))
+            .expect("static schema is valid");
+            obj.properties.insert("reason".to_string(), prop);
+        }
     }
 
     pub fn into_root_schema(self) -> RootSchema {
@@ -398,13 +426,13 @@ mod tests {
     }
 
     #[test]
-    fn output_schema_accessor_returns_declared() {
+    fn output_schema_accessor_returns_declared_with_control_flow_fields() {
         let custom_value = serde_json::json!({
             "type": "object",
             "required": ["verdict"],
             "properties": { "verdict": {"type": "string"} }
         });
-        let custom: OutputSchema = serde_json::from_value(custom_value.clone()).unwrap();
+        let custom: OutputSchema = serde_json::from_value(custom_value).unwrap();
         let step = WorkflowStepDef::AgentStep {
             name: "judge".into(),
             skill: "judge".into(),
@@ -416,7 +444,18 @@ mod tests {
             condition: None,
         };
         let actual = serde_json::to_value(step.output_schema().expect("AgentStep")).unwrap();
-        assert_eq!(actual, custom_value);
+        let props = actual["properties"].as_object().unwrap();
+        assert!(props.contains_key("verdict"), "user field preserved");
+        assert!(props.contains_key("success"), "success injected");
+        assert!(props.contains_key("reason"), "reason injected");
+        let required: Vec<&str> = actual["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(required.contains(&"verdict"));
+        assert!(required.contains(&"success"));
     }
 
     #[test]
@@ -616,6 +655,61 @@ mod tests {
         let trigger = WorkflowTrigger::Manual { condition: None };
         let s = serde_yaml::to_string(&trigger).unwrap();
         assert!(!s.contains("condition"));
+    }
+
+    #[test]
+    fn custom_schema_gets_control_flow_fields_injected() {
+        let schema: OutputSchema = serde_json::from_value(serde_json::json!({
+            "type": "object",
+            "required": ["verdict"],
+            "properties": {
+                "verdict": { "type": "string", "enum": ["pass", "fail"] }
+            }
+        }))
+        .unwrap();
+        let value = serde_json::to_value(&schema).unwrap();
+        let props = value["properties"].as_object().unwrap();
+        assert!(props.contains_key("verdict"), "user field kept");
+        assert!(props.contains_key("success"), "success injected");
+        assert!(props.contains_key("reason"), "reason injected");
+        assert_eq!(props["success"]["type"], "boolean");
+        assert_eq!(props["reason"]["type"], "string");
+
+        let required: Vec<&str> = value["required"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .filter_map(|v| v.as_str())
+            .collect();
+        assert!(required.contains(&"success"), "success is required");
+        assert!(required.contains(&"verdict"), "user required field kept");
+        assert!(
+            !required.contains(&"reason"),
+            "reason stays optional (not in required)"
+        );
+    }
+
+    #[test]
+    fn schema_already_containing_success_reason_is_unchanged() {
+        let input = serde_json::json!({
+            "type": "object",
+            "required": ["success", "data"],
+            "properties": {
+                "success": { "type": "boolean", "description": "custom desc" },
+                "reason": { "type": "string", "description": "custom reason desc" },
+                "data": { "type": "object" }
+            }
+        });
+        let schema: OutputSchema = serde_json::from_value(input.clone()).unwrap();
+        let output = serde_json::to_value(&schema).unwrap();
+        assert_eq!(
+            output["properties"]["success"]["description"], "custom desc",
+            "existing success description preserved"
+        );
+        assert_eq!(
+            output["properties"]["reason"]["description"], "custom reason desc",
+            "existing reason description preserved"
+        );
     }
 
     /// Old serialized triggers without the `condition` field must

--- a/core/src/workflow/yaml.rs
+++ b/core/src/workflow/yaml.rs
@@ -709,7 +709,7 @@ steps:
                 "verdict": { "type": "string", "enum": ["pass", "fail"] }
             }
         });
-        let schema: OutputSchema = serde_json::from_value(schema_value.clone()).unwrap();
+        let schema: OutputSchema = serde_json::from_value(schema_value).unwrap();
         let steps = vec![WorkflowStepDef::AgentStep {
             name: "judge".to_string(),
             skill: "judge".to_string(),
@@ -741,7 +741,10 @@ steps:
         match &parsed.steps[0] {
             WorkflowStepDef::AgentStep { output_schema, .. } => {
                 let actual = serde_json::to_value(output_schema).unwrap();
-                assert_eq!(actual, schema_value);
+                let props = actual["properties"].as_object().unwrap();
+                assert!(props.contains_key("verdict"), "user field preserved");
+                assert!(props.contains_key("success"), "success injected");
+                assert!(props.contains_key("reason"), "reason injected");
             }
             other => panic!("expected AgentStep, got {other:?}"),
         }


### PR DESCRIPTION
## Summary
- `OutputSchema::new()` now injects `success` (boolean, required) and `reason` (string, optional) into any agent step output schema that doesn't already include them
- These control-flow fields are essential for the executor to distinguish step success from failure (run-state classification)
- Custom schemas that already declare these fields are left untouched — only missing fields are injected

## Test plan
- [x] New test: custom schema without success/reason gets both injected
- [x] New test: schema already containing success/reason is not modified
- [x] Updated existing tests to account for injected fields
- [x] Default schema still works unchanged
- [x] `nix flake check` passes (fmt, clippy, nextest, graphql-schema)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow `OutputSchema` construction to mutate user-provided JSON Schemas by injecting required control-flow fields, which can affect validation/serialization of existing custom schemas and agent tool calls.
> 
> **Overview**
> Ensures every agent step `output_schema` always includes control-flow fields by having `OutputSchema::new()` inject `success` (*boolean, required*) and `reason` (*string, optional*) when missing, while preserving any user-defined versions of those fields.
> 
> Updates schema-validation and YAML/serde roundtrip tests to reflect the injected fields, including new coverage for injection behavior and for leaving preexisting `success`/`reason` definitions unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ef354230182bff43636d2ce587448320a56ebd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->