### PR TITLE
perf(workflow): reuse CEL context across wait step output expressions

### DIFF
--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -59,14 +59,27 @@ const AUDIT_ACTION_TRIGGER_FILTERED: &str = "workflow.trigger_filtered";
 const AUDIT_ACTION_TRIGGER_CONDITION_ERRORED: &str = "workflow.trigger_condition_errored";
 
 /// Evaluate each output's CEL expression against the resume context.
+/// Builds the CEL context once and reuses it across all expressions.
 /// Failed expressions log a warning and produce `null` for that key.
 fn extract_wait_output(
     ctx: &template::ResumeContext<'_>,
     outputs: &std::collections::BTreeMap<String, String>,
 ) -> serde_json::Value {
+    let built = match ctx.build() {
+        Ok(b) => b,
+        Err(e) => {
+            tracing::warn!(error = %e, "failed to build resume CEL context; outputs default to null");
+            return serde_json::Value::Object(
+                outputs
+                    .keys()
+                    .map(|k| (k.clone(), serde_json::Value::Null))
+                    .collect(),
+            );
+        }
+    };
     let mut out = serde_json::Map::with_capacity(outputs.len());
     for (key, expr) in outputs {
-        let value = match ctx.evaluate_extract(expr) {
+        let value = match built.evaluate_extract(expr) {
             Ok(v) => v,
             Err(e) => {
                 tracing::warn!(key, expr, error = %e, "output CEL evaluation failed");

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -208,21 +208,46 @@ impl ResumeContext<'_> {
     /// Evaluate a CEL expression in the resume context and return
     /// the result as a JSON value.
     pub fn evaluate_extract(&self, expr: &str) -> Result<Value, TemplateError> {
-        let trimmed = expr.trim();
-        let raw = format!("{OPEN} {trimmed} {CLOSE}");
-        if trimmed.is_empty() {
-            return Err(TemplateError::EmptyPath(raw));
-        }
         let built = self.build_cel_context()?;
-        let program = Program::compile(trimmed)
-            .map_err(|e| TemplateError::Compile(raw.clone(), e.to_string()))?;
-        let value = program
-            .execute(&built.cel)
-            .map_err(|e| TemplateError::Resolve(raw.clone(), e.to_string()))?;
-        value
-            .json()
-            .map_err(|e| TemplateError::JsonConvert(raw.clone(), e.to_string()))
+        evaluate_extract_with_built(&built, expr)
     }
+
+    /// Build the CEL context once and return it for callers that
+    /// evaluate multiple expressions against the same context —
+    /// avoids cloning trigger/steps/resume_payload per expression.
+    pub fn build(&self) -> Result<BuiltResumeContext, TemplateError> {
+        Ok(BuiltResumeContext {
+            built: self.build_cel_context()?,
+        })
+    }
+}
+
+/// CEL context built from a [`ResumeContext`], reusable across
+/// multiple evaluations. Hides the internal `BuiltContext` type.
+pub struct BuiltResumeContext {
+    built: BuiltContext,
+}
+
+impl BuiltResumeContext {
+    pub fn evaluate_extract(&self, expr: &str) -> Result<Value, TemplateError> {
+        evaluate_extract_with_built(&self.built, expr)
+    }
+}
+
+fn evaluate_extract_with_built(built: &BuiltContext, expr: &str) -> Result<Value, TemplateError> {
+    let trimmed = expr.trim();
+    let raw = format!("{OPEN} {trimmed} {CLOSE}");
+    if trimmed.is_empty() {
+        return Err(TemplateError::EmptyPath(raw));
+    }
+    let program = Program::compile(trimmed)
+        .map_err(|e| TemplateError::Compile(raw.clone(), e.to_string()))?;
+    let value = program
+        .execute(&built.cel)
+        .map_err(|e| TemplateError::Resolve(raw.clone(), e.to_string()))?;
+    value
+        .json()
+        .map_err(|e| TemplateError::JsonConvert(raw.clone(), e.to_string()))
 }
 
 fn resolve_with_built(built: &BuiltContext, r: &TemplateRef) -> Option<Value> {


### PR DESCRIPTION
## Summary

- Addresses bugbot comment on #383: `ResumeContext::evaluate_extract` rebuilt the full CEL context (cloning trigger/steps/resume_payload) on every call, so `extract_wait_output` did N rebuilds for N output expressions.
- Adds `ResumeContext::build()` returning a reusable `BuiltResumeContext`; `extract_wait_output` now builds once and threads it through all evaluations.

## Test plan

- [x] `nix flake check` — fmt, clippy, nextest, graphql schema all pass
- [ ] Trace a wait step with multiple outputs and confirm only one context-build span

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk performance refactor confined to wait-step output extraction; only behavioral change is failing fast to `null` all outputs if the resume CEL context cannot be built.
> 
> **Overview**
> Improves wait-step resume performance by **building the resume CEL context once** and reusing it across all output CEL expressions, avoiding per-output context reconstruction.
> 
> Introduces `ResumeContext::build()` returning a reusable `BuiltResumeContext` and refactors extract evaluation into a shared helper; if context build fails, wait-step outputs now default to `null` with a single warning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ef65045588d783d625573ab780a22b7c2f7a654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->