### PR TITLE
fix(session): lazy recovery for orphaned tool dispatches + remove await_run

### DIFF
--- a/bats/workflow.bats
+++ b/bats/workflow.bats
@@ -9,8 +9,8 @@
 #      single tool_step calling `whoami` (composable, declares an
 #      `output_schema`, returns deterministic structured content).
 #   2. admin `workflow trigger` spawns a run with a payload.
-#   3. admin `workflow await_run` blocks until terminal and surfaces
-#      the per-step structured outputs.
+#   3. poll `workflow run` until terminal and inspect per-step
+#      structured outputs.
 #
 # The executor mints `AuthSubject::WorkflowExecutor(project_id, run_id)`
 # at dispatch time; `whoami` introspects the subject and writes the
@@ -65,6 +65,23 @@ _wait_for_audit_log() {
       return 0
     fi
     sleep 0.1
+  done
+  return 1
+}
+
+_poll_run() {
+  local run_id="$1"
+  local max_wait="${2:-60}"
+  for _i in $(seq 1 "$max_wait"); do
+    run admin_call "workflow" "$(jq -nc --arg rid "$run_id" '{
+      command: "run", run_id: $rid
+    }')"
+    if [[ "$output" == *"state: succeeded"* ]] \
+      || [[ "$output" == *"state: failed"* ]] \
+      || [[ "$output" == *"state: errored"* ]]; then
+      return 0
+    fi
+    sleep 1
   done
   return 1
 }
@@ -131,12 +148,8 @@ _wait_for_audit_log() {
   run_id="$(extract_id_field "$output")"
   [ -n "$run_id" ] || { echo "could not extract run id"; return 1; }
 
-  # 4. Block until terminal and surface step outputs in the response.
-  run admin_call "workflow" "$(jq -nc --arg rid "$run_id" '{
-    command: "await_run",
-    run_id: $rid,
-    timeout_seconds: 60
-  }')"
+  # 4. Poll until terminal and surface step outputs in the response.
+  _poll_run "$run_id" 60
   echo "$output"
   [[ "$output" == *"state: succeeded"* ]]
 
@@ -255,11 +268,7 @@ _wait_for_audit_log() {
   run_id="$(extract_id_field "$output")"
   [ -n "$run_id" ] || { echo "could not extract run id"; return 1; }
 
-  run admin_call "workflow" "$(jq -nc --arg rid "$run_id" '{
-    command: "await_run",
-    run_id: $rid,
-    timeout_seconds: 60
-  }')"
+  _poll_run "$run_id" 60
   echo "$output"
   # Step 1 (whoami, no payload deps) should succeed. Step 2
   # (notes, depends on missing payload fields) errors — but
@@ -337,9 +346,7 @@ _wait_for_audit_log() {
   run_id="$(extract_id_field "$output")"
   [ -n "$run_id" ] || { echo "expected run to be created when condition true"; return 1; }
 
-  run admin_call "workflow" "$(jq -nc --arg rid "$run_id" '{
-    command: "await_run", run_id: $rid, timeout_seconds: 60
-  }')"
+  _poll_run "$run_id" 60
   echo "$output"
   [[ "$output" == *"state: succeeded"* ]]
 

--- a/charts/drua/templates/deployment.yaml
+++ b/charts/drua/templates/deployment.yaml
@@ -38,6 +38,7 @@ spec:
         checksum/external-secret: {{ .Values.galoyAgents.secretChecksum | quote }}
         {{- end }}
     spec:
+      terminationGracePeriodSeconds: 60
       {{- if .Values.sandbox.enabled }}
       serviceAccountName: {{ template "galoyAgents.fullname" . }}-sandbox
       {{- end }}

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -707,6 +707,8 @@ impl AgentSession {
 
     /// Synthesizes error tool results for a thread stuck in ToolUse turn
     /// after a dispatcher restart. Called lazily from `next_prompt`.
+    /// No-ops when the thread is not in ToolUse or the dispatch is
+    /// younger than `STALE_TOOL_USE_THRESHOLD`.
     fn recover_stale_tool_use(
         &mut self,
         thread_id: SessionThreadId,
@@ -715,7 +717,7 @@ impl AgentSession {
             .threads
             .get_persisted(&thread_id)
             .is_some_and(|t| t.is_tool_use_turn());
-        if !is_tool_use {
+        if !is_tool_use || !self.is_tool_use_stale(thread_id) {
             return Ok(());
         }
         let tool_use_ids = self.pending_tool_use_ids(thread_id);

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -271,7 +271,11 @@ impl AgentSession {
         if thread.is_user_turn() {
             Ok(AgentSessionResponse::PromptPending { target })
         } else if thread.is_tool_use_turn() {
-            Ok(AgentSessionResponse::AwaitingToolUsageComplete)
+            if self.is_tool_use_stale(thread_id) {
+                Ok(AgentSessionResponse::PromptPending { target })
+            } else {
+                Ok(AgentSessionResponse::AwaitingToolUsageComplete)
+            }
         } else {
             Ok(AgentSessionResponse::AwaitingAssistantResponse)
         }
@@ -294,6 +298,8 @@ impl AgentSession {
             return self.build_prompt(target, prompt_definition);
         }
         let thread_id = thread_id.unwrap();
+
+        self.recover_stale_tool_use(thread_id)?;
 
         let total_blocks = self.events.iter_all().fold(0usize, |acc, e| match e {
             AgentSessionEvent::UserInputAdded { .. }
@@ -648,6 +654,84 @@ impl AgentSession {
             }),
             _ => None,
         })
+    }
+
+    /// 15 minutes — longer than any non-await tool timeout (sandbox.create = 6 min).
+    const STALE_TOOL_USE_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(900);
+
+    fn is_tool_use_stale(&self, thread_id: SessionThreadId) -> bool {
+        let last_ts = self
+            .events
+            .iter_persisted()
+            .rev()
+            .find_map(|pe| match &pe.event {
+                AgentSessionEvent::AssistantResponseReceived { thread_id: tid, .. }
+                    if *tid == thread_id =>
+                {
+                    Some(pe.recorded_at)
+                }
+                _ => None,
+            });
+        match last_ts {
+            Some(ts) => {
+                let elapsed = chrono::Utc::now() - ts;
+                elapsed.to_std().unwrap_or(std::time::Duration::ZERO)
+                    > Self::STALE_TOOL_USE_THRESHOLD
+            }
+            None => false,
+        }
+    }
+
+    fn pending_tool_use_ids(&self, thread_id: SessionThreadId) -> Vec<String> {
+        self.events
+            .iter_all()
+            .rev()
+            .find_map(|e| match e {
+                AgentSessionEvent::AssistantResponseReceived {
+                    thread_id: tid,
+                    content,
+                    ..
+                } if *tid == thread_id => Some(
+                    content
+                        .iter()
+                        .filter_map(|b| match b {
+                            AssistantBlock::ToolUse { id, .. } => Some(id.clone()),
+                            _ => None,
+                        })
+                        .collect(),
+                ),
+                _ => None,
+            })
+            .unwrap_or_default()
+    }
+
+    /// Synthesizes error tool results for a thread stuck in ToolUse turn
+    /// after a dispatcher restart. Called lazily from `next_prompt`.
+    fn recover_stale_tool_use(
+        &mut self,
+        thread_id: SessionThreadId,
+    ) -> Result<(), AgentSessionError> {
+        let is_tool_use = self
+            .threads
+            .get_persisted(&thread_id)
+            .is_some_and(|t| t.is_tool_use_turn());
+        if !is_tool_use {
+            return Ok(());
+        }
+        let tool_use_ids = self.pending_tool_use_ids(thread_id);
+        if tool_use_ids.is_empty() {
+            return Ok(());
+        }
+        let results = tool_use_ids
+            .into_iter()
+            .map(|id| ToolResultInput {
+                tool_use_id: id,
+                content: "tool_execution_interrupted: dispatcher restarted".into(),
+                is_error: true,
+            })
+            .collect();
+        let _ = self.add_tool_results(thread_id, results)?;
+        Ok(())
     }
 
     pub fn assistant_response_received(

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -311,9 +311,6 @@ enum WorkflowCommand {
     Delete,
     /// Spawn a run with the given trigger payload. Returns the run id.
     Trigger,
-    /// Block until a run reaches a terminal state, then surface the
-    /// per-step outputs verbatim (full JSON, not truncated).
-    AwaitRun,
     /// Read a single run with full per-step outputs.
     Run,
 }
@@ -503,7 +500,7 @@ struct WorkflowParams {
     #[schemars(with = "Option<uuid::Uuid>")]
     definition_id: Option<WorkflowDefinitionId>,
 
-    /// Required for `await_run`, `run`.
+    /// Required for `run`.
     #[schemars(with = "Option<uuid::Uuid>")]
     run_id: Option<WorkflowRunId>,
 
@@ -511,10 +508,6 @@ struct WorkflowParams {
     /// `trigger.*` template namespace. Defaults to `{}`.
     #[serde(default)]
     payload: Option<serde_json::Value>,
-
-    /// `await_run`: wait budget in seconds. Defaults to 360.
-    #[serde(default)]
-    timeout_seconds: Option<u64>,
 
     /// `create`: required. `update`: optional rename.
     name: Option<String>,
@@ -1452,22 +1445,6 @@ impl AdminToolSet {
                     None => "Trigger condition evaluated to false; no run created.".to_string(),
                 };
                 Ok(CallToolResult::success(vec![Content::text(body)]))
-            }
-
-            WorkflowCommand::AwaitRun => {
-                let run_id = params.run_id.ok_or_else(|| {
-                    ToolSetsError::MissingArgument("run_id is required for await_run".to_string())
-                })?;
-                Audit::record_action("workflow.await_run");
-                let timeout = std::time::Duration::from_secs(params.timeout_seconds.unwrap_or(360));
-                let run = self
-                    .workflows
-                    .await_run_completion(subject, run_id, Some(timeout))
-                    .await
-                    .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
-                Ok(CallToolResult::success(vec![Content::text(format_run(
-                    &run,
-                ))]))
             }
 
             WorkflowCommand::Run => {

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -68,12 +68,6 @@ enum WorkflowParams {
         #[serde(default)]
         payload: Option<serde_json::Value>,
     },
-    AwaitRun {
-        run_id: WorkflowRunId,
-        /// Wait budget. Defaults to 360 seconds.
-        #[serde(default)]
-        timeout_seconds: Option<u64>,
-    },
     Runs {
         definition_id: WorkflowDefinitionId,
     },
@@ -311,7 +305,6 @@ impl WorkflowParams {
             Self::List => "workflow.list",
             Self::Get { .. } => "workflow.get",
             Self::Trigger { .. } => "workflow.trigger",
-            Self::AwaitRun { .. } => "workflow.await_run",
             Self::Runs { .. } => "workflow.runs",
             Self::Run { .. } => "workflow.run",
             Self::Update { .. } => "workflow.update",
@@ -478,8 +471,8 @@ static WORKFLOW_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
         "properties": {
             "command": {
                 "type": "string",
-                "enum": ["create", "list", "get", "trigger", "await_run", "runs", "run", "update", "delete"],
-                "description": "Which workflow operation to perform. `trigger` returns immediately with the freshly-spawned run; pair with `await_run` to block until terminal. `runs` lists runs (truncated outputs); `run` returns a single run with full per-step output."
+                "enum": ["create", "list", "get", "trigger", "runs", "run", "update", "delete"],
+                "description": "Which workflow operation to perform. `trigger` returns immediately with the freshly-spawned run. `runs` lists runs (truncated outputs); `run` returns a single run with full per-step output."
             },
             "name": {
                 "type": "string",
@@ -518,7 +511,7 @@ static WORKFLOW_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
             "timeout_seconds": {
                 "type": "integer",
                 "minimum": 1,
-                "description": "Per-step timeout in seconds (create); wait budget in seconds (await_run). Defaults: create=300, await_run=360."
+                "description": "Per-step timeout in seconds (create). Default: 300."
             },
             "definition_id": {
                 "type": "string",
@@ -616,9 +609,7 @@ impl TopLevelTool for WorkflowTool {
          optional `provider`, `sandboxes`, `manual`, `model_chain`), \
          `list`, `get` (requires `definition_id`), `trigger` (requires \
          `definition_id`, optional `payload`; returns immediately with \
-         the spawned run), `await_run` (requires `run_id`; blocks until \
-         terminal — pair with `trigger` when you need the final state \
-         inline), `runs` (requires `definition_id`; truncated step \
+         the spawned run), `runs` (requires `definition_id`; truncated step \
          outputs), `run` (requires `run_id`; full per-step outputs), \
          `update` (requires `definition_id`; optional `name`, \
          `description`+`clear_description`, `steps`+`update_steps`, \
@@ -804,25 +795,6 @@ impl TopLevelTool for WorkflowTool {
                 let out = WorkflowOutput {
                     command: "trigger".to_string(),
                     run: run_out,
-                    ..Default::default()
-                };
-                (text, out)
-            }
-
-            WorkflowParams::AwaitRun {
-                run_id,
-                timeout_seconds,
-            } => {
-                let timeout = std::time::Duration::from_secs(timeout_seconds.unwrap_or(360));
-                let run = self
-                    .workflows
-                    .await_run_completion(subject, run_id, Some(timeout))
-                    .await
-                    .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
-                let text = format_run_text(&run);
-                let out = WorkflowOutput {
-                    command: "await_run".to_string(),
-                    run: Some(run_to_output(&run)),
                     ..Default::default()
                 };
                 (text, out)
@@ -1338,7 +1310,7 @@ fn format_run_text(r: &WorkflowRun) -> String {
         WorkflowRunState::Pending | WorkflowRunState::Running
     ) {
         out.push_str(&format!(
-            "Block until terminal: workflow command=await_run run_id={}\n\n",
+            "Poll status: workflow command=run run_id={}\n\n",
             r.id
         ));
     }

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -167,9 +167,6 @@ pub struct Workflows {
     sandboxes: Arc<Sandboxes>,
     execute_run_spawner: ::job::JobSpawner<ExecuteRunConfig>,
     cron_spawner: ::job::JobSpawner<TriggerCronConfig>,
-    /// Cloned `Jobs` handle so `await_run_completion` can block on the
-    /// `ExecuteRun` job (whose id == run id) without polling.
-    jobs: ::job::Jobs,
 }
 
 impl Workflows {
@@ -212,7 +209,6 @@ impl Workflows {
             sandboxes,
             execute_run_spawner,
             cron_spawner,
-            jobs: jobs.clone(),
         }
     }
 
@@ -970,35 +966,6 @@ impl Workflows {
             AuthResource::Workflow(run.project_id, Some(run.definition_id)),
         )?;
         Ok(run)
-    }
-
-    /// Block until the run reaches a terminal state, then return it.
-    /// Backed by `Jobs::await_completions` on the `ExecuteRun` job —
-    /// the spawner uses the run id as the job id (see `spawn_run`).
-    /// Returns immediately if the run is already terminal.
-    #[instrument(name = "core.workflow.await_run_completion", skip_all)]
-    pub async fn await_run_completion(
-        &self,
-        sub: &AuthSubject,
-        run_id: WorkflowRunId,
-        timeout: Option<std::time::Duration>,
-    ) -> Result<WorkflowRun, WorkflowError> {
-        let run = self.run_repo.find_by_id(run_id).await?;
-        sub.can(
-            AuthVerb::Read,
-            AuthResource::Workflow(run.project_id, Some(run.definition_id)),
-        )?;
-        if matches!(
-            run.state,
-            WorkflowRunState::Succeeded | WorkflowRunState::Failed | WorkflowRunState::Errored
-        ) {
-            return Ok(run);
-        }
-        self.jobs
-            .await_completions(&[run_id.into()], timeout)
-            .await
-            .map_err(|e| WorkflowError::Job(e.to_string()))?;
-        Ok(self.run_repo.find_by_id(run_id).await?)
     }
 
     #[instrument(name = "core.workflow.delete_for_project_in_op", skip_all)]


### PR DESCRIPTION
## Summary
- **Lazy orphaned tool recovery**: `add_user_input` detects stale ToolUse threads (>15 min since last assistant response) and `next_prompt` synthesizes error ToolResults to unwedge the session — prevents permanently stuck sessions after pod restarts kill a dispatcher mid-tool-call
- **Remove `workflow.await_run` tool**: eliminates the long-blocking passive-await pattern (up to 6 min hold) that was the primary vector for deploy-induced stalls. Both top-level and admin toolsets updated; bats tests switched to polling with `workflow command=run`
- **Raise `terminationGracePeriodSeconds` to 60s**: gives in-flight tool dispatches more time to complete before SIGKILL (was default 30s)

## Test plan
- [x] `nix flake check` passes (fmt + clippy + nextest)
- [ ] Verify bats workflow tests pass with polling instead of `await_run`
- [ ] Deploy to staging and verify sessions recover from orphaned tool use after a rolling deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core agent session turn-state handling and removes the `await_run` workflow command, which may affect clients relying on blocking semantics; also introduces time-based recovery logic that needs validation under real restart scenarios.
> 
> **Overview**
> Adds **lazy recovery for sessions stuck in a `ToolUse` turn**: if a tool dispatch has been pending for >15 minutes, the session treats it as stale, synthesizes error `ToolResults` on the next `next_prompt`, and allows prompting to resume instead of remaining permanently blocked.
> 
> Removes the long-blocking `workflow await_run` command from both admin and top-level workflow tools (and deletes the underlying `Workflows::await_run_completion` job-wait path), updating schema/docs and the bats end-to-end workflow tests to **poll `workflow run`** until terminal.
> 
> Updates the Helm deployment to set `terminationGracePeriodSeconds: 60` to give in-flight dispatches more time to finish during shutdown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 014fd242f5d4678a4fdb9734189d85c481da5b07. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->