### PR TITLE
fix(session): dynamic staleness threshold from tool timeout_ms

### DIFF
--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -656,10 +656,43 @@ impl AgentSession {
         })
     }
 
-    /// 15 minutes — longer than any non-await tool timeout (sandbox.create = 6 min).
-    const STALE_TOOL_USE_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(900);
+    const DEFAULT_STALE_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(900);
+    /// Buffer on top of the longest declared `timeout_ms` to cover
+    /// network latency, result-persistence gap, and deploy window.
+    const STALE_BUFFER: std::time::Duration = std::time::Duration::from_secs(300);
+
+    fn stale_threshold_for_tool_uses(&self, thread_id: SessionThreadId) -> std::time::Duration {
+        let max_timeout_ms = self
+            .events
+            .iter_all()
+            .rev()
+            .find_map(|e| match e {
+                AgentSessionEvent::AssistantResponseReceived {
+                    thread_id: tid,
+                    content,
+                    ..
+                } if *tid == thread_id => Some(
+                    content
+                        .iter()
+                        .filter_map(|b| match b {
+                            AssistantBlock::ToolUse { input, .. } => {
+                                input.get("timeout_ms").and_then(|v| v.as_u64())
+                            }
+                            _ => None,
+                        })
+                        .max(),
+                ),
+                _ => None,
+            })
+            .flatten();
+        match max_timeout_ms {
+            Some(ms) => std::time::Duration::from_millis(ms) + Self::STALE_BUFFER,
+            None => Self::DEFAULT_STALE_THRESHOLD,
+        }
+    }
 
     fn is_tool_use_stale(&self, thread_id: SessionThreadId) -> bool {
+        let threshold = self.stale_threshold_for_tool_uses(thread_id);
         let last_ts = self
             .events
             .iter_persisted()
@@ -675,8 +708,7 @@ impl AgentSession {
         match last_ts {
             Some(ts) => {
                 let elapsed = chrono::Utc::now() - ts;
-                elapsed.to_std().unwrap_or(std::time::Duration::ZERO)
-                    > Self::STALE_TOOL_USE_THRESHOLD
+                elapsed.to_std().unwrap_or(std::time::Duration::ZERO) > threshold
             }
             None => false,
         }
@@ -708,7 +740,8 @@ impl AgentSession {
     /// Synthesizes error tool results for a thread stuck in ToolUse turn
     /// after a dispatcher restart. Called lazily from `next_prompt`.
     /// No-ops when the thread is not in ToolUse or the dispatch is
-    /// younger than `STALE_TOOL_USE_THRESHOLD`.
+    /// younger than `max(timeout_ms) + STALE_BUFFER` (or
+    /// `DEFAULT_STALE_THRESHOLD` when no tool declares a timeout).
     fn recover_stale_tool_use(
         &mut self,
         thread_id: SessionThreadId,

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -660,6 +660,8 @@ impl AgentSession {
     /// Buffer on top of the longest declared `timeout_ms` to cover
     /// network latency, result-persistence gap, and deploy window.
     const STALE_BUFFER: std::time::Duration = std::time::Duration::from_secs(300);
+    /// Cap on `timeout_ms` read from tool input — matches bash MAX_TIMEOUT_MS.
+    const MAX_TOOL_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(10_800_000);
 
     fn stale_threshold_for_tool_uses(&self, thread_id: SessionThreadId) -> std::time::Duration {
         let max_timeout_ms = self
@@ -686,7 +688,10 @@ impl AgentSession {
             })
             .flatten();
         match max_timeout_ms {
-            Some(ms) => std::time::Duration::from_millis(ms) + Self::STALE_BUFFER,
+            Some(ms) => {
+                std::time::Duration::from_millis(ms).min(Self::MAX_TOOL_TIMEOUT)
+                    + Self::STALE_BUFFER
+            }
             None => Self::DEFAULT_STALE_THRESHOLD,
         }
     }


### PR DESCRIPTION
## Summary
- Replaces the hardcoded 15-minute `STALE_TOOL_USE_THRESHOLD` with a dynamic threshold that reads `timeout_ms` from the tool call's input JSON
- Uses `max(timeout_ms) + 5 min buffer` when tools declare a timeout, falling back to 15 min when none do
- Prevents premature recovery of long-running tools (e.g. bash compilations that can take up to 3 hours)

## Test plan
- [x] `nix flake check` passes (all tests, clippy, fmt, sdl check)
- [ ] Deploy and verify long-running bash tool calls are not prematurely interrupted
- [ ] Verify that orphaned tool dispatches are still recovered after the dynamic threshold

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the logic that decides when a tool-use turn is considered stale and auto-recovers by synthesizing error tool results, which can impact long-running tool executions and recovery behavior if `timeout_ms` is missing/mis-set.
> 
> **Overview**
> Stops using a hardcoded 15-minute tool-use staleness threshold and instead derives the recovery window from the most recent assistant tool calls’ `timeout_ms` (`max(timeout_ms)`), with a fixed `STALE_BUFFER` added and a `MAX_TOOL_TIMEOUT` cap.
> 
> `recover_stale_tool_use`/`is_tool_use_stale` now use this per-thread dynamic threshold (falling back to `DEFAULT_STALE_THRESHOLD` when no timeouts are provided) to avoid prematurely marking long-running tools as interrupted after dispatcher restarts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34458cc82f75b2bb7aaad5b0f896999b1bf93f02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->