### PR TITLE
refactor(webhook): switch zenduty to Basic auth

### DIFF
--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -9,8 +9,10 @@
 //!
 //! Provider `github_app` uses HMAC-SHA256 verification
 //! (`X-Hub-Signature-256: sha256=<hex>`) instead of bearer tokens.
-//! Provider `zenduty` uses HMAC-SHA256 verification with the digest
-//! base64-encoded in the `X-SIGNATURE` header.
+//! Provider `zenduty` uses the bearer fallback — Zenduty mints a per-
+//! integration HMAC secret on Save and the receiver can't supply one,
+//! so we configure a shared token via the outgoing-webhook's optional
+//! `Authorization: Bearer <secret>` header instead.
 
 use axum::{
     body::Bytes,
@@ -20,7 +22,6 @@ use axum::{
     routing::post,
     Json, Router,
 };
-use base64::{engine::general_purpose::STANDARD, Engine};
 use hmac::{Hmac, Mac};
 use serde::Serialize;
 use sha2::Sha256;
@@ -201,7 +202,6 @@ fn verify_webhook(
 ) -> bool {
     match provider {
         Some("github_app") => verify_github_hmac(expected_secret, headers, body),
-        Some("zenduty") => verify_zenduty_hmac(expected_secret, headers, body),
         other => verify_bearer_or_token(other, expected_secret, headers),
     }
 }
@@ -242,33 +242,6 @@ fn verify_github_hmac(secret: &str, headers: &HeaderMap, body: &[u8]) -> bool {
     mac.update(body);
 
     // `verify_slice` is constant-time.
-    mac.verify_slice(&expected_bytes).is_ok()
-}
-
-/// HMAC-SHA256 verification per Zenduty's outgoing webhook spec: the
-/// `X-SIGNATURE` header carries the base64-encoded digest computed
-/// over the raw body with the webhook secret as key.
-fn verify_zenduty_hmac(secret: &str, headers: &HeaderMap, body: &[u8]) -> bool {
-    let signature = match headers.get("x-signature").and_then(|v| v.to_str().ok()) {
-        Some(s) => s,
-        None => {
-            tracing::warn!("webhook: missing X-SIGNATURE header");
-            return false;
-        }
-    };
-
-    let expected_bytes = match STANDARD.decode(signature) {
-        Ok(b) => b,
-        Err(_) => {
-            tracing::warn!("webhook: X-SIGNATURE contains invalid base64");
-            return false;
-        }
-    };
-
-    let mut mac =
-        Hmac::<Sha256>::new_from_slice(secret.as_bytes()).expect("HMAC accepts any key length");
-    mac.update(body);
-
     mac.verify_slice(&expected_bytes).is_ok()
 }
 
@@ -440,51 +413,9 @@ mod tests {
     }
 
     #[test]
-    fn zenduty_hmac_valid_signature() {
-        let secret = "whsec_zenduty_secret";
-        let body = b"{\"payload\":{\"event_type\":\"triggered\"}}";
-
-        let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
-        mac.update(body);
-        let signature = STANDARD.encode(mac.finalize().into_bytes());
-
+    fn zenduty_uses_bearer_fallback() {
         let mut headers = HeaderMap::new();
-        headers.insert("x-signature", signature.parse().unwrap());
-        assert!(verify_webhook(Some("zenduty"), secret, &headers, body));
-    }
-
-    #[test]
-    fn zenduty_hmac_wrong_signature_rejects() {
-        let mut headers = HeaderMap::new();
-        headers.insert("x-signature", "ZGVhZGJlZWY=".parse().unwrap());
-        assert!(!verify_webhook(
-            Some("zenduty"),
-            "whsec_abc",
-            &headers,
-            b"{}"
-        ));
-    }
-
-    #[test]
-    fn zenduty_hmac_missing_header_rejects() {
-        let headers = HeaderMap::new();
-        assert!(!verify_webhook(
-            Some("zenduty"),
-            "whsec_abc",
-            &headers,
-            b"{}"
-        ));
-    }
-
-    #[test]
-    fn zenduty_hmac_invalid_base64_rejects() {
-        let mut headers = HeaderMap::new();
-        headers.insert("x-signature", "not!valid!base64".parse().unwrap());
-        assert!(!verify_webhook(
-            Some("zenduty"),
-            "whsec_abc",
-            &headers,
-            b"{}"
-        ));
+        headers.insert("authorization", "Bearer whsec_abc".parse().unwrap());
+        assert!(verify_webhook(Some("zenduty"), "whsec_abc", &headers, b""));
     }
 }

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -9,10 +9,13 @@
 //!
 //! Provider `github_app` uses HMAC-SHA256 verification
 //! (`X-Hub-Signature-256: sha256=<hex>`) instead of bearer tokens.
-//! Provider `zenduty` uses the bearer fallback — Zenduty mints a per-
-//! integration HMAC secret on Save and the receiver can't supply one,
-//! so we configure a shared token via the outgoing-webhook's optional
-//! `Authorization: Bearer <secret>` header instead.
+//! Provider `zenduty` uses HTTP Basic auth — Zenduty mints a per-
+//! integration HMAC secret on Save (receiver can't pre-set one), so
+//! one shared secret across N service webhooks needs a different
+//! channel. Basic auth is Zenduty's first-class auth selector and
+//! carries the secret in `Authorization: Basic <base64(user:pass)>`.
+//! Username is ignored; password is compared against the configured
+//! webhook secret.
 
 use axum::{
     body::Bytes,
@@ -22,6 +25,7 @@ use axum::{
     routing::post,
     Json, Router,
 };
+use base64::{engine::general_purpose::STANDARD, Engine};
 use hmac::{Hmac, Mac};
 use serde::Serialize;
 use sha2::Sha256;
@@ -202,6 +206,7 @@ fn verify_webhook(
 ) -> bool {
     match provider {
         Some("github_app") => verify_github_hmac(expected_secret, headers, body),
+        Some("zenduty") => verify_basic_auth(expected_secret, headers),
         other => verify_bearer_or_token(other, expected_secret, headers),
     }
 }
@@ -243,6 +248,56 @@ fn verify_github_hmac(secret: &str, headers: &HeaderMap, body: &[u8]) -> bool {
 
     // `verify_slice` is constant-time.
     mac.verify_slice(&expected_bytes).is_ok()
+}
+
+/// HTTP Basic auth: `Authorization: Basic <base64(user:pass)>`.
+/// Username is ignored; password must equal the configured secret.
+fn verify_basic_auth(secret: &str, headers: &HeaderMap) -> bool {
+    let header = match headers.get("authorization").and_then(|v| v.to_str().ok()) {
+        Some(s) => s,
+        None => {
+            tracing::warn!("webhook: missing Authorization header");
+            return false;
+        }
+    };
+
+    let b64 = match header.strip_prefix("Basic ") {
+        Some(s) => s,
+        None => {
+            tracing::warn!("webhook: Authorization missing Basic prefix");
+            return false;
+        }
+    };
+
+    let decoded = match STANDARD.decode(b64) {
+        Ok(b) => b,
+        Err(_) => {
+            tracing::warn!("webhook: Authorization Basic value is not valid base64");
+            return false;
+        }
+    };
+
+    let credentials = match std::str::from_utf8(&decoded) {
+        Ok(s) => s,
+        Err(_) => {
+            tracing::warn!("webhook: Authorization Basic credentials are not valid utf-8");
+            return false;
+        }
+    };
+
+    let password = match credentials.split_once(':') {
+        Some((_user, pw)) => pw,
+        None => {
+            tracing::warn!("webhook: Authorization Basic credentials missing colon");
+            return false;
+        }
+    };
+
+    if password != secret {
+        tracing::warn!("webhook: secret mismatch");
+        return false;
+    }
+    true
 }
 
 fn verify_bearer_or_token(
@@ -412,10 +467,65 @@ mod tests {
         assert!(verify_webhook(None, "whsec_abc", &headers, b""));
     }
 
+    fn basic_header(user: &str, pass: &str) -> String {
+        format!("Basic {}", STANDARD.encode(format!("{user}:{pass}")))
+    }
+
     #[test]
-    fn zenduty_uses_bearer_fallback() {
+    fn zenduty_basic_auth_accepts_matching_password() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            basic_header("drua", "whsec_abc").parse().unwrap(),
+        );
+        assert!(verify_webhook(Some("zenduty"), "whsec_abc", &headers, b""));
+    }
+
+    #[test]
+    fn zenduty_basic_auth_ignores_username() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            basic_header("anything", "whsec_abc").parse().unwrap(),
+        );
+        assert!(verify_webhook(Some("zenduty"), "whsec_abc", &headers, b""));
+    }
+
+    #[test]
+    fn zenduty_basic_auth_rejects_wrong_password() {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "authorization",
+            basic_header("drua", "wrong").parse().unwrap(),
+        );
+        assert!(!verify_webhook(Some("zenduty"), "whsec_abc", &headers, b""));
+    }
+
+    #[test]
+    fn zenduty_basic_auth_rejects_missing_header() {
+        let headers = HeaderMap::new();
+        assert!(!verify_webhook(Some("zenduty"), "whsec_abc", &headers, b""));
+    }
+
+    #[test]
+    fn zenduty_basic_auth_rejects_bearer_prefix() {
         let mut headers = HeaderMap::new();
         headers.insert("authorization", "Bearer whsec_abc".parse().unwrap());
-        assert!(verify_webhook(Some("zenduty"), "whsec_abc", &headers, b""));
+        assert!(!verify_webhook(Some("zenduty"), "whsec_abc", &headers, b""));
+    }
+
+    #[test]
+    fn zenduty_basic_auth_rejects_invalid_base64() {
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Basic not!base64".parse().unwrap());
+        assert!(!verify_webhook(Some("zenduty"), "whsec_abc", &headers, b""));
+    }
+
+    #[test]
+    fn zenduty_basic_auth_rejects_credentials_without_colon() {
+        let mut headers = HeaderMap::new();
+        let no_colon = format!("Basic {}", STANDARD.encode("nocolonhere"));
+        headers.insert("authorization", no_colon.parse().unwrap());
+        assert!(!verify_webhook(Some("zenduty"), "whsec_abc", &headers, b""));
     }
 }


### PR DESCRIPTION
## Why

Follow-up to #401. When wiring up the actual Zenduty integration we discovered Zenduty's "Signature" auth **generates** the HMAC secret per integration on Save — the receiver can't pre-set it. We want a single shared secret across N service webhooks (one per Zenduty service), so per-integration HMAC keys are the wrong primitive.

## What

Switch zenduty verification from HMAC to **HTTP Basic auth** — Zenduty's first-class auth selector, single-value setup, self-documenting in the Zenduty UI.

- `verify_webhook` dispatches `Some("zenduty")` to a new `verify_basic_auth`.
- `verify_basic_auth` parses `Authorization: Basic <base64(user:pass)>`, ignores the username, compares the password against `WEBHOOK_SECRET_ZENDUTY`.
- Helm + terraform wiring unchanged from #401 — same env var, same `random_password.zenduty_webhook_secret`.

This PR contains two commits:
1. Drop the HMAC verification path (falls through to bearer as a transitional step).
2. Add the Basic auth path proper.

## Operator config

In each Zenduty service's outgoing webhook:
- **Authentication Type:** Basic
- **Username:** `drua` (or anything — ignored by the receiver)
- **Password:** `tofu output -raw zenduty_webhook_secret` (from `ci/deploy/drua/`)

## Test plan
- [x] `cargo test --lib webhook` — 20 passed (7 new Basic-auth tests covering: matching password, ignored username, wrong password, missing header, Bearer-prefix rejection, invalid base64, missing colon).
- [ ] After deploy: configure a Zenduty service outgoing webhook as above; send test event; expect `200` with `{"triggered":0,"filtered":0,...}` until workflows tagged `provider: "zenduty"` exist.

## Why Basic over a bearer in the "optional header" field

| | Bearer via "optional header" | Basic auth |
|---|---|---|
| Zenduty UX | Hack the escape-hatch field | First-class auth selector |
| Self-documenting | Future operator hunts in "optional headers" | "Authentication: Basic" — obvious |
| Misconfig risk | Easy to forget the `Bearer ` prefix | Zenduty does the encoding |
| Wire security | Static token over TLS | Same |

🤖 Generated with [Claude Code](https://claude.com/claude-code)