### PR TITLE
fix(workflow): use fresh JobId when re-spawning resumed runs

### DIFF
--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -548,6 +548,7 @@ fn state_label(state: &str) -> &'static str {
         "RUNNING" => "running",
         "PENDING" => "pending",
         "SKIPPED" => "skipped",
+        "WAITING_FOR_EVENT" => "waiting",
         _ => "unknown",
     }
 }
@@ -558,6 +559,7 @@ fn state_color(state: &str) -> Color {
         "FAILED" | "failed" | "ERRORED" | "errored" => Color::Red,
         "RUNNING" | "running" => Color::Yellow,
         "SKIPPED" | "skipped" => Color::DarkGray,
+        "WAITING_FOR_EVENT" | "waiting" => Color::Cyan,
         _ => Color::White,
     }
 }

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -1030,10 +1030,16 @@ impl Workflows {
         let mut op = self.run_repo.begin_op().await?;
         self.run_repo.update_in_op(&mut op, run).await?;
         let queue_id = format!("workflow:{}", run.definition_id);
+        // Re-spawn under a fresh JobId: the run's original ExecuteRun job (id =
+        // run.id) still occupies the `jobs` row, so reusing it would hit the
+        // primary-key constraint and roll the whole resume back. Parenting on
+        // run.id keeps the lineage queryable via list_by_parent_job_id.
         self.execute_run_spawner
+            .clone()
+            .with_parent(run.id.into())
             .spawn_with_queue_id_in_op(
                 &mut op,
-                run.id,
+                ::job::JobId::new(),
                 ExecuteRunConfig { run_id: run.id },
                 &queue_id,
             )


### PR DESCRIPTION
## Summary
- Wait-step workflow runs were getting the Concourse webhook and matching the resume condition, but the resume transaction was silently rolling back. The webhook returned 200 OK; the run stayed parked in `WaitingForEvent`.
- Root cause: `commit_resume` reused `run.id` as the `JobId` for the new `ExecuteRun`. The original trigger had already inserted a `jobs` row with that id, so the duplicate-PK insert errored, the whole atomic op rolled back, and the `step_resumed` event never persisted. The error was only `warn`-logged, so the webhook still returned 200 and Concourse never retried.
- Fix: mint a fresh `JobId` and set `parent_job_id = run.id` so the execution lineage is queryable via `list_by_parent_job_id`. Patterned after `cron_job.rs`, which already mints fresh ids for re-fires.
- Drive-by TUI fix: `state_label` / `state_color` had no arm for `WAITING_FOR_EVENT`, so parked workflow / run / step rows rendered as `unknown`.

## Repro evidence (prod, bodymindarts project)
- Two runs of `wait-for-check-code-failure-test` waiting on a `check-code` failure.
- Concourse build #697 failed → `on_failure: put: drua-concourse-provider` → 2× `POST /webhooks/providers/concourse → 200`.
- Honeycomb trace `12a543d5c528861332b5975799a5abd4` shows `try_resume_by_provider` calling `commit_resume` for both runs, two `job_spawner.spawn_with_queue_id_in_op` spans, two orphaned `failed to commit resume` warn events on the trace.
- PG: `workflow_run_events` only has `initialized + step_waiting` for both runs (no `step_resumed`); no new `jobs` rows during the webhook window; zero `job_executions` rows for either run id.

## Test plan
- [ ] `cargo check -p drua-core -p drua-client` — green.
- [ ] `cargo test -p drua-core --lib workflow::run::entity` — 36 passed.
- [ ] After merge & deploy: re-fire the bodymindarts `check-code` failure, confirm both parked runs transition to `Running`, an `ExecuteRun` job with `parent_job_id = run.id` appears, and the TUI shows `waiting` instead of `unknown` on parked runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow resume job-spawning semantics to avoid DB PK conflicts; mistakes here could prevent resumed runs from executing or affect job lineage queries.
> 
> **Overview**
> Fixes resume for `WAITING_FOR_EVENT` workflow runs by **re-spawning `ExecuteRun` with a fresh `JobId`** and setting `parent_job_id = run.id`, avoiding a duplicate-PK insert that could roll back the entire resume transaction.
> 
> Updates the TUI workflow display to recognize `WAITING_FOR_EVENT`, rendering it as `waiting` with a cyan color instead of `unknown`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b61eb0734e3cfa25634e4f5cf6ff57272eb0bbac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->