### PR TITLE
fix(deploy): adapt to postgresql/gcp module split

### DIFF
--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -55,20 +55,34 @@ locals {
   ]))
 }
 
-module "postgresql" {
-  source = "git::https://github.com/GaloyMoney/galoy-infra.git//modules/postgresql/gcp?ref=main"
+module "postgresql_instance" {
+  source = "git::https://github.com/GaloyMoney/galoy-infra.git//modules/postgresql/gcp/instance?ref=main"
 
-  gcp_project      = local.gcp_project
-  vpc_name         = local.vpc_name
-  instance_name    = "galoy-agents"
-  region           = local.region
-  databases        = ["galoy-agents"]
-  destroyable      = true
-  highly_available = false
-  tier             = "db-f1-micro"
-  max_connections  = 50
-  replication      = false
-  readonly_users   = ["mcp"]
+  gcp_project                    = local.gcp_project
+  vpc_name                       = local.vpc_name
+  instance_name                  = "galoy-agents"
+  region                         = local.region
+  destroyable                    = true
+  highly_available               = false
+  tier                           = "db-f1-micro"
+  backup_enabled                 = true
+  point_in_time_recovery_enabled = true
+}
+
+module "postgresql_database" {
+  for_each = toset(["galoy-agents"])
+  source   = "git::https://github.com/GaloyMoney/galoy-infra.git//modules/postgresql/gcp/database?ref=main"
+
+  providers = {
+    postgresql = postgresql.galoy_agents
+  }
+
+  db_name         = each.value
+  admin_user_name = module.postgresql_instance.admin_user
+  user_name       = "${each.value}-user"
+  readonly_users  = ["mcp"]
+
+  depends_on = [module.postgresql_instance]
 }
 
 resource "kubernetes_namespace" "galoy_agents" {
@@ -111,11 +125,11 @@ resource "kubernetes_secret" "galoy_agents" {
   }
 
   data = {
-    "pg-con" = module.postgresql.creds["galoy-agents"].conn
+    "pg-con" = "postgres://${module.postgresql_database["galoy-agents"].user}:${module.postgresql_database["galoy-agents"].password}@${module.postgresql_instance.private_ip}:5432/galoy-agents"
     # Read-only DSN for the postgres-mcp sidecar. `?sslmode=require` is
     # required — Cloud SQL's pg_hba.conf rejects unencrypted connections
     # and dbhub crash-loops without it.
-    "pg-mcp-uri"                       = "postgres://${module.postgresql.creds["galoy-agents"].readonly_users["mcp"].user}:${module.postgresql.creds["galoy-agents"].readonly_users["mcp"].password}@${module.postgresql.creds["galoy-agents"].host}:5432/galoy-agents?sslmode=require"
+    "pg-mcp-uri"                       = "postgres://${module.postgresql_database["galoy-agents"].readonly_users["mcp"].user}:${module.postgresql_database["galoy-agents"].readonly_users["mcp"].password}@${module.postgresql_instance.private_ip}:5432/galoy-agents?sslmode=require"
     "github-client-secret"             = var.github_client_secret
     "gcs-creds"                        = file("${path.module}/gcs-creds.json")
     "concourse-username"               = var.concourse_username
@@ -238,7 +252,7 @@ resource "postgresql_extension" "vector" {
   name     = "vector"
   database = "galoy-agents"
 
-  depends_on = [module.postgresql]
+  depends_on = [module.postgresql_database]
 }
 
 resource "helm_release" "galoy_agents" {
@@ -303,10 +317,10 @@ provider "kubectl" {
 
 provider "postgresql" {
   alias     = "galoy_agents"
-  host      = module.postgresql.creds["galoy-agents"].host
+  host      = module.postgresql_instance.private_ip
   port      = 5432
-  username  = module.postgresql.admin-creds.user
-  password  = module.postgresql.admin-creds.password
+  username  = module.postgresql_instance.admin_user
+  password  = module.postgresql_instance.admin_password
   database  = "galoy-agents"
   superuser = false
 }

--- a/ci/deploy/drua/moved.tf
+++ b/ci/deploy/drua/moved.tf
@@ -1,0 +1,24 @@
+moved {
+  from = module.postgresql.random_id.db_name_suffix
+  to   = module.postgresql_instance.random_id.db_name_suffix
+}
+
+moved {
+  from = module.postgresql.google_sql_database_instance.instance
+  to   = module.postgresql_instance.google_sql_database_instance.instance
+}
+
+moved {
+  from = module.postgresql.random_password.admin
+  to   = module.postgresql_instance.random_password.admin
+}
+
+moved {
+  from = module.postgresql.google_sql_user.admin
+  to   = module.postgresql_instance.google_sql_user.admin
+}
+
+moved {
+  from = module.postgresql.module.database
+  to   = module.postgresql_database
+}


### PR DESCRIPTION
## Issue

galoy-infra [PR #329](https://github.com/GaloyMoney/galoy-infra/pull/329) (`refactor(postgresql)!:`, merged 2026-05-24) split `modules/postgresql/gcp` into independent `instance/` and `database/` submodules. `ci/deploy/drua/main.tf` calls the old flat path pinned at `?ref=main`, so the upstream merge silently swapped the call target for a module whose new variables surface rejects every input the existing call supplies — `gcp_project`, `vpc_name`, `instance_name`, `region`, `databases`, `destroyable`, `highly_available`, `tier`, `max_connections`, `replication`, `readonly_users`.

## Symptoms

Three consecutive `deploy-to-prod` builds in the `galoy-agents-bin` Concourse pipeline fail at the terraform-apply step: builds **735**, **736**, **737**. Last green was **734** on 2026-05-23, the day before #329 merged. Build log excerpt:

```
▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼ Terraform Apply ▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼ ▼
╷
│ Error: Unsupported argument
│
│   on main.tf line 61, in module "postgresql":
│   61:   gcp_project      = local.gcp_project
│
│ An argument named "gcp_project" is not expected here.
╵
(... same error for every other argument ...)
Failed To Run Terraform Apply!
```

`deploy-to-prod` is the only path that promotes chart-hash bumps and edge-image digests to galoy-agents prod; until it goes green, no change reaches the cluster.

## New state

Splits the call into `module "postgresql_instance"` + `module "postgresql_database"` (for_each-keyed) mirroring galoy-deployments [PR #2778](https://github.com/GaloyMoney/galoy-deployments/pull/2778), and rewires the four consumers of the old `creds` map to the new outputs. `ci/deploy/drua/moved.tf` migrates the live Cloud SQL instance, admin user, password, database, and `mcp` readonly role in place — a green plan with zero destroys on `module.postgresql.*` is the success condition.