### PR TITLE
Expose GitHub review comment reply tool

### DIFF
--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -146,11 +146,12 @@ galoyAgents:
         toolPrefix: github_pr
         authMode: github_app
         category: source-control-write
-        categoryDescription: "GitHub PR mutations — create"
+        categoryDescription: "GitHub PR mutations — create, review, and inline comment replies"
         internalOnly: true
         allowedTools:
           - create_pull_request
           - pull_request_review_write
+          - add_reply_to_pull_request_comment
       - name: github_issues
         url: https://api.githubcopilot.com/mcp/
         toolPrefix: github_issues

--- a/drua.yml
+++ b/drua.yml
@@ -141,12 +141,14 @@ toolsets:
       url: https://api.githubcopilot.com/mcp/x/pull_requests
       tool_prefix: github_pr
       category: source-control-write
-      category_description: "GitHub PR mutations — create"
+      category_description: "GitHub PR mutations — create, review, and inline comment replies"
       # Hidden from non-agent subjects (Users, ExportedAgents, Anonymous).
       internal_only: true
-      # Minimal whitelist: only PR creation. `merge_pull_request` is
-      # deliberately excluded — the heal-flow guardrail forbids merges,
-      # and we don't want any agent flow ever discovering it.
+      # Minimal whitelist: PR creation, review submission, and inline review
+      # comment replies. `merge_pull_request` is deliberately excluded — the
+      # heal-flow guardrail forbids merges, and we don't want any agent flow
+      # ever discovering it.
       allowed_tools:
         - create_pull_request
         - pull_request_review_write
+        - add_reply_to_pull_request_comment

--- a/server/tests/config.rs
+++ b/server/tests/config.rs
@@ -1,0 +1,57 @@
+use std::path::PathBuf;
+
+use drua_server::config::{Config, EnvSecrets};
+
+const REVIEW_REPLY_TOOL: &str = "add_reply_to_pull_request_comment";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("server crate has repo parent")
+        .to_path_buf()
+}
+
+fn empty_secrets() -> EnvSecrets {
+    EnvSecrets {
+        pg_con: String::new(),
+        github_client_secret: String::new(),
+        github_allowed_teams: Vec::new(),
+        anthropic_api_key: String::new(),
+        openai_api_key: String::new(),
+    }
+}
+
+#[test]
+fn local_config_exposes_internal_github_review_comment_reply_tool() {
+    let config =
+        Config::try_new(repo_root().join("drua.yml"), empty_secrets(), &[]).expect("load drua.yml");
+
+    let upstream = config
+        .toolsets
+        .mcp_upstreams
+        .iter()
+        .find(|u| u.name == "github_pull_requests")
+        .expect("github_pull_requests upstream");
+
+    assert!(upstream.internal_only);
+    assert_eq!(upstream.tool_prefix.as_deref(), Some("github_pr"));
+    assert!(
+        upstream
+            .allowed_tools
+            .as_ref()
+            .is_some_and(|tools| tools.iter().any(|tool| tool == REVIEW_REPLY_TOOL)),
+        "{REVIEW_REPLY_TOOL} should be allowlisted for workflow agents"
+    );
+}
+
+#[test]
+fn prod_values_allowlist_includes_github_review_comment_reply_tool() {
+    let prod_values =
+        std::fs::read_to_string(repo_root().join("ci/deploy/drua/prod-values.yml.tmpl"))
+            .expect("read prod values template");
+
+    assert!(
+        prod_values.contains(REVIEW_REPLY_TOOL),
+        "{REVIEW_REPLY_TOOL} should be present in prod MCP upstream allowlist"
+    );
+}


### PR DESCRIPTION
## Summary
- allowlist upstream Copilot MCP `add_reply_to_pull_request_comment` for the internal GitHub PR write toolset
- update local and prod descriptions to document create, review, and inline comment reply support
- add config regression tests for the local and prod allowlists

## Validation
- confirmed upstream `https://api.githubcopilot.com/mcp/` and `/mcp/x/pull_requests` expose `add_reply_to_pull_request_comment` with args `owner`, `repo`, `pullNumber`, `commentId`, `body`
- `cargo fmt --check`
- `git diff --check`
- `cargo test -p drua-server --test config`
- `cargo check -p drua-core`
