### PR TITLE
feat(keycloak-mcp): add read-only realm state server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3037,6 +3037,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "keycloak-mcp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "clap",
+ "reqwest 0.12.28",
+ "rmcp",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "kube"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
   "code-assistant/crates/core",
   "code-assistant/crates/cli",
   "images/sandbox/server",
+  "images/keycloak-mcp",
   "images/tunnel-connector",
 ]
 resolver = "2"

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -13,6 +13,7 @@ groups:
   - build-edge-image
   - build-sandbox-image
   - build-tunnel-connector-image
+  - build-keycloak-mcp-image
   - build-concourse-drua-resource-image
   - bump-galoy-charts-tunnel-connector-image
   - deploy-to-prod
@@ -433,6 +434,37 @@ jobs:
     get_params:
       skip_download: true
 
+- name: build-keycloak-mcp-image
+  serial: true
+  plan:
+  - get: repo-keycloak-mcp
+    trigger: true
+  - task: build-image
+    config:
+      platform: linux
+      image_resource: #@ nix_flake_image_config()
+      inputs:
+      - name: repo-keycloak-mcp
+        path: repo
+      outputs:
+      - name: image
+      caches:
+      - path: /nix-cache
+      run:
+        path: repo/ci/tasks/with-nix-cache.sh
+        args:
+          - sh
+          - -exc
+          - |
+            cd repo
+            nix build .#keycloak-mcp-image
+            gunzip -c result > ../image/image.tar
+  - put: keycloak-mcp-edge-image
+    params:
+      image: image/image.tar
+    get_params:
+      skip_download: true
+
 #! Builds the OCI image used as a Concourse `resource_type` to fire
 #! drua workflow runs from any pipeline's `on_failure:` (or anywhere
 #! else). Image source lives in `images/concourse-drua-resource/`.
@@ -592,6 +624,18 @@ resources:
     - Cargo.toml
     - Cargo.lock
 
+- name: repo-keycloak-mcp
+  type: git
+  source:
+    uri: #@ data.values.git_uri
+    branch: #@ data.values.git_branch
+    private_key: #@ data.values.github_private_key
+    paths:
+    - images/keycloak-mcp/
+    - flake.nix
+    - Cargo.toml
+    - Cargo.lock
+
 - name: repo-concourse-drua-resource
   type: git
   source:
@@ -699,6 +743,14 @@ resources:
     username: #@ data.values.gar_registry_user
     password: #@ data.values.gar_registry_password
     repository: #@ data.values.gar_registry + "/tunnel-connector"
+
+- name: keycloak-mcp-edge-image
+  type: registry-image
+  source:
+    tag: edge
+    username: #@ data.values.gar_registry_user
+    password: #@ data.values.gar_registry_password
+    repository: #@ data.values.gar_registry + "/keycloak-mcp"
 
 - name: concourse-drua-resource-edge-image
   type: registry-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -14,6 +14,7 @@ groups:
   - build-sandbox-image
   - build-tunnel-connector-image
   - build-keycloak-mcp-image
+  - bump-galoy-charts-keycloak-mcp-image
   - build-concourse-drua-resource-image
   - bump-galoy-charts-tunnel-connector-image
   - deploy-to-prod
@@ -465,6 +466,63 @@ jobs:
     get_params:
       skip_download: true
 
+#! After `build-keycloak-mcp-image` publishes a fresh digest, open
+#! (or force-update) a PR on GaloyMoney/galoy-charts that pins
+#! `keycloakMcp.image.digest` in `charts/galoy-deps/values.yaml`.
+#! This keeps the chart on an auditable immutable digest instead of
+#! silently following the mutable `:edge` tag.
+- name: bump-galoy-charts-keycloak-mcp-image
+  serial: true
+  plan:
+  - in_parallel:
+    - get: keycloak-mcp-edge-image
+      trigger: true
+      passed: [build-keycloak-mcp-image]
+      params:
+        skip_download: true
+    - get: repo
+    - get: galoy-charts-repo
+  - task: update-digest
+    config:
+      platform: linux
+      image_resource: #@ nix_flake_image_config()
+      inputs:
+      - name: repo
+      - name: keycloak-mcp-edge-image
+      - name: galoy-charts-repo
+      outputs:
+      - name: galoy-charts-repo
+      caches:
+      - path: /nix-cache
+      run:
+        path: repo/ci/tasks/with-nix-cache.sh
+        args:
+          - repo/ci/tasks/bump-galoy-charts-keycloak-mcp.sh
+  - put: galoy-charts-keycloak-mcp-bump-branch
+    params:
+      repository: galoy-charts-repo
+      branch: bump-keycloak-mcp-image-bot-branch
+      force: true
+  - task: open-pr
+    config:
+      platform: linux
+      image_resource: #@ nix_flake_image_config()
+      inputs:
+      - name: repo
+      - name: galoy-charts-repo
+      caches:
+      - path: /nix-cache
+      params:
+        GH_APP_ID: #@ data.values.github_app_id
+        GH_APP_PRIVATE_KEY: #@ data.values.github_app_private_key
+        BOT_BRANCH: bump-keycloak-mcp-image-bot-branch
+        BASE_BRANCH: main
+        TARGET_REPO: GaloyMoney/galoy-charts
+      run:
+        path: repo/ci/tasks/with-nix-cache.sh
+        args:
+          - repo/ci/tasks/open-galoy-charts-keycloak-mcp-pr.sh
+
 #! Builds the OCI image used as a Concourse `resource_type` to fire
 #! drua workflow runs from any pipeline's `on_failure:` (or anywhere
 #! else). Image source lives in `images/concourse-drua-resource/`.
@@ -646,9 +704,9 @@ resources:
     - images/concourse-drua-resource/
     - flake.nix
 
-#! Read-only clone of galoy-charts main. The `bump-galoy-charts-
-#! tunnel-connector-image` job uses this to build the commit that gets
-#! force-pushed to the bot branch below.
+#! Read-only clone of galoy-charts main. The galoy-charts image bump
+#! jobs use this to build the commits that get force-pushed to bot
+#! branches below.
 - name: galoy-charts-repo
   type: git
   source:
@@ -664,6 +722,13 @@ resources:
   source:
     uri: git@github.com:GaloyMoney/galoy-charts.git
     branch: bump-tunnel-connector-image-bot-branch
+    private_key: #@ data.values.github_private_key
+
+- name: galoy-charts-keycloak-mcp-bump-branch
+  type: git
+  source:
+    uri: git@github.com:GaloyMoney/galoy-charts.git
+    branch: bump-keycloak-mcp-image-bot-branch
     private_key: #@ data.values.github_private_key
 
 - name: repo-labels

--- a/ci/tasks/bump-galoy-charts-keycloak-mcp.sh
+++ b/ci/tasks/bump-galoy-charts-keycloak-mcp.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+
+# Writes the current `keycloak-mcp:edge` digest into
+# `charts/galoy-deps/values.yaml` in the galoy-charts clone and commits.
+# The pipeline then force-pushes the resulting commit to a bot branch
+# and the `open-pr` task opens/refreshes a PR against main.
+#
+# Runs inside the nix-flakes Concourse image. `nix shell` pulls in
+# `yq-go` and `git` from nixpkgs because the base image has neither.
+#
+# No-op when the digest in values.yaml already matches. This avoids
+# churning identical commits on every registry-image poll.
+
+set -euo pipefail
+
+exec nix shell nixpkgs#yq-go nixpkgs#git nixpkgs#coreutils --command bash <<'SCRIPT'
+set -euo pipefail
+
+DIGEST=$(cat keycloak-mcp-edge-image/digest)
+VALUES="galoy-charts-repo/charts/galoy-deps/values.yaml"
+
+if [[ "$(yq 'has("keycloakMcp")' "$VALUES")" != "true" ]]; then
+  echo "galoy-charts keycloakMcp values are missing; merge chart support first" >&2
+  exit 1
+fi
+
+CURRENT=$(yq '.keycloakMcp.image.digest' "$VALUES")
+if [[ "$CURRENT" == "$DIGEST" ]]; then
+  echo "galoy-charts keycloakMcp.image.digest already at $DIGEST; nothing to do"
+  exit 0
+fi
+
+yq -i ".keycloakMcp.image.digest = \"${DIGEST}\"" "$VALUES"
+
+if [[ -z $(git config --global user.email || true) ]]; then
+  git config --global user.email "bot@galoy.io"
+  git config --global user.name "Galoy CI Bot"
+fi
+
+cd galoy-charts-repo
+git add -A
+git status
+
+if ! git diff --cached --exit-code; then
+  git commit -m "chore(deps): bump keycloak-mcp image digest to ${DIGEST}"
+fi
+SCRIPT

--- a/ci/tasks/open-galoy-charts-keycloak-mcp-pr.sh
+++ b/ci/tasks/open-galoy-charts-keycloak-mcp-pr.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+# Opens (or re-opens) a PR against GaloyMoney/galoy-charts for the bot
+# branch that `bump-galoy-charts-keycloak-mcp.sh` force-pushes to.
+# Closes any existing PR on the branch first because the bot branch is
+# continuously force-pushed, and the goal is one always-current open PR.
+#
+# Auth: mints a short-lived installation token from the shared galoybot
+# GitHub App. `GH_APP_PRIVATE_KEY` is the base64-encoded PEM stored in
+# Vault and is passed straight through to `gh-token -b`.
+#
+# `nix shell` pulls `gh-token`, `gh`, `jq`, `yq-go` and `coreutils`
+# since the base nix-flakes image has none of them.
+
+set -euo pipefail
+
+: "${GH_APP_ID:?GH_APP_ID must be set}"
+: "${GH_APP_PRIVATE_KEY:?GH_APP_PRIVATE_KEY must be set (base64-encoded PEM)}"
+: "${BOT_BRANCH:?BOT_BRANCH must be set}"
+: "${BASE_BRANCH:?BASE_BRANCH must be set}"
+: "${TARGET_REPO:?TARGET_REPO must be set (owner/repo)}"
+
+exec nix shell \
+  nixpkgs#gh-token \
+  nixpkgs#gh \
+  nixpkgs#jq \
+  nixpkgs#yq-go \
+  nixpkgs#coreutils \
+  --command bash <<SCRIPT
+set -euo pipefail
+
+DIGEST=\$(yq '.keycloakMcp.image.digest' galoy-charts-repo/charts/galoy-deps/values.yaml)
+
+cat > /tmp/pr-body.md <<BODY
+Auto-bump of \\\`keycloakMcp.image.digest\\\` in \\\`charts/galoy-deps/values.yaml\\\` to the latest \\\`keycloak-mcp:edge\\\` digest published by drua CI:
+
+\\\`\\\`\\\`
+\${DIGEST}
+\\\`\\\`\\\`
+
+The drua CI bot force-pushes this branch on every new image, so this PR is always current. Pinning the digest instead of tracking the mutable \\\`:edge\\\` tag means a drua CI push does not silently roll the Keycloak MCP deployment.
+
+Opened by GaloyMoney/drua CI via \\\`ci/tasks/open-galoy-charts-keycloak-mcp-pr.sh\\\`.
+BODY
+
+export GH_TOKEN="\$(gh-token generate -b "\${GH_APP_PRIVATE_KEY}" -i "\${GH_APP_ID}" | jq -r '.token')"
+
+gh pr close "\${BOT_BRANCH}" --repo "\${TARGET_REPO}" || true
+gh pr create \\
+  --repo "\${TARGET_REPO}" \\
+  --title "chore(deps): bump keycloak-mcp image digest" \\
+  --body-file /tmp/pr-body.md \\
+  --base "\${BASE_BRANCH}" \\
+  --head "\${BOT_BRANCH}" \\
+  --label galoybot
+SCRIPT

--- a/flake.nix
+++ b/flake.nix
@@ -444,6 +444,17 @@
           sandbox-tool-server = self.packages.${system}.sandbox-tool-server;
         };
 
+        packages.keycloak-mcp = craneLib.buildPackage (commonArgs // {
+          inherit cargoArtifacts;
+          pname = "keycloak-mcp";
+          cargoExtraArgs = "-p keycloak-mcp";
+        });
+
+        packages.keycloak-mcp-image = import ./images/keycloak-mcp/default.nix {
+          inherit pkgs;
+          keycloak-mcp = self.packages.${system}.keycloak-mcp;
+        };
+
         packages.tunnel-connector = craneLib.buildPackage (commonArgs // {
           inherit cargoArtifacts;
           pname = "tunnel-connector";

--- a/images/keycloak-mcp/Cargo.toml
+++ b/images/keycloak-mcp/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "keycloak-mcp"
+version.workspace = true
+edition.workspace = true
+
+[[bin]]
+name = "keycloak-mcp"
+path = "src/main.rs"
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true }
+clap = { workspace = true }
+reqwest = { workspace = true }
+rmcp = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/images/keycloak-mcp/default.nix
+++ b/images/keycloak-mcp/default.nix
@@ -1,0 +1,20 @@
+{ pkgs, keycloak-mcp }:
+# Minimal container image for the read-only Keycloak MCP upstream.
+# The service speaks Streamable HTTP at /mcp and is intended to sit
+# behind the deployment tunnel-connector.
+pkgs.dockerTools.buildLayeredImage {
+  name = "keycloak-mcp";
+  tag = "latest";
+  contents = [
+    pkgs.cacert
+    keycloak-mcp
+  ];
+  config = {
+    Entrypoint = [ "${keycloak-mcp}/bin/keycloak-mcp" ];
+    User = "65534:65534"; # nobody:nogroup
+    Env = [
+      "SSL_CERT_FILE=${pkgs.cacert}/etc/ssl/certs/ca-bundle.crt"
+      "RUST_LOG=info"
+    ];
+  };
+}

--- a/images/keycloak-mcp/src/main.rs
+++ b/images/keycloak-mcp/src/main.rs
@@ -591,6 +591,41 @@ fn parse_realms(raw: &str) -> Vec<String> {
         .collect()
 }
 
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    let default_realms = parse_realms(&cli.realms);
+    if default_realms.is_empty() {
+        anyhow::bail!("KEYCLOAK_REALMS must include at least one realm");
+    }
+
+    let client = KeycloakClient::new(
+        cli.keycloak_base_url,
+        cli.token_realm,
+        cli.client_id,
+        cli.client_secret,
+        default_realms,
+    );
+    let mcp = KeycloakMcp::new(client, cli.declared_snapshot_file)?;
+    let service = mcp.into_service();
+
+    let app = Router::new()
+        .route("/healthz", get(|| async { (StatusCode::OK, "ok") }))
+        .nest_service(&cli.mount, service);
+
+    let listener = tokio::net::TcpListener::bind(cli.bind).await?;
+    let local_addr = listener.local_addr()?;
+    tracing::info!("keycloak-mcp listening on http://{local_addr}{}", cli.mount);
+    axum::serve(listener, app).await?;
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -656,39 +691,4 @@ mod tests {
         assert_eq!(diff["equal"], false);
         assert_eq!(diff["differenceCount"], 2);
     }
-}
-
-#[tokio::main]
-async fn main() -> Result<()> {
-    tracing_subscriber::fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
-        )
-        .init();
-
-    let cli = Cli::parse();
-    let default_realms = parse_realms(&cli.realms);
-    if default_realms.is_empty() {
-        anyhow::bail!("KEYCLOAK_REALMS must include at least one realm");
-    }
-
-    let client = KeycloakClient::new(
-        cli.keycloak_base_url,
-        cli.token_realm,
-        cli.client_id,
-        cli.client_secret,
-        default_realms,
-    );
-    let mcp = KeycloakMcp::new(client, cli.declared_snapshot_file)?;
-    let service = mcp.into_service();
-
-    let app = Router::new()
-        .route("/healthz", get(|| async { (StatusCode::OK, "ok") }))
-        .nest_service(&cli.mount, service);
-
-    let listener = tokio::net::TcpListener::bind(cli.bind).await?;
-    let local_addr = listener.local_addr()?;
-    tracing::info!("keycloak-mcp listening on http://{local_addr}{}", cli.mount);
-    axum::serve(listener, app).await?;
-    Ok(())
 }

--- a/images/keycloak-mcp/src/main.rs
+++ b/images/keycloak-mcp/src/main.rs
@@ -1,0 +1,694 @@
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use axum::{routing::get, Router};
+use clap::Parser;
+use reqwest::StatusCode;
+use rmcp::model::{
+    CallToolRequestParams, CallToolResult, Content, ErrorData, ListToolsResult,
+    PaginatedRequestParams, ServerCapabilities, ServerInfo, Tool,
+};
+use rmcp::service::RequestContext;
+use rmcp::transport::streamable_http_server::{
+    session::local::LocalSessionManager, StreamableHttpServerConfig, StreamableHttpService,
+};
+use rmcp::{RoleServer, ServerHandler};
+use serde::Deserialize;
+use serde_json::{json, Map, Value};
+use tracing::instrument;
+use tracing_subscriber::EnvFilter;
+
+#[derive(Parser, Debug)]
+#[command(about = "Read-only Keycloak Admin REST MCP server.")]
+struct Cli {
+    /// Base URL for Keycloak, without a trailing slash.
+    #[arg(long, env = "KEYCLOAK_BASE_URL")]
+    keycloak_base_url: String,
+
+    /// Realm used for client_credentials token acquisition.
+    #[arg(long, env = "KEYCLOAK_TOKEN_REALM")]
+    token_realm: Option<String>,
+
+    /// Confidential client id used for Admin REST access.
+    #[arg(long, env = "KEYCLOAK_CLIENT_ID")]
+    client_id: String,
+
+    /// Confidential client secret used for Admin REST access.
+    #[arg(long, env = "KEYCLOAK_CLIENT_SECRET")]
+    client_secret: String,
+
+    /// Comma-separated realms included in snapshot_get by default.
+    #[arg(long, env = "KEYCLOAK_REALMS", default_value = "internal,customer")]
+    realms: String,
+
+    /// Optional normalized declared snapshot JSON used by diff_declared.
+    #[arg(long, env = "KEYCLOAK_DECLARED_SNAPSHOT_FILE")]
+    declared_snapshot_file: Option<PathBuf>,
+
+    /// Address to bind the HTTP server to.
+    #[arg(long, env = "KEYCLOAK_MCP_BIND", default_value = "0.0.0.0:8000")]
+    bind: SocketAddr,
+
+    /// HTTP path to mount the MCP service at.
+    #[arg(long, env = "KEYCLOAK_MCP_MOUNT", default_value = "/mcp")]
+    mount: String,
+}
+
+#[derive(Clone)]
+struct KeycloakMcp {
+    client: Arc<KeycloakClient>,
+    declared_snapshot: Option<Arc<Value>>,
+}
+
+#[derive(Clone)]
+struct KeycloakClient {
+    http: reqwest::Client,
+    base_url: String,
+    token_realm: Option<String>,
+    client_id: String,
+    client_secret: String,
+    default_realms: Vec<String>,
+}
+
+#[derive(Deserialize)]
+struct TokenResponse {
+    access_token: String,
+}
+
+impl KeycloakClient {
+    fn new(
+        base_url: String,
+        token_realm: Option<String>,
+        client_id: String,
+        client_secret: String,
+        default_realms: Vec<String>,
+    ) -> Self {
+        Self {
+            http: reqwest::Client::new(),
+            base_url: base_url.trim_end_matches('/').to_string(),
+            token_realm,
+            client_id,
+            client_secret,
+            default_realms,
+        }
+    }
+
+    async fn token(&self, realm: &str) -> Result<String> {
+        let token_realm = self.token_realm.as_deref().unwrap_or(realm);
+        let token_url = format!(
+            "{}/realms/{}/protocol/openid-connect/token",
+            self.base_url, token_realm
+        );
+        let response = self
+            .http
+            .post(token_url)
+            .form(&[
+                ("grant_type", "client_credentials"),
+                ("client_id", self.client_id.as_str()),
+                ("client_secret", self.client_secret.as_str()),
+            ])
+            .send()
+            .await
+            .context("requesting Keycloak access token")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Keycloak token request failed with {status}: {body}");
+        }
+
+        let token = response
+            .json::<TokenResponse>()
+            .await
+            .context("decoding Keycloak token response")?;
+        Ok(token.access_token)
+    }
+
+    async fn admin_get(&self, token: &str, path: &str, query: &[(&str, String)]) -> Result<Value> {
+        let url = format!("{}/admin/{}", self.base_url, path.trim_start_matches('/'));
+        let response = self
+            .http
+            .get(url)
+            .bearer_auth(token)
+            .query(query)
+            .send()
+            .await
+            .with_context(|| format!("requesting Keycloak admin path {path}"))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Keycloak admin GET {path} failed with {status}: {body}");
+        }
+
+        let mut value = response
+            .json::<Value>()
+            .await
+            .with_context(|| format!("decoding Keycloak admin path {path}"))?;
+        redact_value(&mut value);
+        Ok(canonicalize(value))
+    }
+
+    async fn realm_snapshot(&self, token: &str, realm: &str) -> Result<Value> {
+        let realm_info = self
+            .admin_get(token, &format!("realms/{realm}"), &[])
+            .await?;
+        let clients = self
+            .admin_get(
+                token,
+                &format!("realms/{realm}/clients"),
+                &[("briefRepresentation", "false".to_string())],
+            )
+            .await?;
+        let client_scopes = self
+            .admin_get(token, &format!("realms/{realm}/client-scopes"), &[])
+            .await?;
+        let roles = self
+            .admin_get(token, &format!("realms/{realm}/roles"), &[])
+            .await?;
+        let auth_flows = self
+            .admin_get(token, &format!("realms/{realm}/authentication/flows"), &[])
+            .await?;
+        let required_actions = self
+            .admin_get(
+                token,
+                &format!("realms/{realm}/authentication/required-actions"),
+                &[],
+            )
+            .await?;
+        let user_profile = self
+            .admin_get(token, &format!("realms/{realm}/users/profile"), &[])
+            .await?;
+
+        Ok(canonicalize(json!({
+            "realm": realm_info,
+            "clients": clients,
+            "clientScopes": client_scopes,
+            "roles": roles,
+            "authenticationFlows": auth_flows,
+            "requiredActions": required_actions,
+            "userProfile": user_profile,
+        })))
+    }
+}
+
+impl KeycloakMcp {
+    fn new(client: KeycloakClient, declared_snapshot_file: Option<PathBuf>) -> Result<Self> {
+        let declared_snapshot = if let Some(path) = declared_snapshot_file {
+            let body = std::fs::read_to_string(&path)
+                .with_context(|| format!("reading declared snapshot {}", path.display()))?;
+            let mut value = serde_json::from_str::<Value>(&body)
+                .with_context(|| format!("parsing declared snapshot {}", path.display()))?;
+            redact_value(&mut value);
+            Some(Arc::new(canonicalize(value)))
+        } else {
+            None
+        };
+
+        Ok(Self {
+            client: Arc::new(client),
+            declared_snapshot,
+        })
+    }
+
+    fn into_service(self) -> StreamableHttpService<Self, LocalSessionManager> {
+        let mut config = StreamableHttpServerConfig::default().disable_allowed_hosts();
+        config.stateful_mode = false;
+        config.json_response = true;
+        StreamableHttpService::new(
+            move || Ok(self.clone()),
+            LocalSessionManager::default().into(),
+            config,
+        )
+    }
+}
+
+impl ServerHandler for KeycloakMcp {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build()).with_instructions(
+            "Read-only Keycloak Admin REST tools for deployment state inspection.",
+        )
+    }
+
+    async fn list_tools(
+        &self,
+        _: Option<PaginatedRequestParams>,
+        _: RequestContext<RoleServer>,
+    ) -> std::result::Result<ListToolsResult, ErrorData> {
+        Ok(ListToolsResult {
+            tools: vec![
+                tool(
+                    "realm_list",
+                    "Return configured Keycloak realms and read-access status.",
+                    empty_object_schema(),
+                ),
+                tool(
+                    "realm_get",
+                    "Return a normalized read-only realm snapshot, including nested config relevant to drift checks.",
+                    realm_schema(),
+                ),
+                tool(
+                    "realm_diff_declared",
+                    "Compare one live Keycloak realm against the configured declared snapshot.",
+                    realm_schema(),
+                ),
+            ],
+            next_cursor: None,
+            meta: None,
+        })
+    }
+
+    #[instrument(name = "keycloak_mcp.call_tool", skip(self, _ctx), fields(tool = %request.name))]
+    async fn call_tool(
+        &self,
+        request: CallToolRequestParams,
+        _ctx: RequestContext<RoleServer>,
+    ) -> std::result::Result<CallToolResult, ErrorData> {
+        let args = request.arguments.unwrap_or_default();
+        let result = match request.name.as_ref() {
+            "realm_list" => self.realm_list().await,
+            "realm_get" => self.realm_get(&args).await,
+            "realm_diff_declared" => self.realm_diff_declared(&args).await,
+            other => Err(anyhow::anyhow!("unknown tool: {other}")),
+        };
+
+        match result {
+            Ok(value) => Ok(json_result(value)),
+            Err(error) => Ok(error_result(error.to_string())),
+        }
+    }
+}
+
+impl KeycloakMcp {
+    async fn realm_list(&self) -> Result<Value> {
+        let mut realms = Vec::new();
+
+        for realm in &self.client.default_realms {
+            let status = match self.client.token(realm).await {
+                Ok(token) => match self
+                    .client
+                    .admin_get(&token, &format!("realms/{realm}"), &[])
+                    .await
+                {
+                    Ok(info) => json!({
+                        "realm": realm,
+                        "accessible": true,
+                        "enabled": info.get("enabled").cloned().unwrap_or(Value::Null),
+                        "displayName": info.get("displayName").cloned().unwrap_or(Value::Null),
+                    }),
+                    Err(error) => json!({
+                        "realm": realm,
+                        "accessible": false,
+                        "error": error.to_string(),
+                    }),
+                },
+                Err(error) => json!({
+                    "realm": realm,
+                    "accessible": false,
+                    "error": error.to_string(),
+                }),
+            };
+            realms.push(status);
+        }
+
+        Ok(json!({
+            "source": "configured",
+            "realms": realms,
+        }))
+    }
+
+    async fn realm_get(&self, args: &Map<String, Value>) -> Result<Value> {
+        let realm = required_string(args, "realm")?;
+        let token = self.client.token(&realm).await?;
+        self.client.realm_snapshot(&token, &realm).await
+    }
+
+    async fn realm_diff_declared(&self, args: &Map<String, Value>) -> Result<Value> {
+        let realm = required_string(args, "realm")?;
+        let declared = self
+            .declared_snapshot
+            .as_ref()
+            .context("KEYCLOAK_DECLARED_SNAPSHOT_FILE is not configured")?;
+        let declared_realm = declared
+            .get("realms")
+            .and_then(|realms| realms.get(&realm))
+            .with_context(|| format!("declared snapshot does not contain realm {realm}"))?;
+        let live = self.realm_get(args).await?;
+        Ok(diff_values(declared_realm, &live, 100))
+    }
+}
+
+fn json_result(value: Value) -> CallToolResult {
+    let pretty = serde_json::to_string_pretty(&value).unwrap_or_else(|_| value.to_string());
+    let mut result = CallToolResult::success(vec![Content::text(pretty)]);
+    result.structured_content = Some(value);
+    result
+}
+
+fn error_result(message: String) -> CallToolResult {
+    let mut result = CallToolResult::success(vec![Content::text(message)]);
+    result.is_error = Some(true);
+    result
+}
+
+fn tool(name: &str, description: &str, schema: Map<String, Value>) -> Tool {
+    let mut tool = Tool::default();
+    tool.name = name.to_string().into();
+    tool.description = Some(description.to_string().into());
+    tool.input_schema = Arc::new(schema);
+    tool
+}
+
+fn realm_schema() -> Map<String, Value> {
+    object_schema(
+        json!({
+            "realm": {
+                "type": "string",
+                "description": "Keycloak realm name."
+            }
+        }),
+        &["realm"],
+    )
+}
+
+fn empty_object_schema() -> Map<String, Value> {
+    object_schema(json!({}), &[])
+}
+
+fn object_schema(properties: Value, required: &[&str]) -> Map<String, Value> {
+    let mut schema = Map::new();
+    schema.insert("type".into(), Value::String("object".into()));
+    schema.insert("properties".into(), properties);
+    schema.insert(
+        "required".into(),
+        Value::Array(
+            required
+                .iter()
+                .map(|field| Value::String((*field).to_string()))
+                .collect(),
+        ),
+    );
+    schema.insert("additionalProperties".into(), Value::Bool(false));
+    schema
+}
+
+fn required_string(args: &Map<String, Value>, name: &str) -> Result<String> {
+    args.get(name)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .with_context(|| format!("missing required string argument {name}"))
+}
+
+fn redact_value(value: &mut Value) {
+    match value {
+        Value::Object(map) => {
+            let keys: Vec<String> = map.keys().cloned().collect();
+            for key in keys {
+                if should_redact(&key) {
+                    map.insert(key, Value::String("<redacted>".to_string()));
+                    continue;
+                }
+                if should_drop_generated(&key) {
+                    map.remove(&key);
+                    continue;
+                }
+                if let Some(value) = map.get_mut(&key) {
+                    redact_value(value);
+                }
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                redact_value(value);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn should_redact(key: &str) -> bool {
+    let normalized = key.to_ascii_lowercase();
+    normalized.contains("secret")
+        || normalized.contains("password")
+        || normalized == "token"
+        || normalized.ends_with("token")
+        || normalized == "credentials"
+}
+
+fn should_drop_generated(key: &str) -> bool {
+    matches!(
+        key,
+        "id" | "containerId" | "createdTimestamp" | "access" | "adminUrl"
+    )
+}
+
+fn canonicalize(value: Value) -> Value {
+    match value {
+        Value::Array(values) => {
+            let mut values: Vec<Value> = values.into_iter().map(canonicalize).collect();
+            values.sort_by_key(stable_sort_key);
+            Value::Array(values)
+        }
+        Value::Object(map) => {
+            let mapped = map
+                .into_iter()
+                .map(|(key, value)| (key, canonicalize(value)))
+                .collect();
+            Value::Object(mapped)
+        }
+        other => other,
+    }
+}
+
+fn stable_sort_key(value: &Value) -> String {
+    if let Value::Object(map) = value {
+        for key in [
+            "realm",
+            "clientId",
+            "name",
+            "alias",
+            "username",
+            "protocol",
+            "providerId",
+        ] {
+            if let Some(value) = map.get(key).and_then(Value::as_str) {
+                return format!("{key}:{value}");
+            }
+        }
+    }
+    serde_json::to_string(value).unwrap_or_default()
+}
+
+fn diff_values(expected: &Value, actual: &Value, max_differences: usize) -> Value {
+    let mut differences = Vec::new();
+    collect_diff("$", expected, actual, max_differences, &mut differences);
+    json!({
+        "equal": differences.is_empty(),
+        "differenceCount": differences.len(),
+        "truncated": differences.len() >= max_differences,
+        "differences": differences,
+    })
+}
+
+fn collect_diff(
+    path: &str,
+    expected: &Value,
+    actual: &Value,
+    max_differences: usize,
+    differences: &mut Vec<Value>,
+) {
+    if differences.len() >= max_differences || expected == actual {
+        return;
+    }
+
+    match (expected, actual) {
+        (Value::Object(expected), Value::Object(actual)) => {
+            for key in expected.keys() {
+                if differences.len() >= max_differences {
+                    return;
+                }
+                let child_path = format!("{path}.{key}");
+                match actual.get(key) {
+                    Some(actual_value) => {
+                        collect_diff(
+                            &child_path,
+                            &expected[key],
+                            actual_value,
+                            max_differences,
+                            differences,
+                        );
+                    }
+                    None => differences.push(json!({
+                        "path": child_path,
+                        "kind": "removed",
+                        "expected": expected[key],
+                        "actual": Value::Null,
+                    })),
+                }
+            }
+
+            for key in actual.keys() {
+                if differences.len() >= max_differences {
+                    return;
+                }
+                if !expected.contains_key(key) {
+                    differences.push(json!({
+                        "path": format!("{path}.{key}"),
+                        "kind": "added",
+                        "expected": Value::Null,
+                        "actual": actual[key],
+                    }));
+                }
+            }
+        }
+        (Value::Array(expected), Value::Array(actual)) => {
+            let len = expected.len().max(actual.len());
+            for index in 0..len {
+                if differences.len() >= max_differences {
+                    return;
+                }
+                let child_path = format!("{path}[{index}]");
+                match (expected.get(index), actual.get(index)) {
+                    (Some(expected_value), Some(actual_value)) => collect_diff(
+                        &child_path,
+                        expected_value,
+                        actual_value,
+                        max_differences,
+                        differences,
+                    ),
+                    (Some(expected_value), None) => differences.push(json!({
+                        "path": child_path,
+                        "kind": "removed",
+                        "expected": expected_value,
+                        "actual": Value::Null,
+                    })),
+                    (None, Some(actual_value)) => differences.push(json!({
+                        "path": child_path,
+                        "kind": "added",
+                        "expected": Value::Null,
+                        "actual": actual_value,
+                    })),
+                    (None, None) => {}
+                }
+            }
+        }
+        _ => differences.push(json!({
+            "path": path,
+            "kind": "changed",
+            "expected": expected,
+            "actual": actual,
+        })),
+    }
+}
+
+fn parse_realms(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|realm| !realm.is_empty())
+        .map(ToString::to_string)
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_realms_trims_empty_entries() {
+        assert_eq!(
+            parse_realms(" internal, customer, ,"),
+            vec!["internal".to_string(), "customer".to_string()]
+        );
+    }
+
+    #[test]
+    fn canonicalize_redacts_secrets_and_sorts_named_arrays() {
+        let mut value = json!([
+            {
+                "id": "generated-2",
+                "clientId": "z-client",
+                "secret": "sensitive"
+            },
+            {
+                "id": "generated-1",
+                "clientId": "a-client",
+                "clientSecret": "sensitive"
+            }
+        ]);
+
+        redact_value(&mut value);
+        let value = canonicalize(value);
+
+        assert_eq!(value[0]["clientId"], "a-client");
+        assert_eq!(value[0]["clientSecret"], "<redacted>");
+        assert!(value[0].get("id").is_none());
+        assert_eq!(value[1]["clientId"], "z-client");
+        assert_eq!(value[1]["secret"], "<redacted>");
+        assert!(value[1].get("id").is_none());
+    }
+
+    #[test]
+    fn diff_values_reports_added_and_changed_paths() {
+        let expected = json!({
+            "realms": {
+                "internal": {
+                    "clients": [
+                        { "clientId": "admin-panel", "enabled": true }
+                    ]
+                }
+            }
+        });
+        let actual = json!({
+            "realms": {
+                "internal": {
+                    "clients": [
+                        { "clientId": "admin-panel", "enabled": false },
+                        { "clientId": "extra-client", "enabled": true }
+                    ]
+                }
+            }
+        });
+
+        let diff = diff_values(&expected, &actual, 100);
+
+        assert_eq!(diff["equal"], false);
+        assert_eq!(diff["differenceCount"], 2);
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info")),
+        )
+        .init();
+
+    let cli = Cli::parse();
+    let default_realms = parse_realms(&cli.realms);
+    if default_realms.is_empty() {
+        anyhow::bail!("KEYCLOAK_REALMS must include at least one realm");
+    }
+
+    let client = KeycloakClient::new(
+        cli.keycloak_base_url,
+        cli.token_realm,
+        cli.client_id,
+        cli.client_secret,
+        default_realms,
+    );
+    let mcp = KeycloakMcp::new(client, cli.declared_snapshot_file)?;
+    let service = mcp.into_service();
+
+    let app = Router::new()
+        .route("/healthz", get(|| async { (StatusCode::OK, "ok") }))
+        .nest_service(&cli.mount, service);
+
+    let listener = tokio::net::TcpListener::bind(cli.bind).await?;
+    let local_addr = listener.local_addr()?;
+    tracing::info!("keycloak-mcp listening on http://{local_addr}{}", cli.mount);
+    axum::serve(listener, app).await?;
+    Ok(())
+}

--- a/lib/concourse-client/src/lib.rs
+++ b/lib/concourse-client/src/lib.rs
@@ -4,7 +4,7 @@ mod error;
 mod log_buffer;
 mod types;
 
-pub use client::ConcourseClient  ;
+pub use client::ConcourseClient;
 pub use error::ConcourseError;
 pub use log_buffer::{BuildLogResponse, BuildLogStore};
 pub use types::*;


### PR DESCRIPTION
## Summary

Adds a read-only Keycloak MCP server image for deployment state inspection through the existing Drua tunnel path.

The server exposes a deliberately small tool surface:

- `realm_list`
- `realm_get`
- `realm_diff_declared`

`realm_get` aggregates the nested realm configuration needed for drift checks, including realm metadata, clients, client scopes, roles, authentication flows, required actions, and user profile configuration. Responses are normalized, sorted, and redacted before being returned.

## Impact

This gives deployments a Streamable HTTP MCP upstream that can be attached to the tunnel connector as `keycloak`, producing deployment-scoped tools such as `galoy_staging_keycloak_realm_get`.

The CI pipeline now builds and publishes `us.gcr.io/galoyorg/keycloak-mcp:edge`, then opens a galoy-charts digest bump PR for `keycloakMcp.image.digest` after each successful image publish.

## Validation

- `cargo test -p keycloak-mcp`
- `ytt -f ci/pipeline.yml -f ci/fragments.lib.yml -f ci/values.yml`
- `bash -n ci/tasks/bump-galoy-charts-keycloak-mcp.sh ci/tasks/open-galoy-charts-keycloak-mcp-pr.sh`
- GitHub PR checks: `check`, `bats`, `integration`
- `nix eval --impure --expr 'let pkgs = import <nixpkgs> {}; keycloak-mcp = pkgs.writeShellScriptBin "keycloak-mcp" ""; image = import ./images/keycloak-mcp/default.nix { inherit pkgs keycloak-mcp; }; in image.imageName'`
