### PR TITLE
fix(compaction): distinct mask placeholder for errored tool results

### DIFF
--- a/core/src/agent/session/compaction/prune.rs
+++ b/core/src/agent/session/compaction/prune.rs
@@ -8,6 +8,15 @@ use super::super::view::{MessageBlockIndex, MessageView, PromptDefinition};
 use super::{estimation, event_belongs_to_thread};
 
 const MASK_PLACEHOLDER: &str = "[Tool output cleared — re-invoke tool if needed]";
+const MASK_PLACEHOLDER_ERROR: &str = "[Tool error output cleared — do not retry without new inputs]";
+
+fn mask_placeholder_for(is_error: bool) -> &'static str {
+    if is_error {
+        MASK_PLACEHOLDER_ERROR
+    } else {
+        MASK_PLACEHOLDER
+    }
+}
 
 #[derive(Debug, Default)]
 pub struct PruningPlan {
@@ -119,8 +128,9 @@ fn plan_tool_result_masking<'a>(
             continue;
         }
 
+        let placeholder = mask_placeholder_for(result.is_error);
         let content_len = result.content.len();
-        if content_len <= MASK_PLACEHOLDER.len() + 50 {
+        if content_len <= placeholder.len() + 50 {
             continue;
         }
 
@@ -129,7 +139,7 @@ fn plan_tool_result_masking<'a>(
             .map(|s| format!("[sandbox:{s}] "))
             .unwrap_or_default();
 
-        let masked_content = format!("{sandbox_prefix}{MASK_PLACEHOLDER}");
+        let masked_content = format!("{sandbox_prefix}{placeholder}");
         let tokens_before = estimation::estimate_event_tokens_for_content(content_len);
         let tokens_after = estimation::estimate_event_tokens_for_content(masked_content.len());
         tokens_saved += tokens_before.saturating_sub(tokens_after);

--- a/core/src/agent/session/compaction/prune.rs
+++ b/core/src/agent/session/compaction/prune.rs
@@ -8,7 +8,8 @@ use super::super::view::{MessageBlockIndex, MessageView, PromptDefinition};
 use super::{estimation, event_belongs_to_thread};
 
 const MASK_PLACEHOLDER: &str = "[Tool output cleared — re-invoke tool if needed]";
-const MASK_PLACEHOLDER_ERROR: &str = "[Tool error output cleared — do not retry without new inputs]";
+const MASK_PLACEHOLDER_ERROR: &str =
+    "[Tool error output cleared — do not retry without new inputs]";
 
 fn mask_placeholder_for(is_error: bool) -> &'static str {
     if is_error {


### PR DESCRIPTION
## Summary
- Pruning compaction masks old tool results with `[Tool output cleared — re-invoke tool if needed]`. The `is_error` flag is preserved on the replacement, but the placeholder body is the same for success and failure, telling the model to retry a deterministically-failing call whose original error context has just been discarded.
- Adds `MASK_PLACEHOLDER_ERROR = "[Tool error output cleared — do not retry without new inputs]"` and selects it per-result via `mask_placeholder_for(result.is_error)`. Skip-if-tiny guard now uses the chosen placeholder's length.

## Test plan
- [x] `cargo test -p drua-core --lib agent::session::compaction::prune` — all 3 prune tests pass
- [ ] Spot-check a real session where an errored tool result gets masked and confirm the new placeholder appears in the prompt sent to the model

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only the placeholder string used when masking old tool results and a related length check, without altering masking selection or data structures.
> 
> **Overview**
> Compaction pruning now uses a distinct placeholder when masking *errored* tool results ("[Tool error output cleared — do not retry without new inputs]") instead of reusing the success placeholder.
> 
> The "skip masking if content is already small" guard is updated to compare against the selected placeholder’s length, keeping the masking decision consistent for both success and error outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a2b8b9e52d1e40482a3fda48082a4eb4e897e94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->