### PR TITLE
fix: Put CLAUDE.md into context

### DIFF
--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -17,6 +17,18 @@ use crate::note::Notes;
 use crate::skill::Skills;
 use crate::toolset::ToolSets;
 
+/// Pre-wrapped `<repo_instructions>` content for the `Workspace` system
+/// block. `None` when the sandbox has no `CLAUDE.md` (scratch sandbox, or
+/// a repo without one). The agent service owns the wire framing so the
+/// session entity stores ready-to-render text, matching how Notes / Skills
+/// / Spaces blocks flow.
+fn workspace_block_text(sandbox: &Sandbox) -> Option<String> {
+    sandbox
+        .exported_system_prompt
+        .as_ref()
+        .map(|f| format!("<repo_instructions>\n{}\n</repo_instructions>", f.content))
+}
+
 /// Lead → `ProjectAdmin`; Agent → `ProjectMember`; WorkflowStepAgent →
 /// `ProjectMember` + `WorkflowStepAgent` marker (gates submit_output's
 /// visibility). Sandbox scopes are added later via
@@ -38,7 +50,7 @@ use crate::primitives::{
     AgentId, AuthResource, AuthScope, AuthSubject, AuthVerb, ChatOutputEvent, ContextGeneration,
     ProjectId, SandboxId, WorkflowDefinitionId, WorkflowRunId,
 };
-use crate::sandbox::{SandboxAgentMode, Sandboxes};
+use crate::sandbox::{Sandbox, SandboxAgentMode, Sandboxes};
 pub use config::{AgentsConfig, ModelChain, ModelDefaults, RoleConfig};
 pub use entity::*;
 pub use error::AgentError;
@@ -517,6 +529,7 @@ impl Agents {
 
             let (kind, scope) = sandbox.kind_and_scope();
             let push_policy = self.sandboxes.push_policy_text(&sandbox.mode);
+            let workspace_text = workspace_block_text(&sandbox);
             self.sessions
                 .sandbox_notification_in_op(
                     op,
@@ -529,6 +542,7 @@ impl Agents {
                         scope,
                         push_policy,
                     },
+                    workspace_text,
                 )
                 .await?;
         }
@@ -844,6 +858,7 @@ impl Agents {
 
         let (kind, scope) = sandbox.kind_and_scope();
         let push_policy = self.sandboxes.push_policy_text(&sandbox.mode);
+        let workspace_text = workspace_block_text(&sandbox);
         self.sessions
             .sandbox_notification_in_op(
                 &mut op,
@@ -856,6 +871,7 @@ impl Agents {
                     scope,
                     push_policy,
                 },
+                workspace_text,
             )
             .await?;
 
@@ -904,6 +920,7 @@ impl Agents {
                 agent_id,
                 sandbox.name,
                 session::message::SandboxOperation::Detach,
+                None,
             )
             .await?;
 
@@ -997,6 +1014,7 @@ impl Agents {
                 agent_id,
                 sandbox.name,
                 session::message::SandboxOperation::Detach,
+                None,
             )
             .await?;
         self.refresh_skills_block_in_op(op, agent_id, project_id, None)

--- a/core/src/agent/session/compaction/mod.rs
+++ b/core/src/agent/session/compaction/mod.rs
@@ -40,6 +40,7 @@ pub(super) fn event_belongs_to_thread(
         AgentSessionEvent::Initialized { .. }
         | AgentSessionEvent::ToolDefsUpdated { .. }
         | AgentSessionEvent::SystemBlockUpdated { .. }
+        | AgentSessionEvent::SystemBlockCleared { .. }
         | AgentSessionEvent::ThreadStarted { .. }
         | AgentSessionEvent::ToolResultsMasked { .. }
         | AgentSessionEvent::OutputSubmitted { .. }

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -54,6 +54,13 @@ pub enum AgentSessionEvent {
     SystemBlockUpdated {
         block: SystemBlock,
     },
+    /// Removes the latest block of `kind` from the canonical view. Materialize
+    /// keeps the prior `SystemBlockUpdated` entry in the flat list but drops
+    /// the `latest_idx_by_kind` entry, so the prompt omits the kind until a
+    /// new `SystemBlockUpdated` arrives.
+    SystemBlockCleared {
+        kind: SystemBlockKind,
+    },
     UserInputAdded {
         target: TargetThread,
         source: UserMessageSource,
@@ -234,13 +241,27 @@ impl AgentSession {
         self.user_message_response(target)
     }
 
+    /// Records a sandbox attach/detach event in chat history AND keeps the
+    /// `Workspace` system block in sync with the attached sandbox:
+    /// - `Attach` with `Some(text)` pushes / replaces the Workspace block.
+    /// - `Attach` with `None` (sandbox has no CLAUDE.md) leaves any existing
+    ///   Workspace block intact — caller is responsible for clearing first
+    ///   when transitioning between sandboxes (the agent service enforces
+    ///   "at most one attached sandbox").
+    /// - `Detach` clears the Workspace block.
+    ///
+    /// `workspace_text` is the **already-wrapped** block content (the agent
+    /// service owns the `<repo_instructions>` framing convention, consistent
+    /// with how Skills / Notes / Spaces blocks arrive pre-formatted).
     pub fn add_sandbox_notification(
         &mut self,
         sandbox_name: String,
         operation: SandboxOperation,
+        workspace_text: Option<String>,
     ) -> Result<AgentSessionResponse, AgentSessionError> {
         let target = TargetThread::Main;
         let text = sandbox_notification_text(&sandbox_name, &operation);
+        let is_attach = matches!(operation, SandboxOperation::Attach { .. });
         self.events
             .push(AgentSessionEvent::SandboxNotificationAdded {
                 target,
@@ -248,6 +269,13 @@ impl AgentSession {
                 operation,
                 text,
             });
+        if is_attach {
+            if let Some(text) = workspace_text {
+                let _ = self.push_system_block(SystemBlock::Workspace { text });
+            }
+        } else {
+            let _ = self.clear_system_block(SystemBlockKind::Workspace);
+        }
         self.user_message_response(target)
     }
 
@@ -463,15 +491,37 @@ impl AgentSession {
 
     pub fn push_system_block(&mut self, block: SystemBlock) -> Idempotent<()> {
         let kind = block.kind();
-        let latest_of_kind = self.events.iter_all().rev().find_map(|e| match e {
-            AgentSessionEvent::SystemBlockUpdated { block: b } if b.kind() == kind => Some(b),
+        // Walk back stopping at the latest event that mentions this kind —
+        // either an update (block survives) or a clear (kind is currently
+        // absent). Lets us treat post-clear re-pushes as non-idempotent
+        // even when the new block matches the pre-clear content.
+        let latest = self.events.iter_all().rev().find_map(|e| match e {
+            AgentSessionEvent::SystemBlockUpdated { block: b } if b.kind() == kind => Some(Some(b)),
+            AgentSessionEvent::SystemBlockCleared { kind: k } if *k == kind => Some(None),
             _ => None,
         });
-        if latest_of_kind == Some(&block) {
+        if matches!(latest, Some(Some(b)) if b == &block) {
             return Idempotent::AlreadyApplied;
         }
         self.events
             .push(AgentSessionEvent::SystemBlockUpdated { block });
+        Idempotent::Executed(())
+    }
+
+    /// Drops the latest block of `kind` from the canonical view. No-op when
+    /// the kind is already absent (never pushed, or last touched by a
+    /// `SystemBlockCleared`).
+    pub fn clear_system_block(&mut self, kind: SystemBlockKind) -> Idempotent<()> {
+        let latest = self.events.iter_all().rev().find_map(|e| match e {
+            AgentSessionEvent::SystemBlockUpdated { block: b } if b.kind() == kind => Some(true),
+            AgentSessionEvent::SystemBlockCleared { kind: k } if *k == kind => Some(false),
+            _ => None,
+        });
+        if !matches!(latest, Some(true)) {
+            return Idempotent::AlreadyApplied;
+        }
+        self.events
+            .push(AgentSessionEvent::SystemBlockCleared { kind });
         Idempotent::Executed(())
     }
 
@@ -940,6 +990,9 @@ impl AgentSession {
                 AgentSessionEvent::SystemBlockUpdated { block } => {
                     materialized.push_updated_system_block(block);
                 }
+                AgentSessionEvent::SystemBlockCleared { kind } => {
+                    materialized.clear_system_block(*kind);
+                }
                 AgentSessionEvent::UserInputAdded { .. }
                 | AgentSessionEvent::SandboxNotificationAdded { .. } => {
                     materialized.push_user_message();
@@ -1050,6 +1103,7 @@ impl TryFromEvents<AgentSessionEvent> for AgentSession {
                 AgentSessionEvent::AssistantResponseReceived { .. } => {}
                 AgentSessionEvent::ToolDefsUpdated { .. } => {}
                 AgentSessionEvent::SystemBlockUpdated { .. } => {}
+                AgentSessionEvent::SystemBlockCleared { .. } => {}
                 AgentSessionEvent::PromptSent { .. } => {}
                 AgentSessionEvent::ToolResultsAdded { .. } => {}
                 AgentSessionEvent::ToolResultsMasked { .. } => {}
@@ -2444,5 +2498,179 @@ mod tests {
             )
             .expect("assistant response on refreshed thread must succeed");
         assert!(matches!(response, AgentSessionResponse::Done));
+    }
+
+    // ─── workspace block / sandbox notification lifecycle ──────────────────
+
+    fn attach_op() -> SandboxOperation {
+        SandboxOperation::Attach {
+            agent_mode: "read".into(),
+            kind: "repo".into(),
+            cwd: "/work/repo".into(),
+            scope: Some("repo \"x\"".into()),
+            push_policy: None,
+        }
+    }
+
+    /// Workspace block surfaces in the prompt after Attach with text.
+    #[test]
+    fn attach_with_workspace_text_pushes_workspace_block() {
+        let mut session = new_session();
+        let _ = session.push_system_block(SystemBlock::Base { text: "B".into() });
+        session
+            .add_sandbox_notification(
+                "sb".into(),
+                attach_op(),
+                Some("<repo_instructions>\nhello\n</repo_instructions>".into()),
+            )
+            .unwrap();
+        session
+            .add_user_input(TargetThread::Main, user_source(), "hi".into())
+            .unwrap();
+        session.next_prompt(TargetThread::Main).unwrap();
+        hydrate_threads(&mut session);
+
+        let thread_id = session.current_main_thread.unwrap();
+        let resolved = resolved_blocks(&session, thread_id);
+        assert!(
+            resolved
+                .iter()
+                .any(|b| matches!(b, SystemBlock::Workspace { text } if text.contains("hello"))),
+            "Workspace block should appear after Attach, got {:?}",
+            resolved
+        );
+    }
+
+    /// Attach with no CLAUDE.md leaves the Workspace block absent.
+    #[test]
+    fn attach_without_workspace_text_leaves_workspace_absent() {
+        let mut session = new_session();
+        let _ = session.push_system_block(SystemBlock::Base { text: "B".into() });
+        session
+            .add_sandbox_notification("sb".into(), attach_op(), None)
+            .unwrap();
+        session
+            .add_user_input(TargetThread::Main, user_source(), "hi".into())
+            .unwrap();
+        session.next_prompt(TargetThread::Main).unwrap();
+        hydrate_threads(&mut session);
+
+        let thread_id = session.current_main_thread.unwrap();
+        let resolved = resolved_blocks(&session, thread_id);
+        assert!(
+            !resolved
+                .iter()
+                .any(|b| matches!(b, SystemBlock::Workspace { .. })),
+            "Workspace block should be absent when sandbox carries no CLAUDE.md, got {:?}",
+            resolved
+        );
+    }
+
+    /// Detach drops the Workspace block — the canonical view shouldn't
+    /// surface stale CLAUDE.md after the sandbox is gone.
+    #[test]
+    fn detach_clears_workspace_block() {
+        let mut session = new_session();
+        let _ = session.push_system_block(SystemBlock::Base { text: "B".into() });
+        session
+            .add_sandbox_notification(
+                "sb".into(),
+                attach_op(),
+                Some("<repo_instructions>\nhello\n</repo_instructions>".into()),
+            )
+            .unwrap();
+        session
+            .add_user_input(TargetThread::Main, user_source(), "hi".into())
+            .unwrap();
+        session.next_prompt(TargetThread::Main).unwrap();
+        hydrate_threads(&mut session);
+
+        // Drive a refresh so a new thread reflects the clear.
+        session
+            .add_sandbox_notification("sb".into(), SandboxOperation::Detach, None)
+            .unwrap();
+        session
+            .add_user_input(TargetThread::Main, user_source(), "after detach".into())
+            .unwrap();
+        session.next_prompt(TargetThread::Main).unwrap();
+        hydrate_threads(&mut session);
+
+        let thread_id = session.current_main_thread.unwrap();
+        let resolved = resolved_blocks(&session, thread_id);
+        assert!(
+            !resolved
+                .iter()
+                .any(|b| matches!(b, SystemBlock::Workspace { .. })),
+            "Workspace block must be absent after detach, got {:?}",
+            resolved
+        );
+
+        // A `SystemBlockCleared` was emitted exactly once.
+        let cleared_count = session
+            .events
+            .iter_all()
+            .filter(|e| {
+                matches!(
+                    e,
+                    AgentSessionEvent::SystemBlockCleared {
+                        kind: SystemBlockKind::Workspace,
+                    }
+                )
+            })
+            .count();
+        assert_eq!(cleared_count, 1);
+    }
+
+    /// Detach when no Workspace was ever pushed is a no-op (no clear event).
+    #[test]
+    fn detach_without_prior_workspace_is_noop() {
+        let mut session = new_session();
+        let _ = session.push_system_block(SystemBlock::Base { text: "B".into() });
+        session
+            .add_sandbox_notification("sb".into(), SandboxOperation::Detach, None)
+            .unwrap();
+
+        let cleared_count = session
+            .events
+            .iter_all()
+            .filter(|e| matches!(e, AgentSessionEvent::SystemBlockCleared { .. }))
+            .count();
+        assert_eq!(cleared_count, 0, "no clear event when nothing to clear");
+    }
+
+    /// Attach → Detach → Attach with same text re-pushes (post-clear must
+    /// not idempotency-collapse against the pre-clear block).
+    #[test]
+    fn reattach_after_detach_repushes_workspace() {
+        let mut session = new_session();
+        let _ = session.push_system_block(SystemBlock::Base { text: "B".into() });
+        let workspace = "<repo_instructions>\nhello\n</repo_instructions>".to_string();
+
+        session
+            .add_sandbox_notification("sb".into(), attach_op(), Some(workspace.clone()))
+            .unwrap();
+        session
+            .add_sandbox_notification("sb".into(), SandboxOperation::Detach, None)
+            .unwrap();
+        session
+            .add_sandbox_notification("sb".into(), attach_op(), Some(workspace.clone()))
+            .unwrap();
+
+        let updates = session
+            .events
+            .iter_all()
+            .filter(|e| {
+                matches!(
+                    e,
+                    AgentSessionEvent::SystemBlockUpdated {
+                        block: SystemBlock::Workspace { .. },
+                    }
+                )
+            })
+            .count();
+        assert_eq!(
+            updates, 2,
+            "post-clear re-push of identical text must emit a fresh update"
+        );
     }
 }

--- a/core/src/agent/session/history.rs
+++ b/core/src/agent/session/history.rs
@@ -125,6 +125,7 @@ pub enum ThreadSystemBlockKind {
     Notes,
     Skills,
     Spaces,
+    Workspace,
 }
 
 impl From<SystemBlockKind> for ThreadSystemBlockKind {
@@ -137,6 +138,7 @@ impl From<SystemBlockKind> for ThreadSystemBlockKind {
             SystemBlockKind::Notes => ThreadSystemBlockKind::Notes,
             SystemBlockKind::Skills => ThreadSystemBlockKind::Skills,
             SystemBlockKind::Spaces => ThreadSystemBlockKind::Spaces,
+            SystemBlockKind::Workspace => ThreadSystemBlockKind::Workspace,
         }
     }
 }

--- a/core/src/agent/session/message.rs
+++ b/core/src/agent/session/message.rs
@@ -50,6 +50,7 @@ pub struct Prompt {
 #[serde(rename_all = "snake_case")]
 pub enum SystemBlockKind {
     Base,
+    Workspace,
     Tools,
     Behavioral,
     Role,
@@ -62,6 +63,7 @@ impl SystemBlockKind {
     /// Canonical order shared between `system_prompt` and the session entity.
     pub const ORDER: &'static [SystemBlockKind] = &[
         SystemBlockKind::Base,
+        SystemBlockKind::Workspace,
         SystemBlockKind::Tools,
         SystemBlockKind::Behavioral,
         SystemBlockKind::Role,
@@ -75,6 +77,7 @@ impl SystemBlockKind {
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub enum SystemBlock {
     Base { text: String },
+    Workspace { text: String },
     Tools { text: String },
     Behavioral { text: String },
     Role { text: String },
@@ -87,6 +90,7 @@ impl SystemBlock {
     pub fn kind(&self) -> SystemBlockKind {
         match self {
             SystemBlock::Base { .. } => SystemBlockKind::Base,
+            SystemBlock::Workspace { .. } => SystemBlockKind::Workspace,
             SystemBlock::Tools { .. } => SystemBlockKind::Tools,
             SystemBlock::Behavioral { .. } => SystemBlockKind::Behavioral,
             SystemBlock::Role { .. } => SystemBlockKind::Role,
@@ -99,6 +103,7 @@ impl SystemBlock {
     pub fn text(&self) -> &str {
         match self {
             SystemBlock::Base { text }
+            | SystemBlock::Workspace { text }
             | SystemBlock::Tools { text }
             | SystemBlock::Behavioral { text }
             | SystemBlock::Role { text }
@@ -226,6 +231,7 @@ impl From<SystemBlock> for llm::prompt::SystemBlock {
         // Kind is domain-level only; wire format is always `Text`.
         let text = match b {
             SystemBlock::Base { text }
+            | SystemBlock::Workspace { text }
             | SystemBlock::Tools { text }
             | SystemBlock::Behavioral { text }
             | SystemBlock::Role { text }

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -257,6 +257,11 @@ impl Sessions {
         Ok(result)
     }
 
+    /// Records a sandbox attach/detach in chat history. `workspace_text` is
+    /// the pre-wrapped `Workspace` system block content; on Attach with
+    /// `Some` it's pushed alongside the notification, on Detach the Workspace
+    /// block is cleared automatically. Bundling these here means callers can't
+    /// forget to keep CLAUDE.md in sync with the attached sandbox.
     #[instrument(
         name = "domain.agent_session.sandbox_notification_in_op",
         skip(self, op)
@@ -267,9 +272,10 @@ impl Sessions {
         agent_id: AgentId,
         sandbox_name: String,
         operation: message::SandboxOperation,
+        workspace_text: Option<String>,
     ) -> Result<AgentSessionResponse, AgentSessionError> {
         let mut session = self.repo.find_by_agent_id_in_op(op, agent_id).await?;
-        let response = session.add_sandbox_notification(sandbox_name, operation)?;
+        let response = session.add_sandbox_notification(sandbox_name, operation, workspace_text)?;
         self.repo.update_in_op(op, &mut session).await?;
         Ok(response)
     }
@@ -385,7 +391,10 @@ impl Sessions {
     ) -> Result<(), AgentSessionError> {
         let mut session = self.repo.find_by_agent_id_in_op(op, agent_id).await?;
         if let Some((sandbox_name, operation)) = detach {
-            session.add_sandbox_notification(sandbox_name, operation)?;
+            // Session is about to be deleted; the workspace-clear event the
+            // detach emits is moot, but we still go through the same path to
+            // keep the chat-history projection consistent.
+            session.add_sandbox_notification(sandbox_name, operation, None)?;
         }
         self.repo.delete_in_op(op, session).await?;
         Ok(())

--- a/core/src/agent/session/view.rs
+++ b/core/src/agent/session/view.rs
@@ -115,6 +115,15 @@ impl<'a> MaterializedSession<'a> {
         self.latest_idx_by_kind.insert(block.kind(), idx);
     }
 
+    /// Drops `kind` from the canonical view. The historical block stays in
+    /// `system_blocks` (so flat enumeration over `iter_system_blocks` still
+    /// surfaces it for chat-history projections), but `latest_idx_for_kind`
+    /// returns `None` until a fresh `push_updated_system_block` of the same
+    /// kind arrives.
+    pub fn clear_system_block(&mut self, kind: SystemBlockKind) {
+        self.latest_idx_by_kind.remove(&kind);
+    }
+
     pub fn latest_idx_for_kind(&self, kind: SystemBlockKind) -> Option<SystemBlockIndex> {
         self.latest_idx_by_kind.get(&kind).copied()
     }

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -662,6 +662,7 @@ enum SystemBlockKind {
 	SKILLS
 	SPACES
 	TOOLS
+	WORKSPACE
 }
 
 type TextContent {

--- a/server/src/graphql/session.rs
+++ b/server/src/graphql/session.rs
@@ -37,6 +37,7 @@ pub enum SystemBlockKind {
     Notes,
     Skills,
     Spaces,
+    Workspace,
 }
 
 #[derive(Union, Clone)]
@@ -352,6 +353,7 @@ impl From<history::ThreadSystemBlock> for SystemBlockInfo {
                 history::ThreadSystemBlockKind::Notes => SystemBlockKind::Notes,
                 history::ThreadSystemBlockKind::Skills => SystemBlockKind::Skills,
                 history::ThreadSystemBlockKind::Spaces => SystemBlockKind::Spaces,
+                history::ThreadSystemBlockKind::Workspace => SystemBlockKind::Workspace,
             },
             text: b.text,
         }


### PR DESCRIPTION
Sandbox.exported_system_prompt was collected and stored but never injected into the context so the agents in the sandbox never saw it.

This change adds new system block kind Workspace (placed after Base) that carries CLAUDE.md content and injects it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes prompt assembly and session event semantics for sandbox attach/detach; incorrect clearing or idempotency could leak stale repo instructions or omit CLAUDE.md, but scope is localized to session/system blocks with tests.
> 
> **Overview**
> **Injects sandbox `CLAUDE.md` into the agent prompt** via a new **`Workspace`** system block (ordered after `Base`), fixing the gap where `exported_system_prompt` was stored but never sent to the model.
> 
> On **sandbox attach**, the agent layer wraps repo instructions as `<repo_instructions>…</repo_instructions>` and passes that through **`sandbox_notification_in_op`**; the session pushes or replaces the `Workspace` block when text is present and **clears it on detach**. **`SystemBlockCleared`** plus updated idempotency logic ensure re-attach after detach still emits a fresh block even when content is identical.
> 
> **GraphQL** exposes `WORKSPACE` on `SystemBlockKind`. Unit tests cover attach/detach/reattach lifecycle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52eebab63a25c4025c0be07f34d9c52a2d86d6a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->