### PR TITLE
fix: zenduty schema alignment + tool-caching too-large hint shows advertised paths

### DIFF
--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -389,6 +389,12 @@ impl StoredInvocation {
     /// `path` and render the first few as a copy-pasteable hint. Returns
     /// `None` when nothing useful is under this path.
     fn advertised_paths_hint(&self, path: &str, shrink_failed: bool) -> Option<String> {
+        let matching_count = self
+            .summary
+            .elided_paths
+            .iter()
+            .filter(|ep| path_is_ancestor_or_equal(path, &ep.path))
+            .count();
         let nested: Vec<&crate::primitives::ElidedPath> = self
             .summary
             .elided_paths
@@ -416,7 +422,7 @@ impl StoredInvocation {
                 format!("\n  - {} ({}) — {}", ep.path, dims, template)
             })
             .collect();
-        let extra = self.summary.elided_paths.len().saturating_sub(nested.len());
+        let extra = matching_count.saturating_sub(nested.len());
         let trailer = if extra > 0 {
             format!("\n  - (+{extra} more in `_recovery.paths`)")
         } else {

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -277,33 +277,47 @@ impl StoredInvocation {
             });
         }
 
+        let mut shrink_failed = false;
         if let Some(q) = query {
-            if let Some(shrunk) = q.shrink_to_fit(resolved, max_bytes)? {
-                let text = fetch_text_for_raw(&shrunk.value);
-                let wrapped = wrap_at_path(path, shrunk.value)?;
-                let remaining = shrunk.original_len - shrunk.actual_len;
-                let note = format!(
-                    "\n\n[TRUNCATED: returned {actual} of {requested} {unit} \
-                     ({remaining} remaining). Fetch the next page with \
-                     offset: {next_offset}]",
-                    actual = shrunk.actual_len,
-                    requested = shrunk.original_len,
-                    unit = shrunk.unit,
-                    remaining = remaining,
-                    next_offset = shrunk.next_offset,
-                );
-                return Ok(FetchResult {
-                    result: CallToolResult::success(vec![Content::text(format!("{text}{note}"))]),
-                    structured: wrapped,
-                });
+            match q.shrink_to_fit(resolved, max_bytes)? {
+                Some(shrunk) => {
+                    let text = fetch_text_for_raw(&shrunk.value);
+                    let wrapped = wrap_at_path(path, shrunk.value)?;
+                    let remaining = shrunk.original_len - shrunk.actual_len;
+                    let note = format!(
+                        "\n\n[TRUNCATED: returned {actual} of {requested} {unit} \
+                         ({remaining} remaining). Fetch the next page with \
+                         offset: {next_offset}]",
+                        actual = shrunk.actual_len,
+                        requested = shrunk.original_len,
+                        unit = shrunk.unit,
+                        remaining = remaining,
+                        next_offset = shrunk.next_offset,
+                    );
+                    return Ok(FetchResult {
+                        result: CallToolResult::success(vec![Content::text(format!(
+                            "{text}{note}"
+                        ))]),
+                        structured: wrapped,
+                    });
+                }
+                None => {
+                    // Shrink attempted but even the smallest slice exceeds the cap —
+                    // typically a single array element with elided sub-fields.
+                    shrink_failed = matches!(
+                        q,
+                        FetchQuery::JsonArraySlice { .. }
+                            | FetchQuery::Lines { .. }
+                            | FetchQuery::Range { .. }
+                    );
+                }
             }
         }
 
-        // No query or shrink not possible (e.g. single scalar too large).
         Err(ToolCachingError::FetchResponseTooLarge {
             size: text.len(),
             max: max_bytes,
-            hint: self.too_large_hint(path, max_bytes),
+            hint: self.too_large_hint(path, max_bytes, shrink_failed),
         })
     }
 
@@ -315,17 +329,28 @@ impl StoredInvocation {
         Ok(FetchResult { result, structured })
     }
 
-    /// Tail-appended hint for `FetchResponseTooLarge`. Always nudges
-    /// `mode:'summary'`; on a compose root (`sub_invocations` array at
-    /// `$`), names up to three drill-down invocation_ids the agent can
-    /// fetch directly instead of re-slicing the aggregate body.
-    fn too_large_hint(&self, path: &str, max_bytes: usize) -> String {
+    /// Tail-appended hint for `FetchResponseTooLarge`. Surfaces, in order:
+    /// (1) when the upstream walker advertised elided sub-paths under the
+    /// requested path, lists up to three with their byte sizes and the
+    /// exact `tool_output_fetch` template the agent should copy — this is
+    /// the case where even the smallest array slice can't fit because one
+    /// element carries a multi-KB elided field; (2) `mode:'summary'` as
+    /// the always-available escape hatch; (3) on a compose root, names
+    /// drill-down sub-invocation ids.
+    fn too_large_hint(&self, path: &str, max_bytes: usize, shrink_failed: bool) -> String {
         let summary_envelope_bytes = self.summary.build_envelope_text().len();
-        let mut parts = vec![format!(
+        let mut parts = Vec::new();
+
+        if let Some(advertised) = self.advertised_paths_hint(path, shrink_failed) {
+            parts.push(advertised);
+        }
+
+        parts.push(format!(
             ". Try `query: {{mode: \"summary\"}}` for the curated envelope \
              (summary_envelope_bytes: {summary_envelope_bytes}, \
              normal_fetch_limit_bytes: {max_bytes}; summary mode bypasses that cap)"
-        )];
+        ));
+
         let touches_result = path == "$" || path == "$.result" || path.starts_with("$.result.");
         if touches_result {
             if let Some(arr) = self
@@ -358,6 +383,49 @@ impl StoredInvocation {
             }
         }
         parts.join("")
+    }
+
+    /// Find persisted `elided_paths` that fall under the requested fetch
+    /// `path` and render the first few as a copy-pasteable hint. Returns
+    /// `None` when nothing useful is under this path.
+    fn advertised_paths_hint(&self, path: &str, shrink_failed: bool) -> Option<String> {
+        let nested: Vec<&crate::primitives::ElidedPath> = self
+            .summary
+            .elided_paths
+            .iter()
+            .filter(|ep| path_is_ancestor_or_equal(path, &ep.path))
+            .take(4)
+            .collect();
+        if nested.is_empty() {
+            return None;
+        }
+        let lead = if shrink_failed {
+            ". This invocation has per-item elisions; even the smallest \
+             slice exceeds the cap because individual elements carry \
+             multi-KB elided fields. Fetch those fields directly using \
+             the advertised paths"
+        } else {
+            ". The upstream walker advertised elided sub-paths under \
+             this path; fetch them directly instead of slicing the parent"
+        };
+        let rendered: Vec<String> = nested
+            .iter()
+            .map(|ep| {
+                let dims = elided_dims_summary(ep);
+                let template = serde_json::to_string(&ep.recover).unwrap_or_default();
+                format!("\n  - {} ({}) — {}", ep.path, dims, template)
+            })
+            .collect();
+        let extra = self.summary.elided_paths.len().saturating_sub(nested.len());
+        let trailer = if extra > 0 {
+            format!("\n  - (+{extra} more in `_recovery.paths`)")
+        } else {
+            String::new()
+        };
+        Some(format!(
+            "{lead}:{rendered}{trailer}",
+            rendered = rendered.join("")
+        ))
     }
 
     fn navigate(&self, path: &str) -> Result<&Value, ToolCachingError> {
@@ -489,6 +557,34 @@ fn parse_path(path: &str) -> Result<Vec<PathSegment>, ToolCachingError> {
         }
     }
     Ok(out)
+}
+
+/// True when `ancestor` is the root (`$`), equals `descendant`, or is a
+/// strict path-prefix of `descendant` at a segment boundary. Avoids
+/// false positives like `$.items` ancestor-of `$.itemsX`.
+fn path_is_ancestor_or_equal(ancestor: &str, descendant: &str) -> bool {
+    if ancestor == "$" {
+        return descendant == "$" || descendant.starts_with("$.") || descendant.starts_with("$[");
+    }
+    if ancestor == descendant {
+        return true;
+    }
+    if let Some(rest) = descendant.strip_prefix(ancestor) {
+        return rest.starts_with('.') || rest.starts_with('[');
+    }
+    false
+}
+
+/// One-line "43337 bytes, 524 lines" summary of an ElidedPath's dimensions.
+fn elided_dims_summary(ep: &crate::primitives::ElidedPath) -> String {
+    let mut parts = vec![format!("{} bytes", ep.total_bytes)];
+    if let Some(n) = ep.total_lines {
+        parts.push(format!("{n} lines"));
+    }
+    if let Some(n) = ep.total_items {
+        parts.push(format!("{n} items"));
+    }
+    parts.join(", ")
 }
 
 /// Describe what's actually at `cur` so the agent can correct a missing
@@ -695,7 +791,7 @@ mod tests {
     #[test]
     fn too_large_hint_always_suggests_summary_mode() {
         let inv = stored(serde_json::json!({"result": "x"}));
-        let hint = inv.too_large_hint("$.result", 64);
+        let hint = inv.too_large_hint("$.result", 64, false);
         assert!(hint.contains("mode: \"summary\""), "got: {hint}");
         assert!(hint.contains("summary_envelope_bytes:"), "got: {hint}");
         assert!(hint.contains("normal_fetch_limit_bytes: 64"), "got: {hint}");
@@ -742,7 +838,7 @@ mod tests {
                 {"invocation_id": "bbb", "tool_name": "honeycomb_query"},
             ],
         }));
-        let hint = inv.too_large_hint("$.result", 1024);
+        let hint = inv.too_large_hint("$.result", 1024, false);
         assert!(hint.contains("github_list_prs=aaa"), "got: {hint}");
         assert!(hint.contains("honeycomb_query=bbb"), "got: {hint}");
     }
@@ -759,11 +855,128 @@ mod tests {
                 {"invocation_id": "i4", "tool_name": "t4"},
             ],
         }));
-        let hint = inv.too_large_hint("$.result", 1024);
+        let hint = inv.too_large_hint("$.result", 1024, false);
         assert!(hint.contains("t0=i0"), "got: {hint}");
         assert!(hint.contains("t2=i2"), "got: {hint}");
         assert!(!hint.contains("t3=i3"), "should cap at 3; got: {hint}");
         assert!(hint.contains("+2 more"), "got: {hint}");
+    }
+
+    fn stored_with_elided(
+        root: Value,
+        elided_paths: Vec<crate::primitives::ElidedPath>,
+    ) -> StoredInvocation {
+        StoredInvocation {
+            id: ToolInvocationId::new(),
+            query_structure: QueryStructure { root },
+            summary: ToolCallSummary {
+                summary: Value::Null,
+                wire_result: Value::Null,
+                elided_paths,
+                root_path: "$".to_string(),
+                total_bytes: 0,
+                shown_bytes: 0,
+                total_items: None,
+                shown_items: None,
+                total_lines: None,
+                shown_lines: None,
+            },
+            original_structured: None,
+        }
+    }
+
+    fn elided(
+        path: &str,
+        total_bytes: u64,
+        total_lines: Option<u32>,
+    ) -> crate::primitives::ElidedPath {
+        crate::primitives::ElidedPath {
+            path: path.to_string(),
+            total_bytes,
+            shown_bytes: 0,
+            total_lines,
+            shown_lines: total_lines.map(|_| 1),
+            total_items: None,
+            shown_items: None,
+            recover: serde_json::json!({
+                "tool": "tool_output_fetch",
+                "args_template": {"invocation_id": "x", "path": path},
+            }),
+        }
+    }
+
+    #[test]
+    fn path_ancestor_check_handles_root_keys_and_indices() {
+        assert!(path_is_ancestor_or_equal("$", "$.items[0].body"));
+        assert!(path_is_ancestor_or_equal("$", "$[3]"));
+        assert!(path_is_ancestor_or_equal("$", "$"));
+        assert!(path_is_ancestor_or_equal("$.items", "$.items[0].body"));
+        assert!(path_is_ancestor_or_equal("$.items", "$.items"));
+        // segment-boundary check: $.items must not match $.itemsX
+        assert!(!path_is_ancestor_or_equal("$.items", "$.itemsX"));
+        assert!(!path_is_ancestor_or_equal("$.items", "$.other"));
+    }
+
+    #[test]
+    fn too_large_hint_surfaces_advertised_paths_under_requested_path() {
+        let inv = stored_with_elided(
+            serde_json::json!({"items": [{"body": "x"}]}),
+            vec![
+                elided("$.items[0].body", 43337, Some(524)),
+                elided("$.items[1].body", 1521, Some(23)),
+            ],
+        );
+        let hint = inv.too_large_hint("$.items", 16384, true);
+        assert!(hint.contains("$.items[0].body"), "got: {hint}");
+        assert!(hint.contains("43337 bytes"), "got: {hint}");
+        assert!(hint.contains("524 lines"), "got: {hint}");
+        assert!(hint.contains("$.items[1].body"), "got: {hint}");
+        assert!(
+            hint.contains("smallest slice exceeds the cap"),
+            "shrink_failed lead should appear: {hint}"
+        );
+    }
+
+    #[test]
+    fn too_large_hint_uses_softer_lead_when_shrink_was_not_attempted() {
+        let inv = stored_with_elided(
+            serde_json::json!({"logs": "x"}),
+            vec![elided("$.logs", 50000, Some(900))],
+        );
+        let hint = inv.too_large_hint("$", 16384, false);
+        assert!(hint.contains("advertised elided sub-paths"), "got: {hint}");
+        assert!(!hint.contains("smallest slice"), "got: {hint}");
+    }
+
+    #[test]
+    fn too_large_hint_caps_advertised_paths_to_four_with_overflow_note() {
+        let inv = stored_with_elided(
+            serde_json::json!({"items": []}),
+            vec![
+                elided("$.items[0].body", 1000, None),
+                elided("$.items[1].body", 1000, None),
+                elided("$.items[2].body", 1000, None),
+                elided("$.items[3].body", 1000, None),
+                elided("$.items[4].body", 1000, None),
+                elided("$.items[5].body", 1000, None),
+            ],
+        );
+        let hint = inv.too_large_hint("$.items", 16384, true);
+        assert!(hint.contains("$.items[3].body"), "got: {hint}");
+        assert!(!hint.contains("$.items[4].body"), "should cap at 4: {hint}");
+        assert!(hint.contains("+2 more in `_recovery.paths`"), "got: {hint}");
+    }
+
+    #[test]
+    fn too_large_hint_skips_advertised_paths_outside_requested_path() {
+        let inv = stored_with_elided(
+            serde_json::json!({"items": [], "other": "x"}),
+            vec![elided("$.other.body", 50000, None)],
+        );
+        let hint = inv.too_large_hint("$.items", 16384, true);
+        assert!(!hint.contains("$.other.body"), "got: {hint}");
+        // still falls back to the summary suggestion
+        assert!(hint.contains("mode: \"summary\""), "got: {hint}");
     }
 
     #[test]
@@ -774,7 +987,7 @@ mod tests {
                 {"invocation_id": "aaa", "tool_name": "github_list_prs"},
             ],
         }));
-        let hint = inv.too_large_hint("$.sub_invocations", 1024);
+        let hint = inv.too_large_hint("$.sub_invocations", 1024, false);
         assert!(!hint.contains("github_list_prs"), "got: {hint}");
         assert!(hint.contains("mode: \"summary\""), "got: {hint}");
     }

--- a/core/src/toolset/searchable/zenduty.rs
+++ b/core/src/toolset/searchable/zenduty.rs
@@ -37,7 +37,7 @@ fn schema_for<T: schemars::JsonSchema>() -> serde_json::Value {
 /// internal integer codes (1=triggered, 2=acknowledged, 3=resolved) both
 /// work — `list_incidents` results sometimes leak the int form and
 /// agents copy it back unchanged. Schema surfaces the enum names.
-#[derive(Deserialize, schemars::JsonSchema)]
+#[derive(schemars::JsonSchema)]
 #[serde(rename_all = "lowercase")]
 enum IncidentStatusName {
     Triggered,
@@ -51,6 +51,20 @@ impl IncidentStatusName {
             Self::Triggered => IncidentStatus::Triggered,
             Self::Acknowledged => IncidentStatus::Acknowledged,
             Self::Resolved => IncidentStatus::Resolved,
+        }
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for IncidentStatusName {
+    fn deserialize<D: serde::Deserializer<'de>>(d: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(d)?;
+        match s.to_ascii_lowercase().as_str() {
+            "triggered" => Ok(Self::Triggered),
+            "acknowledged" | "ack" => Ok(Self::Acknowledged),
+            "resolved" | "resolve" => Ok(Self::Resolved),
+            other => Err(serde::de::Error::custom(format!(
+                "unknown status '{other}' (expected triggered|acknowledged|ack|resolved|resolve)"
+            ))),
         }
     }
 }
@@ -715,5 +729,31 @@ mod tests {
             find_canonical_enum(&schema),
             "schema does not surface enum constraint for statuses: {schema}"
         );
+    }
+
+    #[test]
+    fn status_input_is_case_insensitive_and_accepts_aliases() {
+        for (input, expected_code) in [
+            ("TRIGGERED", 1u8),
+            ("Acknowledged", 2),
+            ("ack", 2),
+            ("RESOLVED", 3),
+            ("resolve", 3),
+        ] {
+            let args: ListIncidentsArgs = serde_json::from_value(serde_json::json!({
+                "statuses": [input],
+            }))
+            .unwrap_or_else(|e| panic!("'{input}' should deserialize: {e}"));
+            let code = args
+                .statuses
+                .unwrap()
+                .into_iter()
+                .next()
+                .unwrap()
+                .into_incident_status()
+                .unwrap_or_else(|e| panic!("'{input}' should convert: {e}"))
+                .as_u8();
+            assert_eq!(code, expected_code, "input: {input}");
+        }
     }
 }

--- a/core/src/toolset/searchable/zenduty.rs
+++ b/core/src/toolset/searchable/zenduty.rs
@@ -33,12 +33,55 @@ fn schema_for<T: schemars::JsonSchema>() -> serde_json::Value {
     value
 }
 
+/// Incident status accepted on input. Names (canonical) or Zenduty's
+/// internal integer codes (1=triggered, 2=acknowledged, 3=resolved) both
+/// work — `list_incidents` results sometimes leak the int form and
+/// agents copy it back unchanged. Schema surfaces the enum names.
+#[derive(Deserialize, schemars::JsonSchema)]
+#[serde(rename_all = "lowercase")]
+enum IncidentStatusName {
+    Triggered,
+    Acknowledged,
+    Resolved,
+}
+
+impl IncidentStatusName {
+    fn into_incident_status(self) -> IncidentStatus {
+        match self {
+            Self::Triggered => IncidentStatus::Triggered,
+            Self::Acknowledged => IncidentStatus::Acknowledged,
+            Self::Resolved => IncidentStatus::Resolved,
+        }
+    }
+}
+
+#[derive(Deserialize, schemars::JsonSchema)]
+#[serde(untagged)]
+enum StatusInput {
+    Name(IncidentStatusName),
+    Code(u8),
+}
+
+impl StatusInput {
+    fn into_incident_status(self) -> Result<IncidentStatus, ToolSetsError> {
+        match self {
+            Self::Name(n) => Ok(n.into_incident_status()),
+            Self::Code(c) => IncidentStatus::try_from(c).map_err(|_| {
+                ToolSetsError::InvalidArgument(format!(
+                    "unknown status code '{c}' (expected 1=triggered, 2=acknowledged, 3=resolved)"
+                ))
+            }),
+        }
+    }
+}
+
 #[derive(Deserialize, schemars::JsonSchema)]
 struct ListIncidentsArgs {
-    /// Filter by status names: "triggered", "acknowledged", "resolved".
-    /// Defaults to triggered + acknowledged (i.e. ongoing) when omitted.
+    /// Filter by status. Accepts canonical names ("triggered",
+    /// "acknowledged", "resolved") or Zenduty's int codes (1/2/3).
+    /// Defaults to triggered + acknowledged (ongoing) when omitted.
     #[serde(default)]
-    statuses: Option<Vec<String>>,
+    statuses: Option<Vec<StatusInput>>,
     #[serde(default)]
     team_id: Option<String>,
     #[serde(default)]
@@ -51,29 +94,37 @@ struct ListIncidentsArgs {
 
 #[derive(Deserialize, schemars::JsonSchema)]
 struct IncidentIdArgs {
-    /// Zenduty incident `unique_id` (the string id used in URL paths).
-    incident_id: String,
+    /// Zenduty incident `unique_id` — the alphanumeric string returned by
+    /// `list_incidents` (e.g. `"HjZEH2pEMC44c89PWMpsEA"`). Not the
+    /// `incident_number` (small int). Legacy callers may still pass
+    /// `incident_id` for backward compatibility.
+    #[serde(alias = "incident_id")]
+    unique_id: String,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
 struct AddNoteArgs {
-    /// Zenduty incident `unique_id`.
-    incident_id: String,
+    /// Zenduty incident `unique_id` (alphanumeric, from `list_incidents`).
+    #[serde(alias = "incident_id")]
+    unique_id: String,
     /// Note body (markdown supported by Zenduty).
     note: String,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
 struct DeleteNoteArgs {
-    /// Zenduty incident `unique_id`.
-    incident_id: String,
+    /// Zenduty incident `unique_id` (alphanumeric, from `list_incidents`).
+    #[serde(alias = "incident_id")]
+    unique_id: String,
     /// Note `unique_id` (returned by `add_incident_note` / `list_incident_notes`).
     note_id: String,
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
 struct UpdateStatusArgs {
-    incident_id: String,
+    /// Zenduty incident `unique_id` (alphanumeric, from `list_incidents`).
+    #[serde(alias = "incident_id")]
+    unique_id: String,
     /// One of "acknowledged" or "resolved". "triggered" is rarely useful.
     status: String,
 }
@@ -189,7 +240,7 @@ static OUT_DELETED: LazyLock<serde_json::Value> = LazyLock::new(|| {
         "type": "object",
         "properties": {
             "deleted": { "type": "boolean" },
-            "incident_id": { "type": "string" },
+            "unique_id": { "type": "string" },
             "note_id": { "type": "string" },
         },
         "additionalProperties": false,
@@ -329,9 +380,9 @@ impl SearchableToolSet for ZendutyToolSet {
             "list_incidents" => {
                 let args: ListIncidentsArgs = parse_params(arguments)?;
                 let status_codes: Vec<u8> = match args.statuses {
-                    Some(names) => names
-                        .iter()
-                        .map(|s| parse_status_name(s).map(|st| st.as_u8()))
+                    Some(inputs) => inputs
+                        .into_iter()
+                        .map(|s| s.into_incident_status().map(|st| st.as_u8()))
                         .collect::<Result<Vec<_>, _>>()?,
                     None => vec![
                         IncidentStatus::Triggered.as_u8(),
@@ -363,7 +414,7 @@ impl SearchableToolSet for ZendutyToolSet {
             }
             "get_incident" => {
                 let args: IncidentIdArgs = parse_params(arguments)?;
-                let i = self.client.get_incident(&args.incident_id).await?;
+                let i = self.client.get_incident(&args.unique_id).await?;
                 let out = IncidentDetailOutput {
                     unique_id: i.unique_id,
                     incident_number: i.incident_number,
@@ -386,7 +437,7 @@ impl SearchableToolSet for ZendutyToolSet {
                 let args: AddNoteArgs = parse_params(arguments)?;
                 let note = self
                     .client
-                    .add_incident_note(&args.incident_id, &args.note)
+                    .add_incident_note(&args.unique_id, &args.note)
                     .await?;
                 let out = NoteOutput {
                     unique_id: note.unique_id,
@@ -398,7 +449,7 @@ impl SearchableToolSet for ZendutyToolSet {
             }
             "list_incident_notes" => {
                 let args: IncidentIdArgs = parse_params(arguments)?;
-                let notes = self.client.list_incident_notes(&args.incident_id).await?;
+                let notes = self.client.list_incident_notes(&args.unique_id).await?;
                 let mapped: Vec<NoteOutput> = notes
                     .into_iter()
                     .map(|n| NoteOutput {
@@ -417,11 +468,11 @@ impl SearchableToolSet for ZendutyToolSet {
             "delete_incident_note" => {
                 let args: DeleteNoteArgs = parse_params(arguments)?;
                 self.client
-                    .delete_incident_note(&args.incident_id, &args.note_id)
+                    .delete_incident_note(&args.unique_id, &args.note_id)
                     .await?;
                 let out = serde_json::json!({
                     "deleted": true,
-                    "incident_id": args.incident_id,
+                    "unique_id": args.unique_id,
                     "note_id": args.note_id,
                 });
                 let text = serde_json::to_string_pretty(&out).unwrap_or_default();
@@ -434,7 +485,7 @@ impl SearchableToolSet for ZendutyToolSet {
                 let status = parse_status_name(&args.status)?;
                 let i = self
                     .client
-                    .update_incident_status(&args.incident_id, status)
+                    .update_incident_status(&args.unique_id, status)
                     .await?;
                 let out = IncidentDetailOutput {
                     unique_id: i.unique_id,
@@ -556,5 +607,113 @@ mod tests {
         assert_eq!(status_name(Some(3)).as_deref(), Some("resolved"));
         assert_eq!(status_name(Some(99)), None);
         assert_eq!(status_name(None), None);
+    }
+
+    #[test]
+    fn incident_id_args_accepts_unique_id_field() {
+        let args: IncidentIdArgs =
+            serde_json::from_value(serde_json::json!({ "unique_id": "HjZEH2pEMC44c89PWMpsEA" }))
+                .expect("unique_id form deserializes");
+        assert_eq!(args.unique_id, "HjZEH2pEMC44c89PWMpsEA");
+    }
+
+    #[test]
+    fn incident_id_args_still_accepts_legacy_incident_id_alias() {
+        let args: IncidentIdArgs =
+            serde_json::from_value(serde_json::json!({ "incident_id": "HjZEH2pEMC44c89PWMpsEA" }))
+                .expect("legacy incident_id alias deserializes");
+        assert_eq!(args.unique_id, "HjZEH2pEMC44c89PWMpsEA");
+    }
+
+    #[test]
+    fn list_incidents_args_accepts_name_strings() {
+        let args: ListIncidentsArgs = serde_json::from_value(serde_json::json!({
+            "statuses": ["triggered", "acknowledged"],
+        }))
+        .expect("name form deserializes");
+        let codes: Vec<u8> = args
+            .statuses
+            .unwrap()
+            .into_iter()
+            .map(|s| s.into_incident_status().unwrap().as_u8())
+            .collect();
+        assert_eq!(codes, vec![1, 2]);
+    }
+
+    #[test]
+    fn list_incidents_args_accepts_int_codes() {
+        let args: ListIncidentsArgs = serde_json::from_value(serde_json::json!({
+            "statuses": [1, 2, 3],
+        }))
+        .expect("int form deserializes");
+        let codes: Vec<u8> = args
+            .statuses
+            .unwrap()
+            .into_iter()
+            .map(|s| s.into_incident_status().unwrap().as_u8())
+            .collect();
+        assert_eq!(codes, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn list_incidents_args_accepts_mixed_names_and_ints() {
+        let args: ListIncidentsArgs = serde_json::from_value(serde_json::json!({
+            "statuses": ["triggered", 2, "resolved"],
+        }))
+        .expect("mixed form deserializes");
+        let codes: Vec<u8> = args
+            .statuses
+            .unwrap()
+            .into_iter()
+            .map(|s| s.into_incident_status().unwrap().as_u8())
+            .collect();
+        assert_eq!(codes, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn status_input_rejects_unknown_int_code() {
+        let args: ListIncidentsArgs = serde_json::from_value(serde_json::json!({
+            "statuses": [9],
+        }))
+        .unwrap();
+        let err = args
+            .statuses
+            .unwrap()
+            .into_iter()
+            .map(|s| s.into_incident_status())
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap_err();
+        assert!(
+            err.to_string().contains("unknown status code '9'"),
+            "got: {err}"
+        );
+    }
+
+    #[test]
+    fn list_incidents_schema_exposes_canonical_status_names() {
+        let schema = serde_json::to_value(&*LIST_INCIDENTS_SCHEMA).unwrap();
+        // Walk to any `enum` keyword whose array matches the canonical names.
+        // Searching recursively avoids brittleness over schemars's exact layout
+        // for the untagged `StatusInput` (it may emit `anyOf` of variants).
+        fn find_canonical_enum(v: &serde_json::Value) -> bool {
+            if let Some(arr) = v.get("enum").and_then(|e| e.as_array()) {
+                let names: Vec<&str> = arr.iter().filter_map(|x| x.as_str()).collect();
+                if names.contains(&"triggered")
+                    && names.contains(&"acknowledged")
+                    && names.contains(&"resolved")
+                {
+                    return true;
+                }
+            }
+            match v {
+                serde_json::Value::Object(map) => map.values().any(find_canonical_enum),
+                serde_json::Value::Array(arr) => arr.iter().any(find_canonical_enum),
+                _ => false,
+            }
+        }
+        assert!(
+            find_canonical_enum(&schema),
+            "schema does not surface enum constraint for statuses: {schema}"
+        );
     }
 }

--- a/lib/zenduty-client/src/client.rs
+++ b/lib/zenduty-client/src/client.rs
@@ -159,10 +159,16 @@ impl ZendutyClient {
             postmortem_filter: -1,
             escalation_policy_ids: Vec::new(),
         };
-        let page: Page<Incident> = self
-            .post_json_with_query("/api/incidents/filter/", &body, &q)
-            .await?;
-        Ok(page.into_results())
+        match self
+            .post_json_with_query::<Page<Incident>, _, _>("/api/incidents/filter/", &body, &q)
+            .await
+        {
+            Ok(page) => Ok(page.into_results()),
+            // Zenduty returns 404 + {"detail":"Invalid page."} when `page`
+            // is past the last page; standard list semantics is an empty page.
+            Err(e) if e.is_invalid_page_overshoot() => Ok(Vec::new()),
+            Err(e) => Err(e),
+        }
     }
 
     #[tracing::instrument(name = "zenduty_client.get_incident", skip_all)]

--- a/lib/zenduty-client/src/error.rs
+++ b/lib/zenduty-client/src/error.rs
@@ -34,3 +34,39 @@ pub enum ZendutyError {
     #[error("API error (HTTP {status}): {message}")]
     Api { status: u16, message: String },
 }
+
+impl ZendutyError {
+    /// True when the upstream returned a 404 whose body is Zenduty's
+    /// off-the-end paging sentinel (`{"detail":"Invalid page."}`).
+    /// `list_incidents` translates this to an empty result; standard
+    /// list semantics rather than a hard error.
+    pub fn is_invalid_page_overshoot(&self) -> bool {
+        matches!(self, ZendutyError::NotFound(body) if body.contains("Invalid page"))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn invalid_page_overshoot_recognises_zenduty_sentinel() {
+        let err = ZendutyError::NotFound(r#"{"detail":"Invalid page."}"#.into());
+        assert!(err.is_invalid_page_overshoot());
+    }
+
+    #[test]
+    fn invalid_page_overshoot_rejects_real_not_found() {
+        let err = ZendutyError::NotFound(r#"{"detail":"Not found."}"#.into());
+        assert!(!err.is_invalid_page_overshoot());
+    }
+
+    #[test]
+    fn invalid_page_overshoot_rejects_non_not_found_errors() {
+        let err = ZendutyError::Api {
+            status: 500,
+            message: "Invalid page".into(),
+        };
+        assert!(!err.is_invalid_page_overshoot());
+    }
+}


### PR DESCRIPTION
## Summary

Two clusters of small fixes driven by a 3-day post-rollout audit of `audit_entries` and `tool_invocations` (since deploy of `69d77bcb` on 2026-05-22 08:47 UTC). The recent tool-caching rollout took compose timeouts from 272 → 1 and `tool_output_fetch` "too large" errors from 73 → 8; this PR addresses the largest *remaining* error patterns.

### `tool-caching`: surface advertised elided paths on `FetchResponseTooLarge`

The 8 remaining "too large" errors in the post-rollout window were all the same agent loop on `github_search_pull_requests`: `path=$.items, json_array_slice, len=21→5→21→7→8→5`. The upstream walker had already persisted per-item recovery paths (`$.items[0].body`, 43 KB, 524 lines) in `summary.elided_paths` — the error just didn't surface them. Now it does, and the error explicitly tells the agent why shrinking failed (one item alone > cap).

### `zenduty`: definitions-side fixes for the three biggest error patterns

- `missing field incident_id` (23 errors): the input parameter was named `incident_id` but the **output** of `list_incidents`/`get_incident` returns `unique_id`. Agents naturally passed it back as `unique_id` and lost. Renamed to `unique_id` with `#[serde(alias = "incident_id")]` for backward compat.
- `unknown status '1'` (6 errors): `statuses` lacked a JSON-schema `enum` and didn't accept Zenduty's int codes. Now a typed `IncidentStatusName` enum (schema: `enum:["triggered","acknowledged","resolved"]`) wrapped in an untagged `StatusInput` that also accepts `1/2/3`.
- `Invalid page` (14 errors): all `page: 2` overshoots. `list_incidents` now translates Zenduty's `404 {"detail":"Invalid page."}` into an empty result — standard list-API semantics.

Together these would have eliminated ~43 of the 144 post-rollout mcp_call errors (~30 %) plus an 18-call `describe_tool` loop that sat on top of the `incident_id` confusion.

## Test plan

- [x] `cargo test --workspace --lib` — full suite green
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New unit tests:
  - `fetch::path_ancestor_check_handles_root_keys_and_indices`
  - `fetch::too_large_hint_surfaces_advertised_paths_under_requested_path`
  - `fetch::too_large_hint_uses_softer_lead_when_shrink_was_not_attempted`
  - `fetch::too_large_hint_caps_advertised_paths_to_four_with_overflow_note`
  - `fetch::too_large_hint_skips_advertised_paths_outside_requested_path`
  - `zenduty::incident_id_args_accepts_unique_id_field`
  - `zenduty::incident_id_args_still_accepts_legacy_incident_id_alias`
  - `zenduty::list_incidents_args_accepts_{name_strings,int_codes,mixed_names_and_ints}`
  - `zenduty::status_input_rejects_unknown_int_code`
  - `zenduty::list_incidents_schema_exposes_canonical_status_names`
  - `zenduty_client::error::invalid_page_overshoot_{recognises_zenduty_sentinel,rejects_real_not_found,rejects_non_not_found_errors}`
- [ ] Verify in staging that `unique_id` and the legacy `incident_id` alias both round-trip through `get_incident`
- [ ] Verify a `page: 2` request on a single-page result set returns `{incidents: []}` rather than a 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted UX/schema fixes and safer paging empty-results; no auth or data-model changes beyond Zenduty argument parsing and fetch error text.
> 
> **Overview**
> Improves **tool-caching** recovery when `tool_output_fetch` hits the size cap: `FetchResponseTooLarge` hints now list **elided sub-paths** under the requested JSON path (sizes, line counts, copy-paste `tool_output_fetch` templates), with a stronger message when auto-shrink still can’t fit even one slice. Summary mode and compose sub-invocation drill-down hints are unchanged but ordered after that guidance.
> 
> **Zenduty** tools align with how agents actually call them: incident tools take **`unique_id`** (with `incident_id` still accepted), `list_incidents` **`statuses`** accept canonical names or Zenduty **1/2/3** codes (schema shows name enums), and the client treats past-end **`page`** as an **empty list** instead of `Invalid page` 404.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37994855c8c8deabd64b30bb6c82dd7c79befabf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->