### PR TITLE
feat(workflow): native loop step with break_condition and iteration semantics

### DIFF
--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -372,6 +372,28 @@ enum WorkflowStepParams {
         #[serde(default)]
         condition: Option<String>,
     },
+    /// Repeat the inner `steps` until `break_condition` evaluates to
+    /// true (or `max_iterations` is exhausted). Inner steps have
+    /// access to `iter.<step>.outputs.X` for prior siblings within
+    /// the same iteration.
+    Loop {
+        name: String,
+        /// Bare CEL boolean, evaluated against `trigger`, `steps`
+        /// (pre-loop), `iter` (this iteration's outputs), and
+        /// `iteration` (1-based count). `true` breaks out.
+        break_condition: String,
+        /// Hard cap (default 25). Loop records `success: false` on
+        /// exhaustion.
+        #[serde(default = "default_loop_max_iterations")]
+        max_iterations: u32,
+        steps: Vec<WorkflowStepParams>,
+        #[serde(default)]
+        condition: Option<String>,
+    },
+}
+
+fn default_loop_max_iterations() -> u32 {
+    25
 }
 
 impl WorkflowStepParams {
@@ -432,6 +454,25 @@ impl WorkflowStepParams {
                 outputs,
                 condition,
             }),
+            WorkflowStepParams::Loop {
+                name,
+                break_condition,
+                max_iterations,
+                steps,
+                condition,
+            } => {
+                let inner = steps
+                    .into_iter()
+                    .map(|s| s.into_step())
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(WorkflowStepDef::Loop {
+                    name,
+                    break_condition,
+                    max_iterations,
+                    steps: inner,
+                    condition,
+                })
+            }
         }
     }
 }

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -1040,6 +1040,14 @@ fn step_to_output(s: &WorkflowStepDef) -> WorkflowStepOutput {
             timeout_seconds: None,
             tool: None,
         },
+        WorkflowStepDef::Loop { name, .. } => WorkflowStepOutput {
+            name: name.clone(),
+            step_type: "loop".to_string(),
+            skill: String::new(),
+            sandbox: None,
+            timeout_seconds: None,
+            tool: None,
+        },
     }
 }
 
@@ -1250,6 +1258,17 @@ fn format_get_text(d: &WorkflowDefinition) -> String {
             }
             WorkflowStepDef::Wait { name, provider, .. } => {
                 out.push_str(&format!("  - wait name={name} provider={provider}\n"));
+            }
+            WorkflowStepDef::Loop {
+                name,
+                max_iterations,
+                steps,
+                ..
+            } => {
+                out.push_str(&format!(
+                    "  - loop name={name} max_iterations={max_iterations} inner_steps={}\n",
+                    steps.len()
+                ));
             }
         }
     }

--- a/core/src/workflow/definition.rs
+++ b/core/src/workflow/definition.rs
@@ -269,6 +269,45 @@ pub enum WorkflowStepDef {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         condition: Option<String>,
     },
+    /// Repeats `steps` until `break_condition` evaluates to true OR
+    /// `max_iterations` is exhausted. Each iteration runs inner steps
+    /// sequentially with their own dotted-name `StepResult` rows
+    /// (`{loop}.iter[{N}].{inner}`), so existing idempotency
+    /// (`step_already_terminal`) and wait-resume (`current_wait_step`)
+    /// keep working unchanged. `break_condition` is evaluated against
+    /// an [`crate::workflow::template::IterationContext`] that exposes
+    /// `iter.<inner>.outputs.X` (this iteration's already-completed
+    /// inner outputs) and `iteration` (1-based count). Exhaustion
+    /// without break records `success: false` on the outer loop's
+    /// `StepResult.output` and folds into `WorkflowRunState::Failed`.
+    Loop {
+        name: String,
+        /// Bare CEL boolean. Evaluated AFTER each iteration's last
+        /// inner step completes. `true` → break out of the loop.
+        /// Compiled and validated at workflow create/update time.
+        break_condition: String,
+        /// Hard safety valve. 25 mirrors LangGraph's default
+        /// `recursion_limit`. Loop step records `success: false`
+        /// when exhausted without `break_condition` firing.
+        #[serde(default = "default_loop_max_iterations")]
+        max_iterations: u32,
+        /// Inner steps. Run sequentially per iteration. MVP rejects
+        /// nested loops at parse time. May contain Wait (the driving
+        /// use case — PR review cycle).
+        steps: Vec<WorkflowStepDef>,
+        /// Outer skip gate — false skips the entire loop without
+        /// running any iteration. Same semantics as on other step
+        /// variants.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        condition: Option<String>,
+    },
+}
+
+/// Mirrors LangGraph's `GRAPH_RECURSION_LIMIT` default (25). Loop
+/// authors with tighter convergence expectations should set their
+/// own (e.g. evaluator-optimizer typically caps at 2-3).
+fn default_loop_max_iterations() -> u32 {
+    25
 }
 
 impl WorkflowStepDef {
@@ -276,14 +315,17 @@ impl WorkflowStepDef {
         match self {
             WorkflowStepDef::AgentStep { name, .. }
             | WorkflowStepDef::ToolStep { name, .. }
-            | WorkflowStepDef::Wait { name, .. } => name,
+            | WorkflowStepDef::Wait { name, .. }
+            | WorkflowStepDef::Loop { name, .. } => name,
         }
     }
 
     pub fn model_chain(&self) -> Option<&ModelChain> {
         match self {
             WorkflowStepDef::AgentStep { model_chain, .. } => model_chain.as_ref(),
-            WorkflowStepDef::ToolStep { .. } | WorkflowStepDef::Wait { .. } => None,
+            WorkflowStepDef::ToolStep { .. }
+            | WorkflowStepDef::Wait { .. }
+            | WorkflowStepDef::Loop { .. } => None,
         }
     }
 
@@ -293,7 +335,9 @@ impl WorkflowStepDef {
     pub fn output_schema(&self) -> Option<&OutputSchema> {
         match self {
             WorkflowStepDef::AgentStep { output_schema, .. } => Some(output_schema.as_ref()),
-            WorkflowStepDef::ToolStep { .. } | WorkflowStepDef::Wait { .. } => None,
+            WorkflowStepDef::ToolStep { .. }
+            | WorkflowStepDef::Wait { .. }
+            | WorkflowStepDef::Loop { .. } => None,
         }
     }
 
@@ -303,7 +347,8 @@ impl WorkflowStepDef {
         match self {
             WorkflowStepDef::AgentStep { condition, .. }
             | WorkflowStepDef::ToolStep { condition, .. }
-            | WorkflowStepDef::Wait { condition, .. } => condition.as_deref(),
+            | WorkflowStepDef::Wait { condition, .. }
+            | WorkflowStepDef::Loop { condition, .. } => condition.as_deref(),
         }
     }
 }
@@ -735,6 +780,50 @@ mod tests {
             output["properties"]["reason"]["description"], "custom reason desc",
             "existing reason description preserved"
         );
+    }
+
+    #[test]
+    fn loop_step_round_trips_through_serde() {
+        let step = WorkflowStepDef::Loop {
+            name: "review_cycle".into(),
+            break_condition: "iter.check_pr.outputs.merged == true".into(),
+            max_iterations: 10,
+            steps: vec![WorkflowStepDef::ToolStep {
+                name: "check_pr".into(),
+                tool: "github".into(),
+                params: serde_json::json!({ "command": "get_pr" }),
+                timeout_seconds: None,
+                condition: None,
+            }],
+            condition: None,
+        };
+        let value = serde_json::to_value(&step).unwrap();
+        assert_eq!(value.get("type").and_then(|v| v.as_str()), Some("loop"));
+        assert_eq!(
+            value.get("max_iterations").and_then(|v| v.as_u64()),
+            Some(10)
+        );
+        let back: WorkflowStepDef = serde_json::from_value(value).unwrap();
+        assert_eq!(back.name(), "review_cycle");
+        assert!(back.model_chain().is_none());
+        assert!(back.output_schema().is_none());
+    }
+
+    #[test]
+    fn loop_step_max_iterations_defaults_to_25() {
+        let json = serde_json::json!({
+            "type": "loop",
+            "name": "x",
+            "break_condition": "true",
+            "steps": [
+                { "type": "tool_step", "name": "t", "tool": "whoami" }
+            ]
+        });
+        let step: WorkflowStepDef = serde_json::from_value(json).unwrap();
+        match step {
+            WorkflowStepDef::Loop { max_iterations, .. } => assert_eq!(max_iterations, 25),
+            _ => panic!("expected Loop"),
+        }
     }
 
     /// Old serialized triggers without the `condition` field must

--- a/core/src/workflow/error.rs
+++ b/core/src/workflow/error.rs
@@ -42,6 +42,8 @@ pub enum WorkflowError {
     InvalidTemplateRef(String),
     #[error("WorkflowError - InvalidCondition: {0}")]
     InvalidCondition(String),
+    #[error("WorkflowError - InvalidLoop: loop step '{step}': {reason}")]
+    InvalidLoop { step: String, reason: String },
     #[error("WorkflowError - ConditionNotBoolean: step '{step}' condition `{body}` evaluated to {value} (expected bool)")]
     ConditionNotBoolean {
         step: String,

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -13,17 +13,33 @@ use crate::sandbox::{Sandbox, SandboxAgentMode, SandboxSpecs, SandboxState, Sand
 use crate::skill::Skills;
 use crate::toolset::ToolSets;
 
-use super::definition::{WorkflowSandboxDecl, WorkflowStepDef};
+use super::definition::{OutputSchema, WorkflowSandboxDecl, WorkflowStepDef};
 use super::error::WorkflowError;
 use super::repo::WorkflowDefinitionRepo;
-use super::run::{StepResult, WorkflowRunRepo, WorkflowRunState};
+use super::run::{StepResult, WorkflowRun, WorkflowRunRepo, WorkflowRunState};
 use super::template::{
-    format_template_diagnostics, template_diagnostics, ConditionOutcome, TemplateContext,
+    format_template_diagnostics, template_diagnostics, ConditionOutcome, IterationContext,
+    TemplateContext,
 };
 
 /// Hard cap on the pre-flight per-sandbox readiness wait. Protects the
 /// queue from a stuck infrastructure step.
 const SANDBOX_READY_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Result of [`Executor::run_loop_step`]. Three terminal shapes:
+///
+///   - `Completed` — break_condition fired (`success: true`) or
+///     max_iterations exhausted (`success: false`). Caller emits the
+///     outer `step_completed` event with the carried output.
+///   - `Parked` — an inner Wait step has parked the run. Caller
+///     stops processing further outer steps and returns from `run`.
+///   - `Cancelled` — cooperative cancellation observed between
+///     inner steps; the caller propagates `WorkflowError::Cancelled`.
+enum LoopOutcome {
+    Completed(serde_json::Value),
+    Parked,
+    Cancelled,
+}
 
 /// Default per-`ToolStep` dispatch timeout when the step doesn't
 /// specify one. Same shape as the agent step's idle timeout default.
@@ -60,6 +76,45 @@ fn first_text_content(result: &rmcp::model::CallToolResult) -> Option<String> {
         rmcp::model::RawContent::Text(t) => Some(t.text.clone()),
         _ => None,
     })
+}
+
+/// Build the agent prompt from a pre-templated skill body and the
+/// run's trigger context. The trigger payload is appended as opaque
+/// text (or interpolated via `$ARGUMENTS` if the skill opts in) so
+/// templates smuggled through user-controlled fields can't reach
+/// prior step outputs. Caller is responsible for the substitution
+/// pass on the skill body — both `TemplateContext` and
+/// `IterationContext` are valid sources.
+fn build_agent_prompt(templated_body: String, trigger_context: &serde_json::Value) -> String {
+    let pretty = serde_json::to_string_pretty(trigger_context)
+        .unwrap_or_else(|_| trigger_context.to_string());
+    if templated_body.contains("$ARGUMENTS") {
+        crate::skill::SkillBody::new(templated_body).interpolate(Some(&pretty))
+    } else {
+        format!("{templated_body}\n\nTRIGGER_CONTEXT:\n```json\n{pretty}\n```")
+    }
+}
+
+/// Per-iteration outputs scoped to a single Loop iteration. Walks
+/// the run's `step_results` for entries whose names start with the
+/// `{loop_name}.iter[{iteration}].` prefix and returns a map keyed
+/// by the inner step name (with the dotted prefix stripped). Used
+/// to seed [`crate::workflow::template::IterationContext::iter`]
+/// for inner-step condition gates and break_condition evaluation.
+fn collect_inner_iter_outputs(
+    results: &[StepResult],
+    loop_name: &str,
+    iteration: u32,
+) -> HashMap<String, serde_json::Value> {
+    let prefix = format!("{loop_name}.iter[{iteration}].");
+    let mut out = HashMap::new();
+    for r in results {
+        if let Some(stripped) = r.name.strip_prefix(&prefix) {
+            let val = r.output.clone().unwrap_or(serde_json::Value::Null);
+            out.insert(stripped.to_string(), val);
+        }
+    }
+    out
 }
 
 fn type_label(v: &serde_json::Value) -> &'static str {
@@ -242,6 +297,59 @@ impl Executor {
                 self.suspend_workflow_sandboxes(project_id, workflow_id, &borrowed_preexisting)
                     .await;
                 return Ok(());
+            }
+
+            // Loop step: keep entity bookkeeping (outer step_started
+            // here, step_completed below) identical to the other
+            // variants, but defer the inner iteration logic to
+            // `run_loop_step`. `LoopOutcome::Parked` short-circuits
+            // the outer loop the same way a Wait at the outer level
+            // does.
+            if let WorkflowStepDef::Loop { .. } = step {
+                if run.step_started(step_name.clone()).did_execute() {
+                    self.runs.update(&mut run).await?;
+                }
+                match self
+                    .run_loop_step(
+                        project_id,
+                        workflow_id,
+                        run_id,
+                        step,
+                        &trigger_context,
+                        &sandbox_ids,
+                        &preexisting_ids,
+                        &mut borrowed_preexisting,
+                        &definition,
+                        &mut run,
+                        &cancel,
+                    )
+                    .await
+                {
+                    Ok(LoopOutcome::Completed(output)) => {
+                        if run.step_completed(step_name, output).did_execute() {
+                            self.runs.update(&mut run).await?;
+                        }
+                        continue;
+                    }
+                    Ok(LoopOutcome::Parked) => {
+                        self.suspend_workflow_sandboxes(
+                            project_id,
+                            workflow_id,
+                            &borrowed_preexisting,
+                        )
+                        .await;
+                        return Ok(());
+                    }
+                    Ok(LoopOutcome::Cancelled) => {
+                        return Err(WorkflowError::Cancelled);
+                    }
+                    Err(err) => {
+                        if run.step_errored(step_name, err.to_string()).did_execute() {
+                            self.runs.update(&mut run).await?;
+                        }
+                        break;
+                    }
+                }
             }
 
             if run.step_started(step_name.clone()).did_execute() {
@@ -505,18 +613,6 @@ impl Executor {
                 output_schema,
                 ..
             } => {
-                let attach_sandbox = match sandbox.as_deref() {
-                    Some(sandbox_name) => {
-                        let id = sandbox_ids.get(sandbox_name).copied().ok_or_else(|| {
-                            WorkflowError::UndeclaredSandbox(sandbox_name.to_string())
-                        })?;
-                        Some((id, sandbox_mode.unwrap_or(SandboxAgentMode::Write)))
-                    }
-                    None => None,
-                };
-
-                let sandbox_id = attach_sandbox.map(|(id, _)| id);
-
                 // Two-pass interpolation, ORDER MATTERS for security:
                 //
                 //   1. Resolve `${{ trigger.X }}` / `${{ steps.<n>.outputs.Y }}`
@@ -528,8 +624,7 @@ impl Executor {
                 //      survives this expansion but is no longer re-evaluated,
                 //      so an attacker cannot leak prior step outputs into the
                 //      prompt by smuggling templates through the trigger.
-                // The append-vs-interpolate split avoids exposing the body
-                // to bare `$N` substitution unless the skill opts in.
+                let sandbox_id = sandbox.as_deref().and_then(|n| sandbox_ids.get(n).copied());
                 let raw_body: String = self
                     .skills
                     .find_by_name(skill, Some(project_id), sandbox_id)
@@ -544,88 +639,25 @@ impl Executor {
                 let templated_body = template_ctx
                     .substitute_in_string(&raw_body)
                     .map_err(|e| WorkflowError::Skill(e.to_string()))?;
-                let pretty = serde_json::to_string_pretty(trigger_context)
-                    .unwrap_or_else(|_| trigger_context.to_string());
-                let prompt = if templated_body.contains("$ARGUMENTS") {
-                    crate::skill::SkillBody::new(templated_body).interpolate(Some(&pretty))
-                } else {
-                    format!("{templated_body}\n\nTRIGGER_CONTEXT:\n```json\n{pretty}\n```")
-                };
+                let prompt = build_agent_prompt(templated_body, trigger_context);
 
-                let agent_name = format!("workflow-{}-{name}", run_id.short());
-                let mut op = self.agents.begin_op().await?;
-
-                let existing = self
-                    .agents
-                    .find_for_workflow_step_in_op(&mut op, run_id, &agent_name)
-                    .await?;
-
-                let (agent, detached_agents) = if let Some(agent) = existing {
-                    (agent, Vec::new())
-                } else {
-                    let detached_agents = match attach_sandbox {
-                        Some((sandbox_id, mode)) => {
-                            self.agents
-                                .detach_conflicting_writer_in_op(
-                                    &mut op,
-                                    sandbox_id,
-                                    mode,
-                                    Some(workflow_id),
-                                )
-                                .await?
-                        }
-                        None => Vec::new(),
-                    };
-                    let chain_override = definition.resolve_step_chain(step);
-                    let agent = self
-                        .agents
-                        .create_for_workflow_run_in_op(
-                            &mut op,
-                            project_id,
-                            workflow_id,
-                            run_id,
-                            &agent_name,
-                            attach_sandbox,
-                            chain_override,
-                            output_schema.as_ref().clone(),
-                        )
-                        .await?;
-                    (agent, detached_agents)
-                };
-                op.commit().await?;
-
-                if let Some((sandbox_id, _)) = attach_sandbox {
-                    if preexisting_ids.contains(&sandbox_id) {
-                        borrowed_preexisting.insert(sandbox_id);
-                    }
-                }
-
-                for prior in detached_agents {
-                    self.agents.invalidate_agent_cache(prior);
-                }
-
-                // Reset the workspace repo so leftover state from a prior
-                // workflow run (stale `bot/*` branches, dirty checkout)
-                // doesn't leak into this agent's view of HEAD. Runs after
-                // `notify_sandbox_attach` (which fired in
-                // `create_for_workflow_run_in_op` above) so the freshly
-                // refreshed token is available for `git fetch`. Best-effort.
-                if let Some((sandbox_id, _)) = attach_sandbox {
-                    self.sandboxes.reset_for_workflow_step(sandbox_id).await;
-                }
-
-                let result = self
-                    .run_agent_until_submit_output(&agent, prompt, name, *timeout_seconds)
-                    .await;
-
-                // Detach the sandbox unconditionally so the next step can
-                // attach (Write mode is single-writer). Best-effort; the
-                // step-level result still propagates.
-                if let Some((sandbox_id, _)) = attach_sandbox {
-                    self.detach_step_sandbox(sandbox_id, agent.id).await;
-                }
-
-                result
+                self.dispatch_agent_step(
+                    project_id,
+                    workflow_id,
+                    run_id,
+                    name,
+                    sandbox.as_deref(),
+                    sandbox_mode.unwrap_or(SandboxAgentMode::Write),
+                    *timeout_seconds,
+                    output_schema.as_ref(),
+                    step,
+                    prompt,
+                    sandbox_ids,
+                    preexisting_ids,
+                    borrowed_preexisting,
+                    definition,
+                )
+                .await
             }
             WorkflowStepDef::ToolStep {
                 name,
@@ -653,6 +685,429 @@ impl Executor {
                 step: name.clone(),
                 reason: "wait step reached execute_step unexpectedly".into(),
             }),
+            // Loop steps are dispatched via `run_loop_step` directly
+            // from the outer loop in `run`; this arm should be
+            // unreachable.
+            WorkflowStepDef::Loop { name, .. } => Err(WorkflowError::StepErrored {
+                step: name.clone(),
+                reason: "loop step reached execute_step unexpectedly".into(),
+            }),
+        }
+    }
+
+    /// Post-prompt dispatch: open the agent, attach the sandbox (if
+    /// any), run the chat session to `submit_output`, detach. Shared
+    /// by both the top-level `AgentStep` arm and the inner-loop
+    /// `AgentStep` path so the sandbox/agent lifecycle stays
+    /// identical regardless of where the step lives. `step` is the
+    /// inner [`WorkflowStepDef::AgentStep`] used only to resolve the
+    /// model chain override.
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch_agent_step(
+        &self,
+        project_id: ProjectId,
+        workflow_id: WorkflowDefinitionId,
+        run_id: WorkflowRunId,
+        step_name: &str,
+        sandbox: Option<&str>,
+        sandbox_mode: SandboxAgentMode,
+        timeout_seconds: Option<u64>,
+        output_schema: &OutputSchema,
+        chain_step: &WorkflowStepDef,
+        prompt: String,
+        sandbox_ids: &HashMap<String, SandboxId>,
+        preexisting_ids: &HashSet<SandboxId>,
+        borrowed_preexisting: &mut HashSet<SandboxId>,
+        definition: &super::entity::WorkflowDefinition,
+    ) -> Result<serde_json::Value, WorkflowError> {
+        let attach_sandbox = match sandbox {
+            Some(sandbox_name) => {
+                let id = sandbox_ids
+                    .get(sandbox_name)
+                    .copied()
+                    .ok_or_else(|| WorkflowError::UndeclaredSandbox(sandbox_name.to_string()))?;
+                Some((id, sandbox_mode))
+            }
+            None => None,
+        };
+
+        let agent_name = format!("workflow-{}-{step_name}", run_id.short());
+        let mut op = self.agents.begin_op().await?;
+        let existing = self
+            .agents
+            .find_for_workflow_step_in_op(&mut op, run_id, &agent_name)
+            .await?;
+
+        let (agent, detached_agents) = if let Some(agent) = existing {
+            (agent, Vec::new())
+        } else {
+            let detached_agents = match attach_sandbox {
+                Some((sandbox_id, mode)) => {
+                    self.agents
+                        .detach_conflicting_writer_in_op(
+                            &mut op,
+                            sandbox_id,
+                            mode,
+                            Some(workflow_id),
+                        )
+                        .await?
+                }
+                None => Vec::new(),
+            };
+            let chain_override = definition.resolve_step_chain(chain_step);
+            let agent = self
+                .agents
+                .create_for_workflow_run_in_op(
+                    &mut op,
+                    project_id,
+                    workflow_id,
+                    run_id,
+                    &agent_name,
+                    attach_sandbox,
+                    chain_override,
+                    output_schema.clone(),
+                )
+                .await?;
+            (agent, detached_agents)
+        };
+        op.commit().await?;
+
+        if let Some((sandbox_id, _)) = attach_sandbox {
+            if preexisting_ids.contains(&sandbox_id) {
+                borrowed_preexisting.insert(sandbox_id);
+            }
+        }
+        for prior in detached_agents {
+            self.agents.invalidate_agent_cache(prior);
+        }
+
+        // Reset the workspace repo so leftover state from a prior
+        // workflow run (stale `bot/*` branches, dirty checkout)
+        // doesn't leak into this agent's view of HEAD.
+        if let Some((sandbox_id, _)) = attach_sandbox {
+            self.sandboxes.reset_for_workflow_step(sandbox_id).await;
+        }
+
+        let result = self
+            .run_agent_until_submit_output(&agent, prompt, step_name, timeout_seconds)
+            .await;
+
+        // Detach the sandbox unconditionally so the next step can
+        // attach (Write mode is single-writer). Best-effort.
+        if let Some((sandbox_id, _)) = attach_sandbox {
+            self.detach_step_sandbox(sandbox_id, agent.id).await;
+        }
+        result
+    }
+
+    /// Drive a `WorkflowStepDef::Loop` until its `break_condition`
+    /// fires or `max_iterations` is exhausted. Each iteration's inner
+    /// steps are recorded as dotted-name `StepResult` rows
+    /// (`{loop_name}.iter[{N}].{inner_name}`), so the existing
+    /// idempotency (`step_already_terminal`) and resume-from-wait
+    /// (`current_wait_step`) infrastructure keeps working unchanged.
+    /// Resumable: replays of an in-flight iteration pick up where
+    /// the prior attempt left off via [`WorkflowRun::loop_current_iteration`]
+    /// and per-inner-step terminal checks.
+    #[allow(clippy::too_many_arguments)]
+    async fn run_loop_step(
+        &self,
+        project_id: ProjectId,
+        workflow_id: WorkflowDefinitionId,
+        run_id: WorkflowRunId,
+        loop_step: &WorkflowStepDef,
+        trigger_context: &serde_json::Value,
+        sandbox_ids: &HashMap<String, SandboxId>,
+        preexisting_ids: &HashSet<SandboxId>,
+        borrowed_preexisting: &mut HashSet<SandboxId>,
+        definition: &super::entity::WorkflowDefinition,
+        run: &mut WorkflowRun,
+        cancel: &Arc<AtomicBool>,
+    ) -> Result<LoopOutcome, WorkflowError> {
+        let (loop_name, break_condition, max_iterations, inner_steps) = match loop_step {
+            WorkflowStepDef::Loop {
+                name,
+                break_condition,
+                max_iterations,
+                steps,
+                ..
+            } => (
+                name.clone(),
+                break_condition.clone(),
+                *max_iterations,
+                steps,
+            ),
+            _ => unreachable!("run_loop_step called with non-Loop step"),
+        };
+
+        let mut iteration: u32 = run.loop_current_iteration(&loop_name).max(1);
+
+        loop {
+            if iteration > max_iterations {
+                let iters = run.loop_iterations_so_far(&loop_name);
+                return Ok(LoopOutcome::Completed(serde_json::json!({
+                    "success": false,
+                    "reason": format!(
+                        "loop '{loop_name}' reached max_iterations ({max_iterations}) without break_condition firing"
+                    ),
+                    "iterations": iters,
+                })));
+            }
+
+            if cancel.load(Ordering::Relaxed) {
+                return Ok(LoopOutcome::Cancelled);
+            }
+
+            if run
+                .loop_iteration_started(loop_name.clone(), iteration)
+                .did_execute()
+            {
+                self.runs.update(run).await?;
+            }
+
+            // Resume safety: if a prior attempt recorded broke=true
+            // we exit here instead of running another iteration.
+            if run.loop_broke(&loop_name) {
+                let iters = run.loop_iterations_so_far(&loop_name);
+                return Ok(LoopOutcome::Completed(serde_json::json!({
+                    "success": true,
+                    "iterations": iters,
+                })));
+            }
+
+            for inner in inner_steps {
+                let dotted_name = format!("{loop_name}.iter[{iteration}].{}", inner.name());
+                if run.step_already_terminal(&dotted_name) {
+                    continue;
+                }
+                if cancel.load(Ordering::Relaxed) {
+                    return Ok(LoopOutcome::Cancelled);
+                }
+
+                let outer_step_outputs = collect_step_outputs(&run.step_results);
+                let inner_outputs =
+                    collect_inner_iter_outputs(&run.step_results, &loop_name, iteration);
+                let ictx = IterationContext {
+                    trigger: trigger_context,
+                    steps: &outer_step_outputs,
+                    iter: &inner_outputs,
+                    iteration,
+                };
+
+                if let Some(body) = inner.condition() {
+                    match ictx.evaluate_condition(body) {
+                        Ok(ConditionOutcome::True) => {}
+                        Ok(ConditionOutcome::False) => {
+                            if run
+                                .step_skipped(dotted_name.clone(), body.to_string())
+                                .did_execute()
+                            {
+                                self.runs.update(run).await?;
+                            }
+                            continue;
+                        }
+                        Ok(ConditionOutcome::NotBoolean(rendered)) => {
+                            return Err(WorkflowError::ConditionNotBoolean {
+                                step: dotted_name,
+                                body: body.to_string(),
+                                value: rendered,
+                            });
+                        }
+                        Err(e) => {
+                            return Err(WorkflowError::InvalidCondition(format!(
+                                "step '{dotted_name}': {e}"
+                            )));
+                        }
+                    }
+                }
+
+                if let WorkflowStepDef::Wait { provider, .. } = inner {
+                    if run
+                        .step_waiting(dotted_name.clone(), provider.clone())
+                        .did_execute()
+                    {
+                        self.runs.update(run).await?;
+                    }
+                    return Ok(LoopOutcome::Parked);
+                }
+
+                if run.step_started(dotted_name.clone()).did_execute() {
+                    self.runs.update(run).await?;
+                }
+
+                let result = match inner {
+                    WorkflowStepDef::AgentStep {
+                        skill,
+                        sandbox,
+                        sandbox_mode,
+                        timeout_seconds,
+                        output_schema,
+                        ..
+                    } => {
+                        let sandbox_id =
+                            sandbox.as_deref().and_then(|n| sandbox_ids.get(n).copied());
+                        let raw_body: String = match self
+                            .skills
+                            .find_by_name(skill, Some(project_id), sandbox_id)
+                            .await
+                        {
+                            Ok(Some(s)) => s.into(),
+                            Ok(None) => {
+                                let err = WorkflowError::SkillNotFound(skill.clone());
+                                if run
+                                    .step_errored(dotted_name.clone(), err.to_string())
+                                    .did_execute()
+                                {
+                                    self.runs.update(run).await?;
+                                }
+                                return Err(err);
+                            }
+                            Err(e) => {
+                                let err = WorkflowError::Skill(e.to_string());
+                                if run
+                                    .step_errored(dotted_name.clone(), err.to_string())
+                                    .did_execute()
+                                {
+                                    self.runs.update(run).await?;
+                                }
+                                return Err(err);
+                            }
+                        };
+                        let templated_body = match ictx.substitute_in_string(&raw_body) {
+                            Ok(s) => s,
+                            Err(e) => {
+                                let err = WorkflowError::Skill(e.to_string());
+                                if run
+                                    .step_errored(dotted_name.clone(), err.to_string())
+                                    .did_execute()
+                                {
+                                    self.runs.update(run).await?;
+                                }
+                                return Err(err);
+                            }
+                        };
+                        let prompt = build_agent_prompt(templated_body, trigger_context);
+                        self.dispatch_agent_step(
+                            project_id,
+                            workflow_id,
+                            run_id,
+                            &dotted_name,
+                            sandbox.as_deref(),
+                            sandbox_mode.unwrap_or(SandboxAgentMode::Write),
+                            *timeout_seconds,
+                            output_schema.as_ref(),
+                            inner,
+                            prompt,
+                            sandbox_ids,
+                            preexisting_ids,
+                            borrowed_preexisting,
+                            definition,
+                        )
+                        .await
+                    }
+                    WorkflowStepDef::ToolStep {
+                        tool,
+                        params,
+                        timeout_seconds,
+                        ..
+                    } => {
+                        // Pre-resolve `${{ … }}` refs via the iteration
+                        // context (covers trigger/steps/iter/iteration).
+                        // Then call `execute_tool_step` with empty
+                        // trigger/steps maps so its own substitution
+                        // pass is a no-op on the already-resolved tree.
+                        let resolved = match ictx.substitute(params) {
+                            Ok(v) => v,
+                            Err(e) => {
+                                let err = WorkflowError::InvalidTemplateRef(e.to_string());
+                                if run
+                                    .step_errored(dotted_name.clone(), err.to_string())
+                                    .did_execute()
+                                {
+                                    self.runs.update(run).await?;
+                                }
+                                return Err(err);
+                            }
+                        };
+                        let empty_outputs: HashMap<String, serde_json::Value> = HashMap::new();
+                        let empty_trigger = serde_json::Value::Null;
+                        self.execute_tool_step(
+                            project_id,
+                            workflow_id,
+                            run_id,
+                            &dotted_name,
+                            tool,
+                            &resolved,
+                            *timeout_seconds,
+                            &empty_trigger,
+                            &empty_outputs,
+                        )
+                        .await
+                    }
+                    WorkflowStepDef::Wait { .. } | WorkflowStepDef::Loop { .. } => unreachable!(
+                        "Wait handled via park-and-return; nested Loop rejected at validate time"
+                    ),
+                };
+
+                match result {
+                    Ok(output) => {
+                        if run.step_completed(dotted_name, output).did_execute() {
+                            self.runs.update(run).await?;
+                        }
+                    }
+                    Err(err) => {
+                        if run.step_errored(dotted_name, err.to_string()).did_execute() {
+                            self.runs.update(run).await?;
+                        }
+                        return Err(err);
+                    }
+                }
+            }
+
+            // All inner steps for this iteration complete. Evaluate
+            // break_condition against the now-finalized iter map.
+            let outer_step_outputs = collect_step_outputs(&run.step_results);
+            let inner_outputs =
+                collect_inner_iter_outputs(&run.step_results, &loop_name, iteration);
+            let ictx = IterationContext {
+                trigger: trigger_context,
+                steps: &outer_step_outputs,
+                iter: &inner_outputs,
+                iteration,
+            };
+            let broke = match ictx.evaluate_condition(&break_condition) {
+                Ok(ConditionOutcome::True) => true,
+                Ok(ConditionOutcome::False) => false,
+                Ok(ConditionOutcome::NotBoolean(rendered)) => {
+                    return Err(WorkflowError::ConditionNotBoolean {
+                        step: loop_name.clone(),
+                        body: break_condition.clone(),
+                        value: rendered,
+                    });
+                }
+                Err(e) => {
+                    return Err(WorkflowError::InvalidCondition(format!(
+                        "loop '{loop_name}' break_condition: {e}"
+                    )));
+                }
+            };
+
+            if run
+                .loop_iteration_completed(loop_name.clone(), iteration, broke)
+                .did_execute()
+            {
+                self.runs.update(run).await?;
+            }
+
+            if broke {
+                let iters = run.loop_iterations_so_far(&loop_name);
+                return Ok(LoopOutcome::Completed(serde_json::json!({
+                    "success": true,
+                    "iterations": iters,
+                })));
+            }
+
+            iteration += 1;
         }
     }
 

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -184,6 +184,74 @@ fn reject_forward_step_refs(
     Ok(())
 }
 
+/// Resolve a `StepResult.name` back to its `WorkflowStepDef`.
+/// Top-level names match directly; loop-scoped names of the form
+/// `{loop_name}.iter[{N}].{inner_name}` recurse into the matching
+/// Loop's inner `steps` and return the inner def. `None` if no
+/// match found (e.g. the snapshot was edited after the run started
+/// — should not happen since snapshots are immutable per run).
+fn lookup_wait_step_def<'a>(
+    steps: &'a [WorkflowStepDef],
+    name: &str,
+) -> Option<&'a WorkflowStepDef> {
+    // Fast path: top-level match.
+    if let Some(s) = steps.iter().find(|s| s.name() == name) {
+        return Some(s);
+    }
+    // Dotted-name path: `{loop}.iter[{N}].{inner}`.
+    let dot_iter = ".iter[";
+    let dot_iter_idx = name.find(dot_iter)?;
+    let outer_name = &name[..dot_iter_idx];
+    let after = &name[dot_iter_idx + dot_iter.len()..];
+    let bracket_end = after.find("].")?;
+    let inner_name = &after[bracket_end + "].".len()..];
+    let outer = steps.iter().find(|s| s.name() == outer_name)?;
+    if let WorkflowStepDef::Loop {
+        steps: inner_steps, ..
+    } = outer
+    {
+        return inner_steps.iter().find(|s| s.name() == inner_name);
+    }
+    None
+}
+
+/// Forward-ref checks for a parsed iteration-scope expression
+/// (`break_condition` or any inner step's body/condition). Splits
+/// the two distinct namespaces: `steps.<X>` must be a pre-loop outer
+/// step (in `outer_seen`), `iter.<X>` must be an inner loop step (in
+/// `inner_seen`). Caller is responsible for running the
+/// root-validate step first (the parse_iteration_* helpers do that).
+fn validate_loop_iteration_ref(
+    loop_name: &str,
+    r: &TemplateRef,
+    outer_seen: &std::collections::HashSet<String>,
+    inner_seen: &std::collections::HashSet<String>,
+) -> Result<(), WorkflowError> {
+    for target in template::referenced_step_names(r) {
+        if !outer_seen.contains(&target) {
+            return Err(WorkflowError::InvalidLoop {
+                step: loop_name.to_string(),
+                reason: format!(
+                    "{} references step '{target}' which is not declared earlier in the workflow",
+                    r.raw
+                ),
+            });
+        }
+    }
+    for target in template::referenced_iter_names(r) {
+        if !inner_seen.contains(&target) {
+            return Err(WorkflowError::InvalidLoop {
+                step: loop_name.to_string(),
+                reason: format!(
+                    "{} references iter.{target} which is not a declared inner step of this loop",
+                    r.raw
+                ),
+            });
+        }
+    }
+    Ok(())
+}
+
 fn validate_ref_against_prior_steps(
     step_name: &str,
     r: &TemplateRef,
@@ -532,6 +600,76 @@ impl Workflows {
                         validate_ref_against_prior_steps(name, r, &seen_step_names)?;
                     }
                 }
+                WorkflowStepDef::Loop {
+                    name,
+                    break_condition,
+                    max_iterations,
+                    steps: inner_steps,
+                    ..
+                } => {
+                    if *max_iterations == 0 {
+                        return Err(WorkflowError::InvalidLoop {
+                            step: name.clone(),
+                            reason: "max_iterations must be >= 1".into(),
+                        });
+                    }
+                    if inner_steps.is_empty() {
+                        return Err(WorkflowError::InvalidLoop {
+                            step: name.clone(),
+                            reason: "steps must contain at least one inner step".into(),
+                        });
+                    }
+                    // Eagerly reject nested loops here so the per-inner
+                    // arm doesn't have to special-case the variant.
+                    for inner in inner_steps {
+                        if matches!(inner, WorkflowStepDef::Loop { .. }) {
+                            return Err(WorkflowError::InvalidLoop {
+                                step: name.clone(),
+                                reason: format!(
+                                    "nested loops are not supported (inner step '{}')",
+                                    inner.name()
+                                ),
+                            });
+                        }
+                    }
+                    // Inner step name set — needed to forward-ref-check
+                    // `iter.<X>` references and to enforce
+                    // CEL-identifier shape per inner step name.
+                    let mut inner_names: std::collections::HashSet<String> =
+                        std::collections::HashSet::new();
+                    for inner in inner_steps {
+                        if !is_cel_identifier(inner.name()) {
+                            return Err(WorkflowError::InvalidStep(format!(
+                                "loop '{name}' inner step '{}': name must be a CEL identifier",
+                                inner.name()
+                            )));
+                        }
+                        inner_names.insert(inner.name().to_string());
+                    }
+                    // `break_condition` runs after every iteration's
+                    // last inner step, so all inner names are in scope.
+                    let r = template::parse_iteration_condition(break_condition).map_err(|e| {
+                        WorkflowError::InvalidLoop {
+                            step: name.clone(),
+                            reason: format!("break_condition: {e}"),
+                        }
+                    })?;
+                    validate_loop_iteration_ref(name, &r, &seen_step_names, &inner_names)?;
+                    self.validate_loop_inner_steps(
+                        sub,
+                        project_id,
+                        name,
+                        inner_steps,
+                        sandboxes,
+                        &decl_names,
+                        &preexisting_ids,
+                        &seen_step_names,
+                        &inner_names,
+                        &mut missing_skills,
+                        &mut undeclared_sandboxes,
+                    )
+                    .await?;
+                }
             }
             seen_step_names.insert(step.name().to_string());
         }
@@ -556,6 +694,134 @@ impl Workflows {
                 "{listed}. Add each name to the workflow's top-level `sandboxes` declarations"
             )));
         }
+        Ok(())
+    }
+
+    /// Inner-step validator for a `Loop`. Mirrors the per-variant
+    /// validation in `validate_steps`, but with iteration-scope
+    /// expression parsers (`iter` / `iteration` accepted) and dual
+    /// forward-ref scoping (`steps.X` against `outer_seen`, `iter.X`
+    /// against the running `inner_seen_so_far` — same "must be
+    /// earlier in this loop body" rule, scoped to the loop).
+    #[allow(clippy::too_many_arguments)]
+    async fn validate_loop_inner_steps(
+        &self,
+        _sub: &AuthSubject,
+        project_id: ProjectId,
+        loop_name: &str,
+        inner_steps: &[WorkflowStepDef],
+        _sandboxes: &[WorkflowSandboxDecl],
+        decl_names: &std::collections::HashSet<&str>,
+        preexisting_ids: &std::collections::HashMap<String, SandboxId>,
+        outer_seen: &std::collections::HashSet<String>,
+        inner_names: &std::collections::HashSet<String>,
+        missing_skills: &mut Vec<(String, String)>,
+        undeclared_sandboxes: &mut Vec<(String, String)>,
+    ) -> Result<(), WorkflowError> {
+        let mut inner_seen_so_far: std::collections::HashSet<String> =
+            std::collections::HashSet::new();
+        for inner in inner_steps {
+            if let Some(body) = inner.condition() {
+                let r = template::parse_iteration_condition(body).map_err(|e| {
+                    WorkflowError::InvalidLoop {
+                        step: loop_name.to_string(),
+                        reason: format!("inner step '{}': condition: {e}", inner.name()),
+                    }
+                })?;
+                validate_loop_iteration_ref(loop_name, &r, outer_seen, &inner_seen_so_far)?;
+            }
+            match inner {
+                WorkflowStepDef::AgentStep {
+                    name,
+                    skill,
+                    sandbox,
+                    ..
+                } => {
+                    let preexisting_sandbox_id = sandbox
+                        .as_deref()
+                        .and_then(|n| preexisting_ids.get(n).copied());
+                    let found = self
+                        .skills
+                        .find_by_name(skill, Some(project_id), preexisting_sandbox_id)
+                        .await
+                        .map_err(|e| WorkflowError::Skill(e.to_string()))?;
+                    if found.is_none() {
+                        missing_skills.push((format!("{loop_name}.{}", name), skill.clone()));
+                    }
+                    if let Some(sandbox_name) = sandbox {
+                        if !decl_names.contains(sandbox_name.as_str()) {
+                            undeclared_sandboxes
+                                .push((format!("{loop_name}.{}", name), sandbox_name.clone()));
+                        }
+                    }
+                }
+                WorkflowStepDef::Wait {
+                    name,
+                    provider,
+                    resume_condition,
+                    outputs,
+                    ..
+                } => {
+                    if provider.is_empty() {
+                        return Err(WorkflowError::InvalidStep(format!(
+                            "loop '{loop_name}' wait step '{name}': `provider` must be a non-empty string"
+                        )));
+                    }
+                    let r = template::parse_resume_iteration_condition(resume_condition.trim())
+                        .map_err(|e| WorkflowError::InvalidLoop {
+                            step: loop_name.to_string(),
+                            reason: format!("wait step '{name}': resume_condition: {e}"),
+                        })?;
+                    validate_loop_iteration_ref(loop_name, &r, outer_seen, &inner_seen_so_far)?;
+                    for (key, expr) in outputs {
+                        let r = template::parse_resume_iteration_condition(expr.trim()).map_err(
+                            |e| WorkflowError::InvalidLoop {
+                                step: loop_name.to_string(),
+                                reason: format!("wait step '{name}': outputs.{key}: {e}"),
+                            },
+                        )?;
+                        validate_loop_iteration_ref(loop_name, &r, outer_seen, &inner_seen_so_far)?;
+                    }
+                }
+                WorkflowStepDef::ToolStep {
+                    name, tool, params, ..
+                } => {
+                    self.toolsets.find_for_workflow(tool).map_err(|e| {
+                        WorkflowError::InvalidStep(format!(
+                            "loop '{loop_name}' tool_step '{name}': {e}"
+                        ))
+                    })?;
+                    let refs = template::extract_refs_in_value(params).map_err(|e| {
+                        WorkflowError::InvalidTemplateRef(format!(
+                            "loop '{loop_name}' tool_step '{name}': {e}"
+                        ))
+                    })?;
+                    for r in &refs {
+                        template::validate_iteration_root(r).map_err(|e| {
+                            WorkflowError::InvalidLoop {
+                                step: loop_name.to_string(),
+                                reason: format!("tool_step '{name}': {e}"),
+                            }
+                        })?;
+                        validate_loop_iteration_ref(loop_name, r, outer_seen, &inner_seen_so_far)?;
+                    }
+                }
+                WorkflowStepDef::Loop { .. } => {
+                    // Pre-screened in the outer arm. Defensive
+                    // guard so a future refactor can't silently
+                    // permit nested loops.
+                    return Err(WorkflowError::InvalidLoop {
+                        step: loop_name.to_string(),
+                        reason: format!(
+                            "nested loops are not supported (inner step '{}')",
+                            inner.name()
+                        ),
+                    });
+                }
+            }
+            inner_seen_so_far.insert(inner.name().to_string());
+        }
+        let _ = inner_names; // reserved for richer error messages
         Ok(())
     }
 
@@ -953,10 +1219,7 @@ impl Workflows {
                     None => continue,
                 };
 
-                let wait_def = run
-                    .steps_snapshot
-                    .iter()
-                    .find(|s| s.name() == wait_step_name);
+                let wait_def = lookup_wait_step_def(&run.steps_snapshot, &wait_step_name);
 
                 let (step_provider, resume_condition, outputs) = match wait_def {
                     Some(WorkflowStepDef::Wait {
@@ -1369,5 +1632,50 @@ mod tests {
         assert!(!is_cel_identifier("1step"));
         assert!(!is_cel_identifier("has space"));
         assert!(!is_cel_identifier("dot.in.middle"));
+    }
+
+    // ── Loop-step dotted-name lookup ──
+
+    fn wait_step(name: &str) -> WorkflowStepDef {
+        WorkflowStepDef::Wait {
+            name: name.into(),
+            provider: "github_app".into(),
+            resume_condition: "true".into(),
+            outputs: Default::default(),
+            condition: None,
+        }
+    }
+
+    fn loop_with(name: &str, inner: Vec<WorkflowStepDef>) -> WorkflowStepDef {
+        WorkflowStepDef::Loop {
+            name: name.into(),
+            break_condition: "true".into(),
+            max_iterations: 5,
+            steps: inner,
+            condition: None,
+        }
+    }
+
+    #[test]
+    fn lookup_wait_step_def_finds_top_level_wait() {
+        let snapshot = vec![wait_step("approval")];
+        let found = lookup_wait_step_def(&snapshot, "approval").unwrap();
+        assert_eq!(found.name(), "approval");
+    }
+
+    #[test]
+    fn lookup_wait_step_def_finds_dotted_inner_wait() {
+        let snapshot = vec![loop_with("review_cycle", vec![wait_step("await_review")])];
+        let found = lookup_wait_step_def(&snapshot, "review_cycle.iter[3].await_review").unwrap();
+        assert!(matches!(found, WorkflowStepDef::Wait { .. }));
+        assert_eq!(found.name(), "await_review");
+    }
+
+    #[test]
+    fn lookup_wait_step_def_returns_none_for_unknown() {
+        let snapshot = vec![loop_with("review_cycle", vec![wait_step("await_review")])];
+        assert!(lookup_wait_step_def(&snapshot, "review_cycle.iter[1].nope").is_none());
+        assert!(lookup_wait_step_def(&snapshot, "missing.iter[1].x").is_none());
+        assert!(lookup_wait_step_def(&snapshot, "not_dotted").is_none());
     }
 }

--- a/core/src/workflow/run/entity.rs
+++ b/core/src/workflow/run/entity.rs
@@ -138,6 +138,28 @@ pub enum WorkflowRunEvent {
         source: String,
         resumed_at: DateTime<Utc>,
     },
+    /// Emitted at the start of each iteration of a `Loop` step.
+    /// `iteration` is 1-based. Inner steps in this iteration record
+    /// themselves under dotted names like
+    /// `{step_name}.iter[{iteration}].{inner_name}`.
+    LoopIterationStarted {
+        step_name: String,
+        iteration: u32,
+        started_at: DateTime<Utc>,
+    },
+    /// Emitted when an iteration's last inner step finishes, before
+    /// the next iteration starts (or before the outer loop's
+    /// `StepCompleted` if `broke` is true / `max_iterations` exhausted).
+    LoopIterationCompleted {
+        step_name: String,
+        iteration: u32,
+        /// `true` → this iteration's `break_condition` evaluated to
+        /// true; the loop terminates here. `false` → the loop will
+        /// move to iteration+1 (or terminate via max-iterations
+        /// exhaustion, recorded on the outer step's `StepCompleted`).
+        broke: bool,
+        completed_at: DateTime<Utc>,
+    },
     RunCompleted {
         state: WorkflowRunState,
         completed_at: DateTime<Utc>,
@@ -387,6 +409,153 @@ impl WorkflowRun {
         Idempotent::Executed(())
     }
 
+    /// Records the start of a `Loop` step's iteration. Driven by the
+    /// executor before it begins running that iteration's inner
+    /// steps. Idempotent: replaying the same `(step_name, iteration)`
+    /// pair is a no-op so at-least-once job retries are safe.
+    pub fn loop_iteration_started(&mut self, step_name: String, iteration: u32) -> Idempotent<()> {
+        idempotency_guard!(
+            self.events.iter_all().rev(),
+            already_applied:
+                WorkflowRunEvent::LoopIterationStarted { step_name: n, iteration: i, .. }
+                    if n == &step_name && *i == iteration,
+        );
+        let now = Utc::now();
+        if self.state == WorkflowRunState::Pending {
+            self.state = WorkflowRunState::Running;
+        }
+        self.events.push(WorkflowRunEvent::LoopIterationStarted {
+            step_name,
+            iteration,
+            started_at: now,
+        });
+        Idempotent::Executed(())
+    }
+
+    /// Records the end of a `Loop` step's iteration after its
+    /// `break_condition` has been evaluated. `broke == true` →
+    /// the executor exits the loop here. Idempotent on
+    /// `(step_name, iteration)`.
+    pub fn loop_iteration_completed(
+        &mut self,
+        step_name: String,
+        iteration: u32,
+        broke: bool,
+    ) -> Idempotent<()> {
+        idempotency_guard!(
+            self.events.iter_all().rev(),
+            already_applied:
+                WorkflowRunEvent::LoopIterationCompleted { step_name: n, iteration: i, .. }
+                    if n == &step_name && *i == iteration,
+        );
+        let now = Utc::now();
+        self.events.push(WorkflowRunEvent::LoopIterationCompleted {
+            step_name,
+            iteration,
+            broke,
+            completed_at: now,
+        });
+        Idempotent::Executed(())
+    }
+
+    /// Highest iteration of a Loop step for which `LoopIterationStarted`
+    /// has been emitted. `0` → no iteration has begun yet. Used by the
+    /// executor on resume to pick up where the previous attempt left off.
+    pub fn loop_current_iteration(&self, step_name: &str) -> u32 {
+        let mut max = 0u32;
+        for ev in self.events.iter_all() {
+            if let WorkflowRunEvent::LoopIterationStarted {
+                step_name: n,
+                iteration,
+                ..
+            } = ev
+            {
+                if n == step_name && *iteration > max {
+                    max = *iteration;
+                }
+            }
+        }
+        max
+    }
+
+    /// True once `LoopIterationCompleted { broke: true }` has been
+    /// emitted for this loop step OR the outer step itself has
+    /// reached a terminal state. The executor uses this to short-
+    /// circuit the inner iteration loop on resume.
+    pub fn loop_broke(&self, step_name: &str) -> bool {
+        for ev in self.events.iter_all() {
+            if let WorkflowRunEvent::LoopIterationCompleted {
+                step_name: n,
+                broke,
+                ..
+            } = ev
+            {
+                if n == step_name && *broke {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// All `LoopIterationCompleted` outputs collected from the
+    /// recorded inner step results. Used to populate the `iterations`
+    /// CEL binding and to compute the outer loop's `StepResult.output`.
+    pub fn loop_iterations_so_far(&self, step_name: &str) -> Vec<serde_json::Value> {
+        let mut by_iter: std::collections::BTreeMap<
+            u32,
+            serde_json::Map<String, serde_json::Value>,
+        > = std::collections::BTreeMap::new();
+        let prefix = format!("{step_name}.iter[");
+        for r in &self.step_results {
+            if !r.name.starts_with(&prefix) {
+                continue;
+            }
+            // `{step}.iter[{N}].{inner}` — extract N and inner
+            let after = &r.name[prefix.len()..];
+            let Some(close_idx) = after.find(']') else {
+                continue;
+            };
+            let Ok(iteration) = after[..close_idx].parse::<u32>() else {
+                continue;
+            };
+            // Skip the leading "]." then take the remainder
+            let inner = match after.get(close_idx + 2..) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            let inner_output = r.output.clone().unwrap_or(serde_json::Value::Null);
+            by_iter
+                .entry(iteration)
+                .or_default()
+                .insert(inner, inner_output);
+        }
+        let broke_map: std::collections::HashMap<u32, bool> = self
+            .events
+            .iter_all()
+            .filter_map(|ev| match ev {
+                WorkflowRunEvent::LoopIterationCompleted {
+                    step_name: n,
+                    iteration,
+                    broke,
+                    ..
+                } if n == step_name => Some((*iteration, *broke)),
+                _ => None,
+            })
+            .collect();
+        by_iter
+            .into_iter()
+            .map(|(iteration, steps)| {
+                let broke = broke_map.get(&iteration).copied().unwrap_or(false);
+                serde_json::json!({
+                    "iteration": iteration,
+                    "steps": serde_json::Value::Object(steps),
+                    "broke": broke,
+                })
+            })
+            .collect()
+    }
+
     /// Transitions Running → WaitingForEvent when the executor
     /// reaches a Wait step.
     pub fn step_waiting(&mut self, step_name: String, provider: String) -> Idempotent<()> {
@@ -588,6 +757,12 @@ impl TryFromEvents<WorkflowRunEvent> for WorkflowRun {
                             waiting_provider: None,
                         });
                     }
+                }
+                WorkflowRunEvent::LoopIterationStarted { .. } => {
+                    state = WorkflowRunState::Running;
+                }
+                WorkflowRunEvent::LoopIterationCompleted { .. } => {
+                    state = WorkflowRunState::Running;
                 }
                 WorkflowRunEvent::StepWaiting {
                     step_name,
@@ -1252,5 +1427,173 @@ mod tests {
             waiting_provider: Some("github_app".into()),
         };
         assert_eq!(sr.step_state(), WorkflowStepState::WaitingForEvent);
+    }
+
+    // ── Loop step tests ──
+
+    #[test]
+    fn loop_iteration_started_event_wire_format() {
+        let ev = WorkflowRunEvent::LoopIterationStarted {
+            step_name: "review_cycle".into(),
+            iteration: 1,
+            started_at: Utc::now(),
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(
+            v.get("type").and_then(|t| t.as_str()),
+            Some("loop_iteration_started")
+        );
+        assert_eq!(v.get("iteration").and_then(|i| i.as_u64()), Some(1));
+    }
+
+    #[test]
+    fn loop_iteration_completed_event_wire_format() {
+        let ev = WorkflowRunEvent::LoopIterationCompleted {
+            step_name: "review_cycle".into(),
+            iteration: 2,
+            broke: true,
+            completed_at: Utc::now(),
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(
+            v.get("type").and_then(|t| t.as_str()),
+            Some("loop_iteration_completed")
+        );
+        assert_eq!(v.get("broke").and_then(|b| b.as_bool()), Some(true));
+        assert_eq!(v.get("iteration").and_then(|i| i.as_u64()), Some(2));
+    }
+
+    #[test]
+    fn loop_iteration_started_is_idempotent_per_iteration() {
+        let mut run = fresh_run(&["loop_step"]);
+        run.loop_iteration_started("loop_step".into(), 1)
+            .did_execute();
+        let outcome = run.loop_iteration_started("loop_step".into(), 1);
+        assert!(matches!(outcome, Idempotent::AlreadyApplied));
+        // Next iteration is not blocked.
+        run.loop_iteration_started("loop_step".into(), 2)
+            .did_execute();
+        assert_eq!(run.loop_current_iteration("loop_step"), 2);
+    }
+
+    #[test]
+    fn loop_iteration_completed_is_idempotent_per_iteration() {
+        let mut run = fresh_run(&["loop_step"]);
+        run.loop_iteration_started("loop_step".into(), 1)
+            .did_execute();
+        run.loop_iteration_completed("loop_step".into(), 1, false)
+            .did_execute();
+        let outcome = run.loop_iteration_completed("loop_step".into(), 1, false);
+        assert!(matches!(outcome, Idempotent::AlreadyApplied));
+    }
+
+    #[test]
+    fn loop_current_iteration_returns_highest_started() {
+        let mut run = fresh_run(&["loop_step"]);
+        assert_eq!(run.loop_current_iteration("loop_step"), 0);
+        run.loop_iteration_started("loop_step".into(), 1)
+            .did_execute();
+        assert_eq!(run.loop_current_iteration("loop_step"), 1);
+        run.loop_iteration_started("loop_step".into(), 2)
+            .did_execute();
+        assert_eq!(run.loop_current_iteration("loop_step"), 2);
+    }
+
+    #[test]
+    fn loop_broke_is_false_until_broke_event_recorded() {
+        let mut run = fresh_run(&["loop_step"]);
+        assert!(!run.loop_broke("loop_step"));
+        run.loop_iteration_started("loop_step".into(), 1)
+            .did_execute();
+        run.loop_iteration_completed("loop_step".into(), 1, false)
+            .did_execute();
+        assert!(!run.loop_broke("loop_step"));
+        run.loop_iteration_started("loop_step".into(), 2)
+            .did_execute();
+        run.loop_iteration_completed("loop_step".into(), 2, true)
+            .did_execute();
+        assert!(run.loop_broke("loop_step"));
+    }
+
+    #[test]
+    fn loop_events_hydrate_with_running_state() {
+        let mut run = fresh_run(&["loop_step"]);
+        run.loop_iteration_started("loop_step".into(), 1)
+            .did_execute();
+        run.loop_iteration_completed("loop_step".into(), 1, true)
+            .did_execute();
+        let events = run.events;
+        let rehydrated = WorkflowRun::try_from_events(events).unwrap();
+        assert_eq!(rehydrated.state, WorkflowRunState::Running);
+        assert_eq!(rehydrated.loop_current_iteration("loop_step"), 1);
+        assert!(rehydrated.loop_broke("loop_step"));
+    }
+
+    /// End-to-end: a Loop step over two iterations. Inner step
+    /// records use the dotted-name shape produced by the executor
+    /// (`{loop}.iter[{N}].{inner}`). After completion,
+    /// `loop_iterations_so_far` returns one row per iteration with
+    /// each inner step's output keyed by its inner name and the
+    /// `broke` flag from the corresponding `LoopIterationCompleted`
+    /// event. Mirrors what the executor builds at break_condition
+    /// time and what the outer `StepResult.output` would surface.
+    #[test]
+    fn loop_iterations_so_far_aggregates_two_iterations() {
+        let mut run = fresh_run(&["review"]);
+        // Outer step starts
+        run.step_started("review".into()).did_execute();
+        // Iteration 1
+        run.loop_iteration_started("review".into(), 1).did_execute();
+        run.step_started("review.iter[1].check".into())
+            .did_execute();
+        run.step_completed("review.iter[1].check".into(), json!({ "merged": false }))
+            .did_execute();
+        run.loop_iteration_completed("review".into(), 1, false)
+            .did_execute();
+        // Iteration 2 — break
+        run.loop_iteration_started("review".into(), 2).did_execute();
+        run.step_started("review.iter[2].check".into())
+            .did_execute();
+        run.step_completed("review.iter[2].check".into(), json!({ "merged": true }))
+            .did_execute();
+        run.loop_iteration_completed("review".into(), 2, true)
+            .did_execute();
+
+        let iters = run.loop_iterations_so_far("review");
+        assert_eq!(iters.len(), 2);
+        assert_eq!(iters[0]["iteration"], json!(1));
+        assert_eq!(iters[0]["broke"], json!(false));
+        assert_eq!(iters[0]["steps"]["check"], json!({ "merged": false }));
+        assert_eq!(iters[1]["iteration"], json!(2));
+        assert_eq!(iters[1]["broke"], json!(true));
+        assert_eq!(iters[1]["steps"]["check"], json!({ "merged": true }));
+        assert!(run.loop_broke("review"));
+    }
+
+    /// Inner Wait inside Loop parks the run. The waiting step's
+    /// name is the dotted form, so a resume that targets it must
+    /// resolve back through the Loop's `steps` to find the def
+    /// (covered by `lookup_wait_step_def` in mod.rs tests).
+    /// Confirms the run state machine here: park flips to
+    /// `WaitingForEvent`, resume flips back to `Running`.
+    #[test]
+    fn loop_inner_wait_parks_and_resumes_via_dotted_name() {
+        let mut run = fresh_run(&["review"]);
+        run.step_started("review".into()).did_execute();
+        run.loop_iteration_started("review".into(), 1).did_execute();
+        run.step_waiting("review.iter[1].await_review".into(), "github_app".into())
+            .did_execute();
+        assert_eq!(run.state, WorkflowRunState::WaitingForEvent);
+        let ws = run.current_wait_step().expect("waiting step");
+        assert_eq!(ws.name, "review.iter[1].await_review");
+        assert_eq!(ws.waiting_provider.as_deref(), Some("github_app"));
+
+        run.step_resumed(
+            "review.iter[1].await_review".into(),
+            json!({ "action": "approved" }),
+            "provider:github_app".into(),
+        )
+        .did_execute();
+        assert_eq!(run.state, WorkflowRunState::Running);
     }
 }

--- a/core/src/workflow/template.rs
+++ b/core/src/workflow/template.rs
@@ -234,6 +234,62 @@ impl BuiltResumeContext {
     }
 }
 
+/// Evaluation context for `break_condition` and for inner-step
+/// `condition:` / `params` substitution inside a `Loop` step. Binds
+/// `iter` (this iteration's already-completed inner step outputs)
+/// and `iteration` (1-based count) alongside the usual `trigger` and
+/// `steps` (pre-loop outer outputs only — inner siblings live under
+/// `iter`).
+pub struct IterationContext<'a> {
+    pub trigger: &'a Value,
+    pub steps: &'a std::collections::HashMap<String, Value>,
+    /// Per-iteration outputs keyed by inner step name. Wrapped under
+    /// `outputs` exactly like `steps.<name>.outputs.X` so authors who
+    /// already know the `steps` shape pick up `iter` for free.
+    pub iter: &'a std::collections::HashMap<String, Value>,
+    pub iteration: u32,
+}
+
+impl IterationContext<'_> {
+    fn build_cel_context(&self) -> Result<BuiltContext, TemplateError> {
+        let mut cel = build_base_cel_context(self.trigger, self.steps)?;
+        let iter_value = Value::Object(
+            self.iter
+                .iter()
+                .map(|(k, v)| {
+                    let mut wrapper = serde_json::Map::with_capacity(1);
+                    wrapper.insert("outputs".to_string(), v.clone());
+                    (k.clone(), Value::Object(wrapper))
+                })
+                .collect(),
+        );
+        cel.add_variable("iter", iter_value)
+            .map_err(|e| TemplateError::Resolve("<context>".to_string(), format!("iter: {e}")))?;
+        // CEL evaluates ints as i64; `iteration` is u32 in the runtime
+        // but fits trivially.
+        cel.add_variable("iteration", Value::from(self.iteration as i64))
+            .map_err(|e| {
+                TemplateError::Resolve("<context>".to_string(), format!("iteration: {e}"))
+            })?;
+        Ok(BuiltContext { cel })
+    }
+
+    pub fn evaluate_condition(&self, body: &str) -> Result<ConditionOutcome, TemplateError> {
+        let built = self.build_cel_context()?;
+        evaluate_condition_with_built(&built, body)
+    }
+
+    pub fn substitute(&self, value: &Value) -> Result<Value, TemplateError> {
+        let built = self.build_cel_context()?;
+        substitute_value_with_built(value, &built)
+    }
+
+    pub fn substitute_in_string(&self, s: &str) -> Result<String, TemplateError> {
+        let built = self.build_cel_context()?;
+        substitute_in_string_with_built(s, &built)
+    }
+}
+
 fn evaluate_extract_with_built(built: &BuiltContext, expr: &str) -> Result<Value, TemplateError> {
     let trimmed = expr.trim();
     let raw = format!("{OPEN} {trimmed} {CLOSE}");
@@ -358,6 +414,26 @@ pub fn validate_resume_root(r: &TemplateRef) -> Result<(), TemplateError> {
     validate_root_inner(r, &["trigger", "steps", "resume_payload"])
 }
 
+pub fn validate_iteration_root(r: &TemplateRef) -> Result<(), TemplateError> {
+    validate_root_inner(r, &["trigger", "steps", "iter", "iteration"])
+}
+
+pub fn validate_resume_iteration_root(r: &TemplateRef) -> Result<(), TemplateError> {
+    validate_root_inner(
+        r,
+        &["trigger", "steps", "resume_payload", "iter", "iteration"],
+    )
+}
+
+/// Wait step inside a Loop: `resume_condition` / `outputs` may
+/// reference both `resume_payload` (inbound webhook) and
+/// `iter.<sibling>.outputs.…` (same iteration's prior inner steps).
+pub fn parse_resume_iteration_condition(body: &str) -> Result<TemplateRef, TemplateError> {
+    let r = parse_path(body)?;
+    validate_resume_iteration_root(&r)?;
+    Ok(r)
+}
+
 /// Compile-time parse + root validation for a wait step
 /// `resume_condition`. Like [`parse_condition`] but additionally
 /// allows `resume_payload` as a root.
@@ -365,6 +441,36 @@ pub fn parse_resume_condition(body: &str) -> Result<TemplateRef, TemplateError> 
     let r = parse_path(body)?;
     validate_resume_root(&r)?;
     Ok(r)
+}
+
+/// Compile-time parse + root validation for a `break_condition:` or
+/// an inner-step `condition:` inside a `Loop`. Accepts `iter` and
+/// `iteration` in addition to the usual roots.
+pub fn parse_iteration_condition(body: &str) -> Result<TemplateRef, TemplateError> {
+    let r = parse_path(body)?;
+    validate_iteration_root(&r)?;
+    Ok(r)
+}
+
+/// Names of every inner step referenced via `iter.<name>` in the
+/// expression body. Mirror of [`referenced_step_names`] for the
+/// per-iteration namespace; same identifier shape, same hyphen
+/// caveat.
+pub fn referenced_iter_names(r: &TemplateRef) -> Vec<String> {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    let re = RE.get_or_init(|| Regex::new(r"\biter\.([A-Za-z_][A-Za-z0-9_]*)").unwrap());
+    let mut out: Vec<String> = Vec::new();
+    let mut seen = HashSet::new();
+    for cap in re.captures_iter(&r.body) {
+        let name = cap
+            .get(1)
+            .map(|m| m.as_str().to_string())
+            .unwrap_or_default();
+        if seen.insert(name.clone()) {
+            out.push(name);
+        }
+    }
+    out
 }
 
 /// Names of every step referenced via `steps.<name>` in the
@@ -1204,6 +1310,93 @@ mod tests {
     /// at create time, so this case is unreachable in practice —
     /// the test pins the narrow extraction behaviour as a
     /// belt-and-braces match against that validation contract.
+    #[test]
+    fn iteration_context_resolves_iter_outputs() {
+        let trigger = json!({});
+        let steps = std::collections::HashMap::new();
+        let mut iter_map = std::collections::HashMap::new();
+        iter_map.insert(
+            "check_pr".to_string(),
+            json!({ "merged": true, "title": "fix bug" }),
+        );
+        let ctx = IterationContext {
+            trigger: &trigger,
+            steps: &steps,
+            iter: &iter_map,
+            iteration: 2,
+        };
+        match ctx.evaluate_condition("iter.check_pr.outputs.merged == true") {
+            Ok(ConditionOutcome::True) => {}
+            other => panic!("expected True, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn iteration_context_iteration_count_visible() {
+        let trigger = json!({});
+        let steps = std::collections::HashMap::new();
+        let iter_map = std::collections::HashMap::new();
+        let ctx = IterationContext {
+            trigger: &trigger,
+            steps: &steps,
+            iter: &iter_map,
+            iteration: 5,
+        };
+        match ctx.evaluate_condition("iteration >= 5") {
+            Ok(ConditionOutcome::True) => {}
+            other => panic!("expected True, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn iteration_context_skipped_sibling_null_coalesces_to_false() {
+        // Inner sibling `foo` was skipped this iteration → executor
+        // collects it as `null`. CEL's `null.outputs.bar` quirk
+        // (same as `steps.<skipped>.outputs.X`) flattens the access
+        // to `false`, so a strict equality check evaluates to False
+        // without raising. The point: gated-out inner siblings
+        // don't blow up downstream conditions, they cascade as the
+        // path's natural falsy collapse.
+        let trigger = json!({});
+        let steps = std::collections::HashMap::new();
+        let mut iter_map = std::collections::HashMap::new();
+        iter_map.insert("foo".to_string(), Value::Null);
+        let ctx = IterationContext {
+            trigger: &trigger,
+            steps: &steps,
+            iter: &iter_map,
+            iteration: 1,
+        };
+        assert_eq!(
+            ctx.evaluate_condition("iter.foo.outputs.kind == 'autofix'")
+                .unwrap(),
+            ConditionOutcome::False
+        );
+    }
+
+    #[test]
+    fn parse_iteration_condition_accepts_iter_and_iteration() {
+        parse_iteration_condition("iter.check.outputs.merged == true").unwrap();
+        parse_iteration_condition("iteration > 3").unwrap();
+        parse_iteration_condition("trigger.payload.x == 'y'").unwrap();
+        parse_iteration_condition("steps.prior.outputs.kind == 'autofix'").unwrap();
+    }
+
+    #[test]
+    fn parse_iteration_condition_rejects_unknown_root() {
+        let err = parse_iteration_condition("resume_payload.x == 'y'").unwrap_err();
+        assert!(matches!(err, TemplateError::UnknownRoot(_, _)));
+    }
+
+    #[test]
+    fn referenced_iter_names_extracts_unique_ordered() {
+        let r = parse_path("iter.a.outputs.x && iter.b.outputs.y && iter.a.outputs.z").unwrap();
+        assert_eq!(
+            referenced_iter_names(&r),
+            vec!["a".to_string(), "b".to_string()]
+        );
+    }
+
     #[test]
     fn referenced_step_names_stops_at_hyphen() {
         // We can't `parse_path("steps.store-note.outputs.x")`

--- a/core/src/workflow/yaml.rs
+++ b/core/src/workflow/yaml.rs
@@ -264,6 +264,19 @@ enum WorkflowStepYaml {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         condition: Option<String>,
     },
+    Loop {
+        name: String,
+        break_condition: String,
+        #[serde(default = "default_loop_max_iterations_yaml")]
+        max_iterations: u32,
+        steps: Vec<WorkflowStepYaml>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        condition: Option<String>,
+    },
+}
+
+fn default_loop_max_iterations_yaml() -> u32 {
+    25
 }
 
 impl WorkflowStepYaml {
@@ -314,6 +327,19 @@ impl WorkflowStepYaml {
                 outputs: outputs.clone(),
                 condition: condition.clone(),
             },
+            WorkflowStepDef::Loop {
+                name,
+                break_condition,
+                max_iterations,
+                steps,
+                condition,
+            } => WorkflowStepYaml::Loop {
+                name: name.clone(),
+                break_condition: break_condition.clone(),
+                max_iterations: *max_iterations,
+                steps: steps.iter().map(WorkflowStepYaml::from_runtime).collect(),
+                condition: condition.clone(),
+            },
         }
     }
 
@@ -362,6 +388,22 @@ impl WorkflowStepYaml {
                 provider,
                 resume_condition,
                 outputs,
+                condition,
+            },
+            WorkflowStepYaml::Loop {
+                name,
+                break_condition,
+                max_iterations,
+                steps,
+                condition,
+            } => WorkflowStepDef::Loop {
+                name,
+                break_condition,
+                max_iterations,
+                steps: steps
+                    .into_iter()
+                    .map(WorkflowStepYaml::into_runtime)
+                    .collect(),
                 condition,
             },
         }

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -862,6 +862,7 @@ enum WorkflowStepState {
 
 enum WorkflowStepType {
 	AGENT_STEP
+	LOOP
 	TOOL_STEP
 	WAIT
 }

--- a/server/src/graphql/workflow.rs
+++ b/server/src/graphql/workflow.rs
@@ -224,6 +224,20 @@ impl From<&DomainWorkflowStepDef> for WorkflowStep {
                 output_schema: None,
                 outputs: serde_json::to_value(outputs).ok().map(Into::into),
             },
+            DomainWorkflowStepDef::Loop {
+                name, condition, ..
+            } => Self {
+                name: name.clone(),
+                step_type: WorkflowStepType::Loop,
+                skill: None,
+                tool: None,
+                sandbox: None,
+                sandbox_mode: None,
+                timeout_seconds: None,
+                condition: condition.clone(),
+                output_schema: None,
+                outputs: None,
+            },
         }
     }
 }
@@ -233,6 +247,7 @@ pub enum WorkflowStepType {
     AgentStep,
     ToolStep,
     Wait,
+    Loop,
 }
 
 #[derive(SimpleObject, Clone)]

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1835,6 +1835,14 @@ fn workflow_step_to_view(s: &domain::workflow::WorkflowStepDef) -> WorkflowStepV
             sandbox: None,
             timeout_seconds: None,
         },
+        domain::workflow::WorkflowStepDef::Loop { name, .. } => WorkflowStepView {
+            name: name.clone(),
+            step_type: "loop".to_string(),
+            skill: String::new(),
+            tool: None,
+            sandbox: None,
+            timeout_seconds: None,
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `WorkflowStepDef::Loop { name, break_condition, max_iterations, steps, condition }` — repeats inner steps until a CEL `break_condition` fires or `max_iterations` is exhausted. Driving use case: PR review cycles (Wait for review event → agent addresses feedback → check PR → loop back until merged).
- Inner step results use dotted names `{loop}.iter[{N}].{inner}` so existing `step_already_terminal` idempotency and `current_wait_step` resume routing keep working unchanged; a webhook resume targeting a wait inside a loop splits the dotted name back through the snapshot via the new `lookup_wait_step_def` helper.
- New `IterationContext` binds `iter.<inner>.outputs.X` (current iteration's already-completed siblings) and `iteration` (1-based) alongside the usual `trigger` and `steps`; validate-time forward-ref checks split the two namespaces (`steps.X` → pre-loop outer; `iter.X` → inner sibling earlier in the loop body).

## Design

- **Two new events** `LoopIterationStarted` + `LoopIterationCompleted { broke }`, idempotent on `(step_name, iteration)`, hydrate as Pending→Running transitions only.
- **`max_iterations` default 25** — mirrors LangGraph's `recursion_limit`. Exhaustion records outer step output `{success: false, reason, iterations}`, which folds into `WorkflowRunState::Failed` via the existing rollup. Break records `{success: true, iterations}`.
- **Executor** dispatches Loop via a dedicated `run_loop_step` returning `LoopOutcome::{Completed, Parked, Cancelled}`. `Parked` short-circuits identically to a top-level Wait. Inner AgentStep skill bodies template through `IterationContext::substitute_in_string`; inner ToolStep params are pre-resolved through `IterationContext::substitute` then handed to `execute_tool_step` with empty trigger/steps maps (no-op second pass).
- **Nested loops rejected at validate time.**

## Test plan

- [x] `cargo test --lib --all` — 534 (core) + the rest all green
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` — clean
- [x] `cargo check --all-targets` — clean
- [x] SDL regenerated via `make sdl-rust` (added `LOOP` to `WorkflowStepType` enum)
- [x] Round-trip serde tests for the variant + max_iterations default
- [x] Round-trip YAML tests for the variant
- [x] Event wire-format + idempotency tests for the two new events
- [x] Hydration test: loop events bring the run back to `Running` state
- [x] End-to-end entity test: two iterations with broke=true on second
- [x] Wait-inside-loop park + resume cycle test
- [x] `lookup_wait_step_def` covers top-level + dotted + missing cases
- [x] `IterationContext` tests: iter resolution, iteration counter, null-coalesce on skipped sibling
- [ ] Integration test against a live Postgres (requires DB setup; existing integration suite fails with `PoolTimedOut` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it extends the workflow execution engine with a new looping step type, new run events/state transitions, and new template evaluation/validation paths that affect resume/idempotency and failure handling.
> 
> **Overview**
> Adds a new workflow step type `loop` that repeatedly runs a sequence of inner steps until a CEL `break_condition` evaluates true or `max_iterations` is hit (default 25), exposing per-iteration outputs via `iter.<inner>.outputs.*` and `iteration`.
> 
> Implements executor/runtime support by recording inner step results under dotted names (`{loop}.iter[N].{inner}`), parking runs when an inner `wait` is reached, and emitting new run events for iteration start/completion; includes validation to prevent nested loops and to scope template refs correctly across `steps.*` vs `iter.*`.
> 
> Updates YAML/admin parsing, GraphQL/REST step type enums, and output formatting to surface the new `LOOP` step, plus targeted unit tests for serde/YAML round-trips, iteration context behavior, dotted-name wait lookup, and run hydration/idempotency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 406a1b1e40922cedba39ba761016d99657f6fd61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->