### PR TITLE
fix(deploy): restore postgresql provider compatibility

### DIFF
--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -69,6 +69,17 @@ module "postgresql_instance" {
   point_in_time_recovery_enabled = true
 }
 
+# Keep the old child-module provider address while removed blocks process
+# legacy manual/big_query database resources from the pre-split module state.
+module "postgresql" {
+  source = "git::https://github.com/GaloyMoney/galoy-infra.git//modules/postgresql/gcp/provider-compat?ref=main"
+
+  host     = module.postgresql_instance.private_ip
+  port     = 5432
+  username = module.postgresql_instance.admin_user
+  password = module.postgresql_instance.admin_password
+}
+
 module "postgresql_database" {
   for_each = toset(["galoy-agents"])
   source   = "git::https://github.com/GaloyMoney/galoy-infra.git//modules/postgresql/gcp/database?ref=main"


### PR DESCRIPTION
Fixes https://ci.galoy.io/teams/galoy-agents/pipelines/galoy-agents-bin/jobs/deploy-to-prod/builds/738

## Summary
- add a temporary postgresql provider-compat module under the old module name
- keep the split postgresql instance/database modules from PR #411 in place
- allow OpenTofu to process legacy manual/big_query database resources still bound to the old child-module provider address

## Root cause
Build 738 got past the module interface error from builds 735-737, but failed during apply because state still contains orphaned resources whose original provider address is module.postgresql.provider["registry.opentofu.org/cyrilgdn/postgresql"]. PR #411 removed that provider configuration when it replaced the old flat module with split modules.

## Validation
- tofu fmt -check ci/deploy/drua/main.tf ci/deploy/drua/moved.tf
- git diff --check
- tofu validate in a Concourse-style temporary deployment directory with charts/drua copied to chart and a placeholder gcs-creds.json

The validate run still emits the expected galoy-infra removed-block lifecycle warnings.