### PR TITLE
feat(workflow): expose wait-step provider + resume_condition in TUI

### DIFF
--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -92,7 +92,7 @@ const WORKFLOW_DEFINITIONS_QUERY: &str = r#"
             name
             description
             trigger { kind provider cronSchedule cronTimezone nextRunAt condition webhookUrl }
-            steps { name stepType skill tool sandbox sandboxMode condition }
+            steps { name stepType skill tool sandbox sandboxMode condition provider resumeCondition }
             recentRuns(first: 1) {
                 id
                 state
@@ -112,7 +112,7 @@ const WORKFLOW_DEFINITION_QUERY: &str = r#"
             description
             yaml
             trigger { kind provider cronSchedule cronTimezone nextRunAt condition webhookUrl }
-            steps { name stepType skill tool sandbox sandboxMode condition }
+            steps { name stepType skill tool sandbox sandboxMode condition provider resumeCondition }
             sandboxes { name kind branch repoUrl }
             recentRuns(first: 10) { id state startedAt completedAt stepResults { name state output error skipped completedAt } }
         }
@@ -141,7 +141,7 @@ const WORKFLOW_RUN_QUERY: &str = r#"
             startedAt
             completedAt
             triggerContext
-            stepsSnapshot { name stepType skill tool sandbox sandboxMode condition }
+            stepsSnapshot { name stepType skill tool sandbox sandboxMode condition provider resumeCondition }
             stepResults { name state output error skipped completedAt }
             agents { id name role session { model } attachedSandbox { name mode } }
         }
@@ -240,6 +240,8 @@ struct WorkflowStepNode {
     sandbox: Option<String>,
     sandbox_mode: Option<String>,
     condition: Option<String>,
+    provider: Option<String>,
+    resume_condition: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -779,6 +781,8 @@ fn workflow_step_node_to_item(s: WorkflowStepNode) -> WorkflowStepItem {
         sandbox: s.sandbox,
         sandbox_mode: s.sandbox_mode,
         condition: s.condition,
+        provider: s.provider,
+        resume_condition: s.resume_condition,
     }
 }
 

--- a/client/src/tui/state/workflow.rs
+++ b/client/src/tui/state/workflow.rs
@@ -79,6 +79,8 @@ pub struct WorkflowStepItem {
     pub sandbox: Option<String>,
     pub sandbox_mode: Option<String>,
     pub condition: Option<String>,
+    pub provider: Option<String>,
+    pub resume_condition: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -493,6 +493,12 @@ fn selected_step_body(run: &WorkflowRunDetail, cursor: usize, expanded: bool) ->
             let mode = step.sandbox_mode.as_deref().unwrap_or("default");
             lines.push(format!("sandbox: {sandbox} ({mode})"));
         }
+        if let Some(provider) = &step.provider {
+            lines.push(format!("provider: {provider}"));
+        }
+        if let Some(resume_condition) = &step.resume_condition {
+            lines.push(format!("resume_condition: {resume_condition}"));
+        }
         if let Some(condition) = &step.condition {
             lines.push(format!("condition: {condition}"));
         }

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -834,6 +834,15 @@ type WorkflowStep {
 	Wait-step `outputs` map serialized as `{ name: cel_expr }`.
 	"""
 	outputs: Json
+	"""
+	Wait-step only: webhook provider this step parks on.
+	"""
+	provider: String
+	"""
+	Wait-step only: CEL boolean evaluated against the inbound
+	webhook payload (`resume_payload.*`) plus `trigger` and `steps`.
+	"""
+	resumeCondition: String
 	sandbox: String
 	sandboxMode: SandboxAttachmentMode
 	skill: String

--- a/server/src/graphql/workflow.rs
+++ b/server/src/graphql/workflow.rs
@@ -161,6 +161,11 @@ pub struct WorkflowStep {
     output_schema: Option<JsonValue>,
     /// Wait-step `outputs` map serialized as `{ name: cel_expr }`.
     outputs: Option<JsonValue>,
+    /// Wait-step only: webhook provider this step parks on.
+    provider: Option<String>,
+    /// Wait-step only: CEL boolean evaluated against the inbound
+    /// webhook payload (`resume_payload.*`) plus `trigger` and `steps`.
+    resume_condition: Option<String>,
 }
 
 impl From<&DomainWorkflowStepDef> for WorkflowStep {
@@ -188,6 +193,8 @@ impl From<&DomainWorkflowStepDef> for WorkflowStep {
                     .ok()
                     .map(Into::into),
                 outputs: None,
+                provider: None,
+                resume_condition: None,
             },
             DomainWorkflowStepDef::ToolStep {
                 name,
@@ -206,9 +213,13 @@ impl From<&DomainWorkflowStepDef> for WorkflowStep {
                 condition: condition.clone(),
                 output_schema: None,
                 outputs: None,
+                provider: None,
+                resume_condition: None,
             },
             DomainWorkflowStepDef::Wait {
                 name,
+                provider,
+                resume_condition,
                 condition,
                 outputs,
                 ..
@@ -223,6 +234,8 @@ impl From<&DomainWorkflowStepDef> for WorkflowStep {
                 condition: condition.clone(),
                 output_schema: None,
                 outputs: serde_json::to_value(outputs).ok().map(Into::into),
+                provider: Some(provider.clone()),
+                resume_condition: Some(resume_condition.clone()),
             },
         }
     }


### PR DESCRIPTION
## Summary
- GraphQL `WorkflowStep` carried only the skip-`condition`, so a wait step's defining config (`provider`, `resumeCondition`) wasn't visible in the TUI — you could see a step was type `WAIT` but not what it was actually waiting on.
- Expose `provider` and `resumeCondition` on `WorkflowStep`, populated from the `Wait` arm of `DomainWorkflowStepDef`. SDL regenerated.
- Client: extend `WorkflowStepNode` + `WorkflowStepItem` and the three step-selection queries (`workflowDefinitions`, `workflowDefinition`, `workflowRun.stepsSnapshot`), then render the new fields in the miller step-detail panel above the existing `condition` line.

## Test plan
- [ ] `cargo check -p drua-server -p drua-client` — green.
- [ ] After deploy: open `wait-for-check-code-failure-v2` in the TUI step detail and confirm `provider: concourse` and the full CEL `resume_condition` are displayed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk additive change: extends GraphQL `WorkflowStep` with two optional wait-step fields and plumbs them through the Rust client/TUI for display; main risk is minor schema/client compatibility if any consumers assume a fixed selection set.
> 
> **Overview**
> **Exposes wait-step configuration in the workflow TUI.** The server GraphQL `WorkflowStep` type now includes `provider` and `resumeCondition`, populated from the `Wait` variant of `DomainWorkflowStepDef`.
> 
> The client updates workflow step queries, deserialization/state (`WorkflowStepNode`/`WorkflowStepItem`), and the step detail panel to show `provider` and `resume_condition` alongside existing step metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc491d4cd072d8ed2a7f0c95980d81cf6959cd7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->