### PR TITLE
fix(sandbox): route nix through cache proxy

### DIFF
--- a/charts/drua/templates/_helpers.tpl
+++ b/charts/drua/templates/_helpers.tpl
@@ -80,28 +80,60 @@ Sandbox Nix netrc Secret. Used for authenticated private binary caches.
 {{- end -}}
 
 {{/*
+Sandbox Nix cache proxy names and service URL.
+*/}}
+{{- define "galoyAgents.sandbox.nixCacheProxy.fullname" -}}
+{{- printf "%s-sandbox-nix-cache-proxy" (include "galoyAgents.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "galoyAgents.sandbox.nixCacheProxy.url" -}}
+http://{{ include "galoyAgents.sandbox.nixCacheProxy.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.sandbox.nixCacheProxy.service.port }}
+{{- end -}}
+
+{{/*
 Sandbox NIX_CONFIG contents for configured remote substituters.
 */}}
 {{- define "galoyAgents.sandbox.nixSubstituterUrls" -}}
+{{- if and .Values.sandbox.nixCacheProxy.enabled (not (gt (len .Values.sandbox.nixCacheProxy.upstreams) 0)) -}}
+{{- fail "sandbox.nixCacheProxy.upstreams must not be empty when sandbox.nixCacheProxy.enabled=true" -}}
+{{- end -}}
+{{- if .Values.sandbox.nixCacheProxy.enabled -}}
+{{- $root := . -}}
+{{- range $i, $upstream := .Values.sandbox.nixCacheProxy.upstreams -}}
+{{- $name := required "sandbox.nixCacheProxy.upstreams[].name is required" $upstream.name -}}
+{{- if $i }} {{ end -}}{{ include "galoyAgents.sandbox.nixCacheProxy.url" $root }}/{{ $name }}/
+{{- end -}}
+{{- else -}}
 {{- range $i, $substituter := .Values.sandbox.nixSubstituters -}}
 {{- if $i }} {{ end -}}{{ $substituter.url -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
 {{- define "galoyAgents.sandbox.nixPublicKeys" -}}
 {{- $first := true -}}
+{{- if .Values.sandbox.nixCacheProxy.enabled -}}
+{{- range $substituter := .Values.sandbox.nixCacheProxy.upstreams -}}
+{{- if $substituter.publicKey -}}
+{{- if not $first }} {{ end -}}{{ $substituter.publicKey -}}
+{{- $first = false -}}
+{{- end -}}
+{{- end -}}
+{{- else -}}
 {{- range $substituter := .Values.sandbox.nixSubstituters -}}
 {{- if $substituter.publicKey -}}
 {{- if not $first }} {{ end -}}{{ $substituter.publicKey -}}
 {{- $first = false -}}
 {{- end -}}
 {{- end -}}
+{{- if not $first }} {{ end -}}cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+{{- end -}}
 {{- end -}}
 
 {{- define "galoyAgents.sandbox.nixConfig" -}}
-substituters ={{- with (include "galoyAgents.sandbox.nixSubstituterUrls" .) }} {{ . }}{{- end }} https://cache.nixos.org/
-trusted-public-keys ={{- with (include "galoyAgents.sandbox.nixPublicKeys" .) }} {{ . }}{{- end }} cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
-{{- if .Values.sandbox.nixNetrc.enabled }}
+substituters ={{- with (include "galoyAgents.sandbox.nixSubstituterUrls" .) }} {{ . }}{{- end }}{{- if not .Values.sandbox.nixCacheProxy.enabled }} https://cache.nixos.org/{{- end }}
+trusted-public-keys ={{- with (include "galoyAgents.sandbox.nixPublicKeys" .) }} {{ . }}{{- end }}
+{{- if and .Values.sandbox.nixNetrc.enabled (not .Values.sandbox.nixCacheProxy.enabled) }}
 netrc-file = {{ .Values.sandbox.nixNetrc.mountPath }}
 {{- end }}
 {{- end -}}

--- a/charts/drua/templates/sandbox-network-policy.yaml
+++ b/charts/drua/templates/sandbox-network-policy.yaml
@@ -68,13 +68,20 @@ spec:
         matchLabels:
           kubernetes.io/metadata.name: {{ .Values.sandbox.otelCollectorNamespace }}
   {{- end }}
-  # No general non-RFC1918 egress. Memo `019dfebc` M5 kill-switch:
-  # all GitHub traffic flows through `drua-internal/git/...` (covered
-  # by rule 2 above). Anything outside the allow-listed paths
-  # (kube-dns, drua-server, OTel) is denied.
-  #
-  # Workflows that still need external HTTP for non-git tasks (test
-  # fixtures hitting third-party APIs, npm install) require a
-  # per-domain proxy in the drua namespace. Audit run logs from M3/M4
-  # before flipping the upgrade for a project.
+  {{- if .Values.sandbox.nixCacheProxy.enabled }}
+  # 4. Nix binary cache proxy — sandboxes fetch substitutes from the
+  # in-cluster reverse cache, not directly from public Cachix/NixOS hosts.
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.sandbox.nixCacheProxy.service.port }}
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      podSelector:
+        matchLabels:
+          app: {{ template "galoyAgents.fullname" . }}
+          release: {{ .Release.Name }}
+          app.kubernetes.io/component: sandbox-nix-cache-proxy
+  {{- end }}
 {{- end }}

--- a/charts/drua/templates/sandbox-nix-cache-proxy-configmap.yaml
+++ b/charts/drua/templates/sandbox-nix-cache-proxy-configmap.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.nixCacheProxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "galoyAgents.sandbox.nixCacheProxy.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/component: sandbox-nix-cache-proxy
+data:
+  nginx.conf: |-
+    worker_processes auto;
+    error_log /dev/stderr info;
+    pid /tmp/nginx.pid;
+
+    events {
+      worker_connections 1024;
+    }
+
+    http {
+      access_log /dev/stdout;
+      proxy_cache_path /var/cache/nginx/nix levels=1:2 keys_zone=nix_cache:{{ .Values.sandbox.nixCacheProxy.cache.keysZoneSize }} max_size={{ .Values.sandbox.nixCacheProxy.cache.maxSize }} inactive={{ .Values.sandbox.nixCacheProxy.cache.inactive }} use_temp_path=off;
+      proxy_temp_path /var/cache/nginx/proxy_temp;
+
+      server {
+        listen {{ .Values.sandbox.nixCacheProxy.service.port }};
+        server_name _;
+
+        location = /healthz {
+          return 204;
+        }
+
+        location = / {
+          return 404;
+        }
+
+        {{ range .Values.sandbox.nixCacheProxy.upstreams }}
+        {{- $name := required "sandbox.nixCacheProxy.upstreams[].name is required" .name }}
+        {{- $url := required "sandbox.nixCacheProxy.upstreams[].url is required" .url }}
+        location /{{ $name }}/ {
+          proxy_pass {{ trimSuffix "/" $url }}/;
+          proxy_ssl_server_name on;
+          proxy_http_version 1.1;
+          proxy_set_header Connection "";
+          proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+          {{- with .auth }}
+          include /etc/nginx/auth/{{ $name }}.conf;
+          {{- else }}
+          proxy_set_header Authorization "";
+          {{- end }}
+          proxy_read_timeout {{ $.Values.sandbox.nixCacheProxy.proxy.readTimeout }};
+          proxy_send_timeout {{ $.Values.sandbox.nixCacheProxy.proxy.sendTimeout }};
+
+          proxy_cache nix_cache;
+          proxy_cache_lock on;
+          proxy_cache_valid 200 206 {{ $.Values.sandbox.nixCacheProxy.cache.validTtl }};
+          proxy_cache_valid 404 {{ $.Values.sandbox.nixCacheProxy.cache.notFoundTtl }};
+          proxy_cache_use_stale error timeout updating http_500 http_502 http_503 http_504;
+          proxy_ignore_headers Cache-Control Expires Set-Cookie;
+          proxy_hide_header Set-Cookie;
+          add_header X-Cache-Status $upstream_cache_status always;
+        }
+        {{ end }}
+      }
+    }
+{{- end }}

--- a/charts/drua/templates/sandbox-nix-cache-proxy-deployment.yaml
+++ b/charts/drua/templates/sandbox-nix-cache-proxy-deployment.yaml
@@ -1,0 +1,108 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.nixCacheProxy.enabled }}
+{{- $hasAuth := false -}}
+{{- range .Values.sandbox.nixCacheProxy.upstreams }}
+{{- if .auth }}
+{{- $hasAuth = true -}}
+{{- end }}
+{{- end }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "galoyAgents.sandbox.nixCacheProxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/component: sandbox-nix-cache-proxy
+spec:
+  {{- if .Values.sandbox.nixCacheProxy.persistence.enabled }}
+  strategy:
+    type: Recreate
+  {{- end }}
+  replicas: {{ .Values.sandbox.nixCacheProxy.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "galoyAgents.fullname" . }}
+      release: {{ .Release.Name }}
+      app.kubernetes.io/component: sandbox-nix-cache-proxy
+  template:
+    metadata:
+      labels:
+        app: {{ template "galoyAgents.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        app.kubernetes.io/component: sandbox-nix-cache-proxy
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/sandbox-nix-cache-proxy-configmap.yaml") . | sha256sum }}
+        {{- if .Values.sandbox.nixCacheProxy.authSecretChecksum }}
+        checksum/auth-secret: {{ .Values.sandbox.nixCacheProxy.authSecretChecksum | quote }}
+        {{- end }}
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 101
+        runAsGroup: 101
+        fsGroup: 101
+      containers:
+      - name: nix-cache-proxy
+        image: "{{ .Values.sandbox.nixCacheProxy.image.repository }}:{{ .Values.sandbox.nixCacheProxy.image.tag }}"
+        imagePullPolicy: {{ .Values.sandbox.nixCacheProxy.image.pullPolicy }}
+        ports:
+        - name: http
+          containerPort: {{ .Values.sandbox.nixCacheProxy.service.port }}
+          protocol: TCP
+        livenessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: http
+        resources:
+          {{- toYaml .Values.sandbox.nixCacheProxy.resources | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: config
+          mountPath: /etc/nginx/nginx.conf
+          subPath: nginx.conf
+          readOnly: true
+        - name: cache
+          mountPath: /var/cache/nginx
+        {{- if $hasAuth }}
+        - name: auth
+          mountPath: /etc/nginx/auth
+          readOnly: true
+        {{- end }}
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "galoyAgents.sandbox.nixCacheProxy.fullname" . }}-config
+      - name: cache
+        {{- if .Values.sandbox.nixCacheProxy.persistence.enabled }}
+        persistentVolumeClaim:
+          claimName: {{ include "galoyAgents.sandbox.nixCacheProxy.fullname" . }}-cache
+        {{- else }}
+        emptyDir: {}
+        {{- end }}
+      {{- if $hasAuth }}
+      - name: auth
+        projected:
+          sources:
+          {{- range .Values.sandbox.nixCacheProxy.upstreams }}
+          {{- $name := required "sandbox.nixCacheProxy.upstreams[].name is required" .name }}
+          {{- with .auth }}
+          - secret:
+              name: {{ required "sandbox.nixCacheProxy.upstreams[].auth.secretName is required" .secretName }}
+              items:
+              - key: {{ required "sandbox.nixCacheProxy.upstreams[].auth.secretKey is required" .secretKey | quote }}
+                path: {{ printf "%s.conf" $name | quote }}
+          {{- end }}
+          {{- end }}
+      {{- end }}
+{{- end }}

--- a/charts/drua/templates/sandbox-nix-cache-proxy-pvc.yaml
+++ b/charts/drua/templates/sandbox-nix-cache-proxy-pvc.yaml
@@ -1,0 +1,21 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.nixCacheProxy.enabled .Values.sandbox.nixCacheProxy.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "galoyAgents.sandbox.nixCacheProxy.fullname" . }}-cache
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/component: sandbox-nix-cache-proxy
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.sandbox.nixCacheProxy.persistence.size }}
+  {{- if .Values.sandbox.nixCacheProxy.persistence.storageClassName }}
+  storageClassName: {{ .Values.sandbox.nixCacheProxy.persistence.storageClassName | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/drua/templates/sandbox-nix-cache-proxy-service.yaml
+++ b/charts/drua/templates/sandbox-nix-cache-proxy-service.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.nixCacheProxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "galoyAgents.sandbox.nixCacheProxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/component: sandbox-nix-cache-proxy
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: {{ .Values.sandbox.nixCacheProxy.service.port }}
+    targetPort: http
+    protocol: TCP
+  selector:
+    app: {{ template "galoyAgents.fullname" . }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/component: sandbox-nix-cache-proxy
+{{- end }}

--- a/charts/drua/templates/sandbox-template.yaml
+++ b/charts/drua/templates/sandbox-template.yaml
@@ -61,7 +61,7 @@ spec:
           # Override via `sandbox.gitProxyUrl`. Defaults to the
           # in-cluster service URL — see `galoyAgents.gitProxyUrl`.
           value: {{ .Values.sandbox.gitProxyUrl | default (include "galoyAgents.gitProxyUrl" .) | quote }}
-        {{- if or .Values.sandbox.nixSubstituters .Values.sandbox.nixNetrc.enabled }}
+        {{- if or .Values.sandbox.nixSubstituters .Values.sandbox.nixNetrc.enabled .Values.sandbox.nixCacheProxy.enabled }}
         - name: NIX_CONFIG
           value: |-
 {{ include "galoyAgents.sandbox.nixConfig" . | indent 12 }}
@@ -75,7 +75,7 @@ spec:
           readOnly: true
         - name: project-secrets
           mountPath: /run/secrets
-        {{- if .Values.sandbox.nixNetrc.enabled }}
+        {{- if and .Values.sandbox.nixNetrc.enabled (not .Values.sandbox.nixCacheProxy.enabled) }}
         - name: nix-netrc
           mountPath: {{ .Values.sandbox.nixNetrc.mountPath | quote }}
           subPath: {{ .Values.sandbox.nixNetrc.secret.key | quote }}
@@ -92,7 +92,7 @@ spec:
               audience: {{ .Values.sandbox.saTokenAudience | default "galoy-agents-git" }}
               expirationSeconds: 3600
               path: token
-      {{- if .Values.sandbox.nixNetrc.enabled }}
+      {{- if and .Values.sandbox.nixNetrc.enabled (not .Values.sandbox.nixCacheProxy.enabled) }}
       - name: nix-netrc
         secret:
           secretName: {{ include "galoyAgents.sandbox.nixNetrcSecretName" . }}

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -340,7 +340,10 @@ sandbox:
   installController: true
   templateName: agent-sandbox
   runtimeClassName: gvisor
-  networkPolicyManagement: Managed
+  ## Drua owns sandbox network isolation through sandbox-network-policy.yaml.
+  ## Direct Sandbox resources do not carry the SandboxTemplate ref label used by
+  ## the upstream managed policy, so keep the upstream template policy disabled.
+  networkPolicyManagement: Unmanaged
   ## MCP gateway URL for sandbox pods (e.g. "http://drua.drua.svc.cluster.local:5254/mcp")
   mcpGatewayUrl: ""
   ## drua git-proxy URL for sandbox pods. When set, the sandbox image's
@@ -348,8 +351,6 @@ sandbox:
   ## rewrite + a `drua-sa` credential helper so all `git clone` /
   ## `git push` traffic flows through drua, not directly to github.com.
   ## Pair with `sandbox.saTokenAudience = "galoy-agents-git"` (default).
-  ## Required for M5 — without this, the kill-switch NetworkPolicy
-  ## leaves the sandbox unable to reach github.com.
   gitProxyUrl: ""
   ## Audience claim for the projected SA token (must match drua's
   ## SaTokenValidator audience). Repurposed from the prior
@@ -376,14 +377,61 @@ sandbox:
   ## should normally come from `nixSubstituters` below, not here.
   env: []
   ## Namespace of the OTel collector for trace export.
-  ## When set, adds an egress rule allowing port 4318 (OTLP HTTP).
+  ## When set, adds an egress rule allowing ports 4317 and 4318.
   otelCollectorNamespace: ""
   ## Nix substituters placed before cache.nixos.org in the sandbox's
-  ## NIX_CONFIG. Point this at a private Cachix or in-cluster nix-serve
-  ## so sandbox flakes pull from the local/project cache first.
+  ## NIX_CONFIG when nixCacheProxy.enabled=false. Proxy mode uses
+  ## nixCacheProxy.upstreams instead.
   nixSubstituters:
     - url: https://galoy-agents.cachix.org
       publicKey: galoy-agents.cachix.org-1:wGb5wYMLJ3yPYoOvf2O5vt9gEZEJ7hHsqDCNPMELGPY=
+  ## Internal reverse cache for public Nix binary caches. Sandboxes talk only
+  ## to this ClusterIP service; the proxy fetches and caches approved upstreams.
+  ## Authenticated upstreams can mount Secret-backed Nginx snippets via
+  ## upstreams[].auth, keeping tokens out of the ConfigMap and sandbox pods.
+  nixCacheProxy:
+    enabled: true
+    authSecretChecksum: ""
+    replicas: 1
+    image:
+      repository: nginxinc/nginx-unprivileged
+      tag: 1.27-alpine
+      pullPolicy: IfNotPresent
+    service:
+      port: 8080
+    cache:
+      maxSize: 10g
+      inactive: 30d
+      keysZoneSize: 20m
+      validTtl: 30d
+      notFoundTtl: 10m
+    proxy:
+      readTimeout: 300s
+      sendTimeout: 300s
+    persistence:
+      enabled: false
+      size: 20Gi
+      storageClassName: ""
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 512Mi
+    upstreams:
+      - name: galoy-agents
+        url: https://galoy-agents.cachix.org
+        publicKey: galoy-agents.cachix.org-1:wGb5wYMLJ3yPYoOvf2O5vt9gEZEJ7hHsqDCNPMELGPY=
+        ## Optional Nginx snippet Secret for authenticated caches.
+        ## The Secret key content should be a location-safe directive such as:
+        ##   proxy_set_header Authorization "Basic <base64(:token)>";
+        # auth:
+        #   secretName: sandbox-nix-cache-proxy-auth
+        #   secretKey: my-cache.conf
+      - name: nixos
+        url: https://cache.nixos.org
+        publicKey: cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
   ## Optional Nix netrc file for authenticated binary caches, such as a
   ## private Cachix cache. When enabled, `netrc-file = <mountPath>` is added
   ## to sandbox NIX_CONFIG and the Secret is mounted into the sandbox

--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -42,6 +42,11 @@ locals {
 
   tunnel_deployments = fileexists("${path.module}/tunnel-deployments-public-keys.json") ? jsondecode(file("${path.module}/tunnel-deployments-public-keys.json")) : {}
 
+  lana_bank_cachix_nginx_auth = format(
+    "proxy_set_header Authorization \"Basic %s\";\n",
+    base64encode(format(":%s", var.lana_bank_cachix_auth_token)),
+  )
+
   # The helm provider diffs `helm_release` on chart name + version + values,
   # NOT on the chart's file contents. With `chart = "./chart"` and
   # `Chart.yaml` pinned to a static version, edits to the bundled chart
@@ -152,6 +157,29 @@ resource "kubernetes_secret" "sandbox_nix_netrc" {
   depends_on = [kubernetes_namespace.sandbox]
 }
 
+resource "kubernetes_secret" "sandbox_nix_cache_proxy_auth" {
+  count = var.lana_bank_cachix_enabled ? 1 : 0
+
+  metadata {
+    name      = "sandbox-nix-cache-proxy-auth"
+    namespace = local.namespace
+  }
+
+  data = {
+    "lana-bank-github-actions.conf" = local.lana_bank_cachix_nginx_auth
+  }
+
+  depends_on = [kubernetes_namespace.galoy_agents]
+}
+
+locals {
+  nix_cache_proxy_auth_secret_checksum = (
+    var.lana_bank_cachix_enabled
+    ? sha256(jsonencode(kubernetes_secret.sandbox_nix_cache_proxy_auth[0].data))
+    : ""
+  )
+}
+
 resource "google_container_node_pool" "gvisor" {
   provider = google-beta
   project  = local.gcp_project
@@ -248,12 +276,13 @@ resource "helm_release" "galoy_agents" {
 
   values = [
     templatefile("${path.module}/prod-values.yml.tmpl", {
-      image_digest                = var.image_digest
-      sandbox_image_digest        = var.sandbox_image_digest
-      secret_checksum             = sha256(jsonencode(kubernetes_secret.galoy_agents.data))
-      tunnel_deployments          = local.tunnel_deployments
-      lana_bank_cachix_enabled    = var.lana_bank_cachix_enabled
-      lana_bank_cachix_public_key = var.lana_bank_cachix_public_key
+      image_digest                         = var.image_digest
+      sandbox_image_digest                 = var.sandbox_image_digest
+      secret_checksum                      = sha256(jsonencode(kubernetes_secret.galoy_agents.data))
+      tunnel_deployments                   = local.tunnel_deployments
+      lana_bank_cachix_enabled             = var.lana_bank_cachix_enabled
+      lana_bank_cachix_public_key          = var.lana_bank_cachix_public_key
+      nix_cache_proxy_auth_secret_checksum = local.nix_cache_proxy_auth_secret_checksum
     })
   ]
 

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -197,6 +197,31 @@ sandbox:
   createNamespace: false
   templateName: agent-sandbox
   runtimeClassName: gvisor
+  networkPolicyManagement: Unmanaged
+  nixCacheProxy:
+    enabled: true
+    authSecretChecksum: "${nix_cache_proxy_auth_secret_checksum}"
+    cache:
+      maxSize: 80g
+    persistence:
+      enabled: true
+      size: 100Gi
+      storageClassName: standard-rwo
+    upstreams:
+%{ if lana_bank_cachix_enabled ~}
+      - name: lana-bank
+        url: https://lana-bank-github-actions.cachix.org
+        publicKey: ${lana_bank_cachix_public_key}
+        auth:
+          secretName: sandbox-nix-cache-proxy-auth
+          secretKey: lana-bank-github-actions.conf
+%{ endif ~}
+      - name: galoy-agents
+        url: https://galoy-agents.cachix.org
+        publicKey: galoy-agents.cachix.org-1:wGb5wYMLJ3yPYoOvf2O5vt9gEZEJ7hHsqDCNPMELGPY=
+      - name: nixos
+        url: https://cache.nixos.org
+        publicKey: cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
   image:
     repository: us.gcr.io/galoyorg/sandbox
     digest: "${sandbox_image_digest}"
@@ -209,6 +234,8 @@ sandbox:
       enabled: true
       size: 50Gi
       storageClassName: standard-rwo
+  ## Used only if nixCacheProxy.enabled is turned off. Production
+  ## sandbox Nix traffic normally goes through nixCacheProxy.upstreams above.
   nixSubstituters:
 %{ if lana_bank_cachix_enabled ~}
   - url: https://lana-bank-github-actions.cachix.org


### PR DESCRIPTION
## Summary
- add an in-cluster Nginx reverse cache for approved Nix binary caches
- point sandbox NIX_CONFIG at internal proxy URLs for Lana Cachix, Galoy Cachix, and cache.nixos.org
- inject the Lana Cachix cache token from a release-namespace Secret at the proxy layer
- keep sandbox egress locked down to DNS, Drua, OTel, and the proxy service
- enable the proxy in prod with a persistent 100Gi cache

## Why
PR #290 removed broad public sandbox egress. That was the right direction for isolation, but Nix still needs substitute access. Kubernetes NetworkPolicy cannot allow hostnames directly, so the sandbox now talks only to a ClusterIP proxy and the proxy owns the upstream allowlist.

## Notes
- Lana private Cachix stays first in the substituter list when its prod token is configured
- proxy mode does not mount the Cachix netrc into sandbox pods; direct mode still supports netrc if the proxy is disabled

## Validation
- helm lint charts/drua
- helm template galoy-agents charts/drua --namespace galoy-agents --set global.security.allowInsecureImages=true --set sandbox.enabled=true --set sandbox.namespace=galoy-agents-sandboxes --set sandbox.nixNetrc.enabled=true --set sandbox.nixNetrc.secret.name=sandbox-nix-netrc --set sandbox.otelCollectorNamespace=galoy-agents-otel --set sandbox.nixCacheProxy.persistence.enabled=true --set sandbox.nixCacheProxy.persistence.size=100Gi --set sandbox.nixCacheProxy.persistence.storageClassName=standard-rwo --set sandbox.nixCacheProxy.cache.maxSize=80g --set sandbox.nixCacheProxy.authSecretChecksum=abc123 --set sandbox.nixCacheProxy.upstreams[0].name=lana-bank ...
- helm template galoy-agents charts/drua --set global.security.allowInsecureImages=true --set sandbox.enabled=true --set sandbox.nixCacheProxy.enabled=false --set sandbox.nixNetrc.enabled=true --set sandbox.nixNetrc.secret.name=sandbox-nix-netrc
- tofu fmt -check ci/deploy/drua
- git diff --check

`tofu validate` was attempted but cannot run in this checkout until modules/providers are initialized (`tofu init`). `kubectl apply --dry-run=client` was attempted earlier but this shell lacks `gke-gcloud-auth-plugin` for the current kubeconfig.