### PR TITLE
fix(github-app): request CI read permissions

### DIFF
--- a/lib/github-app/src/lib.rs
+++ b/lib/github-app/src/lib.rs
@@ -68,14 +68,7 @@ impl GitHubAppTokenProvider {
             self.installation_id
         );
 
-        let body = serde_json::json!({
-            "permissions": {
-                "contents": "write",
-                "pull_requests": "write",
-                "issues": "write",
-                "metadata": "read"
-            }
-        });
+        let body = installation_token_request_body();
 
         let resp = self
             .http_client
@@ -107,5 +100,72 @@ impl GitHubAppTokenProvider {
         let expires_at = json["expires_at"].as_str().unwrap_or_default().to_string();
 
         Ok(InstallationToken { token, expires_at })
+    }
+}
+
+fn installation_token_request_body() -> serde_json::Value {
+    serde_json::json!({
+        "permissions": {
+            "contents": "write",
+            "pull_requests": "write",
+            "issues": "write",
+            "metadata": "read",
+            "checks": "read",
+            "statuses": "read",
+            "actions": "read"
+        }
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::installation_token_request_body;
+
+    #[test]
+    fn installation_token_requests_ci_read_permissions() {
+        let body = installation_token_request_body();
+        let permissions = body
+            .get("permissions")
+            .and_then(|v| v.as_object())
+            .expect("permissions object");
+
+        assert_eq!(
+            permissions.get("checks").and_then(|v| v.as_str()),
+            Some("read")
+        );
+        assert_eq!(
+            permissions.get("statuses").and_then(|v| v.as_str()),
+            Some("read")
+        );
+        assert_eq!(
+            permissions.get("actions").and_then(|v| v.as_str()),
+            Some("read")
+        );
+    }
+
+    #[test]
+    fn installation_token_preserves_existing_permissions() {
+        let body = installation_token_request_body();
+        let permissions = body
+            .get("permissions")
+            .and_then(|v| v.as_object())
+            .expect("permissions object");
+
+        assert_eq!(
+            permissions.get("contents").and_then(|v| v.as_str()),
+            Some("write")
+        );
+        assert_eq!(
+            permissions.get("pull_requests").and_then(|v| v.as_str()),
+            Some("write")
+        );
+        assert_eq!(
+            permissions.get("issues").and_then(|v| v.as_str()),
+            Some("write")
+        );
+        assert_eq!(
+            permissions.get("metadata").and_then(|v| v.as_str()),
+            Some("read")
+        );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the GitHub App installation token request used by Drua so workflow agents can read CI state for bot PRs. The token request now preserves the existing repo write/read permissions and additionally asks GitHub for:

- `checks: read`
- `statuses: read`
- `actions: read`

This addresses the `403 Resource not accessible by integration` failures seen when `route_ci` called `github_pull_request_read(method=get_check_runs)` and `github_pull_request_read(method=get_status)` for Lana PR #5980.

## Operational dependency

Before this change is deployed or Drua is restarted, the `galoy-agents` GitHub App installation must be granted or reauthorized for:

- Checks: read
- Commit statuses: read
- Actions: read

If the GitHub App installation is not reauthorized first, installation token exchange may fail because Drua will request permissions that exceed the installation grant. That could break all `authMode: github_app` GitHub upstreams, not only CI monitoring.

## Post-deploy verification

After reauthorization and deploy/restart:

1. Restart/deploy Drua so GitHub MCP upstream clients receive fresh installation tokens.
2. Verify `github_pull_request_read` can call `get_check_runs` and `get_status` on `GaloyMoney/lana-bank` PR #5980 without `Resource not accessible by integration`.
3. Verify `github_actions` tool discovery advertises Actions tools.
4. If `github_actions` still exposes 0 tools after this permission fix, handle the upstream endpoint/allowlist separately in a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Requests additional GitHub App permissions (`checks`, `statuses`, `actions`), which may cause installation token exchange to fail until the app installation is reauthorized with those grants. Otherwise the change is small and localized to token generation.
> 
> **Overview**
> Extends the GitHub App installation access token request to also ask for CI visibility by adding `checks: read`, `statuses: read`, and `actions: read` to the permissions payload.
> 
> Refactors the permissions JSON into `installation_token_request_body()` and adds unit tests to ensure the new CI permissions are requested and the existing `contents`/`pull_requests`/`issues`/`metadata` permissions remain unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70352f17c2de1306f3c54b44365c7b7e01a71b99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->