### PR TITLE
fix(deploy): use current github MCP formal review tool name

### DIFF
--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -150,7 +150,7 @@ galoyAgents:
         internalOnly: true
         allowedTools:
           - create_pull_request
-          - create_and_submit_pull_request_review
+          - pull_request_review_write
       - name: github_issues
         url: https://api.githubcopilot.com/mcp/
         toolPrefix: github_issues

--- a/drua.yml
+++ b/drua.yml
@@ -149,4 +149,4 @@ toolsets:
       # and we don't want any agent flow ever discovering it.
       allowed_tools:
         - create_pull_request
-        - create_and_submit_pull_request_review
+        - pull_request_review_write


### PR DESCRIPTION
## Summary

PR #385 whitelisted `create_and_submit_pull_request_review` under `github_pull_requests.allowedTools`, but the current GitHub MCP exposes the formal review write surface as **`pull_request_review_write`** (the consolidated mutation tool, params: `method`, `event`, `body`, `commitID`, `owner`, `repo`, `pullNumber` — `method: create` plus an `event` submits the review).

This PR swaps both `ci/deploy/drua/prod-values.yml.tmpl` and `drua.yml` `github_pull_requests.allowedTools` from the old name to the current one. `create_pull_request` is kept.

After deploy, workflow agents (Citadel reviewer, etc.) will see the prefixed tool name **`github_pr_pull_request_review_write`** instead of the now-nonexistent `github_pr_create_and_submit_pull_request_review`.

## Changes

- `ci/deploy/drua/prod-values.yml.tmpl` — replace `create_and_submit_pull_request_review` with `pull_request_review_write`
- `drua.yml` — same swap in the local dev config

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk config-only change that swaps a tool name in the GitHub MCP allowlist; main risk is agents losing PR review capability if the new tool name is incorrect or differs across environments.
> 
> **Overview**
> Updates the GitHub PR-mutation MCP allowlist to use the current formal review tool name `pull_request_review_write` instead of the deprecated `create_and_submit_pull_request_review`.
> 
> Applies the rename in both the prod Helm values template (`ci/deploy/drua/prod-values.yml.tmpl`) and the local dev config (`drua.yml`), keeping `create_pull_request` allowed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bd56ab452a0653108d4ce85c8d866827aa1c61f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->