### PR TITLE
fix(sandbox): Add pypi.io to allowlist

### DIFF
--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -465,6 +465,7 @@ sandbox:
       - "^static\\.rust-lang\\.org$"
       - "^tarballs\\.nixos\\.org$"
       - "^ci\\.galoy\\.io$"
+      - "^pypi\\.io$"
       - "^static\\.crates\\.io$"
   ## Optional Nix netrc file for authenticated binary caches, such as a
   ## private Cachix cache. When enabled, `netrc-file = <mountPath>` is added


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk Helm values change that only expands the sandbox forward-proxy domain allowlist; impact is limited to permitting egress to an additional host.
> 
> **Overview**
> Updates the `sandbox.forwardProxy.allowedDomains` allowlist in `charts/drua/values.yaml` to permit requests to `pypi.io`, enabling sandboxed workloads to access Python package downloads through the forward proxy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f02369f1582e6c02340b53271c8345ab51c50f6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->