### PR TITLE
fix(ci): adapt prod deploy to galoy-infra postgres split

### DIFF
--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -65,6 +65,7 @@ module "postgresql_instance" {
   destroyable                    = true
   highly_available               = false
   tier                           = "db-f1-micro"
+  database_version               = "POSTGRES_17"
   backup_enabled                 = true
   point_in_time_recovery_enabled = true
 }

--- a/ci/deploy/drua/moved.tf
+++ b/ci/deploy/drua/moved.tf
@@ -19,6 +19,6 @@ moved {
 }
 
 moved {
-  from = module.postgresql.module.database
-  to   = module.postgresql_database
+  from = module.postgresql.module.database["galoy-agents"]
+  to   = module.postgresql_database["galoy-agents"]
 }


### PR DESCRIPTION
## Summary
- update prod deploy Terraform to use split galoy-infra GCP PostgreSQL instance/database modules
- add moved blocks for existing Cloud SQL/database Terraform state
- keep provider-compat module and default PostgreSQL provider for existing provider state
- pin database version to POSTGRES_17 to avoid an implicit upgrade during the module migration

## Validation
- `tofu -chdir=ci/deploy/drua fmt -check -diff`
- temp deploy copy with dummy generated files: `tofu init -backend=false -input=false && tofu validate`

Fixes Concourse deploy failure from build 737: unsupported arguments on `module.postgresql` after the ../galoy-infra PostgreSQL module split.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production Cloud SQL Terraform and state addresses; mis-moved state or version drift could affect deploys or the database instance.
> 
> **Overview**
> Updates **prod deploy** (`ci/deploy/drua`) for the **galoy-infra PostgreSQL module split** so Concourse/Terraform can apply again.
> 
> The Cloud SQL **instance** module now sets **`database_version = "POSTGRES_17"`** so the migration does not trigger an implicit Postgres upgrade. A **`moved`** block is corrected to remap **`module.postgresql.module.database["galoy-agents"]`** → **`module.postgresql_database["galoy-agents"]`**, matching the new `for_each` database module layout and preserving existing state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98eccbbd4a66fe4cc17709ba19e12b00d7b491bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->