### PR TITLE
feat(tui): fast-scroll and thread-view toggle in workflow conversation

### DIFF
--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1931,11 +1931,7 @@ async fn run_event_loop(
                             }
                             handlers::Action::ToggleThreads => {
                                 if state.thread_view.is_some() {
-                                    state.thread_view = None;
-                                    state.focus = state.thread_return_focus.take().unwrap_or(Focus::Chat);
-                                    if state.focus != Focus::Workflows {
-                                        state.loaded_agent_id = None;
-                                    }
+                                    state.dismiss_threads();
                                 } else if let Some(agent_id) = state.selected_agent_id() {
                                     state.thread_return_focus = None;
                                     state.status_message = Some("Loading threads…".to_string());

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1949,20 +1949,16 @@ async fn run_event_loop(
                                 }
                             }
                             handlers::Action::ToggleThreadsForAgent { agent_id } => {
-                                if state.thread_view.is_some() {
-                                    state.thread_view = None;
-                                    state.focus = state.thread_return_focus.take().unwrap_or(Focus::Workflows);
-                                } else {
-                                    state.thread_return_focus = Some(Focus::Workflows);
-                                    state.status_message = Some("Loading threads…".to_string());
-                                    spawn_threads_fetch(
-                                        config.server_url.clone(),
-                                        config.auth_token.clone(),
-                                        agent_id,
-                                        false,
-                                        stream_tx.clone(),
-                                    );
-                                }
+                                state.thread_return_focus = Some(Focus::Workflows);
+                                state.status_message =
+                                    Some("Loading threads…".to_string());
+                                spawn_threads_fetch(
+                                    config.server_url.clone(),
+                                    config.auth_token.clone(),
+                                    agent_id,
+                                    false,
+                                    stream_tx.clone(),
+                                );
                             }
                             handlers::Action::OpenWorkflows => {
                                 state.enter_workflows();

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1432,18 +1432,24 @@ fn spawn_threads_fetch(
     base_url: String,
     token: String,
     agent_id: String,
+    tag_with_agent: bool,
     tx: mpsc::UnboundedSender<TaggedEvent>,
 ) {
     tokio::spawn(async move {
         let client = GraphqlClient::new(&base_url, &token);
+        let wrap = |event| {
+            if tag_with_agent {
+                TaggedEvent::for_agent(&agent_id, event)
+            } else {
+                TaggedEvent::untagged(event)
+            }
+        };
         match fetch_threads(&client, &agent_id).await {
             Ok(grid) => {
-                let _ = tx.send(TaggedEvent::untagged(ChatStreamEvent::ThreadsLoaded(
-                    Box::new(grid),
-                )));
+                let _ = tx.send(wrap(ChatStreamEvent::ThreadsLoaded(Box::new(grid))));
             }
             Err(e) => {
-                let _ = tx.send(TaggedEvent::untagged(ChatStreamEvent::Error(format!(
+                let _ = tx.send(wrap(ChatStreamEvent::Error(format!(
                     "Failed to load threads: {e}"
                 ))));
             }
@@ -1937,6 +1943,7 @@ async fn run_event_loop(
                                         config.server_url.clone(),
                                         config.auth_token.clone(),
                                         agent_id,
+                                        true,
                                         stream_tx.clone(),
                                     );
                                 }
@@ -1952,6 +1959,7 @@ async fn run_event_loop(
                                         config.server_url.clone(),
                                         config.auth_token.clone(),
                                         agent_id,
+                                        false,
                                         stream_tx.clone(),
                                     );
                                 }

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1438,16 +1438,14 @@ fn spawn_threads_fetch(
         let client = GraphqlClient::new(&base_url, &token);
         match fetch_threads(&client, &agent_id).await {
             Ok(grid) => {
-                let _ = tx.send(TaggedEvent::for_agent(
-                    &agent_id,
-                    ChatStreamEvent::ThreadsLoaded(Box::new(grid)),
-                ));
+                let _ = tx.send(TaggedEvent::untagged(ChatStreamEvent::ThreadsLoaded(
+                    Box::new(grid),
+                )));
             }
             Err(e) => {
-                let _ = tx.send(TaggedEvent::for_agent(
-                    &agent_id,
-                    ChatStreamEvent::Error(format!("Failed to load threads: {e}")),
-                ));
+                let _ = tx.send(TaggedEvent::untagged(ChatStreamEvent::Error(format!(
+                    "Failed to load threads: {e}"
+                ))));
             }
         }
     });

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -1928,9 +1928,27 @@ async fn run_event_loop(
                             handlers::Action::ToggleThreads => {
                                 if state.thread_view.is_some() {
                                     state.thread_view = None;
-                                    state.focus = Focus::Chat;
-                                    state.loaded_agent_id = None; // triggers reactive reload below
+                                    state.focus = state.thread_return_focus.take().unwrap_or(Focus::Chat);
+                                    if state.focus != Focus::Workflows {
+                                        state.loaded_agent_id = None;
+                                    }
                                 } else if let Some(agent_id) = state.selected_agent_id() {
+                                    state.thread_return_focus = None;
+                                    state.status_message = Some("Loading threads…".to_string());
+                                    spawn_threads_fetch(
+                                        config.server_url.clone(),
+                                        config.auth_token.clone(),
+                                        agent_id,
+                                        stream_tx.clone(),
+                                    );
+                                }
+                            }
+                            handlers::Action::ToggleThreadsForAgent { agent_id } => {
+                                if state.thread_view.is_some() {
+                                    state.thread_view = None;
+                                    state.focus = state.thread_return_focus.take().unwrap_or(Focus::Workflows);
+                                } else {
+                                    state.thread_return_focus = Some(Focus::Workflows);
                                     state.status_message = Some("Loading threads…".to_string());
                                     spawn_threads_fetch(
                                         config.server_url.clone(),

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -425,6 +425,9 @@ fn handle_threads_key(state: &mut ScreenState, key: KeyEvent) -> Action {
         KeyCode::Esc => {
             state.thread_view = None;
             state.focus = state.thread_return_focus.take().unwrap_or(Focus::Chat);
+            if state.focus != Focus::Workflows {
+                state.loaded_agent_id = None;
+            }
             Action::None
         }
         _ => Action::None,

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -762,11 +762,7 @@ mod tests {
         let mut state = state();
         state.enter_workflows();
         state.workflows.focus = MillerFocus::StepDetail;
-        state.show_step_conversation(
-            "agent-1".into(),
-            "test-agent".into(),
-            vec![],
-        );
+        state.show_step_conversation("agent-1".into(), "test-agent".into(), vec![]);
         state.update_conversation_viewport_height(40);
         state
     }

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -76,12 +76,10 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
                     if state.focus == Focus::Workflows
                         && state.workflows.conversation.is_some() =>
                 {
-                    if let Some(conv) = &state.workflows.conversation {
-                        return Action::ToggleThreadsForAgent {
-                            agent_id: conv.agent_id.clone(),
-                        };
-                    }
-                    return Action::None;
+                    let conv = state.workflows.conversation.as_ref().unwrap();
+                    return Action::ToggleThreadsForAgent {
+                        agent_id: conv.agent_id.clone(),
+                    };
                 }
                 KeyCode::Char('t') => return Action::ToggleThreads,
                 KeyCode::Char('w')

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -31,6 +31,9 @@ pub enum Action {
         agent_id: String,
         agent_name: String,
     },
+    ToggleThreadsForAgent {
+        agent_id: String,
+    },
 }
 
 pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
@@ -67,6 +70,17 @@ pub fn handle_key(state: &mut ScreenState, key: KeyEvent) -> Action {
                 }
                 KeyCode::Char('l') => {
                     state.focus_right();
+                    return Action::None;
+                }
+                KeyCode::Char('t')
+                    if state.focus == Focus::Workflows
+                        && state.workflows.conversation.is_some() =>
+                {
+                    if let Some(conv) = &state.workflows.conversation {
+                        return Action::ToggleThreadsForAgent {
+                            agent_id: conv.agent_id.clone(),
+                        };
+                    }
                     return Action::None;
                 }
                 KeyCode::Char('t') => return Action::ToggleThreads,
@@ -231,6 +245,20 @@ fn handle_workflow_step_detail_key(state: &mut ScreenState, key: KeyEvent) -> Ac
 }
 
 fn handle_workflow_conversation_key(state: &mut ScreenState, key: KeyEvent) -> Action {
+    let ctrl = key.modifiers.contains(KeyModifiers::CONTROL);
+    if ctrl {
+        match key.code {
+            KeyCode::Char('d') => {
+                state.conversation_fast_scroll_down();
+                return Action::None;
+            }
+            KeyCode::Char('u') => {
+                state.conversation_fast_scroll_up();
+                return Action::None;
+            }
+            _ => {}
+        }
+    }
     match key.code {
         KeyCode::Char('j') | KeyCode::Down => {
             state.conversation_scroll_down();
@@ -388,7 +416,6 @@ fn handle_threads_key(state: &mut ScreenState, key: KeyEvent) -> Action {
             state.grid_cycle_section();
             Action::None
         }
-        // Shift+Tab — jump to next unique/summary cell within current section
         KeyCode::BackTab => {
             state.grid_tab_next();
             Action::None
@@ -398,7 +425,8 @@ fn handle_threads_key(state: &mut ScreenState, key: KeyEvent) -> Action {
             Action::None
         }
         KeyCode::Esc => {
-            state.focus = Focus::Chat;
+            state.thread_view = None;
+            state.focus = state.thread_return_focus.take().unwrap_or(Focus::Chat);
             Action::None
         }
         _ => Action::None,
@@ -728,5 +756,86 @@ mod tests {
             assert!(matches!(action, Action::None));
             assert_eq!(state.focus, Focus::Chat);
         }
+    }
+
+    fn state_with_conversation() -> ScreenState {
+        let mut state = state();
+        state.enter_workflows();
+        state.workflows.focus = MillerFocus::StepDetail;
+        state.show_step_conversation(
+            "agent-1".into(),
+            "test-agent".into(),
+            vec![],
+        );
+        state.update_conversation_viewport_height(40);
+        state
+    }
+
+    #[test]
+    fn ctrl_d_fast_scrolls_conversation_down() {
+        let mut state = state_with_conversation();
+        let action = handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Char('d'), KeyModifiers::CONTROL),
+        );
+        assert!(matches!(action, Action::None));
+        assert_eq!(state.workflows.conversation.as_ref().unwrap().scroll, 20);
+    }
+
+    #[test]
+    fn ctrl_u_fast_scrolls_conversation_up() {
+        let mut state = state_with_conversation();
+        if let Some(conv) = &mut state.workflows.conversation {
+            conv.scroll = 30;
+        }
+        let action = handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Char('u'), KeyModifiers::CONTROL),
+        );
+        assert!(matches!(action, Action::None));
+        assert_eq!(state.workflows.conversation.as_ref().unwrap().scroll, 10);
+    }
+
+    #[test]
+    fn ctrl_t_in_conversation_returns_toggle_threads_for_agent() {
+        let mut state = state_with_conversation();
+        let action = handle_key(
+            &mut state,
+            KeyEvent::new(KeyCode::Char('t'), KeyModifiers::CONTROL),
+        );
+        match action {
+            Action::ToggleThreadsForAgent { agent_id } => {
+                assert_eq!(agent_id, "agent-1");
+            }
+            _ => panic!("expected ToggleThreadsForAgent"),
+        }
+    }
+
+    #[test]
+    fn esc_on_threads_returns_to_workflow_when_return_focus_set() {
+        let mut state = state();
+        state.focus = Focus::Threads;
+        state.thread_return_focus = Some(Focus::Workflows);
+        state.thread_view = Some(crate::tui::state::ThreadGridState {
+            threads: vec![],
+            positions: vec![],
+            grid: vec![],
+            details: std::collections::HashMap::new(),
+            cursor_col: 0,
+            cursor_row: 0,
+            scroll_col: 0,
+            visible_cols: 0,
+            system_positions: vec![],
+            system_grid: vec![],
+            tool_def_counts: vec![],
+            cursor_section: crate::tui::state::GridSection::Messages,
+            system_details: std::collections::HashMap::new(),
+        });
+
+        let action = handle_key(&mut state, key(KeyCode::Esc));
+
+        assert!(matches!(action, Action::None));
+        assert_eq!(state.focus, Focus::Workflows);
+        assert!(state.thread_view.is_none());
     }
 }

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -423,11 +423,7 @@ fn handle_threads_key(state: &mut ScreenState, key: KeyEvent) -> Action {
             Action::None
         }
         KeyCode::Esc => {
-            state.thread_view = None;
-            state.focus = state.thread_return_focus.take().unwrap_or(Focus::Chat);
-            if state.focus != Focus::Workflows {
-                state.loaded_agent_id = None;
-            }
+            state.dismiss_threads();
             Action::None
         }
         _ => Action::None,

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -283,6 +283,8 @@ pub struct ScreenState {
     pub loaded_agent_id: Option<String>,
 
     pub thread_view: Option<ThreadGridState>,
+    /// When set, closing the thread view returns here instead of `Focus::Chat`.
+    pub thread_return_focus: Option<Focus>,
     pub workflows: WorkflowState,
 
     pub mode: Mode,
@@ -325,6 +327,7 @@ impl ScreenState {
             loaded_agent_id: None,
 
             thread_view: None,
+            thread_return_focus: None,
             workflows: WorkflowState::default(),
 
             mode: Mode::default(),
@@ -641,6 +644,7 @@ impl ScreenState {
             agent_name,
             messages,
             scroll: 0,
+            viewport_height: 0,
         });
     }
 
@@ -657,6 +661,26 @@ impl ScreenState {
     pub fn conversation_scroll_up(&mut self) {
         if let Some(conv) = &mut self.workflows.conversation {
             conv.scroll = conv.scroll.saturating_sub(1);
+        }
+    }
+
+    pub fn conversation_fast_scroll_down(&mut self) {
+        if let Some(conv) = &mut self.workflows.conversation {
+            let jump = (conv.viewport_height / 2).max(1);
+            conv.scroll = conv.scroll.saturating_add(jump);
+        }
+    }
+
+    pub fn conversation_fast_scroll_up(&mut self) {
+        if let Some(conv) = &mut self.workflows.conversation {
+            let jump = (conv.viewport_height / 2).max(1);
+            conv.scroll = conv.scroll.saturating_sub(jump);
+        }
+    }
+
+    pub fn update_conversation_viewport_height(&mut self, h: u16) {
+        if let Some(conv) = &mut self.workflows.conversation {
+            conv.viewport_height = h;
         }
     }
 

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -409,6 +409,14 @@ impl ScreenState {
         self.input_field = 0;
     }
 
+    pub fn dismiss_threads(&mut self) {
+        self.thread_view = None;
+        self.focus = self.thread_return_focus.take().unwrap_or(Focus::Chat);
+        if self.focus != Focus::Workflows {
+            self.loaded_agent_id = None;
+        }
+    }
+
     pub fn enter_export_mode(&mut self) {
         self.export_path = "export.jsonl".to_string();
         self.mode = Mode::ExportThread;

--- a/client/src/tui/state/workflow.rs
+++ b/client/src/tui/state/workflow.rs
@@ -34,6 +34,7 @@ pub struct StepConversation {
     pub agent_name: String,
     pub messages: Vec<ChatMessage>,
     pub scroll: u16,
+    pub viewport_height: u16,
 }
 
 #[derive(Debug, Clone)]

--- a/client/src/tui/ui/mod.rs
+++ b/client/src/tui/ui/mod.rs
@@ -24,7 +24,7 @@ pub fn draw(frame: &mut Frame, state: &mut ScreenState) {
     let status_area = chunks[1];
 
     if state.focus == Focus::Workflows {
-        workflows::draw_workflows(frame, state, main_area);
+        workflows::draw_workflows(frame, &mut *state, main_area);
     } else {
         let panels = Layout::default()
             .direction(Direction::Horizontal)

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -12,7 +12,7 @@ use super::super::state::{
     WorkflowStepResultItem,
 };
 
-pub fn draw_workflows(frame: &mut Frame, state: &ScreenState, area: Rect) {
+pub fn draw_workflows(frame: &mut Frame, state: &mut ScreenState, area: Rect) {
     let chunks = Layout::default()
         .direction(Direction::Horizontal)
         .constraints([
@@ -37,7 +37,7 @@ pub fn status_keys(state: &ScreenState) -> &'static str {
             " │ ↑/↓:nav  J/K:scroll  ←:defs  →:steps  ^R:trigger  r:refresh  Esc:chat "
         }
         MillerFocus::StepDetail if state.workflows.conversation.is_some() => {
-            " │ ↑/↓:scroll  c/←/Esc:back "
+            " │ ↑/↓:scroll  ^D/^U:fast  ^T:threads  c/←/Esc:back "
         }
         MillerFocus::StepDetail => " │ ↑/↓:step  ←:runs  Enter:expand  c:conversation  Esc:chat ",
     }
@@ -142,10 +142,10 @@ fn draw_col_runs(frame: &mut Frame, state: &ScreenState, area: Rect) {
     frame.render_widget(List::new(items).block(block), area);
 }
 
-fn draw_col_detail(frame: &mut Frame, state: &ScreenState, area: Rect) {
+fn draw_col_detail(frame: &mut Frame, state: &mut ScreenState, area: Rect) {
     match state.workflows.focus {
         MillerFocus::Definitions | MillerFocus::YamlDetail => {
-            draw_definition_detail(frame, state, area)
+            draw_definition_detail(frame, state, area);
         }
         MillerFocus::Runs | MillerFocus::StepDetail => draw_run_split(frame, state, area),
     }
@@ -191,8 +191,8 @@ fn draw_definition_detail(frame: &mut Frame, state: &ScreenState, area: Rect) {
     );
 }
 
-fn draw_run_split(frame: &mut Frame, state: &ScreenState, area: Rect) {
-    let Some(run) = &state.workflows.selected_run else {
+fn draw_run_split(frame: &mut Frame, state: &mut ScreenState, area: Rect) {
+    if state.workflows.selected_run.is_none() {
         let msg = if state.workflows.runs.is_empty() {
             "No run selected"
         } else {
@@ -207,7 +207,7 @@ fn draw_run_split(frame: &mut Frame, state: &ScreenState, area: Rect) {
             area,
         );
         return;
-    };
+    }
 
     let chunks = Layout::default()
         .direction(Direction::Vertical)
@@ -215,6 +215,12 @@ fn draw_run_split(frame: &mut Frame, state: &ScreenState, area: Rect) {
         .split(area);
 
     let step_focused = state.workflows.focus == MillerFocus::StepDetail;
+
+    if step_focused && state.workflows.conversation.is_some() {
+        state.update_conversation_viewport_height(chunks[1].height.saturating_sub(2));
+    }
+
+    let run = state.workflows.selected_run.as_ref().unwrap();
     draw_step_list(frame, state, run, chunks[0], step_focused);
 
     if step_focused {


### PR DESCRIPTION
## Summary
- Add **Ctrl+D / Ctrl+U** half-page scrolling in the workflow agent-step conversation view (mirrors vim/less fast-scroll)
- Add **Ctrl+T** thread-view toggle from the conversation view — loads threads for the step agent and returns to the workflow view (not chat) when dismissed
- Track `thread_return_focus` so Esc in thread view also returns to the correct origin

## Test plan
- [x] Unit tests for Ctrl+D fast-scroll down (verifies half-page jump based on viewport height)
- [x] Unit tests for Ctrl+U fast-scroll up
- [x] Unit test for Ctrl+T returning `ToggleThreadsForAgent` action with correct agent ID
- [x] Unit test for Esc on threads returning to `Focus::Workflows` when `thread_return_focus` is set
- [x] `nix flake check` passes (fmt, clippy, nextest, graphql-schema, default-config)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX changes limited to TUI key handling and view state; main risk is minor focus/scroll regressions when opening/closing thread view from workflows.
> 
> **Overview**
> Adds *half-page fast scrolling* (`Ctrl+D`/`Ctrl+U`) to the workflow step conversation view by tracking its viewport height and jumping scroll accordingly.
> 
> Enables opening the thread grid from a workflow conversation via `Ctrl+T`, fetching threads for the step agent and introducing `thread_return_focus`/`dismiss_threads()` so closing threads returns to the originating view (workflows vs chat) and avoids unintended chat reload behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36fe99e1e09024fec0c990fc8da2a38e540c8d35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->