### PR TITLE
chore: expose internal PR update tool

### DIFF
--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -150,6 +150,7 @@ galoyAgents:
         internalOnly: true
         allowedTools:
           - create_pull_request
+          - update_pull_request
           - pull_request_review_write
       - name: github_issues
         url: https://api.githubcopilot.com/mcp/

--- a/drua.yml
+++ b/drua.yml
@@ -149,4 +149,5 @@ toolsets:
       # and we don't want any agent flow ever discovering it.
       allowed_tools:
         - create_pull_request
+        - update_pull_request
         - pull_request_review_write


### PR DESCRIPTION
## Summary

- add upstream `update_pull_request` to the internal `github_pull_requests` allowlist in `drua.yml`
- add the same tool to production Helm values under `github_pull_requests.allowedTools`
- keep the PR mutation upstream internal-only and continue excluding `merge_pull_request`

## Validation

- Ruby structured config allowlist check for both files
- `git diff --check`
- `cargo test -p drua-core --test toolset`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config-only allowlist expansion on an already internal-only PR write upstream; merge remains blocked.
> 
> **Overview**
> Adds **`update_pull_request`** to the internal **`github_pull_requests`** MCP allowlist in **`drua.yml`** and production **`ci/deploy/drua/prod-values.yml.tmpl`**, so internal-only agents can update existing PRs (alongside create and review write).
> 
> The write upstream stays **`internal_only`**; **`merge_pull_request`** is still not allowlisted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fadc3b50342a56f69e6664e6917ce402ab46adfc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->