### PR TITLE
fix(deploy): use traefik for dashboard ingress

### DIFF
--- a/charts/drua/templates/_helpers.tpl
+++ b/charts/drua/templates/_helpers.tpl
@@ -27,6 +27,13 @@ http://{{ template "galoyAgents.fullname" . }}.{{ .Release.Namespace }}.svc.clus
 {{- end -}}
 
 {{/*
+Traefik ServersTransport for the main drua Service.
+*/}}
+{{- define "galoyAgents.serverTransport.fullname" -}}
+{{- printf "%s-servertransport" (include "galoyAgents.fullname" .) | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Postgres MCP fullname: <release>-postgres-mcp
 */}}
 {{- define "galoyAgents.postgresMcp.fullname" -}}

--- a/charts/drua/templates/servertransport.yaml
+++ b/charts/drua/templates/servertransport.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.galoyAgents.serverTransport.enabled }}
+apiVersion: traefik.io/v1alpha1
+kind: ServersTransport
+metadata:
+  name: {{ template "galoyAgents.serverTransport.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ template "galoyAgents.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    release: "{{ .Release.Name }}"
+spec:
+  {{- with .Values.galoyAgents.serverTransport.forwardingTimeouts }}
+  forwardingTimeouts:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/drua/templates/service.yaml
+++ b/charts/drua/templates/service.yaml
@@ -1,5 +1,12 @@
 apiVersion: v1
 kind: Service
+{{- $serviceAnnotations := dict -}}
+{{- with .Values.galoyAgents.server.service.annotations -}}
+{{- $serviceAnnotations = . -}}
+{{- end -}}
+{{- if .Values.galoyAgents.serverTransport.enabled -}}
+{{- $_ := set $serviceAnnotations "traefik.ingress.kubernetes.io/service.serverstransport" (printf "%s-%s@kubernetescrd" .Release.Namespace (include "galoyAgents.serverTransport.fullname" .)) -}}
+{{- end }}
 metadata:
   name: {{ template "galoyAgents.fullname" . }}
   namespace: {{ .Release.Namespace }}
@@ -7,7 +14,7 @@ metadata:
     app: {{ template "galoyAgents.fullname" . }}
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
-  {{- with .Values.galoyAgents.server.service.annotations }}
+  {{- with $serviceAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -11,6 +11,9 @@ galoyAgents:
       type: ClusterIP
       port: 5254
       annotations: {}
+  serverTransport:
+    enabled: false
+    forwardingTimeouts: {}
   ingress:
     enabled: false
     host: ""

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -164,6 +164,11 @@ galoyAgents:
     enabled: true
     databaseUrlSecret:
       key: pg-mcp-uri
+  serverTransport:
+    enabled: true
+    forwardingTimeouts:
+      responseHeaderTimeout: 3600s
+      idleConnTimeout: 3600s
   ingress:
     enabled: true
     host: dashboard.agents.galoy.io

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -167,11 +167,9 @@ galoyAgents:
   ingress:
     enabled: true
     host: dashboard.agents.galoy.io
-    ingressClassName: nginx
+    ingressClassName: traefik
     annotations:
       cert-manager.io/cluster-issuer: letsencrypt-issuer
-      nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
-      nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     tls:
       - hosts:
           - dashboard.agents.galoy.io


### PR DESCRIPTION
## Summary
- switch the production dashboard ingress class from nginx to traefik
- remove nginx-specific timeout annotations from the production values

## Test
- rg confirmed no nginx ingress class or nginx ingress annotations remain in the Drua deploy values/chart ingress paths

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production ingress controller and how long-running dashboard connections are timed out; misconfiguration could break access or truncate long sessions until validated in prod.
> 
> **Overview**
> Production dashboard ingress moves from **nginx** to **Traefik**: `ingressClassName` is `traefik`, and the nginx `proxy-read-timeout` / `proxy-send-timeout` annotations are removed.
> 
> The **drua** chart adds optional **Traefik `ServersTransport`** (off by default) with configurable `forwardingTimeouts`. When enabled, it renders a `ServersTransport` resource, names it via a new helper, and annotates the main Service so Traefik uses that transport. Prod turns this on with **3600s** `responseHeaderTimeout` and `idleConnTimeout`, preserving long-lived connections that nginx timeouts used to provide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95610a2a78adf2081e92f9206bf904c0db031d45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->