### PR TITLE
feat(webhook): add zenduty as inbound webhook provider

### DIFF
--- a/charts/drua/templates/deployment.yaml
+++ b/charts/drua/templates/deployment.yaml
@@ -180,6 +180,12 @@ spec:
               name: {{ template "galoyAgents.fullname" . }}
               key: "zenduty-api-token"
               optional: true
+        - name: WEBHOOK_SECRET_ZENDUTY
+          valueFrom:
+            secretKeyRef:
+              name: {{ template "galoyAgents.fullname" . }}
+              key: "zenduty-webhook-secret"
+              optional: true
         {{- range .Values.galoyAgents.config.mcpUpstreams }}
         - name: {{ .name | upper }}_AUTH_HEADER
           valueFrom:

--- a/charts/drua/templates/secret.yaml
+++ b/charts/drua/templates/secret.yaml
@@ -43,6 +43,9 @@ data:
   {{- if .Values.galoyAgents.secrets.concourseWebhookSecret }}
   concourse-webhook-secret: {{ .Values.galoyAgents.secrets.concourseWebhookSecret | trim | b64enc | trim }}
   {{- end }}
+  {{- if .Values.galoyAgents.secrets.zendutyWebhookSecret }}
+  zenduty-webhook-secret: {{ .Values.galoyAgents.secrets.zendutyWebhookSecret | trim | b64enc | trim }}
+  {{- end }}
   {{- if .Values.galoyAgents.secrets.tunnelInternalSecret }}
   tunnel-internal-secret: {{ .Values.galoyAgents.secrets.tunnelInternalSecret | trim | b64enc | trim }}
   {{- end }}

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -247,6 +247,7 @@ galoyAgents:
     concoursePassword: ""
     concourseWebhookSecret: ""
     zendutyApiToken: ""
+    zendutyWebhookSecret: ""
     anthropicApiKey: ""
     openaiApiKey: ""
     tunnelInternalSecret: ""

--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -109,6 +109,11 @@ resource "random_password" "concourse_webhook_secret" {
   special = false
 }
 
+resource "random_password" "zenduty_webhook_secret" {
+  length  = 48
+  special = false
+}
+
 resource "kubernetes_secret" "galoy_agents" {
   metadata {
     name      = "galoy-agents"
@@ -136,6 +141,7 @@ resource "kubernetes_secret" "galoy_agents" {
     "github-app-private-key"           = local.github_app_private_key
     "github-app-webhook-secret"        = random_password.github_app_webhook_secret.result
     "concourse-webhook-secret"         = random_password.concourse_webhook_secret.result
+    "zenduty-webhook-secret"           = random_password.zenduty_webhook_secret.result
     "tunnel-internal-secret"           = random_password.tunnel_internal_secret.result
   }
 
@@ -355,5 +361,10 @@ output "github_app_webhook_secret" {
 
 output "concourse_webhook_secret" {
   value     = random_password.concourse_webhook_secret.result
+  sensitive = true
+}
+
+output "zenduty_webhook_secret" {
+  value     = random_password.zenduty_webhook_secret.result
   sensitive = true
 }

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -9,6 +9,8 @@
 //!
 //! Provider `github_app` uses HMAC-SHA256 verification
 //! (`X-Hub-Signature-256: sha256=<hex>`) instead of bearer tokens.
+//! Provider `zenduty` uses HMAC-SHA256 verification with the digest
+//! base64-encoded in the `X-SIGNATURE` header.
 
 use axum::{
     body::Bytes,
@@ -18,6 +20,7 @@ use axum::{
     routing::post,
     Json, Router,
 };
+use base64::{engine::general_purpose::STANDARD, Engine};
 use hmac::{Hmac, Mac};
 use serde::Serialize;
 use sha2::Sha256;
@@ -198,6 +201,7 @@ fn verify_webhook(
 ) -> bool {
     match provider {
         Some("github_app") => verify_github_hmac(expected_secret, headers, body),
+        Some("zenduty") => verify_zenduty_hmac(expected_secret, headers, body),
         other => verify_bearer_or_token(other, expected_secret, headers),
     }
 }
@@ -238,6 +242,33 @@ fn verify_github_hmac(secret: &str, headers: &HeaderMap, body: &[u8]) -> bool {
     mac.update(body);
 
     // `verify_slice` is constant-time.
+    mac.verify_slice(&expected_bytes).is_ok()
+}
+
+/// HMAC-SHA256 verification per Zenduty's outgoing webhook spec: the
+/// `X-SIGNATURE` header carries the base64-encoded digest computed
+/// over the raw body with the webhook secret as key.
+fn verify_zenduty_hmac(secret: &str, headers: &HeaderMap, body: &[u8]) -> bool {
+    let signature = match headers.get("x-signature").and_then(|v| v.to_str().ok()) {
+        Some(s) => s,
+        None => {
+            tracing::warn!("webhook: missing X-SIGNATURE header");
+            return false;
+        }
+    };
+
+    let expected_bytes = match STANDARD.decode(signature) {
+        Ok(b) => b,
+        Err(_) => {
+            tracing::warn!("webhook: X-SIGNATURE contains invalid base64");
+            return false;
+        }
+    };
+
+    let mut mac =
+        Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
+    mac.update(body);
+
     mac.verify_slice(&expected_bytes).is_ok()
 }
 
@@ -406,5 +437,54 @@ mod tests {
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "whsec_abc".parse().unwrap());
         assert!(verify_webhook(None, "whsec_abc", &headers, b""));
+    }
+
+    #[test]
+    fn zenduty_hmac_valid_signature() {
+        let secret = "whsec_zenduty_secret";
+        let body = b"{\"payload\":{\"event_type\":\"triggered\"}}";
+
+        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        let signature = STANDARD.encode(mac.finalize().into_bytes());
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-signature", signature.parse().unwrap());
+        assert!(verify_webhook(Some("zenduty"), secret, &headers, body));
+    }
+
+    #[test]
+    fn zenduty_hmac_wrong_signature_rejects() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-signature", "ZGVhZGJlZWY=".parse().unwrap());
+        assert!(!verify_webhook(
+            Some("zenduty"),
+            "whsec_abc",
+            &headers,
+            b"{}"
+        ));
+    }
+
+    #[test]
+    fn zenduty_hmac_missing_header_rejects() {
+        let headers = HeaderMap::new();
+        assert!(!verify_webhook(
+            Some("zenduty"),
+            "whsec_abc",
+            &headers,
+            b"{}"
+        ));
+    }
+
+    #[test]
+    fn zenduty_hmac_invalid_base64_rejects() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-signature", "not!valid!base64".parse().unwrap());
+        assert!(!verify_webhook(
+            Some("zenduty"),
+            "whsec_abc",
+            &headers,
+            b"{}"
+        ));
     }
 }


### PR DESCRIPTION
## Summary
- Add `zenduty` as a recognized provider in `verify_webhook()` with HMAC-SHA256 verification keyed off the `X-SIGNATURE` header (base64-encoded digest of the raw body) — distinct from the `github_app` HMAC path which uses hex with a `sha256=` prefix.
- Wire `WEBHOOK_SECRET_ZENDUTY` through the helm chart (deployment env var, optional secret key, and chart value) so the existing fan-out endpoint `POST /webhooks/providers/zenduty` accepts incident events.
- Add unit tests mirroring the `github_app` HMAC coverage (valid signature, wrong signature, missing header, invalid base64).

No changes were needed in `core/` — the provider dispatch, trigger fan-out, and Wait-step `try_resume_by_provider` logic all work generically once verification passes. Workflows opt in by setting `provider: \"zenduty\"` on their trigger or Wait step.

## Test plan
- [x] `cargo test --lib webhook` — 17 passed (4 new zenduty tests + existing)
- [x] `nix flake check` — all checks pass (fmt, clippy, nextest, graphql schema, default config)
- [ ] Configure outgoing webhook in Zenduty UI pointing at `POST https://<drua-host>/webhooks/providers/zenduty` with HMAC signing enabled
- [ ] Verify an incident `triggered` event resumes a workflow Wait step keyed on `provider: \"zenduty\"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new webhook authentication path (Zenduty HMAC verification) and new secret wiring through Helm/Terraform; mistakes could cause unintended webhook rejection/acceptance or rollout issues if secrets aren’t configured.
> 
> **Overview**
> Adds `zenduty` as a first-class inbound webhook provider by extending `verify_webhook()` to validate `X-SIGNATURE` using HMAC-SHA256 with a base64-encoded digest, plus unit tests covering valid/invalid signatures and missing/invalid headers.
> 
> Wires a new `WEBHOOK_SECRET_ZENDUTY` secret end-to-end: Helm chart values and Secret template gain `zendutyWebhookSecret`/`zenduty-webhook-secret`, the Deployment injects it as an env var, and Terraform generates/stores/outputs the corresponding random secret.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f248d705ba8af6586bececea63fa625a011add0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->