### PR TITLE
fix(tool-caching): bracket-quote dotted keys + proxy tool_output_fetch via call_tool

### DIFF
--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -540,20 +540,46 @@ fn parse_path(path: &str) -> Result<Vec<PathSegment>, ToolCachingError> {
             }
             b'[' => {
                 i += 1;
-                let start = i;
-                while i < bytes.len() && bytes[i] != b']' {
+                if i < bytes.len() && bytes[i] == b'"' {
+                    // Bracket-quoted key: ["key.with.dots"]
+                    i += 1;
+                    let start = i;
+                    while i < bytes.len() && bytes[i] != b'"' {
+                        i += 1;
+                    }
+                    if i == bytes.len() {
+                        return Err(ToolCachingError::InvalidPath(format!(
+                            "unclosed `[\"` in path {path}"
+                        )));
+                    }
+                    let key = rest[start..i].to_string();
+                    i += 1; // skip closing "
+                    if i >= bytes.len() || bytes[i] != b']' {
+                        return Err(ToolCachingError::InvalidPath(format!(
+                            "expected `]` after quoted key in path {path}"
+                        )));
+                    }
+                    i += 1; // skip ]
+                    out.push(PathSegment::Key(key));
+                } else {
+                    // Numeric array index: [0]
+                    let start = i;
+                    while i < bytes.len() && bytes[i] != b']' {
+                        i += 1;
+                    }
+                    if i == bytes.len() {
+                        return Err(ToolCachingError::InvalidPath(format!(
+                            "unclosed `[` in path {path}"
+                        )));
+                    }
+                    let idx: usize = rest[start..i].parse().map_err(|_| {
+                        ToolCachingError::InvalidPath(format!(
+                            "invalid array index in path {path}"
+                        ))
+                    })?;
+                    out.push(PathSegment::Index(idx));
                     i += 1;
                 }
-                if i == bytes.len() {
-                    return Err(ToolCachingError::InvalidPath(format!(
-                        "unclosed `[` in path {path}"
-                    )));
-                }
-                let idx: usize = rest[start..i].parse().map_err(|_| {
-                    ToolCachingError::InvalidPath(format!("invalid array index in path {path}"))
-                })?;
-                out.push(PathSegment::Index(idx));
-                i += 1;
             }
             _ => {
                 return Err(ToolCachingError::InvalidPath(format!(
@@ -683,6 +709,31 @@ mod tests {
         assert!(matches!(&segs[0], PathSegment::Key(k) if k == "items"));
         assert!(matches!(&segs[1], PathSegment::Index(3)));
         assert!(matches!(&segs[2], PathSegment::Key(k) if k == "name"));
+    }
+
+    #[test]
+    fn parse_path_bracket_quoted_key_with_dot() {
+        let segs = parse_path(r#"$.files["values.yaml"].content"#).unwrap();
+        assert_eq!(segs.len(), 3);
+        assert!(matches!(&segs[0], PathSegment::Key(k) if k == "files"));
+        assert!(matches!(&segs[1], PathSegment::Key(k) if k == "values.yaml"));
+        assert!(matches!(&segs[2], PathSegment::Key(k) if k == "content"));
+    }
+
+    #[test]
+    fn navigate_bracket_quoted_key_resolves_dotted_key() {
+        let inv = stored(serde_json::json!({"files": {"values.yaml": {"content": "x"}}}));
+        assert_eq!(
+            inv.navigate(r#"$.files["values.yaml"].content"#).unwrap(),
+            &Value::String("x".into())
+        );
+    }
+
+    #[test]
+    fn wrap_at_path_bracket_quoted_key() {
+        let wrapped =
+            wrap_at_path(r#"$.files["values.yaml"]"#, Value::String("hi".into())).unwrap();
+        assert_eq!(wrapped, serde_json::json!({"files": {"values.yaml": "hi"}}));
     }
 
     #[test]

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -541,18 +541,32 @@ fn parse_path(path: &str) -> Result<Vec<PathSegment>, ToolCachingError> {
             b'[' => {
                 i += 1;
                 if i < bytes.len() && bytes[i] == b'"' {
-                    // Bracket-quoted key: ["key.with.dots"]
+                    // Bracket-quoted key: ["key.with.dots"] or ["key with \"quotes\""]
                     i += 1;
-                    let start = i;
-                    while i < bytes.len() && bytes[i] != b'"' {
-                        i += 1;
+                    let mut key = String::new();
+                    while i < bytes.len() {
+                        if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                            match bytes[i + 1] {
+                                b'"' => key.push('"'),
+                                b'\\' => key.push('\\'),
+                                other => {
+                                    key.push('\\');
+                                    key.push(other as char);
+                                }
+                            }
+                            i += 2;
+                        } else if bytes[i] == b'"' {
+                            break;
+                        } else {
+                            key.push(bytes[i] as char);
+                            i += 1;
+                        }
                     }
                     if i == bytes.len() {
                         return Err(ToolCachingError::InvalidPath(format!(
                             "unclosed `[\"` in path {path}"
                         )));
                     }
-                    let key = rest[start..i].to_string();
                     i += 1; // skip closing "
                     if i >= bytes.len() || bytes[i] != b']' {
                         return Err(ToolCachingError::InvalidPath(format!(
@@ -573,9 +587,7 @@ fn parse_path(path: &str) -> Result<Vec<PathSegment>, ToolCachingError> {
                         )));
                     }
                     let idx: usize = rest[start..i].parse().map_err(|_| {
-                        ToolCachingError::InvalidPath(format!(
-                            "invalid array index in path {path}"
-                        ))
+                        ToolCachingError::InvalidPath(format!("invalid array index in path {path}"))
                     })?;
                     out.push(PathSegment::Index(idx));
                     i += 1;
@@ -718,6 +730,14 @@ mod tests {
         assert!(matches!(&segs[0], PathSegment::Key(k) if k == "files"));
         assert!(matches!(&segs[1], PathSegment::Key(k) if k == "values.yaml"));
         assert!(matches!(&segs[2], PathSegment::Key(k) if k == "content"));
+    }
+
+    #[test]
+    fn parse_path_bracket_quoted_key_with_escaped_quote() {
+        let segs = parse_path(r#"$.files["he said \"hi\".txt"]"#).unwrap();
+        assert_eq!(segs.len(), 2);
+        assert!(matches!(&segs[0], PathSegment::Key(k) if k == "files"));
+        assert!(matches!(&segs[1], PathSegment::Key(k) if k == r#"he said "hi".txt"#));
     }
 
     #[test]

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -457,6 +457,7 @@ impl StoredInvocation {
     }
 }
 
+#[derive(Debug, PartialEq)]
 enum PathSegment {
     Key(String),
     Index(usize),
@@ -541,24 +542,23 @@ fn parse_path(path: &str) -> Result<Vec<PathSegment>, ToolCachingError> {
             b'[' => {
                 i += 1;
                 if i < bytes.len() && bytes[i] == b'"' {
-                    // Bracket-quoted key: ["key.with.dots"] or ["key with \"quotes\""]
                     i += 1;
                     let mut key = String::new();
+                    let mut span_start = i;
                     while i < bytes.len() {
                         if bytes[i] == b'\\' && i + 1 < bytes.len() {
+                            key.push_str(&rest[span_start..i]);
                             match bytes[i + 1] {
                                 b'"' => key.push('"'),
                                 b'\\' => key.push('\\'),
-                                other => {
-                                    key.push('\\');
-                                    key.push(other as char);
-                                }
+                                _ => key.push_str(&rest[i..i + 2]),
                             }
                             i += 2;
+                            span_start = i;
                         } else if bytes[i] == b'"' {
+                            key.push_str(&rest[span_start..i]);
                             break;
                         } else {
-                            key.push(bytes[i] as char);
                             i += 1;
                         }
                     }
@@ -754,6 +754,18 @@ mod tests {
         let wrapped =
             wrap_at_path(r#"$.files["values.yaml"]"#, Value::String("hi".into())).unwrap();
         assert_eq!(wrapped, serde_json::json!({"files": {"values.yaml": "hi"}}));
+    }
+
+    #[test]
+    fn parse_path_bracket_quoted_key_with_unicode() {
+        let segs = parse_path(r#"$.files["données.txt"]"#).unwrap();
+        assert_eq!(
+            segs,
+            vec![
+                PathSegment::Key("files".into()),
+                PathSegment::Key("données.txt".into()),
+            ]
+        );
     }
 
     #[test]

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -548,12 +548,14 @@ fn parse_path(path: &str) -> Result<Vec<PathSegment>, ToolCachingError> {
                     while i < bytes.len() {
                         if bytes[i] == b'\\' && i + 1 < bytes.len() {
                             key.push_str(&rest[span_start..i]);
+                            let escaped_char_len =
+                                rest[i + 1..].chars().next().map_or(1, |c| c.len_utf8());
                             match bytes[i + 1] {
                                 b'"' => key.push('"'),
                                 b'\\' => key.push('\\'),
-                                _ => key.push_str(&rest[i..i + 2]),
+                                _ => key.push_str(&rest[i..i + 1 + escaped_char_len]),
                             }
-                            i += 2;
+                            i += 1 + escaped_char_len;
                             span_start = i;
                         } else if bytes[i] == b'"' {
                             key.push_str(&rest[span_start..i]);
@@ -765,6 +767,15 @@ mod tests {
                 PathSegment::Key("files".into()),
                 PathSegment::Key("données.txt".into()),
             ]
+        );
+    }
+
+    #[test]
+    fn parse_path_bracket_backslash_before_multibyte_no_panic() {
+        let segs = parse_path(r#"$.x["\é"]"#).unwrap();
+        assert_eq!(
+            segs,
+            vec![PathSegment::Key("x".into()), PathSegment::Key("\\é".into()),]
         );
     }
 

--- a/core/crates/tool-caching/src/walker.rs
+++ b/core/crates/tool-caching/src/walker.rs
@@ -250,7 +250,7 @@ impl Walker {
                 let per_key = (usable.saturating_mul(size) / total).max(1);
                 (
                     k.clone(),
-                    self.walk(v, &format!("{path}.{k}"), per_key, ctx, elided_paths),
+                    self.walk(v, &format_path_key(path, k), per_key, ctx, elided_paths),
                 )
             })
             .collect();
@@ -1075,6 +1075,16 @@ fn byte_offset_for_line(raw: &str, line: usize) -> usize {
 
 fn make_truncated_array(walked: &[Value], head_count: usize) -> Value {
     Value::Array(walked.iter().take(head_count).cloned().collect())
+}
+
+/// Bracket-quote keys that contain `.` or `[` so the path parser
+/// round-trips them as a single segment instead of splitting on the dot.
+pub(crate) fn format_path_key(parent: &str, key: &str) -> String {
+    if key.contains('.') || key.contains('[') {
+        format!("{parent}[\"{key}\"]")
+    } else {
+        format!("{parent}.{key}")
+    }
 }
 
 #[cfg(test)]

--- a/core/crates/tool-caching/src/walker.rs
+++ b/core/crates/tool-caching/src/walker.rs
@@ -1382,14 +1382,6 @@ mod tests {
     /// Off-by-default helper: regenerates the bats `<summary>+<recovery>`
     /// golden files for fixtures the walker touches, by driving it over
     /// the raw input. Run with `REGEN_GOLDEN=1 cargo test -p
-    #[test]
-    fn format_path_key_brackets_dotted_keys() {
-        assert_eq!(format_path_key("$", "normal"), "$.normal");
-        assert_eq!(format_path_key("$", "values.yaml"), r#"$["values.yaml"]"#);
-        assert_eq!(format_path_key("$.a", "b[0]"), r#"$.a["b[0]"]"#);
-        assert_eq!(format_path_key("$", r#"say "hi""#), r#"$["say \"hi\""]"#);
-    }
-
     /// drua-tool-caching --lib walker::tests::regen_bats_goldens --
     /// --nocapture`.
     #[test]
@@ -1403,6 +1395,14 @@ mod tests {
         ] {
             regen_one(fixture_name, tool_name);
         }
+    }
+
+    #[test]
+    fn format_path_key_brackets_dotted_keys() {
+        assert_eq!(format_path_key("$", "normal"), "$.normal");
+        assert_eq!(format_path_key("$", "values.yaml"), r#"$["values.yaml"]"#);
+        assert_eq!(format_path_key("$.a", "b[0]"), r#"$.a["b[0]"]"#);
+        assert_eq!(format_path_key("$", r#"say "hi""#), r#"$["say \"hi\""]"#);
     }
 
     #[test]

--- a/core/crates/tool-caching/src/walker.rs
+++ b/core/crates/tool-caching/src/walker.rs
@@ -1077,11 +1077,12 @@ fn make_truncated_array(walked: &[Value], head_count: usize) -> Value {
     Value::Array(walked.iter().take(head_count).cloned().collect())
 }
 
-/// Bracket-quote keys that contain `.` or `[` so the path parser
+/// Bracket-quote keys that contain `.`, `[`, or `"` so the path parser
 /// round-trips them as a single segment instead of splitting on the dot.
 pub(crate) fn format_path_key(parent: &str, key: &str) -> String {
-    if key.contains('.') || key.contains('[') {
-        format!("{parent}[\"{key}\"]")
+    if key.contains('.') || key.contains('[') || key.contains('"') {
+        let escaped = key.replace('\\', "\\\\").replace('"', "\\\"");
+        format!("{parent}[\"{escaped}\"]")
     } else {
         format!("{parent}.{key}")
     }
@@ -1381,6 +1382,14 @@ mod tests {
     /// Off-by-default helper: regenerates the bats `<summary>+<recovery>`
     /// golden files for fixtures the walker touches, by driving it over
     /// the raw input. Run with `REGEN_GOLDEN=1 cargo test -p
+    #[test]
+    fn format_path_key_brackets_dotted_keys() {
+        assert_eq!(format_path_key("$", "normal"), "$.normal");
+        assert_eq!(format_path_key("$", "values.yaml"), r#"$["values.yaml"]"#);
+        assert_eq!(format_path_key("$.a", "b[0]"), r#"$.a["b[0]"]"#);
+        assert_eq!(format_path_key("$", r#"say "hi""#), r#"$["say \"hi\""]"#);
+    }
+
     /// drua-tool-caching --lib walker::tests::regen_bats_goldens --
     /// --nocapture`.
     #[test]

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -446,9 +446,23 @@ impl TopLevelTool for CallCatalogTool {
 
         let extra_keys: Vec<String> = args.keys().cloned().collect();
 
-        let (set, name) = self
-            .find_set(subject, &tool_name)
-            .ok_or_else(|| ToolSetsError::ToolNotFound(tool_name.clone()))?;
+        let (set, name) = match self.find_set(subject, &tool_name) {
+            Some(found) => found,
+            None
+                if tool_name == "tool_output_fetch"
+                    || tool_name == "mcp__drua__tool_output_fetch" =>
+            {
+                let tc = self
+                    .tool_caching
+                    .as_ref()
+                    .ok_or_else(|| ToolSetsError::ToolNotFound(tool_name.clone()))?;
+                let fetch =
+                    super::tool_output_fetch::ToolOutputFetch::new(std::sync::Arc::clone(tc));
+                Audit::record_action("tool_output_fetch");
+                return fetch.call(subject, inner_args).await;
+            }
+            None => return Err(ToolSetsError::ToolNotFound(tool_name.clone())),
+        };
 
         // Auto-parse inner_args against the upstream tool's input schema —
         // the outer call_tool envelope only declares `arguments: object`, so

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -448,9 +448,8 @@ impl TopLevelTool for CallCatalogTool {
 
         let (set, name) = match self.find_set(subject, &tool_name) {
             Some(found) => found,
-            None
-                if tool_name == "tool_output_fetch"
-                    || tool_name == "mcp__drua__tool_output_fetch" =>
+            None if tool_name == "tool_output_fetch"
+                || tool_name == "mcp__drua__tool_output_fetch" =>
             {
                 let tc = self
                     .tool_caching


### PR DESCRIPTION
## Summary
- **Dotted-key path fix**: JSON keys containing `.` (e.g. `values.yaml`) were split into multiple path segments by the recovery path parser, causing `tool_output_fetch` to fail. The walker now emits bracket notation (`["values.yaml"]`) for such keys, and the parser handles `["quoted"]` segments.
- **call_tool proxy for tool_output_fetch**: External MCP clients calling `tool_output_fetch` through `call_tool({tool_name: "tool_output_fetch"})` got `ToolNotFound` (18 errors, 0 successes via that path in audit_entries). `call_tool` now recognises both `tool_output_fetch` and `mcp__drua__tool_output_fetch` and proxies directly to `ToolOutputFetch`, preserving owner-scoped authz. Only this one tool is proxied — no generic fallback to top-level tools, so `is_visible` gating is not bypassed.

## Test plan
- [x] 94 unit tests pass (`cargo test -p drua-tool-caching --lib`)
- [x] 3 new tests: bracket-quoted path parsing, navigation through dotted keys, wrap_at_path round-trip
- [ ] Integration tests require PG (CI)
- [ ] Verify in production: `tool_output_fetch` calls via `call_tool` no longer return `ToolNotFound`
- [ ] Verify: recovery paths for keys like `charts/galoy-deps/values.yaml` use bracket notation and resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recovery path parsing and call_tool dispatch; scope is limited to path syntax and a single whitelisted fetch proxy with existing ToolCaching auth.
> 
> **Overview**
> Fixes **tool output recovery** when JSON object keys contain `.`, `[`, or `"` (e.g. `values.yaml`). The walker now emits **bracket-quoted path segments** (`$["values.yaml"]`), and **`parse_path`** in fetch/navigation understands those segments (including escapes and UTF-8) so **`tool_output_fetch`** can resolve and wrap values at the correct key.
> 
> **`call_tool`** no longer returns **`ToolNotFound`** for **`tool_output_fetch`** / **`mcp__drua__tool_output_fetch`** when invoked via the catalog envelope; it proxies only those names to **`ToolOutputFetch`** (still subject-scoped, not a generic top-level bypass).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4f415c7d44bb00c0ddf0d5a1459367730dd06e1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->