### PR TITLE
fix: per model entry owns the max tokens

### DIFF
--- a/core/src/agent/session/message.rs
+++ b/core/src/agent/session/message.rs
@@ -195,11 +195,9 @@ pub enum StopReason {
 
 impl From<Prompt> for llm::Prompt {
     fn from(p: Prompt) -> Self {
-        let max_tokens = Some(p.model_chain.primary.max_tokens_per_response);
-        let mut chain = llm::ModelChain::new(
-            llm::ModelSpec::new(p.model_chain.primary.model)
-                .with_max_tokens(p.model_chain.primary.max_tokens_per_response),
-        );
+        let primary = llm::ModelSpec::new(p.model_chain.primary.model)
+            .with_max_tokens(p.model_chain.primary.max_tokens_per_response);
+        let mut chain = llm::ModelChain::new(primary);
         for fallback in p.model_chain.fallbacks {
             chain = chain.with_fallback(
                 llm::ModelSpec::new(fallback.model)
@@ -208,7 +206,6 @@ impl From<Prompt> for llm::Prompt {
         }
         llm::Prompt {
             chain,
-            max_tokens,
             cache_key: p.cache_key,
             system: p
                 .system

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -255,10 +255,7 @@ impl ExecutorState {
         for spec in prompt.chain.iter() {
             match self.find(&spec.name) {
                 Some(model) => entries.push(ChainEntry {
-                    spec: llm::ModelSpec {
-                        name: spec.name.clone(),
-                        max_tokens: spec.max_tokens,
-                    },
+                    spec: spec.clone(),
                     provider: model.client.clone(),
                 }),
                 None => {

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -26,8 +26,6 @@ pub struct PromptExecutorConfig {
 pub struct ModelConfig {
     pub name: String,
     pub provider: Provider,
-    #[serde(default)]
-    pub default_max_tokens: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -257,8 +255,10 @@ impl ExecutorState {
         for spec in prompt.chain.iter() {
             match self.find(&spec.name) {
                 Some(model) => entries.push(ChainEntry {
-                    model_id: spec.name.clone(),
-                    max_tokens: spec.max_tokens.or(model.default_max_tokens),
+                    spec: llm::ModelSpec {
+                        name: spec.name.clone(),
+                        max_tokens: spec.max_tokens,
+                    },
                     provider: model.client.clone(),
                 }),
                 None => {
@@ -329,7 +329,6 @@ async fn evaluate_chain(entries: Vec<ChainEntry>, prompt: Prompt, response: Prom
 #[derive(Clone)]
 struct ResolvedModel {
     name: String,
-    default_max_tokens: Option<u32>,
     client: Arc<dyn LlmProvider>,
 }
 
@@ -354,7 +353,6 @@ impl ResolvedModel {
         };
         Self {
             name: config.name,
-            default_max_tokens: config.default_max_tokens,
             client,
         }
     }

--- a/core/tests/prompt_executor.rs
+++ b/core/tests/prompt_executor.rs
@@ -18,14 +18,13 @@ async fn anthropic_round_trip_via_executor() {
                 api_key,
                 base_url: None,
             },
-            default_max_tokens: Some(64),
         }],
     };
 
     let (_executor, prompt_tx) = PromptExecutor::init(config).await;
 
     let prompt = Prompt {
-        chain: llm::ModelChain::new(MODEL),
+        chain: llm::ModelChain::new(llm::ModelSpec::new(MODEL).with_max_tokens(64)),
         messages: vec![Message::User {
             content: vec![UserBlock::Text {
                 text: "Reply with the single word: pong".to_string(),
@@ -34,7 +33,6 @@ async fn anthropic_round_trip_via_executor() {
         system: Vec::new(),
         tools: Vec::new(),
         tool_choice: None,
-        max_tokens: None, // executor should fill this in from default_max_tokens
         cache_key: None,
     };
 

--- a/lib/anthropic-client/src/convert.rs
+++ b/lib/anthropic-client/src/convert.rs
@@ -406,7 +406,7 @@ mod tests {
     }
 
     fn base_spec() -> ModelSpec {
-        ModelSpec::new("claude-sonnet-4").with_max_tokens(1024)
+        ModelSpec::new("claude-fallback-id").with_max_tokens(1024)
     }
 
     #[test]
@@ -434,8 +434,8 @@ mod tests {
     }
 
     #[test]
-    fn primary_model_id_is_used() {
+    fn spec_model_id_lands_on_request_not_prompt_primary() {
         let req = prompt_to_request(&base_prompt(), &base_spec());
-        assert_eq!(req.model, "claude-sonnet-4");
+        assert_eq!(req.model, "claude-fallback-id");
     }
 }

--- a/lib/anthropic-client/src/convert.rs
+++ b/lib/anthropic-client/src/convert.rs
@@ -35,7 +35,7 @@ impl AnthropicCacheTtl {
     }
 }
 
-pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> AnthropicRequest {
+pub(crate) fn prompt_to_request(prompt: &llm::Prompt, spec: &llm::ModelSpec) -> AnthropicRequest {
     let messages: Vec<AnthropicMessage> = prompt.messages.iter().map(convert_message).collect();
 
     let system = if prompt.system.is_empty() {
@@ -53,10 +53,10 @@ pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> AnthropicRequest {
     let tool_choice = prompt.tool_choice.as_ref().map(convert_tool_choice);
 
     let mut request = AnthropicRequest {
-        model: prompt.chain.primary.name.clone(),
+        model: spec.name.clone(),
         messages,
         system,
-        max_tokens: prompt.max_tokens.unwrap_or(8192),
+        max_tokens: spec.max_tokens.unwrap_or(8192),
         temperature: None,
         tools,
         tool_choice,
@@ -390,7 +390,7 @@ impl AnthropicDeltaConverter {
 mod tests {
     use super::*;
     use llm::prompt::{Message, Prompt, SystemBlock, UserBlock};
-    use llm::ModelChain;
+    use llm::{ModelChain, ModelSpec};
 
     fn base_prompt() -> Prompt {
         Prompt {
@@ -401,14 +401,17 @@ mod tests {
             }],
             tools: vec![],
             tool_choice: None,
-            max_tokens: Some(1024),
             cache_key: None,
         }
     }
 
+    fn base_spec() -> ModelSpec {
+        ModelSpec::new("claude-sonnet-4").with_max_tokens(1024)
+    }
+
     #[test]
     fn cache_marker_lands_on_last_user_block() {
-        let req = prompt_to_request(&base_prompt());
+        let req = prompt_to_request(&base_prompt(), &base_spec());
         let last = req.messages.last().unwrap();
         match &last.content[0] {
             AnthropicContent::Text { cache_control, .. } => {
@@ -425,14 +428,14 @@ mod tests {
     fn cache_marker_falls_through_to_system_when_no_messages() {
         let mut p = base_prompt();
         p.messages.clear();
-        let req = prompt_to_request(&p);
+        let req = prompt_to_request(&p, &base_spec());
         let sys = req.system.as_ref().unwrap().last().unwrap();
         assert!(sys.cache_control.is_some());
     }
 
     #[test]
     fn primary_model_id_is_used() {
-        let req = prompt_to_request(&base_prompt());
+        let req = prompt_to_request(&base_prompt(), &base_spec());
         assert_eq!(req.model, "claude-sonnet-4");
     }
 }

--- a/lib/anthropic-client/src/lib.rs
+++ b/lib/anthropic-client/src/lib.rs
@@ -11,9 +11,8 @@ use thiserror::Error;
 use tracing::instrument;
 
 use llm::provider::LlmProvider;
-use llm::{Prompt, PromptError, PromptResponse};
-
 use llm::stream::StreamDelta;
+use llm::{ModelSpec, Prompt, PromptError, PromptResponse};
 
 use crate::convert::{accumulated_to_response, prompt_to_request, AnthropicDeltaConverter};
 use crate::sse::{parse_sse_stream, SseError};
@@ -70,8 +69,12 @@ impl AnthropicClient {
 
     /// Streams the Messages API and returns the fully-accumulated reply.
     #[instrument(name = "anthropic_client.send_prompt", skip_all)]
-    pub async fn send_prompt(&self, prompt: &Prompt) -> Result<PromptResponse, AnthropicError> {
-        let request_body = prompt_to_request(prompt);
+    pub async fn send_prompt(
+        &self,
+        prompt: &Prompt,
+        spec: &ModelSpec,
+    ) -> Result<PromptResponse, AnthropicError> {
+        let request_body = prompt_to_request(prompt, spec);
 
         let resp = self
             .http
@@ -126,9 +129,10 @@ impl AnthropicClient {
     pub async fn send_prompt_streaming(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, AnthropicError>>, AnthropicError>
     {
-        let request_body = prompt_to_request(prompt);
+        let request_body = prompt_to_request(prompt, spec);
 
         let resp = self
             .http
@@ -208,8 +212,9 @@ impl LlmProvider for AnthropicClient {
     async fn send_prompt_streaming(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
-        let rx = AnthropicClient::send_prompt_streaming(self, prompt)
+        let rx = AnthropicClient::send_prompt_streaming(self, prompt, spec)
             .await
             .map_err(classify)?;
 

--- a/lib/anthropic-client/tests/live_prompt_caching.rs
+++ b/lib/anthropic-client/tests/live_prompt_caching.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anthropic_client::AnthropicClient;
 use llm::prompt::{Message, SystemBlock, UserBlock};
-use llm::{ModelChain, Prompt};
+use llm::{ModelChain, ModelSpec, Prompt};
 
 const LIVE_TESTS_ENV: &str = "DRUA_LIVE_CACHE_TESTS";
 const API_KEY_ENV: &str = "ANTHROPIC_API_KEY";
@@ -36,7 +36,7 @@ fn unique_nonce() -> String {
 /// `lib/llm` `Prompt` shape carries no cache hints.
 fn build_prompt(model: &str, system_text: String, user_text: impl Into<String>) -> Prompt {
     Prompt {
-        chain: ModelChain::new(model),
+        chain: ModelChain::new(ModelSpec::new(model).with_max_tokens(64)),
         messages: vec![Message::User {
             content: vec![UserBlock::Text {
                 text: user_text.into(),
@@ -45,7 +45,6 @@ fn build_prompt(model: &str, system_text: String, user_text: impl Into<String>) 
         system: vec![SystemBlock::Text { text: system_text }],
         tools: Vec::new(),
         tool_choice: None,
-        max_tokens: Some(64),
         cache_key: None,
     }
 }
@@ -99,8 +98,9 @@ async fn anthropic_reports_cache_write_then_cache_read_on_follow_up_prompt() {
         system_text.clone(),
         "Reply with the single word: seeded",
     );
+    let warm_spec = warm_prompt.chain.primary.clone();
     let warm_response = client
-        .send_prompt(&warm_prompt)
+        .send_prompt(&warm_prompt, &warm_spec)
         .await
         .expect("warm request should succeed");
     assert!(
@@ -121,8 +121,9 @@ async fn anthropic_reports_cache_write_then_cache_read_on_follow_up_prompt() {
             format!("Reply with the single word: warmed-{attempt}"),
         );
 
+        let spec = prompt.chain.primary.clone();
         let response = client
-            .send_prompt(&prompt)
+            .send_prompt(&prompt, &spec)
             .await
             .expect("follow-up request should succeed");
         cache_reads.push(response.usage.cache_read_input_tokens);

--- a/lib/llm/src/prompt.rs
+++ b/lib/llm/src/prompt.rs
@@ -13,8 +13,6 @@ pub struct Prompt {
     pub tools: Vec<Tool>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub tool_choice: Option<ToolChoice>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_tokens: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_key: Option<String>,
 }
@@ -27,7 +25,6 @@ impl Default for Prompt {
             system: Vec::new(),
             tools: Vec::new(),
             tool_choice: None,
-            max_tokens: None,
             cache_key: None,
         }
     }
@@ -136,19 +133,19 @@ impl Prompt {
         #[derive(Serialize)]
         struct Hashable<'a> {
             primary_model: &'a str,
+            primary_max_tokens: Option<u32>,
             messages: &'a [Message],
             system: &'a [SystemBlock],
             tools: &'a [Tool],
             tool_choice: Option<&'a ToolChoice>,
-            max_tokens: Option<u32>,
         }
         let hashable = Hashable {
             primary_model: &self.chain.primary.name,
+            primary_max_tokens: self.chain.primary.max_tokens,
             messages: &self.messages,
             system: &self.system,
             tools: &self.tools,
             tool_choice: self.tool_choice.as_ref(),
-            max_tokens: self.max_tokens,
         };
         let value = serde_json::to_value(&hashable).expect("hashable is always serializable");
         let canonical = canonicalize(&value);
@@ -233,7 +230,9 @@ mod tests {
 
     fn sample_prompt(msg_text: &str) -> Prompt {
         Prompt {
-            chain: ModelChain::new(ModelSpec::new("claude-sonnet-4-20250514")),
+            chain: ModelChain::new(
+                ModelSpec::new("claude-sonnet-4-20250514").with_max_tokens(1024),
+            ),
             system: vec![SystemBlock::Text {
                 text: "You are a helpful assistant.".to_string(),
             }],
@@ -255,7 +254,6 @@ mod tests {
                 strict: false,
             }],
             tool_choice: None,
-            max_tokens: Some(1024),
             cache_key: None,
         }
     }
@@ -298,7 +296,6 @@ mod tests {
             }],
             tools: vec![],
             tool_choice: None,
-            max_tokens: None,
             cache_key: None,
         };
 

--- a/lib/llm/src/provider.rs
+++ b/lib/llm/src/provider.rs
@@ -5,18 +5,24 @@ use async_trait::async_trait;
 use tokio::sync::mpsc;
 
 use crate::stream::StreamDelta;
-use crate::{Prompt, PromptError};
+use crate::{ModelSpec, Prompt, PromptError};
 
 #[async_trait]
 pub trait LlmProvider: Send + Sync {
     /// e.g. `"anthropic"`, `"openai"`.
     fn name(&self) -> &str;
 
+    /// `spec` identifies the chain entry being attempted — providers MUST
+    /// read the wire-level model id from `spec.name` and the output cap
+    /// from `spec.max_tokens`. `prompt.chain.primary` is metadata about
+    /// the originally-requested model and may differ on fallback attempts.
+    ///
     /// Typical event order: content deltas, then `Usage` (additive, may
     /// arrive at any point), then `Done`. Providers emit only the events
     /// natural to their wire format.
     async fn send_prompt_streaming(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError>;
 }

--- a/lib/llm/src/router.rs
+++ b/lib/llm/src/router.rs
@@ -7,21 +7,18 @@ use std::sync::Arc;
 use crate::provider::LlmProvider;
 use crate::request::PromptError;
 use crate::response::Usage;
-use crate::{Prompt, StreamHandle};
+use crate::{ModelSpec, Prompt, StreamHandle};
 
 #[derive(Clone)]
 pub struct ChainEntry {
-    pub model_id: String,
-    /// Today only `max_tokens` is plumbed through per-attempt.
-    pub max_tokens: Option<u32>,
+    pub spec: ModelSpec,
     pub provider: Arc<dyn LlmProvider>,
 }
 
 impl std::fmt::Debug for ChainEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ChainEntry")
-            .field("model_id", &self.model_id)
-            .field("max_tokens", &self.max_tokens)
+            .field("spec", &self.spec)
             .field("provider", &self.provider.name())
             .finish()
     }
@@ -78,40 +75,39 @@ pub async fn walk(chain: &[ChainEntry], base: &Prompt) -> Result<WalkOutcome, Pr
     let mut last_err: Option<PromptError> = None;
 
     for entry in chain {
-        let mut prompt = base.clone();
-        if let Some(mt) = entry.max_tokens {
-            prompt.max_tokens = Some(mt);
-        }
-
-        match entry.provider.send_prompt_streaming(&prompt).await {
+        match entry
+            .provider
+            .send_prompt_streaming(base, &entry.spec)
+            .await
+        {
             Ok(rx) => {
                 attempts.push(AttemptRecord {
-                    model_id: entry.model_id.clone(),
+                    model_id: entry.spec.name.clone(),
                     provider_name: entry.provider.name().to_string(),
                     outcome: AttemptOutcome::Succeeded,
                     usage: None,
                 });
                 tracing::info!(
-                    model = %entry.model_id,
+                    model = %entry.spec.name,
                     provider = entry.provider.name(),
                     attempts = attempts.len(),
                     "router.walk: stream opened",
                 );
                 return Ok(WalkOutcome {
                     stream: StreamHandle { rx },
-                    model_used: entry.model_id.clone(),
+                    model_used: entry.spec.name.clone(),
                     attempts,
                 });
             }
             Err(e) if e.is_terminal() => {
                 attempts.push(AttemptRecord {
-                    model_id: entry.model_id.clone(),
+                    model_id: entry.spec.name.clone(),
                     provider_name: entry.provider.name().to_string(),
                     outcome: AttemptOutcome::Terminal(e.to_string()),
                     usage: None,
                 });
                 tracing::error!(
-                    model = %entry.model_id,
+                    model = %entry.spec.name,
                     provider = entry.provider.name(),
                     error = %e,
                     "router.walk: terminal error, aborting chain",
@@ -120,13 +116,13 @@ pub async fn walk(chain: &[ChainEntry], base: &Prompt) -> Result<WalkOutcome, Pr
             }
             Err(e) => {
                 tracing::warn!(
-                    model = %entry.model_id,
+                    model = %entry.spec.name,
                     provider = entry.provider.name(),
                     error = %e,
                     "router.walk: transient error, trying next",
                 );
                 attempts.push(AttemptRecord {
-                    model_id: entry.model_id.clone(),
+                    model_id: entry.spec.name.clone(),
                     provider_name: entry.provider.name().to_string(),
                     outcome: AttemptOutcome::Transient(e.to_string()),
                     usage: None,
@@ -160,6 +156,7 @@ mod tests {
         async fn send_prompt_streaming(
             &self,
             _prompt: &Prompt,
+            _spec: &ModelSpec,
         ) -> Result<mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
             let (_tx, rx) = mpsc::channel(1);
             Ok(rx)
@@ -188,6 +185,7 @@ mod tests {
         async fn send_prompt_streaming(
             &self,
             _prompt: &Prompt,
+            _spec: &ModelSpec,
         ) -> Result<mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
             self.calls.fetch_add(1, Ordering::SeqCst);
             Err(self.err.clone())
@@ -196,8 +194,7 @@ mod tests {
 
     fn entry(model_id: &str, provider: Arc<dyn LlmProvider>) -> ChainEntry {
         ChainEntry {
-            model_id: model_id.to_string(),
-            max_tokens: None,
+            spec: ModelSpec::new(model_id),
             provider,
         }
     }

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -18,7 +18,7 @@ use crate::types::{
 /// these as a passthrough field.
 const ANTHROPIC_MODEL_PREFIX: &str = "anthropic/";
 
-pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> OpenAiRequest {
+pub(crate) fn prompt_to_request(prompt: &llm::Prompt, spec: &llm::ModelSpec) -> OpenAiRequest {
     let mut messages: Vec<OpenAiMessage> = Vec::new();
 
     for block in &prompt.system {
@@ -47,10 +47,10 @@ pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> OpenAiRequest {
     let tool_choice = prompt.tool_choice.as_ref().map(convert_tool_choice);
 
     let mut request = OpenAiRequest {
-        model: prompt.chain.primary.name.clone(),
+        model: spec.name.clone(),
         messages,
         prompt_cache_key: prompt.cache_key.clone(),
-        max_completion_tokens: prompt.max_tokens,
+        max_completion_tokens: spec.max_tokens,
         temperature: None,
         tools,
         tool_choice,
@@ -444,15 +444,18 @@ mod tests {
                 strict: false,
             }],
             tool_choice: None,
-            max_tokens: Some(1024),
             cache_key: None,
         }
+    }
+
+    fn sample_spec() -> llm::ModelSpec {
+        llm::ModelSpec::new("gpt-4o").with_max_tokens(1024)
     }
 
     #[test]
     fn prompt_to_request_basic() {
         let prompt = sample_prompt();
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, &sample_spec());
 
         assert_eq!(req.model, "gpt-4o");
         assert!(req.stream);
@@ -471,7 +474,7 @@ mod tests {
         let mut prompt = sample_prompt();
         prompt.cache_key = Some("agent-session:test".to_string());
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, &sample_spec());
         assert_eq!(req.prompt_cache_key.as_deref(), Some("agent-session:test"));
     }
 
@@ -500,11 +503,10 @@ mod tests {
             ],
             tools: vec![],
             tool_choice: None,
-            max_tokens: None,
             cache_key: None,
         };
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, &sample_spec());
         assert_eq!(req.messages.len(), 2);
         assert_eq!(req.messages[0].role, "assistant");
         assert!(req.messages[0].tool_calls.is_some());
@@ -531,11 +533,10 @@ mod tests {
             }],
             tools: vec![],
             tool_choice: None,
-            max_tokens: None,
             cache_key: None,
         };
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, &sample_spec());
         assert_eq!(req.messages.len(), 1);
         assert_eq!(
             content_text(&req.messages[0]),
@@ -855,14 +856,20 @@ mod tests {
                 strict: false,
             }],
             tool_choice: None,
-            max_tokens: Some(1024),
             cache_key: None,
         }
     }
 
+    fn anthropic_via_openrouter_spec() -> llm::ModelSpec {
+        llm::ModelSpec::new("anthropic/claude-sonnet-4.6").with_max_tokens(1024)
+    }
+
     #[test]
     fn anthropic_via_openrouter_marks_last_user_text_block() {
-        let req = prompt_to_request(&anthropic_via_openrouter_prompt());
+        let req = prompt_to_request(
+            &anthropic_via_openrouter_prompt(),
+            &anthropic_via_openrouter_spec(),
+        );
 
         let last = req.messages.last().expect("messages present");
         assert_eq!(last.role, "user");
@@ -893,10 +900,10 @@ mod tests {
 
     #[test]
     fn non_anthropic_model_emits_plain_string_content() {
-        let mut prompt = anthropic_via_openrouter_prompt();
-        prompt.chain = llm::ModelChain::new("openai/gpt-5-mini");
+        let prompt = anthropic_via_openrouter_prompt();
+        let spec = llm::ModelSpec::new("openai/gpt-5-mini").with_max_tokens(1024);
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, &spec);
 
         for msg in &req.messages {
             assert!(
@@ -924,7 +931,7 @@ mod tests {
         prompt.messages.clear();
         prompt.system.clear();
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, &anthropic_via_openrouter_spec());
 
         let tool = req
             .tools
@@ -937,7 +944,10 @@ mod tests {
 
     #[test]
     fn anthropic_serialised_request_has_cache_control_inside_content_block() {
-        let req = prompt_to_request(&anthropic_via_openrouter_prompt());
+        let req = prompt_to_request(
+            &anthropic_via_openrouter_prompt(),
+            &anthropic_via_openrouter_spec(),
+        );
         let json = serde_json::to_value(&req).unwrap();
 
         // Wire-format check: the marker is nested inside a content block on

--- a/lib/openai-client/src/lib.rs
+++ b/lib/openai-client/src/lib.rs
@@ -14,7 +14,7 @@ use tracing::{instrument, Instrument};
 
 use llm::provider::LlmProvider;
 use llm::stream::StreamDelta;
-use llm::{Prompt, PromptError, PromptResponse};
+use llm::{ModelSpec, Prompt, PromptError, PromptResponse};
 
 use crate::convert::{prompt_to_request, DeltaSynthesizer, EMPTY_COMPLETION_ERR};
 use crate::sse::{parse_sse_stream, SseError};
@@ -87,8 +87,9 @@ impl OpenAiClient {
     pub async fn send_prompt(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<PromptResponse, OpenAiChatCompletionsError> {
-        let rx = self.send_prompt_streaming_internal(prompt).await?;
+        let rx = self.send_prompt_streaming_internal(prompt, spec).await?;
         let mut rx = rx;
 
         let mut accumulator = llm::stream::StreamAccumulator::new();
@@ -174,11 +175,12 @@ impl OpenAiClient {
     async fn send_prompt_streaming_internal(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<
         tokio::sync::mpsc::Receiver<Result<StreamDelta, OpenAiChatCompletionsError>>,
         OpenAiChatCompletionsError,
     > {
-        let request_body = prompt_to_request(prompt);
+        let request_body = prompt_to_request(prompt, spec);
         let body_bytes = Arc::new(
             serde_json::to_vec(&request_body)
                 .map_err(|e| OpenAiChatCompletionsError::Stream(format!("body serialize: {e}")))?,
@@ -392,9 +394,10 @@ impl LlmProvider for OpenAiClient {
     async fn send_prompt_streaming(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
         let rx = self
-            .send_prompt_streaming_internal(prompt)
+            .send_prompt_streaming_internal(prompt, spec)
             .await
             .map_err(classify)?;
 

--- a/lib/openai-client/src/responses.rs
+++ b/lib/openai-client/src/responses.rs
@@ -7,7 +7,7 @@ use llm::prompt::{
 };
 use llm::provider::LlmProvider;
 use llm::stream::StreamDelta;
-use llm::{Prompt, PromptError};
+use llm::{ModelSpec, Prompt, PromptError};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
@@ -99,11 +99,12 @@ impl OpenAiResponsesClient {
     async fn send_prompt_streaming_internal(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<
         tokio::sync::mpsc::Receiver<Result<StreamDelta, OpenAiResponsesError>>,
         OpenAiResponsesError,
     > {
-        let request_body = prompt_to_responses_request(prompt, &self.auth);
+        let request_body = prompt_to_responses_request(prompt, spec, &self.auth);
         let mut request = self
             .http
             .post(&self.api_url)
@@ -231,9 +232,10 @@ impl LlmProvider for OpenAiResponsesClient {
     async fn send_prompt_streaming(
         &self,
         prompt: &Prompt,
+        spec: &ModelSpec,
     ) -> Result<tokio::sync::mpsc::Receiver<Result<StreamDelta, PromptError>>, PromptError> {
         let rx = self
-            .send_prompt_streaming_internal(prompt)
+            .send_prompt_streaming_internal(prompt, spec)
             .await
             .map_err(classify)?;
 
@@ -320,7 +322,11 @@ struct ResponsesReasoningConfig {
     summary: &'static str,
 }
 
-fn prompt_to_responses_request(prompt: &Prompt, auth: &OpenAiResponsesAuth) -> ResponsesRequest {
+fn prompt_to_responses_request(
+    prompt: &Prompt,
+    spec: &ModelSpec,
+    auth: &OpenAiResponsesAuth,
+) -> ResponsesRequest {
     let mut input = Vec::new();
 
     for message in &prompt.messages {
@@ -343,13 +349,13 @@ fn prompt_to_responses_request(prompt: &Prompt, auth: &OpenAiResponsesAuth) -> R
         .join("\n");
 
     ResponsesRequest {
-        model: prompt.chain.primary.name.clone(),
+        model: spec.name.clone(),
         input,
         instructions: (!instructions.is_empty()).then_some(instructions),
         prompt_cache_key: prompt.cache_key.clone(),
         max_output_tokens: match auth {
             OpenAiResponsesAuth::ApiKey { .. } => {
-                prompt.max_tokens.or(Some(DEFAULT_MAX_OUTPUT_TOKENS))
+                spec.max_tokens.or(Some(DEFAULT_MAX_OUTPUT_TOKENS))
             }
             OpenAiResponsesAuth::Subscription => None,
         },
@@ -1058,9 +1064,12 @@ mod tests {
             system: Vec::new(),
             tools: Vec::new(),
             tool_choice: None,
-            max_tokens: Some(1234),
             cache_key: None,
         }
+    }
+
+    fn sample_spec() -> ModelSpec {
+        ModelSpec::new("gpt-5.4-mini").with_max_tokens(1234)
     }
 
     fn build_test_jwt(account_id: &str) -> String {
@@ -1155,6 +1164,7 @@ mod tests {
     fn api_key_requests_include_max_output_tokens() {
         let request = prompt_to_responses_request(
             &sample_prompt(),
+            &sample_spec(),
             &OpenAiResponsesAuth::ApiKey {
                 api_key: "sk-test".to_string(),
             },
@@ -1166,8 +1176,11 @@ mod tests {
 
     #[test]
     fn subscription_requests_omit_max_output_tokens() {
-        let request =
-            prompt_to_responses_request(&sample_prompt(), &OpenAiResponsesAuth::Subscription);
+        let request = prompt_to_responses_request(
+            &sample_prompt(),
+            &sample_spec(),
+            &OpenAiResponsesAuth::Subscription,
+        );
 
         let value = serde_json::to_value(request).expect("request serializes");
         assert!(
@@ -1183,6 +1196,7 @@ mod tests {
 
         let request = prompt_to_responses_request(
             &prompt,
+            &sample_spec(),
             &OpenAiResponsesAuth::ApiKey {
                 api_key: "sk-test".to_string(),
             },

--- a/lib/openai-client/tests/live_prompt_caching.rs
+++ b/lib/openai-client/tests/live_prompt_caching.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use llm::prompt::{Message, SystemBlock, UserBlock};
 use llm::provider::LlmProvider;
 use llm::stream::StreamAccumulator;
-use llm::{ModelChain, Prompt, PromptResponse};
+use llm::{ModelChain, ModelSpec, Prompt, PromptResponse};
 use openai_client::{OpenAiResponsesAuth, OpenAiResponsesClient};
 
 const LIVE_TESTS_ENV: &str = "DRUA_LIVE_CACHE_TESTS";
@@ -41,7 +41,7 @@ fn build_prompt(
     user_text: impl Into<String>,
 ) -> Prompt {
     Prompt {
-        chain: ModelChain::new(model),
+        chain: ModelChain::new(ModelSpec::new(model).with_max_tokens(64)),
         messages: vec![Message::User {
             content: vec![UserBlock::Text {
                 text: user_text.into(),
@@ -50,7 +50,6 @@ fn build_prompt(
         system: vec![SystemBlock::Text { text: system_text }],
         tools: Vec::new(),
         tool_choice: None,
-        max_tokens: Some(64),
         cache_key: Some(cache_key.to_string()),
     }
 }
@@ -82,7 +81,7 @@ async fn send_prompt(
     prompt: &Prompt,
 ) -> Result<PromptResponse, String> {
     let mut rx = client
-        .send_prompt_streaming(prompt)
+        .send_prompt_streaming(prompt, &prompt.chain.primary)
         .await
         .map_err(|err| err.to_string())?;
 

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -95,7 +95,6 @@ impl Config {
                 models.push(ModelConfig {
                     name: model.name.clone(),
                     provider: provider.clone(),
-                    default_max_tokens: None,
                 });
             }
         }


### PR DESCRIPTION
Before: `Prompt.max_tokens` was a single mutable field; the router cloned the prompt per attempt and overwrote that field with the current entry's cap, so primary's cap could leak onto a fallback.

Now each `ChainEntry` carries its own `ModelSpec`; providers take `(&Prompt, &ModelSpec)` and read wire id + cap from the spec. The prompt stays immutable across attempts, and the dead `default_max_tokens` executor tier is removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core LLM provider trait and fallback routing path; behavior is more correct for multi-model chains but any missed call sites or serde migrations could mis-set limits at runtime.
> 
> **Overview**
> **Output limits and wire model IDs now live on each chain entry’s `ModelSpec`, not on a mutable `Prompt.max_tokens` field.**
> 
> The PR removes `Prompt.max_tokens` and executor `default_max_tokens`. The router stops cloning the prompt and overwriting tokens per fallback attempt; it passes an immutable prompt plus `(&Prompt, &ModelSpec)` into providers. Anthropic, OpenAI Chat Completions, and OpenAI Responses read **model name** and **max tokens** from the active `spec`, so a fallback uses its own cap and id instead of leaking the primary’s settings. Agent prompts map `max_tokens_per_response` onto each `ModelSpec` in the chain; prompt hashing uses the primary chain entry’s max tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c297291f920ba0edc6c4fd6c0bd8ab2eed3ee0de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->