### PR TITLE
chore: allow galoy-business dashboard access

### DIFF
--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -18,6 +18,7 @@ galoyAgents:
       githubRedirectUri: "https://dashboard.agents.galoy.io/auth/github/callback"
       githubAllowedTeams:
         - "GaloyMoney/galoy-devs"
+        - "GaloyMoney/galoy-business"
     # `providers` and `defaultChain` inherit from charts/drua/values.yaml
     # (gpt-5-mini primary → deepseek-v3.2 fallback).
     agents:


### PR DESCRIPTION
## Summary
- Add `GaloyMoney/galoy-business` to the production Drua GitHub OAuth allowed teams.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands who can authenticate to the production agents dashboard; scope is limited to one new GitHub team but still changes production access control.
> 
> **Overview**
> Production **Drua** dashboard GitHub OAuth now allows members of **`GaloyMoney/galoy-business`** to sign in, in addition to the existing **`GaloyMoney/galoy-devs`** team.
> 
> The change is a single entry under `galoyAgents.config.oauth.githubAllowedTeams` in `ci/deploy/drua/prod-values.yml.tmpl` (production `dashboard.agents.galoy.io`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ee97642e8cd0d5793fbb01587c6a5ea430065d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->