### PR TITLE
fix(workflow): expose trigger_condition in the workflow tool input schema

### DIFF
--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -490,6 +490,10 @@ static WORKFLOW_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
                 "type": "boolean",
                 "description": "Opt out of webhooks entirely and create a manually-triggered workflow (create)."
             },
+            "trigger_condition": {
+                "type": "string",
+                "description": "Bare CEL boolean evaluated against the `trigger` payload before a run is created; non-matching events are filtered with no run spawned (create). On update, applies when `update_trigger` is true. Only `trigger` is in scope, not `steps`."
+            },
             "skill": {
                 "type": "string",
                 "description": "Single-step shorthand: NAME of an existing skill in this project (create skill first via the `skill` tool). Used only when `steps` is omitted/empty."
@@ -606,14 +610,16 @@ impl TopLevelTool for WorkflowTool {
          as raw shell scripts). The trigger payload is interpolated into \
          each step's skill via `$ARGUMENTS`. Commands: `create` (requires \
          `name`; either `steps` array or single-step shorthand `skill`; \
-         optional `provider`, `sandboxes`, `manual`, `model_chain`), \
+         optional `provider`, `trigger_condition`, `sandboxes`, `manual`, \
+         `model_chain`), \
          `list`, `get` (requires `definition_id`), `trigger` (requires \
          `definition_id`, optional `payload`; returns immediately with \
          the spawned run), `runs` (requires `definition_id`; truncated step \
          outputs), `run` (requires `run_id`; full per-step outputs), \
          `update` (requires `definition_id`; optional `name`, \
          `description`+`clear_description`, `steps`+`update_steps`, \
-         `sandboxes`+`update_sandboxes`, `provider`/`manual`+`update_trigger`, \
+         `sandboxes`+`update_sandboxes`, \
+         `provider`/`manual`/`trigger_condition`+`update_trigger`, \
          `model_chain`+`clear_model_chain`), \
          `delete` (requires `definition_id`; cascades to runs and queues \
          a `DeleteFile` on the canonical YAML)."


### PR DESCRIPTION
## Issue

`trigger_condition` is accepted by the top-level `workflow` tool's `WorkflowParams` (create + update) and applied end-to-end — the dispatch builds the trigger from it and `spawn_run_static` gates run creation on it. But it is absent from that tool's hand-written `WORKFLOW_SCHEMA` (`input_schema`). #341 added the field to the struct, dispatch, the spawn gate, YAML, and validation, but never to this `json!` literal. The admin `workflow` tool is unaffected because its schema is *derived* (`schema_for::<WorkflowParams>()`); only the top-level tool hand-writes its schema, so only it drifted.

## Symptoms

`WORKFLOW_SCHEMA` sets `additionalProperties: false`, so an MCP client/gateway validating against the advertised schema strips `trigger_condition` before it reaches the handler. A `create`/`update` call that passes `trigger_condition` therefore succeeds while the condition silently vanishes — the trigger is rebuilt with `condition: None`. In practice a `provider: github_app` workflow authored through the tool ends up unconditioned and spawns a run on *every* github_app delivery (all repos, all event types), flooding the runs table; the intended per-repo/per-action filter never takes effect.

## New state

`trigger_condition` is advertised in `WORKFLOW_SCHEMA`, so it survives client-side schema validation, reaches the handler, and `create`/`update` (with `update_trigger`) set the trigger-level CEL condition that `spawn_run_static` already enforces. The command help text lists it for both. Crate compiles and the existing `drua-core` lib tests pass; full agent-path verification lands on deploy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema and documentation alignment only; enables existing trigger gating behavior without changing execution logic.
> 
> **Overview**
> The top-level **`workflow`** MCP tool now advertises **`trigger_condition`** in its hand-written **`WORKFLOW_SCHEMA`** and documents it in the tool description for **`create`** and **`update`** (with **`update_trigger`**).
> 
> Because the schema uses **`additionalProperties: false`**, clients that validate inputs were stripping **`trigger_condition`** even though **`WorkflowParams`** and dispatch already supported it. Workflows created or updated through the tool could be saved **without** the intended trigger-level CEL filter, so webhooks (e.g. **`github_app`**) could spawn a run on every delivery instead of only matching events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c0cf3c13c861eef6107b6bf2923851f2a94c7ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->