### PR TITLE
fix(workflow): prune orphan YAMLs when reverse-sync sees soft-deleted record

### DIFF
--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -280,16 +280,17 @@ impl Workflows {
             ..
         } = parsed;
 
-        Self::validate_trigger(&trigger)?;
-
+        // Soft-delete cleanup runs BEFORE `validate_trigger`: an orphan
+        // YAML with an invalid trigger (bad cron, malformed condition, …)
+        // would otherwise error out here every sync tick and never reach
+        // the cleanup. drua is authoritative for workflow lifecycle, so
+        // a soft-deleted record means the YAML is an orphan (e.g. record
+        // was removed via a path that bypassed `Workflows::delete`'s
+        // file-delete enqueue — project cascade rollback, manual DB
+        // cleanup, …). Schedule a cleanup commit so the next reverse-sync
+        // tick converges library → drua state instead of letting the
+        // file linger forever.
         if self.repo.is_soft_deleted_in_op(op, workflow_id).await? {
-            // drua is authoritative for workflow lifecycle: a soft-deleted
-            // record means the YAML is an orphan (e.g. record was removed
-            // via a path that bypassed `Workflows::delete`'s file-delete
-            // enqueue — project cascade rollback, manual DB cleanup, …).
-            // Schedule a cleanup commit so the next reverse-sync tick
-            // converges library → drua state instead of letting the file
-            // linger forever.
             let id_uuid: uuid::Uuid = workflow_id.into();
             let message = format!(
                 "workflow: prune orphan {}-{}",
@@ -313,6 +314,8 @@ impl Workflows {
             );
             return Ok(None);
         }
+
+        Self::validate_trigger(&trigger)?;
 
         let file_hash = drua_library::GitFileHash::new(rendered);
 

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -283,9 +283,33 @@ impl Workflows {
         Self::validate_trigger(&trigger)?;
 
         if self.repo.is_soft_deleted_in_op(op, workflow_id).await? {
+            // drua is authoritative for workflow lifecycle: a soft-deleted
+            // record means the YAML is an orphan (e.g. record was removed
+            // via a path that bypassed `Workflows::delete`'s file-delete
+            // enqueue — project cascade rollback, manual DB cleanup, …).
+            // Schedule a cleanup commit so the next reverse-sync tick
+            // converges library → drua state instead of letting the file
+            // linger forever.
+            let id_uuid: uuid::Uuid = workflow_id.into();
+            let message = format!(
+                "workflow: prune orphan {}-{}",
+                slugify(&name),
+                &id_uuid.to_string()[..8]
+            );
+            self.library
+                .enqueue_write_in_op(
+                    op,
+                    WriteOp::DeleteFile {
+                        path: original_path.clone(),
+                        message,
+                    },
+                    CommitAttribution::system(),
+                )
+                .await?;
             tracing::info!(
                 %workflow_id,
-                "skipping reverse-sync import for soft-deleted workflow"
+                path = %original_path,
+                "enqueued orphan-YAML delete for soft-deleted workflow"
             );
             return Ok(None);
         }


### PR DESCRIPTION
## Summary

- When `Workflows::import_from_library` encounters a YAML whose workflow record is soft-deleted, enqueue a `WriteOp::DeleteFile` for the file's on-disk path instead of silently skipping.
- Converges library → drua state when a workflow record is removed via any path that bypassed `Workflows::delete`'s file-delete enqueue (project-cascade rollback, manual DB cleanup, future code paths).

## Root cause

The drua-library repo at GaloyMoney/drua-library#3 had two orphan YAMLs (`fx-status-update-run.yml` v1, `fx-status-update-v3-run.yml` v3) that had to be hand-deleted because the matching drua workflow records were soft-deleted with no library-write counterpart.

Audit + DB evidence:
- All four `019e50f1` project workflows show `deleted = TRUE` in `workflow_definitions`.
- Only one of them (v2 `019e5519`) has a matching `workflow.delete` audit entry (`audit_entries.id = 164683` at 2026-05-24T15:42:30Z, success). That delete went through `Workflows::delete()`, which enqueues `WriteOp::DeleteFile` via `enqueue_workflow_delete_in_op` (`core/src/workflow/mod.rs:722`) — library commit `72c7ee0 workflow: delete fx-status-update-v2-run-019e5519`.
- v1 (`019e50f2`), v3 (`019e56e9`), and v2-first (`019e5184`) have **no `workflow.delete` audit entry**. The two later admin attempts (audit ids 164684 + 164691) at 15:42:30 and 16:22:54 both errored with `WorkflowDefinitionFindError::NotFound` — the records were already gone.
- The project itself (`019e50f1-51d6-7491-8cf0-5722c48aa0a1`) is still `deleted = false` with only `initialized + space_mounted` events, so `Projects::delete_in_op` (the only legitimate caller of `Workflows::delete_for_project_in_op`) never ran.
- `workflow_definition_events` for all four IDs has exactly the `initialized` row — `delete = "soft_without_queries"` doesn't emit a delete event, so the row alone cannot distinguish the legitimate-cascade path from a bypass.

Best-fit hypothesis (matches PR-3's narrative): a path outside the service layer flipped `deleted = TRUE` on those three rows without queuing the corresponding library write. Whatever the cause, the system has no mechanism to clean up after itself. `import_from_library` was the architectural gap — it explicitly checked `is_soft_deleted_in_op` and bailed:

```rust
if self.repo.is_soft_deleted_in_op(op, workflow_id).await? {
    tracing::info!("skipping reverse-sync import for soft-deleted workflow");
    return Ok(None);
}
```

## Fix

Same branch, now schedules a `WriteOp::DeleteFile` (system attribution, message `workflow: prune orphan <slug>-<id8>`) for `parsed.original_path` before returning `Ok(None)`. The commit lands on the next `library.write` job tick; the subsequent `library.sync` tick observes `DeltaKind::Deleted` and `WorkflowsImporter::delete_in_op` → `delete_by_path_in_op` no-ops because the record is already soft-deleted (active-only canonical-path lookup excludes it).

## Caveats

- Doesn't retroactively clean up orphans that are not touched by any commit — they have no delta to drive `upsert_in_op`. The pre-existing orphans were already cleaned up by PR-3. A periodic library-walk reconciliation could close this remaining gap; out of scope for this PR.
- Stays in the drua-authoritative model already implied by the existing soft-deleted skip check. The README says `runtime/` is bidirectional; an alternative direction is to make workflows match skills' revive-on-import behavior (`Skills::import_from_library` at `core/src/skill/mod.rs:931`). That'd be a larger semantics change and is left as a follow-up workstream.

## Test plan

- [ ] `cargo check -p drua-core` (passes locally)
- [ ] `cargo clippy -p drua-core --tests` (passes locally)
- [ ] CI green
- [ ] Manual: create a workflow, raw-SQL-soft-delete the row, touch the YAML in library — confirm next sync tick lands a `workflow: prune orphan …` commit and the file disappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes library write behavior during sync for soft-deleted workflows; scope is narrow but affects data convergence between DB and git.
> 
> **Overview**
> **Reverse-sync** now treats a workflow YAML whose DB row is soft-deleted as an orphan: instead of skipping import, it enqueues a system-attributed `WriteOp::DeleteFile` on `original_path` (commit message `workflow: prune orphan <slug>-<id8>`) so the library converges when deletes bypassed `Workflows::delete`'s file enqueue.
> 
> The soft-deleted branch runs **before** `validate_trigger`, so broken triggers on orphan files no longer block cleanup on every sync tick.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47eba14213bc175d7d35841b603cf6ecd74c3c47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->