### PR TITLE
feat(deploy): citadelbanking-portal git-proxy + PR review tool exposure

### DIFF
--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -150,6 +150,7 @@ galoyAgents:
         internalOnly: true
         allowedTools:
           - create_pull_request
+          - create_and_submit_pull_request_review
       - name: github_issues
         url: https://api.githubcopilot.com/mcp/
         toolPrefix: github_issues

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -98,6 +98,9 @@ galoyAgents:
             modes: [pull, push]
             allowedPushRefs:
               - refs/heads/bot/*
+          - owner: GaloyMoney
+            repo: citadelbanking-portal
+            modes: [pull]
     mcpUpstreams:
       - name: honeycomb
         url: https://mcp.honeycomb.io/mcp

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -100,7 +100,9 @@ galoyAgents:
               - refs/heads/bot/*
           - owner: GaloyMoney
             repo: citadelbanking-portal
-            modes: [pull]
+            modes: [pull, push]
+            allowedPushRefs:
+              - refs/heads/bot/*
     mcpUpstreams:
       - name: honeycomb
         url: https://mcp.honeycomb.io/mcp

--- a/drua.yml
+++ b/drua.yml
@@ -149,3 +149,4 @@ toolsets:
       # and we don't want any agent flow ever discovering it.
       allowed_tools:
         - create_pull_request
+        - create_and_submit_pull_request_review


### PR DESCRIPTION
## Summary
- **git-proxy allowlist:** add `GaloyMoney/citadelbanking-portal` to `galoyAgents.config.gitProxy.allowlist.entries` in `ci/deploy/drua/prod-values.yml.tmpl` with `modes: [pull, push]` and `allowedPushRefs: [refs/heads/bot/*]`, matching the existing pattern (`drua`, `lana-bank`, `es-entity`, `cala`, `obix`, `job`). Unblocks `RepoNotAllowed` errors for `citadel-portal-security-review` and lets agents push to `bot/*` from the sandbox.
- **PR review tool exposure:** add `create_and_submit_pull_request_review` to the internal-only `github_pull_requests` MCP upstream `allowedTools` in `ci/deploy/drua/prod-values.yml.tmpl`, and mirror in local `drua.yml`. Lets workflow agents call `github_pr_create_and_submit_pull_request_review` to APPROVE / REQUEST_CHANGES. Merge tools, line-comment and pending-review tools remain excluded.

## Test plan
- [ ] Verify rendered prod values include the new allowlist entry and the new allowedTool after `terraform apply`.
- [ ] Re-run a `citadel-portal-security-review` workflow against a PR in `GaloyMoney/citadelbanking-portal` and confirm the sandbox can clone via the git-proxy.
- [ ] Confirm agents can push to `refs/heads/bot/*` on `citadelbanking-portal` (and only those refs) via the proxy.
- [ ] Confirm an internal agent can call `github_pr_create_and_submit_pull_request_review` (APPROVE / REQUEST_CHANGES) and that the tool is still hidden from User / ExportedAgent / Anonymous subjects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it expands the set of repos and write-capabilities available through the git-proxy/MCP configuration; misconfiguration could enable unintended pushes or PR-review mutations, though pushes remain restricted to `refs/heads/bot/*`.
> 
> **Overview**
> Adds `GaloyMoney/citadelbanking-portal` to the production `gitProxy.allowlist` with `pull` + `push` access, restricting pushes to `refs/heads/bot/*`.
> 
> Expands the internal-only GitHub PR mutation MCP upstream allowlist to include `create_and_submit_pull_request_review` (in both `ci/deploy/drua/prod-values.yml.tmpl` and `drua.yml`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9460a7593b0fd969e05341e0b281c0470e3171f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->