### PR TITLE
chore: Add nix pkgs needed for lana

### DIFF
--- a/images/sandbox/default.nix
+++ b/images/sandbox/default.nix
@@ -264,6 +264,9 @@ pkgs.dockerTools.buildLayeredImage {
     pkgs.gnused
     pkgs.gnugrep
     pkgs.ripgrep
+    pkgs.cargo
+    pkgs.cargo-nextest
+    pkgs.gnumake
     nix
     gitCredentialHelper
     gitconfig


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk functional change; it only expands the sandbox image contents, though it may increase image size and available tooling surface area.
> 
> **Overview**
> Updates the sandbox Docker image (`images/sandbox/default.nix`) to ship additional build/test tooling by adding `cargo`, `cargo-nextest`, and `gnumake` to the image `contents` list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8333b7ef78902b82c12955b7a546809cddb053a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->