### PR TITLE
feat(sandbox): forward HTTPS proxy for nix flake inputs

### DIFF
--- a/charts/drua/templates/_helpers.tpl
+++ b/charts/drua/templates/_helpers.tpl
@@ -91,6 +91,17 @@ http://{{ include "galoyAgents.sandbox.nixCacheProxy.fullname" . }}.{{ .Release.
 {{- end -}}
 
 {{/*
+Sandbox forward HTTPS proxy names and service URL.
+*/}}
+{{- define "galoyAgents.sandbox.forwardProxy.fullname" -}}
+{{- printf "%s-sandbox-forward-proxy" (include "galoyAgents.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "galoyAgents.sandbox.forwardProxy.url" -}}
+http://{{ include "galoyAgents.sandbox.forwardProxy.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.sandbox.forwardProxy.service.port }}
+{{- end -}}
+
+{{/*
 Sandbox NIX_CONFIG contents for configured remote substituters.
 */}}
 {{- define "galoyAgents.sandbox.nixSubstituterUrls" -}}

--- a/charts/drua/templates/sandbox-forward-proxy-configmap.yaml
+++ b/charts/drua/templates/sandbox-forward-proxy-configmap.yaml
@@ -1,0 +1,30 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.forwardProxy.enabled }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "galoyAgents.sandbox.forwardProxy.fullname" . }}-config
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/component: sandbox-forward-proxy
+data:
+  tinyproxy.conf: |-
+    Port {{ .Values.sandbox.forwardProxy.service.port }}
+    Listen 0.0.0.0
+    Timeout {{ .Values.sandbox.forwardProxy.timeout }}
+    MaxClients {{ .Values.sandbox.forwardProxy.maxClients }}
+    Allow 0.0.0.0/0
+    ConnectPort 443
+    ConnectPort 80
+    Filter "/etc/tinyproxy/filter"
+    FilterDefaultDeny Yes
+    LogLevel Info
+    Syslog Off
+    LogFile "/dev/stdout"
+  filter: |-
+    {{- range .Values.sandbox.forwardProxy.allowedDomains }}
+    {{ . }}
+    {{- end }}
+{{- end }}

--- a/charts/drua/templates/sandbox-forward-proxy-deployment.yaml
+++ b/charts/drua/templates/sandbox-forward-proxy-deployment.yaml
@@ -1,0 +1,66 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.forwardProxy.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "galoyAgents.sandbox.forwardProxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/component: sandbox-forward-proxy
+spec:
+  replicas: {{ .Values.sandbox.forwardProxy.replicas }}
+  selector:
+    matchLabels:
+      app: {{ template "galoyAgents.fullname" . }}
+      release: {{ .Release.Name }}
+      app.kubernetes.io/component: sandbox-forward-proxy
+  template:
+    metadata:
+      labels:
+        app: {{ template "galoyAgents.fullname" . }}
+        chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        release: "{{ .Release.Name }}"
+        app.kubernetes.io/component: sandbox-forward-proxy
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/sandbox-forward-proxy-configmap.yaml") . | sha256sum }}
+    spec:
+      containers:
+      - name: forward-proxy
+        image: "{{ .Values.sandbox.forwardProxy.image.repository }}:{{ .Values.sandbox.forwardProxy.image.tag }}"
+        imagePullPolicy: {{ .Values.sandbox.forwardProxy.image.pullPolicy }}
+        command: ["sh", "-c"]
+        args:
+          - apk add --no-cache tinyproxy && exec tinyproxy -d -c /etc/tinyproxy/tinyproxy.conf
+        ports:
+        - name: http
+          containerPort: {{ .Values.sandbox.forwardProxy.service.port }}
+          protocol: TCP
+        livenessProbe:
+          tcpSocket:
+            port: http
+        readinessProbe:
+          tcpSocket:
+            port: http
+        resources:
+          {{- toYaml .Values.sandbox.forwardProxy.resources | nindent 10 }}
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        volumeMounts:
+        - name: config
+          mountPath: /etc/tinyproxy/tinyproxy.conf
+          subPath: tinyproxy.conf
+          readOnly: true
+        - name: config
+          mountPath: /etc/tinyproxy/filter
+          subPath: filter
+          readOnly: true
+      volumes:
+      - name: config
+        configMap:
+          name: {{ include "galoyAgents.sandbox.forwardProxy.fullname" . }}-config
+{{- end }}

--- a/charts/drua/templates/sandbox-forward-proxy-service.yaml
+++ b/charts/drua/templates/sandbox-forward-proxy-service.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.sandbox.enabled .Values.sandbox.forwardProxy.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "galoyAgents.sandbox.forwardProxy.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+    app.kubernetes.io/component: sandbox-forward-proxy
+spec:
+  type: ClusterIP
+  ports:
+  - name: http
+    port: {{ .Values.sandbox.forwardProxy.service.port }}
+    targetPort: http
+    protocol: TCP
+  selector:
+    app: {{ template "galoyAgents.fullname" . }}
+    release: {{ .Release.Name }}
+    app.kubernetes.io/component: sandbox-forward-proxy
+{{- end }}

--- a/charts/drua/templates/sandbox-network-policy.yaml
+++ b/charts/drua/templates/sandbox-network-policy.yaml
@@ -84,4 +84,21 @@ spec:
           release: {{ .Release.Name }}
           app.kubernetes.io/component: sandbox-nix-cache-proxy
   {{- end }}
+  {{- if .Values.sandbox.forwardProxy.enabled }}
+  # 5. Forward HTTPS proxy — sandboxes fetch flake inputs through a
+  # CONNECT-capable proxy with a domain allowlist. Only the nix daemon
+  # inside the sandbox uses this; the agent shell has no proxy env vars.
+  - ports:
+    - protocol: TCP
+      port: {{ .Values.sandbox.forwardProxy.service.port }}
+    to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      podSelector:
+        matchLabels:
+          app: {{ template "galoyAgents.fullname" . }}
+          release: {{ .Release.Name }}
+          app.kubernetes.io/component: sandbox-forward-proxy
+  {{- end }}
 {{- end }}

--- a/charts/drua/templates/sandbox-template.yaml
+++ b/charts/drua/templates/sandbox-template.yaml
@@ -66,6 +66,10 @@ spec:
           value: |-
 {{ include "galoyAgents.sandbox.nixConfig" . | indent 12 }}
         {{- end }}
+        {{- if .Values.sandbox.forwardProxy.enabled }}
+        - name: DRUA_FORWARD_PROXY_URL
+          value: {{ include "galoyAgents.sandbox.forwardProxy.url" . | quote }}
+        {{- end }}
         volumeMounts:
         # Repurposed from the previous MCP-only volume (memo `019dfebc`
         # §3.2). Audience is now the git-proxy audience; same projected

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -432,6 +432,36 @@ sandbox:
       - name: nixos
         url: https://cache.nixos.org
         publicKey: cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+  ## Forward HTTPS proxy for the nix daemon inside sandbox pods. Allows
+  ## nix to fetch flake input sources (e.g. GitHub tarballs) through a
+  ## CONNECT-capable proxy with a domain allowlist. Only the nix daemon
+  ## process uses the proxy — the agent shell has no proxy env vars.
+  ## Separate from nixCacheProxy (reverse cache for binary substitutes).
+  forwardProxy:
+    enabled: true
+    replicas: 1
+    image:
+      repository: alpine
+      tag: "3.20"
+      pullPolicy: IfNotPresent
+    service:
+      port: 8888
+    timeout: 600
+    maxClients: 100
+    resources:
+      requests:
+        cpu: 25m
+        memory: 32Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi
+    ## Domain allowlist — one POSIX extended regex per entry, matched
+    ## against the requested host. FilterDefaultDeny is on: unlisted
+    ## domains are blocked.
+    allowedDomains:
+      - "^github\\.com$"
+      - "^.*\\.github\\.com$"
+      - "^.*\\.githubusercontent\\.com$"
   ## Optional Nix netrc file for authenticated binary caches, such as a
   ## private Cachix cache. When enabled, `netrc-file = <mountPath>` is added
   ## to sandbox NIX_CONFIG and the Secret is mounted into the sandbox

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -222,6 +222,8 @@ sandbox:
       - name: nixos
         url: https://cache.nixos.org
         publicKey: cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+  forwardProxy:
+    enabled: true
   image:
     repository: us.gcr.io/galoyorg/sandbox
     digest: "${sandbox_image_digest}"

--- a/images/sandbox/default.nix
+++ b/images/sandbox/default.nix
@@ -215,9 +215,20 @@ let
 EOF
     fi
 
+    # Forward proxy for nix-daemon only — flake input fetches (GitHub
+    # tarballs) go through the proxy while the agent shell stays isolated.
+    proxy_env=()
+    if [ -n "''${DRUA_FORWARD_PROXY_URL:-}" ]; then
+        proxy_env=(
+            "http_proxy=''$DRUA_FORWARD_PROXY_URL"
+            "https_proxy=''$DRUA_FORWARD_PROXY_URL"
+            "no_proxy=.svc.cluster.local,.cluster.local,localhost,127.0.0.1"
+        )
+    fi
+
     # Clients use NIX_REMOTE=daemon, but the daemon itself must open the local
     # store or it recursively connects back to its own socket.
-    env -u NIX_REMOTE ${nix}/bin/nix-daemon &
+    env -u NIX_REMOTE "''${proxy_env[@]}" ${nix}/bin/nix-daemon &
 
     for i in $(seq 1 100); do
       [ -S /nix/var/nix/daemon-socket/socket ] && break


### PR DESCRIPTION
## Summary
- Adds a tinyproxy-based CONNECT forward proxy with a domain allowlist so sandboxes can fetch nix flake input sources (GitHub tarballs)
- Proxy env vars are scoped to the **nix daemon process only** — the agent shell has no proxy access and cannot reach external hosts
- Allowlist: `github.com`, `*.github.com`, `*.githubusercontent.com`

## Changes
- **New templates**: `sandbox-forward-proxy-{configmap,deployment,service}.yaml` — tinyproxy on port 8888 with `FilterDefaultDeny`
- **Network policy**: egress rule #5 allowing sandbox → forward proxy
- **Sandbox template**: injects `DRUA_FORWARD_PROXY_URL` env var (not `HTTP_PROXY`)
- **Sandbox image entrypoint**: sets `http_proxy`/`https_proxy` only on the `nix-daemon` process, with `no_proxy` for internal services
- **Values/prod**: `sandbox.forwardProxy` section with domain allowlist config

## Security model
```
Agent shell (curl, cargo, npm) → NO proxy → blocked by NetworkPolicy
Nix daemon (flake inputs)      → forward proxy → allowlisted domains only
Nix daemon (binary cache)      → nix-cache-proxy → no change
```

## Test plan
- [ ] `helm template` renders all three new resources correctly (verified locally)
- [ ] Deploy to staging, run `nix flake check` in a sandbox — flake inputs should fetch via proxy
- [ ] From sandbox shell, `curl https://github.com` should timeout (no proxy in shell env)
- [ ] Nix binary cache traffic still routes through nix-cache-proxy (no_proxy covers .svc.cluster.local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new in-cluster proxy infrastructure and egress allowances for sandbox pods; misconfiguration could unintentionally expand outbound access or break nix flake input fetching.
> 
> **Overview**
> Adds an optional **CONNECT-capable forward proxy** (`tinyproxy`) for sandboxed nix daemons to fetch flake inputs from an allowlisted set of domains.
> 
> The Helm chart now renders a `ConfigMap`/`Deployment`/`Service` for the proxy, adds a sandbox `NetworkPolicy` egress rule to reach it, injects `DRUA_FORWARD_PROXY_URL` into sandbox pods, and updates the sandbox image entrypoint to apply `http_proxy`/`https_proxy` *only* to the `nix-daemon` process (with `no_proxy` for in-cluster traffic).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cb44bdf2b2305b6681b4d2cd02f9ab67b2347662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->