### PR TITLE
fix(ci): stop pinning upgraded postgres version

### DIFF
--- a/ci/deploy/drua/main.tf
+++ b/ci/deploy/drua/main.tf
@@ -65,7 +65,6 @@ module "postgresql_instance" {
   destroyable                    = true
   highly_available               = false
   tier                           = "db-f1-micro"
-  database_version               = "POSTGRES_17"
   backup_enabled                 = true
   point_in_time_recovery_enabled = true
 }


### PR DESCRIPTION
## Summary
- remove the POSTGRES_17 pin now that build 739 already moved the Cloud SQL instance/state to POSTGRES_18 before it was aborted
- lets the deploy config match galoy-infra's current GCP PostgreSQL module default and avoids a forbidden downgrade plan

## Context
While verifying #413, an older queued deploy (#739) started before the pin was merged and applied the Cloud SQL version change. The next deploy then planned POSTGRES_18 -> POSTGRES_17 and failed while the instance was still restarting.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production database infrastructure version semantics; the change is intentionally conservative (no downgrade) but misaligned module defaults could still surprise future major-version behavior.
> 
> **Overview**
> Removes the explicit **`database_version = "POSTGRES_17"`** argument from the **`postgresql_instance`** module in **`ci/deploy/drua/main.tf`**, so Cloud SQL version follows the **galoy-infra** GCP PostgreSQL module default instead of a pinned major.
> 
> This aligns deploy Terraform with an instance that was already upgraded to **PostgreSQL 18** (e.g. from an earlier apply) and avoids a planned **18 → 17** downgrade that GCP rejects while the instance is restarting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48a18017defd1e543725b35ed20b03adbb6b4600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->