### PR TITLE
fix(library): stop workflow YAMLs vanishing/flapping under HA (sync echo + delete + push)

### DIFF
--- a/core/crates/library/src/attribution.rs
+++ b/core/crates/library/src/attribution.rs
@@ -29,6 +29,19 @@ pub const AGENT_BOT_EMAIL: &str = "agent@agent.galoy.io";
 pub const WORKFLOW_BOT_NAME: &str = "drua-workflow[bot]";
 pub const WORKFLOW_BOT_EMAIL: &str = "workflow@agent.galoy.io";
 
+/// Trailer key stamped on commits that merely project DB state into git
+/// (forward-sync writes, orphan/delete cleanup). See
+/// [`CommitAttribution::mark_projection`].
+pub const PROJECTION_TRAILER_KEY: &str = "Drua-Projection";
+
+/// True if `message` carries the [`PROJECTION_TRAILER_KEY`] trailer — i.e.
+/// the commit is drua's own DB→git projection and reverse-sync should ignore
+/// it. Matches the rendered `Drua-Projection: <value>` trailer line.
+pub fn message_is_projection(message: &str) -> bool {
+    let prefix = format!("{PROJECTION_TRAILER_KEY}:");
+    message.lines().any(|l| l.trim_start().starts_with(&prefix))
+}
+
 /// Stable subject-type tag rendered into the `Drua-Subject-Type:` trailer.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -123,6 +136,15 @@ impl CommitAttribution {
         }
     }
 
+    /// Mark this commit as a DB→git projection (forward-sync write or
+    /// orphan/delete cleanup). Reverse-sync skips such commits: their content
+    /// is already persisted in the DB, so re-ingesting them is what caused the
+    /// workflow-delete domino. Direct authoring writes (e.g. `spaces edit`)
+    /// must NOT call this, so reverse-sync still imports them.
+    pub fn mark_projection(&mut self) {
+        self.add_trailer(PROJECTION_TRAILER_KEY, "true");
+    }
+
     pub fn add_co_authored_by(&mut self, name: impl Into<String>, email: impl Into<String>) {
         let entry = (name.into(), email.into());
         if !self.co_authored_by.contains(&entry) {
@@ -186,6 +208,20 @@ impl CommitAttribution {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn projection_mark_renders_and_is_detected() {
+        // The rendered trailer must be recognised by `message_is_projection`,
+        // so a render-format change can't silently defeat echo-suppression.
+        let mut a = CommitAttribution::library_default();
+        a.mark_projection();
+        let message = format!("workflow: foo-abcd1234{}", a.render_message_suffix());
+        assert!(message_is_projection(&message));
+
+        let plain = CommitAttribution::library_default();
+        let plain_message = format!("spaces: edit{}", plain.render_message_suffix());
+        assert!(!message_is_projection(&plain_message));
+    }
 
     #[test]
     fn library_default_has_minimal_subject_type() {

--- a/core/crates/library/src/git.rs
+++ b/core/crates/library/src/git.rs
@@ -226,8 +226,9 @@ impl GitEngine {
         .map_err(|e| LibraryError::Git(format!("changes_since join: {e}")))?
     }
 
-    /// Build [`CommitDelta`]s for a tree-to-tree diff. `Deleted` deltas carry
-    /// empty content (the new side is gone); add/modify carry the new blob.
+    /// Build [`CommitDelta`]s for a tree-to-tree diff. For `Deleted` the
+    /// `content` is the removed file's old blob (so importers can make
+    /// id-aware delete decisions); add/modify carry the new blob.
     fn tree_diff_deltas(
         repo: &git2::Repository,
         from_tree: Option<&git2::Tree>,
@@ -254,12 +255,13 @@ impl GitEngine {
                 None => continue,
             };
             let oid = entry.id();
-            let content = match kind {
-                DeltaKind::Deleted => Vec::new(),
-                _ => match repo.find_blob(oid) {
-                    Ok(b) => b.content().to_vec(),
-                    Err(_) => continue,
-                },
+            // For deletes, `oid` is the removed blob (still in the object DB via
+            // the parent commit). Empty on read failure → importers fall back
+            // to a path lookup / skip.
+            let content = match repo.find_blob(oid) {
+                Ok(b) => b.content().to_vec(),
+                Err(_) if matches!(kind, DeltaKind::Deleted) => Vec::new(),
+                Err(_) => continue,
             };
             deltas.push(CommitDelta {
                 path: path_str,
@@ -730,24 +732,28 @@ impl GitEngine {
         // Cluster-wide push serialization (HA): the per-pod `repo_mutex` only
         // orders writes within a pod; this advisory lock ensures at most one
         // pod mutates `main` at a time, so divergent ephemeral clones can't
-        // race the remote into non-ff retries / lost commits. `xact`-scoped so
-        // it always releases (commit, rollback, or connection drop). Best
-        // effort: a DB hiccup degrades to the prior unlocked behavior rather
-        // than wedging all library writes.
-        let mut push_lock = match pool.begin().await {
-            Ok(mut tx) => match sqlx::query("SELECT pg_advisory_xact_lock($1)")
+        // race the remote into non-ff retries / lost commits.
+        //
+        // SESSION-scoped (not `xact`): the git fetch/commit/push below runs
+        // with no open transaction, so `idle_in_transaction_session_timeout`
+        // can't reap it and drop the lock mid-push. Released explicitly after;
+        // a crashed/closed connection releases it server-side too. Best effort:
+        // a DB hiccup degrades to the prior unlocked behavior rather than
+        // wedging all library writes.
+        let mut lock_conn = match pool.acquire().await {
+            Ok(mut conn) => match sqlx::query("SELECT pg_advisory_lock($1)")
                 .bind(LIBRARY_PUSH_LOCK_KEY)
-                .execute(&mut *tx)
+                .execute(&mut *conn)
                 .await
             {
-                Ok(_) => Some(tx),
+                Ok(_) => Some(conn),
                 Err(e) => {
                     tracing::warn!(error = %e, "library push lock: acquire failed; proceeding unlocked");
                     None
                 }
             },
             Err(e) => {
-                tracing::warn!(error = %e, "library push lock: begin failed; proceeding unlocked");
+                tracing::warn!(error = %e, "library push lock: connection failed; proceeding unlocked");
                 None
             }
         };
@@ -768,8 +774,12 @@ impl GitEngine {
                 .collect()
         });
 
-        if let Some(tx) = push_lock.take() {
-            if let Err(e) = tx.commit().await {
+        if let Some(mut conn) = lock_conn.take() {
+            if let Err(e) = sqlx::query("SELECT pg_advisory_unlock($1)")
+                .bind(LIBRARY_PUSH_LOCK_KEY)
+                .execute(&mut *conn)
+                .await
+            {
                 tracing::warn!(error = %e, "library push lock: release failed");
             }
         }
@@ -1434,6 +1444,39 @@ mod tests {
         let paths: std::collections::BTreeSet<&str> =
             deltas.iter().map(|d| d.path.as_str()).collect();
         assert_eq!(paths, ["ext.yml"].into_iter().collect());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn deleted_delta_carries_removed_blob() {
+        let dir = unique_dir("del");
+        let repo = git2::Repository::init_bare(&dir).unwrap();
+        let c0 = commit_file(
+            &repo,
+            None,
+            "a.yml",
+            b"removed-bytes",
+            "human@example.com",
+            "init",
+        );
+        // c1 removes a.yml (external human commit → empty tree).
+        let c1 = {
+            let tb = repo.treebuilder(None).unwrap();
+            let tree = repo.find_tree(tb.write().unwrap()).unwrap();
+            let sig = git2::Signature::now("tester", "human@example.com").unwrap();
+            let parent = repo.find_commit(c0).unwrap();
+            repo.commit(None, &sig, &sig, "rm", &tree, &[&parent])
+                .unwrap()
+        };
+
+        let deltas =
+            GitEngine::external_deltas(&repo, Some(&c0.to_string()), &c1.to_string()).unwrap();
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].path, "a.yml");
+        assert!(matches!(deltas[0].kind, DeltaKind::Deleted));
+        // The removed blob is carried so the importer can do an id-aware delete.
+        assert_eq!(deltas[0].content, b"removed-bytes");
         let _ = std::fs::remove_dir_all(&dir);
     }
 

--- a/core/crates/library/src/git.rs
+++ b/core/crates/library/src/git.rs
@@ -43,6 +43,11 @@ pub struct CommitDelta {
     pub file_hash: GitFileHash,
     /// Empty for `Deleted`.
     pub content: Vec<u8>,
+    /// True when the originating commit was authored by drua itself
+    /// (committer in the `@{AGENT_DOMAIN}` namespace). DB-authoritative
+    /// importers use this to drop echoes of their own writes/prunes;
+    /// git-authoritative importers (spaces/notes/skills) ignore it.
+    pub from_drua: bool,
 }
 
 /// Closure used by [`BatchOpKind::Rmw`]. Receives the current bytes at
@@ -220,7 +225,7 @@ impl GitEngine {
                 None => None,
             };
 
-            Self::tree_diff_deltas(&repo, from_tree.as_ref(), Some(&to_tree))
+            Self::tree_diff_deltas(&repo, from_tree.as_ref(), Some(&to_tree), false)
         })
         .await
         .map_err(|e| LibraryError::Git(format!("changes_since join: {e}")))?
@@ -228,10 +233,12 @@ impl GitEngine {
 
     /// Build [`CommitDelta`]s for a tree-to-tree diff. `Deleted` deltas carry
     /// empty content (the new side is gone); add/modify carry the new blob.
+    /// `from_drua` tags every produced delta with the commit's provenance.
     fn tree_diff_deltas(
         repo: &git2::Repository,
         from_tree: Option<&git2::Tree>,
         to_tree: Option<&git2::Tree>,
+        from_drua: bool,
     ) -> Result<Vec<CommitDelta>, LibraryError> {
         let diff = repo
             .diff_tree_to_tree(from_tree, to_tree, None)
@@ -266,24 +273,30 @@ impl GitEngine {
                 kind,
                 file_hash: GitFileHash::new(oid.to_string()),
                 content,
+                from_drua,
             });
         }
         Ok(deltas)
     }
 
-    /// Like [`Self::changes_since`] but ignores commits authored by drua
-    /// itself (committer in the `@{AGENT_DOMAIN}` namespace).
+    /// Like [`Self::changes_since`], but every delta is tagged with whether
+    /// its originating commit was authored by drua (`from_drua`). The sync
+    /// dispatcher uses that tag so DB-authoritative importers (workflows) can
+    /// drop echoes of their own forward-sync writes / prune-orphan deletes —
+    /// e.g. a prune-orphan re-read as a `Deleted` delta would otherwise
+    /// soft-delete the live workflow at that path. Git-authoritative importers
+    /// (spaces / notes / skills) are written *to git first* by drua and then
+    /// reverse-synced into the DB, so they must still process drua commits and
+    /// ignore the tag.
     ///
-    /// Reverse-sync must treat only *external* edits as authoritative inputs:
-    /// drua's own forward-sync writes (`library[bot]`) and prune-orphan
-    /// deletes (`system[bot]`) are projections of DB state that's already
-    /// persisted, so re-ingesting them feeds back into spurious deletes — e.g.
-    /// a prune-orphan re-read as a `Deleted` delta would soft-delete the live
-    /// workflow at that path. Each external commit is diffed against its first
-    /// parent rather than collapsing the whole range, so interleaved echo
-    /// churn can't mis-attribute a net deletion to the wrong blob.
-    #[tracing::instrument(name = "library.git.external_changes_since", skip_all)]
-    pub async fn external_changes_since(
+    /// Each commit is diffed against its first parent (a collapsed range diff
+    /// could mis-attribute a net deletion to the wrong blob). When `from` is
+    /// missing or not an ancestor of `to` (force-pushed `main`, GC'd
+    /// checkpoint, rebuilt clone) the revwalk's `hide` wouldn't trim history,
+    /// so we fall back to a bounded net tree diff tagged external — matching
+    /// the pre-tagging behavior instead of replaying to the root.
+    #[tracing::instrument(name = "library.git.changes_with_provenance", skip_all)]
+    pub async fn changes_with_provenance(
         &self,
         from: Option<&str>,
         to: &str,
@@ -295,34 +308,43 @@ impl GitEngine {
         tokio::task::spawn_blocking(move || -> Result<Vec<CommitDelta>, LibraryError> {
             let repo = git2::Repository::open_bare(&path)
                 .map_err(|e| LibraryError::Git(format!("open bare: {e}")))?;
-            Self::external_deltas(&repo, from.as_deref(), &to)
+            Self::provenance_deltas(&repo, from.as_deref(), &to)
         })
         .await
-        .map_err(|e| LibraryError::Git(format!("external_changes_since join: {e}")))?
+        .map_err(|e| LibraryError::Git(format!("changes_with_provenance join: {e}")))?
     }
 
-    /// Blocking core of [`Self::external_changes_since`]; see its docs.
-    fn external_deltas(
+    /// Blocking core of [`Self::changes_with_provenance`]; see its docs.
+    fn provenance_deltas(
         repo: &git2::Repository,
         from: Option<&str>,
         to: &str,
     ) -> Result<Vec<CommitDelta>, LibraryError> {
         let to_oid =
             git2::Oid::from_str(to).map_err(|e| LibraryError::Git(format!("parse to oid: {e}")))?;
+        let to_tree = repo
+            .find_commit(to_oid)
+            .and_then(|c| c.tree())
+            .map_err(|e| LibraryError::Git(format!("to tree: {e}")))?;
 
         // Initial sync (no checkpoint): import the whole tree as a snapshot.
-        // Provenance is irrelevant — every present file is desired state —
-        // and walking all history would be wasteful.
+        // Every present file is desired state, tagged external so all
+        // importers ingest it (workflows included, on a fresh clone).
         let Some(from) = from else {
-            let to_tree = repo
-                .find_commit(to_oid)
-                .and_then(|c| c.tree())
-                .map_err(|e| LibraryError::Git(format!("to tree: {e}")))?;
-            return Self::tree_diff_deltas(repo, None, Some(&to_tree));
+            return Self::tree_diff_deltas(repo, None, Some(&to_tree), false);
         };
-
         let from_oid = git2::Oid::from_str(from)
             .map_err(|e| LibraryError::Git(format!("parse from oid: {e}")))?;
+
+        // Fall back to a bounded net diff (tagged external) when `from` is not
+        // a strict ancestor of `to` — otherwise the walk below would re-emit
+        // every commit back to the root.
+        let from_is_ancestor = repo.find_commit(from_oid).is_ok()
+            && repo.graph_descendant_of(to_oid, from_oid).unwrap_or(false);
+        if !from_is_ancestor {
+            let from_tree = repo.find_commit(from_oid).ok().and_then(|c| c.tree().ok());
+            return Self::tree_diff_deltas(repo, from_tree.as_ref(), Some(&to_tree), false);
+        }
 
         let mut walk = repo
             .revwalk()
@@ -341,14 +363,11 @@ impl GitEngine {
             let commit = repo
                 .find_commit(oid)
                 .map_err(|e| LibraryError::Git(format!("find commit: {e}")))?;
-            let is_echo = commit
+            let from_drua = commit
                 .committer()
                 .email()
                 .map(|e| e.ends_with(&drua_suffix))
                 .unwrap_or(false);
-            if is_echo {
-                continue;
-            }
             let commit_tree = commit
                 .tree()
                 .map_err(|e| LibraryError::Git(format!("commit tree: {e}")))?;
@@ -357,6 +376,7 @@ impl GitEngine {
                 repo,
                 parent_tree.as_ref(),
                 Some(&commit_tree),
+                from_drua,
             )?);
         }
         Ok(deltas)
@@ -1299,12 +1319,12 @@ mod tests {
     }
 
     #[test]
-    fn external_deltas_ignores_drua_commits() {
+    fn provenance_deltas_tags_drua_commits() {
         let dir = unique_dir("echo");
         let repo = git2::Repository::init_bare(&dir).unwrap();
 
         let c0 = commit_file(&repo, None, "a.yml", b"v0", "human@example.com");
-        // drua echo (forward-sync style): must be suppressed.
+        // drua forward-sync style: tagged from_drua = true.
         let c1 = commit_file(
             &repo,
             Some(c0),
@@ -1312,25 +1332,29 @@ mod tests {
             b"v1",
             crate::attribution::LIBRARY_BOT_EMAIL,
         );
-        // external human edit: must surface.
+        // external human edit: tagged from_drua = false.
         let c2 = commit_file(&repo, Some(c1), "b.yml", b"hi", "human@example.com");
 
         let deltas =
-            GitEngine::external_deltas(&repo, Some(&c0.to_string()), &c2.to_string()).unwrap();
+            GitEngine::provenance_deltas(&repo, Some(&c0.to_string()), &c2.to_string()).unwrap();
 
-        assert_eq!(
-            deltas.len(),
-            1,
-            "only the external commit's change should surface"
-        );
-        assert_eq!(deltas[0].path, "b.yml");
-        assert!(matches!(deltas[0].kind, DeltaKind::Added));
+        let a = deltas
+            .iter()
+            .find(|d| d.path == "a.yml")
+            .expect("a.yml delta present");
+        assert!(a.from_drua, "drua commit's delta must be tagged from_drua");
+        let b = deltas
+            .iter()
+            .find(|d| d.path == "b.yml")
+            .expect("b.yml delta present");
+        assert!(!b.from_drua, "external commit's delta must not be tagged");
+        assert!(matches!(b.kind, DeltaKind::Added));
 
         let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
-    fn external_deltas_snapshots_without_checkpoint() {
+    fn provenance_deltas_snapshots_without_checkpoint() {
         let dir = unique_dir("snapshot");
         let repo = git2::Repository::init_bare(&dir).unwrap();
         // Even a drua-authored commit is desired state on initial snapshot.
@@ -1342,10 +1366,41 @@ mod tests {
             crate::attribution::LIBRARY_BOT_EMAIL,
         );
 
-        let deltas = GitEngine::external_deltas(&repo, None, &c0.to_string()).unwrap();
+        let deltas = GitEngine::provenance_deltas(&repo, None, &c0.to_string()).unwrap();
 
         assert_eq!(deltas.len(), 1);
         assert_eq!(deltas[0].path, "a.yml");
+        // Snapshot is authoritative — workflows must import on a fresh clone.
+        assert!(!deltas[0].from_drua);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn provenance_deltas_net_diff_when_from_not_ancestor() {
+        let dir = unique_dir("forcepush");
+        let repo = git2::Repository::init_bare(&dir).unwrap();
+        let c0 = commit_file(&repo, None, "a.yml", b"v0", "human@example.com");
+        // Two divergent children of c0 — neither is an ancestor of the other,
+        // as if `main` was force-updated under a stale checkpoint.
+        let to = commit_file(&repo, Some(c0), "b.yml", b"b", "human@example.com");
+        let stale_from = commit_file(&repo, Some(c0), "c.yml", b"c", "human@example.com");
+
+        let deltas =
+            GitEngine::provenance_deltas(&repo, Some(&stale_from.to_string()), &to.to_string())
+                .unwrap();
+
+        // Bounded net diff between the two trees (b.yml added, c.yml removed) —
+        // NOT a replay of history back to the root.
+        let paths: std::collections::BTreeSet<&str> =
+            deltas.iter().map(|d| d.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            ["b.yml", "c.yml"]
+                .into_iter()
+                .collect::<std::collections::BTreeSet<_>>()
+        );
+        assert!(deltas.iter().all(|d| !d.from_drua));
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/core/crates/library/src/git.rs
+++ b/core/crates/library/src/git.rs
@@ -2,6 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
+use sqlx::PgPool;
 use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 use tokio::task::JoinHandle;
 
@@ -16,6 +17,10 @@ use crate::{GitHubAppTokenProvider, LibraryError};
 const BATCH_WINDOW: Duration = Duration::from_millis(25);
 const MAX_BATCH: usize = 32;
 const QUEUE_CAPACITY: usize = 256;
+
+/// Cluster-wide Postgres advisory-lock key for serializing pushes to the
+/// library repo's `main`. Fixed (one library repo per deployment); `0x647275616c6962` = "drualib".
+const LIBRARY_PUSH_LOCK_KEY: i64 = 0x647275616c6962;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeltaKind {
@@ -141,6 +146,7 @@ impl GitEngine {
         repo_url: &str,
         repo_path: PathBuf,
         github_app: Option<Arc<GitHubAppTokenProvider>>,
+        pool: PgPool,
     ) -> Result<Self, LibraryError> {
         if repo_url.is_empty() {
             return Err(LibraryError::Config("repo_url is empty".into()));
@@ -164,6 +170,7 @@ impl GitEngine {
             Arc::clone(&repo_mutex),
             Arc::clone(&local_commit_notify),
             write_rx,
+            pool,
         ));
 
         Ok(Self {
@@ -213,45 +220,146 @@ impl GitEngine {
                 None => None,
             };
 
-            let diff = repo
-                .diff_tree_to_tree(from_tree.as_ref(), Some(&to_tree), None)
-                .map_err(|e| LibraryError::Git(format!("diff: {e}")))?;
-
-            let mut deltas: Vec<CommitDelta> = Vec::new();
-            for delta in diff.deltas() {
-                let kind = match delta.status() {
-                    git2::Delta::Added => DeltaKind::Added,
-                    git2::Delta::Modified => DeltaKind::Modified,
-                    git2::Delta::Deleted => DeltaKind::Deleted,
-                    _ => continue,
-                };
-                let entry = match kind {
-                    DeltaKind::Deleted => delta.old_file(),
-                    _ => delta.new_file(),
-                };
-                let path_str = match entry.path() {
-                    Some(p) => p.to_string_lossy().into_owned(),
-                    None => continue,
-                };
-                let oid = entry.id();
-                let content = match kind {
-                    DeltaKind::Deleted => Vec::new(),
-                    _ => match repo.find_blob(oid) {
-                        Ok(b) => b.content().to_vec(),
-                        Err(_) => continue,
-                    },
-                };
-                deltas.push(CommitDelta {
-                    path: path_str,
-                    kind,
-                    file_hash: GitFileHash::new(oid.to_string()),
-                    content,
-                });
-            }
-            Ok(deltas)
+            Self::tree_diff_deltas(&repo, from_tree.as_ref(), Some(&to_tree))
         })
         .await
         .map_err(|e| LibraryError::Git(format!("changes_since join: {e}")))?
+    }
+
+    /// Build [`CommitDelta`]s for a tree-to-tree diff. `Deleted` deltas carry
+    /// empty content (the new side is gone); add/modify carry the new blob.
+    fn tree_diff_deltas(
+        repo: &git2::Repository,
+        from_tree: Option<&git2::Tree>,
+        to_tree: Option<&git2::Tree>,
+    ) -> Result<Vec<CommitDelta>, LibraryError> {
+        let diff = repo
+            .diff_tree_to_tree(from_tree, to_tree, None)
+            .map_err(|e| LibraryError::Git(format!("diff: {e}")))?;
+
+        let mut deltas: Vec<CommitDelta> = Vec::new();
+        for delta in diff.deltas() {
+            let kind = match delta.status() {
+                git2::Delta::Added => DeltaKind::Added,
+                git2::Delta::Modified => DeltaKind::Modified,
+                git2::Delta::Deleted => DeltaKind::Deleted,
+                _ => continue,
+            };
+            let entry = match kind {
+                DeltaKind::Deleted => delta.old_file(),
+                _ => delta.new_file(),
+            };
+            let path_str = match entry.path() {
+                Some(p) => p.to_string_lossy().into_owned(),
+                None => continue,
+            };
+            let oid = entry.id();
+            let content = match kind {
+                DeltaKind::Deleted => Vec::new(),
+                _ => match repo.find_blob(oid) {
+                    Ok(b) => b.content().to_vec(),
+                    Err(_) => continue,
+                },
+            };
+            deltas.push(CommitDelta {
+                path: path_str,
+                kind,
+                file_hash: GitFileHash::new(oid.to_string()),
+                content,
+            });
+        }
+        Ok(deltas)
+    }
+
+    /// Like [`Self::changes_since`] but ignores commits authored by drua
+    /// itself (committer in the `@{AGENT_DOMAIN}` namespace).
+    ///
+    /// Reverse-sync must treat only *external* edits as authoritative inputs:
+    /// drua's own forward-sync writes (`library[bot]`) and prune-orphan
+    /// deletes (`system[bot]`) are projections of DB state that's already
+    /// persisted, so re-ingesting them feeds back into spurious deletes — e.g.
+    /// a prune-orphan re-read as a `Deleted` delta would soft-delete the live
+    /// workflow at that path. Each external commit is diffed against its first
+    /// parent rather than collapsing the whole range, so interleaved echo
+    /// churn can't mis-attribute a net deletion to the wrong blob.
+    #[tracing::instrument(name = "library.git.external_changes_since", skip_all)]
+    pub async fn external_changes_since(
+        &self,
+        from: Option<&str>,
+        to: &str,
+    ) -> Result<Vec<CommitDelta>, LibraryError> {
+        let path = self.repo_path.clone();
+        let from = from.map(String::from);
+        let to = to.to_string();
+
+        tokio::task::spawn_blocking(move || -> Result<Vec<CommitDelta>, LibraryError> {
+            let repo = git2::Repository::open_bare(&path)
+                .map_err(|e| LibraryError::Git(format!("open bare: {e}")))?;
+            Self::external_deltas(&repo, from.as_deref(), &to)
+        })
+        .await
+        .map_err(|e| LibraryError::Git(format!("external_changes_since join: {e}")))?
+    }
+
+    /// Blocking core of [`Self::external_changes_since`]; see its docs.
+    fn external_deltas(
+        repo: &git2::Repository,
+        from: Option<&str>,
+        to: &str,
+    ) -> Result<Vec<CommitDelta>, LibraryError> {
+        let to_oid =
+            git2::Oid::from_str(to).map_err(|e| LibraryError::Git(format!("parse to oid: {e}")))?;
+
+        // Initial sync (no checkpoint): import the whole tree as a snapshot.
+        // Provenance is irrelevant — every present file is desired state —
+        // and walking all history would be wasteful.
+        let Some(from) = from else {
+            let to_tree = repo
+                .find_commit(to_oid)
+                .and_then(|c| c.tree())
+                .map_err(|e| LibraryError::Git(format!("to tree: {e}")))?;
+            return Self::tree_diff_deltas(repo, None, Some(&to_tree));
+        };
+
+        let from_oid = git2::Oid::from_str(from)
+            .map_err(|e| LibraryError::Git(format!("parse from oid: {e}")))?;
+
+        let mut walk = repo
+            .revwalk()
+            .map_err(|e| LibraryError::Git(format!("revwalk: {e}")))?;
+        walk.set_sorting(git2::Sort::TOPOLOGICAL | git2::Sort::REVERSE)
+            .map_err(|e| LibraryError::Git(format!("revwalk sort: {e}")))?;
+        walk.push(to_oid)
+            .map_err(|e| LibraryError::Git(format!("revwalk push: {e}")))?;
+        walk.hide(from_oid)
+            .map_err(|e| LibraryError::Git(format!("revwalk hide: {e}")))?;
+
+        let drua_suffix = format!("@{}", crate::attribution::AGENT_DOMAIN);
+        let mut deltas: Vec<CommitDelta> = Vec::new();
+        for oid in walk {
+            let oid = oid.map_err(|e| LibraryError::Git(format!("revwalk next: {e}")))?;
+            let commit = repo
+                .find_commit(oid)
+                .map_err(|e| LibraryError::Git(format!("find commit: {e}")))?;
+            let is_echo = commit
+                .committer()
+                .email()
+                .map(|e| e.ends_with(&drua_suffix))
+                .unwrap_or(false);
+            if is_echo {
+                continue;
+            }
+            let commit_tree = commit
+                .tree()
+                .map_err(|e| LibraryError::Git(format!("commit tree: {e}")))?;
+            let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
+            deltas.extend(Self::tree_diff_deltas(
+                repo,
+                parent_tree.as_ref(),
+                Some(&commit_tree),
+            )?);
+        }
+        Ok(deltas)
     }
 
     /// Read the blob at `path` from HEAD's tree. `Ok(None)` when the
@@ -555,6 +663,7 @@ impl GitEngine {
         repo_mutex: Arc<Mutex<()>>,
         local_commit_notify: Arc<Notify>,
         mut rx: mpsc::Receiver<QueuedOp>,
+        pool: PgPool,
     ) {
         while let Some(first) = rx.recv().await {
             let mut batch = vec![first];
@@ -572,7 +681,8 @@ impl GitEngine {
                 }
             }
             let any_ok =
-                Self::process_batch(&repo_path, github_app.as_ref(), &repo_mutex, batch).await;
+                Self::process_batch(&repo_path, github_app.as_ref(), &repo_mutex, &pool, batch)
+                    .await;
             if any_ok {
                 local_commit_notify.notify_waiters();
             }
@@ -584,9 +694,34 @@ impl GitEngine {
         repo_path: &Path,
         github_app: Option<&Arc<GitHubAppTokenProvider>>,
         repo_mutex: &Mutex<()>,
+        pool: &PgPool,
         batch: Vec<QueuedOp>,
     ) -> bool {
         let _guard = repo_mutex.lock().await;
+        // Cluster-wide push serialization (HA): the per-pod `repo_mutex` only
+        // orders writes within a pod; this advisory lock ensures at most one
+        // pod mutates `main` at a time, so divergent ephemeral clones can't
+        // race the remote into non-ff retries / lost commits. `xact`-scoped so
+        // it always releases (commit, rollback, or connection drop). Best
+        // effort: a DB hiccup degrades to the prior unlocked behavior rather
+        // than wedging all library writes.
+        let mut push_lock = match pool.begin().await {
+            Ok(mut tx) => match sqlx::query("SELECT pg_advisory_xact_lock($1)")
+                .bind(LIBRARY_PUSH_LOCK_KEY)
+                .execute(&mut *tx)
+                .await
+            {
+                Ok(_) => Some(tx),
+                Err(e) => {
+                    tracing::warn!(error = %e, "library push lock: acquire failed; proceeding unlocked");
+                    None
+                }
+            },
+            Err(e) => {
+                tracing::warn!(error = %e, "library push lock: begin failed; proceeding unlocked");
+                None
+            }
+        };
         let token = Self::fresh_token(github_app).await;
         let path = repo_path.to_path_buf();
         let n = batch.len();
@@ -603,6 +738,12 @@ impl GitEngine {
                 .map(|_| Err(LibraryError::Git(msg.clone())))
                 .collect()
         });
+
+        if let Some(tx) = push_lock.take() {
+            if let Err(e) = tx.commit().await {
+                tracing::warn!(error = %e, "library push lock: release failed");
+            }
+        }
 
         let any_ok = results.iter().any(|r| r.is_ok());
         for (resp, res) in responders.into_iter().zip(results) {
@@ -1115,5 +1256,97 @@ impl GitEngine {
             git2::Cred::default()
         });
         cb
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn unique_dir(tag: &str) -> PathBuf {
+        let nanos = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let dir = std::env::temp_dir().join(format!(
+            "drua-git-test-{tag}-{}-{nanos}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        dir
+    }
+
+    fn commit_file(
+        repo: &git2::Repository,
+        parent: Option<git2::Oid>,
+        path: &str,
+        content: &[u8],
+        committer_email: &str,
+    ) -> git2::Oid {
+        let base = parent.map(|p| repo.find_commit(p).unwrap().tree().unwrap());
+        let mut tb = repo.treebuilder(base.as_ref()).unwrap();
+        let blob = repo.blob(content).unwrap();
+        tb.insert(path, blob, 0o100644).unwrap();
+        let tree = repo.find_tree(tb.write().unwrap()).unwrap();
+        let sig = git2::Signature::now("tester", committer_email).unwrap();
+        let parents: Vec<git2::Commit> = parent
+            .into_iter()
+            .map(|p| repo.find_commit(p).unwrap())
+            .collect();
+        let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+        repo.commit(None, &sig, &sig, "msg", &tree, &parent_refs)
+            .unwrap()
+    }
+
+    #[test]
+    fn external_deltas_ignores_drua_commits() {
+        let dir = unique_dir("echo");
+        let repo = git2::Repository::init_bare(&dir).unwrap();
+
+        let c0 = commit_file(&repo, None, "a.yml", b"v0", "human@example.com");
+        // drua echo (forward-sync style): must be suppressed.
+        let c1 = commit_file(
+            &repo,
+            Some(c0),
+            "a.yml",
+            b"v1",
+            crate::attribution::LIBRARY_BOT_EMAIL,
+        );
+        // external human edit: must surface.
+        let c2 = commit_file(&repo, Some(c1), "b.yml", b"hi", "human@example.com");
+
+        let deltas =
+            GitEngine::external_deltas(&repo, Some(&c0.to_string()), &c2.to_string()).unwrap();
+
+        assert_eq!(
+            deltas.len(),
+            1,
+            "only the external commit's change should surface"
+        );
+        assert_eq!(deltas[0].path, "b.yml");
+        assert!(matches!(deltas[0].kind, DeltaKind::Added));
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn external_deltas_snapshots_without_checkpoint() {
+        let dir = unique_dir("snapshot");
+        let repo = git2::Repository::init_bare(&dir).unwrap();
+        // Even a drua-authored commit is desired state on initial snapshot.
+        let c0 = commit_file(
+            &repo,
+            None,
+            "a.yml",
+            b"v0",
+            crate::attribution::LIBRARY_BOT_EMAIL,
+        );
+
+        let deltas = GitEngine::external_deltas(&repo, None, &c0.to_string()).unwrap();
+
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].path, "a.yml");
+
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/core/crates/library/src/git.rs
+++ b/core/crates/library/src/git.rs
@@ -43,11 +43,6 @@ pub struct CommitDelta {
     pub file_hash: GitFileHash,
     /// Empty for `Deleted`.
     pub content: Vec<u8>,
-    /// True when the originating commit was authored by drua itself
-    /// (committer in the `@{AGENT_DOMAIN}` namespace). DB-authoritative
-    /// importers use this to drop echoes of their own writes/prunes;
-    /// git-authoritative importers (spaces/notes/skills) ignore it.
-    pub from_drua: bool,
 }
 
 /// Closure used by [`BatchOpKind::Rmw`]. Receives the current bytes at
@@ -225,7 +220,7 @@ impl GitEngine {
                 None => None,
             };
 
-            Self::tree_diff_deltas(&repo, from_tree.as_ref(), Some(&to_tree), false)
+            Self::tree_diff_deltas(&repo, from_tree.as_ref(), Some(&to_tree))
         })
         .await
         .map_err(|e| LibraryError::Git(format!("changes_since join: {e}")))?
@@ -233,12 +228,10 @@ impl GitEngine {
 
     /// Build [`CommitDelta`]s for a tree-to-tree diff. `Deleted` deltas carry
     /// empty content (the new side is gone); add/modify carry the new blob.
-    /// `from_drua` tags every produced delta with the commit's provenance.
     fn tree_diff_deltas(
         repo: &git2::Repository,
         from_tree: Option<&git2::Tree>,
         to_tree: Option<&git2::Tree>,
-        from_drua: bool,
     ) -> Result<Vec<CommitDelta>, LibraryError> {
         let diff = repo
             .diff_tree_to_tree(from_tree, to_tree, None)
@@ -273,30 +266,30 @@ impl GitEngine {
                 kind,
                 file_hash: GitFileHash::new(oid.to_string()),
                 content,
-                from_drua,
             });
         }
         Ok(deltas)
     }
 
-    /// Like [`Self::changes_since`], but every delta is tagged with whether
-    /// its originating commit was authored by drua (`from_drua`). The sync
-    /// dispatcher uses that tag so DB-authoritative importers (workflows) can
-    /// drop echoes of their own forward-sync writes / prune-orphan deletes —
-    /// e.g. a prune-orphan re-read as a `Deleted` delta would otherwise
-    /// soft-delete the live workflow at that path. Git-authoritative importers
-    /// (spaces / notes / skills) are written *to git first* by drua and then
-    /// reverse-synced into the DB, so they must still process drua commits and
-    /// ignore the tag.
+    /// Like [`Self::changes_since`], but ignores commits drua made to merely
+    /// project DB state into git — those carrying the `Drua-Projection`
+    /// trailer ([`crate::attribution::message_is_projection`]) committed by a
+    /// drua bot. Reverse-sync must treat only *authoritative* edits as inputs:
+    /// a forward-sync write or prune-orphan delete already reflects persisted
+    /// DB state, so re-ingesting it feeds back into spurious deletes — e.g. a
+    /// prune-orphan re-read as a `Deleted` delta would soft-delete the live
+    /// workflow at that path. Direct authoring writes (`spaces edit`, human
+    /// commits) lack the trailer and are imported normally — that's how a
+    /// space-authored note/skill lands in the DB.
     ///
-    /// Each commit is diffed against its first parent (a collapsed range diff
-    /// could mis-attribute a net deletion to the wrong blob). When `from` is
-    /// missing or not an ancestor of `to` (force-pushed `main`, GC'd
+    /// Each surviving commit is diffed against its first parent (a collapsed
+    /// range diff could mis-attribute a net deletion to the wrong blob). When
+    /// `from` is missing or not an ancestor of `to` (force-pushed `main`, GC'd
     /// checkpoint, rebuilt clone) the revwalk's `hide` wouldn't trim history,
-    /// so we fall back to a bounded net tree diff tagged external — matching
-    /// the pre-tagging behavior instead of replaying to the root.
-    #[tracing::instrument(name = "library.git.changes_with_provenance", skip_all)]
-    pub async fn changes_with_provenance(
+    /// so we fall back to a bounded net tree diff instead of replaying to the
+    /// root (provenance can't be recovered for a rewritten range anyway).
+    #[tracing::instrument(name = "library.git.external_changes_since", skip_all)]
+    pub async fn external_changes_since(
         &self,
         from: Option<&str>,
         to: &str,
@@ -308,14 +301,14 @@ impl GitEngine {
         tokio::task::spawn_blocking(move || -> Result<Vec<CommitDelta>, LibraryError> {
             let repo = git2::Repository::open_bare(&path)
                 .map_err(|e| LibraryError::Git(format!("open bare: {e}")))?;
-            Self::provenance_deltas(&repo, from.as_deref(), &to)
+            Self::external_deltas(&repo, from.as_deref(), &to)
         })
         .await
-        .map_err(|e| LibraryError::Git(format!("changes_with_provenance join: {e}")))?
+        .map_err(|e| LibraryError::Git(format!("external_changes_since join: {e}")))?
     }
 
-    /// Blocking core of [`Self::changes_with_provenance`]; see its docs.
-    fn provenance_deltas(
+    /// Blocking core of [`Self::external_changes_since`]; see its docs.
+    fn external_deltas(
         repo: &git2::Repository,
         from: Option<&str>,
         to: &str,
@@ -327,23 +320,22 @@ impl GitEngine {
             .and_then(|c| c.tree())
             .map_err(|e| LibraryError::Git(format!("to tree: {e}")))?;
 
-        // Initial sync (no checkpoint): import the whole tree as a snapshot.
-        // Every present file is desired state, tagged external so all
-        // importers ingest it (workflows included, on a fresh clone).
+        // Initial sync (no checkpoint): import the whole tree as a snapshot —
+        // every present file is desired state (workflows included, fresh clone).
         let Some(from) = from else {
-            return Self::tree_diff_deltas(repo, None, Some(&to_tree), false);
+            return Self::tree_diff_deltas(repo, None, Some(&to_tree));
         };
         let from_oid = git2::Oid::from_str(from)
             .map_err(|e| LibraryError::Git(format!("parse from oid: {e}")))?;
 
-        // Fall back to a bounded net diff (tagged external) when `from` is not
-        // a strict ancestor of `to` — otherwise the walk below would re-emit
-        // every commit back to the root.
+        // Fall back to a bounded net diff when `from` is not a strict ancestor
+        // of `to` — otherwise the walk below would re-emit every commit back to
+        // the root.
         let from_is_ancestor = repo.find_commit(from_oid).is_ok()
             && repo.graph_descendant_of(to_oid, from_oid).unwrap_or(false);
         if !from_is_ancestor {
             let from_tree = repo.find_commit(from_oid).ok().and_then(|c| c.tree().ok());
-            return Self::tree_diff_deltas(repo, from_tree.as_ref(), Some(&to_tree), false);
+            return Self::tree_diff_deltas(repo, from_tree.as_ref(), Some(&to_tree));
         }
 
         let mut walk = repo
@@ -363,11 +355,20 @@ impl GitEngine {
             let commit = repo
                 .find_commit(oid)
                 .map_err(|e| LibraryError::Git(format!("find commit: {e}")))?;
-            let from_drua = commit
+            // Skip drua's own projection commits. Gate on the drua committer too
+            // so an external actor can't forge the trailer to suppress a commit.
+            let by_drua = commit
                 .committer()
                 .email()
                 .map(|e| e.ends_with(&drua_suffix))
                 .unwrap_or(false);
+            let is_projection = commit
+                .message()
+                .map(crate::attribution::message_is_projection)
+                .unwrap_or(false);
+            if by_drua && is_projection {
+                continue;
+            }
             let commit_tree = commit
                 .tree()
                 .map_err(|e| LibraryError::Git(format!("commit tree: {e}")))?;
@@ -376,7 +377,6 @@ impl GitEngine {
                 repo,
                 parent_tree.as_ref(),
                 Some(&commit_tree),
-                from_drua,
             )?);
         }
         Ok(deltas)
@@ -1302,6 +1302,7 @@ mod tests {
         path: &str,
         content: &[u8],
         committer_email: &str,
+        message: &str,
     ) -> git2::Oid {
         let base = parent.map(|p| repo.find_commit(p).unwrap().tree().unwrap());
         let mut tb = repo.treebuilder(base.as_ref()).unwrap();
@@ -1314,80 +1315,93 @@ mod tests {
             .map(|p| repo.find_commit(p).unwrap())
             .collect();
         let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
-        repo.commit(None, &sig, &sig, "msg", &tree, &parent_refs)
+        repo.commit(None, &sig, &sig, message, &tree, &parent_refs)
             .unwrap()
     }
 
+    fn projection_msg() -> String {
+        format!(
+            "msg\n\n{}: true",
+            crate::attribution::PROJECTION_TRAILER_KEY
+        )
+    }
+
+    const LIB_BOT: &str = crate::attribution::LIBRARY_BOT_EMAIL;
+
     #[test]
-    fn provenance_deltas_tags_drua_commits() {
+    fn external_deltas_skips_projections_keeps_authoring() {
         let dir = unique_dir("echo");
         let repo = git2::Repository::init_bare(&dir).unwrap();
 
-        let c0 = commit_file(&repo, None, "a.yml", b"v0", "human@example.com");
-        // drua forward-sync style: tagged from_drua = true.
+        let c0 = commit_file(&repo, None, "a.yml", b"v0", "human@example.com", "init");
+        // drua forward-sync projection (committer drua + trailer) → dropped.
+        let c1 = commit_file(&repo, Some(c0), "a.yml", b"v1", LIB_BOT, &projection_msg());
+        // drua authoring write (e.g. `spaces edit`, committer drua, NO trailer)
+        // → kept, so space-authored docs still import.
+        let c2 = commit_file(&repo, Some(c1), "note.md", b"hi", LIB_BOT, "spaces: edit");
+
+        let deltas =
+            GitEngine::external_deltas(&repo, Some(&c0.to_string()), &c2.to_string()).unwrap();
+
+        let paths: std::collections::BTreeSet<&str> =
+            deltas.iter().map(|d| d.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            ["note.md"].into_iter().collect(),
+            "projection dropped, authoring kept"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn external_deltas_ignores_forged_projection_trailer() {
+        let dir = unique_dir("forge");
+        let repo = git2::Repository::init_bare(&dir).unwrap();
+        let c0 = commit_file(&repo, None, "a.yml", b"v0", "human@example.com", "init");
+        // Non-drua committer carrying the trailer must NOT be suppressed.
         let c1 = commit_file(
             &repo,
             Some(c0),
-            "a.yml",
-            b"v1",
-            crate::attribution::LIBRARY_BOT_EMAIL,
+            "b.yml",
+            b"b",
+            "attacker@example.com",
+            &projection_msg(),
         );
-        // external human edit: tagged from_drua = false.
-        let c2 = commit_file(&repo, Some(c1), "b.yml", b"hi", "human@example.com");
 
         let deltas =
-            GitEngine::provenance_deltas(&repo, Some(&c0.to_string()), &c2.to_string()).unwrap();
+            GitEngine::external_deltas(&repo, Some(&c0.to_string()), &c1.to_string()).unwrap();
 
-        let a = deltas
-            .iter()
-            .find(|d| d.path == "a.yml")
-            .expect("a.yml delta present");
-        assert!(a.from_drua, "drua commit's delta must be tagged from_drua");
-        let b = deltas
-            .iter()
-            .find(|d| d.path == "b.yml")
-            .expect("b.yml delta present");
-        assert!(!b.from_drua, "external commit's delta must not be tagged");
-        assert!(matches!(b.kind, DeltaKind::Added));
-
+        assert_eq!(deltas.len(), 1);
+        assert_eq!(deltas[0].path, "b.yml");
         let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
-    fn provenance_deltas_snapshots_without_checkpoint() {
+    fn external_deltas_snapshots_without_checkpoint() {
         let dir = unique_dir("snapshot");
         let repo = git2::Repository::init_bare(&dir).unwrap();
-        // Even a drua-authored commit is desired state on initial snapshot.
-        let c0 = commit_file(
-            &repo,
-            None,
-            "a.yml",
-            b"v0",
-            crate::attribution::LIBRARY_BOT_EMAIL,
-        );
+        // Even a projection commit is desired state on initial snapshot.
+        let c0 = commit_file(&repo, None, "a.yml", b"v0", LIB_BOT, &projection_msg());
 
-        let deltas = GitEngine::provenance_deltas(&repo, None, &c0.to_string()).unwrap();
+        let deltas = GitEngine::external_deltas(&repo, None, &c0.to_string()).unwrap();
 
         assert_eq!(deltas.len(), 1);
         assert_eq!(deltas[0].path, "a.yml");
-        // Snapshot is authoritative — workflows must import on a fresh clone.
-        assert!(!deltas[0].from_drua);
-
         let _ = std::fs::remove_dir_all(&dir);
     }
 
     #[test]
-    fn provenance_deltas_net_diff_when_from_not_ancestor() {
+    fn external_deltas_net_diff_when_from_not_ancestor() {
         let dir = unique_dir("forcepush");
         let repo = git2::Repository::init_bare(&dir).unwrap();
-        let c0 = commit_file(&repo, None, "a.yml", b"v0", "human@example.com");
+        let c0 = commit_file(&repo, None, "a.yml", b"v0", "human@example.com", "init");
         // Two divergent children of c0 — neither is an ancestor of the other,
         // as if `main` was force-updated under a stale checkpoint.
-        let to = commit_file(&repo, Some(c0), "b.yml", b"b", "human@example.com");
-        let stale_from = commit_file(&repo, Some(c0), "c.yml", b"c", "human@example.com");
+        let to = commit_file(&repo, Some(c0), "b.yml", b"b", "human@example.com", "x");
+        let stale_from = commit_file(&repo, Some(c0), "c.yml", b"c", "human@example.com", "y");
 
         let deltas =
-            GitEngine::provenance_deltas(&repo, Some(&stale_from.to_string()), &to.to_string())
+            GitEngine::external_deltas(&repo, Some(&stale_from.to_string()), &to.to_string())
                 .unwrap();
 
         // Bounded net diff between the two trees (b.yml added, c.yml removed) —
@@ -1400,7 +1414,6 @@ mod tests {
                 .into_iter()
                 .collect::<std::collections::BTreeSet<_>>()
         );
-        assert!(deltas.iter().all(|d| !d.from_drua));
 
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/core/crates/library/src/git.rs
+++ b/core/crates/library/src/git.rs
@@ -284,10 +284,11 @@ impl GitEngine {
     ///
     /// Each surviving commit is diffed against its first parent (a collapsed
     /// range diff could mis-attribute a net deletion to the wrong blob). When
-    /// `from` is missing or not an ancestor of `to` (force-pushed `main`, GC'd
-    /// checkpoint, rebuilt clone) the revwalk's `hide` wouldn't trim history,
-    /// so we fall back to a bounded net tree diff instead of replaying to the
-    /// root (provenance can't be recovered for a rewritten range anyway).
+    /// `from` is not a strict ancestor of `to` (force-pushed `main`) the walk
+    /// is bounded by the merge-base instead of replaying to the root, so the
+    /// projection filter still applies. A `from` whose commit is gone (GC'd /
+    /// force-pushed away) fails the tick rather than silently resyncing and
+    /// dropping deletions.
     #[tracing::instrument(name = "library.git.external_changes_since", skip_all)]
     pub async fn external_changes_since(
         &self,
@@ -328,15 +329,23 @@ impl GitEngine {
         let from_oid = git2::Oid::from_str(from)
             .map_err(|e| LibraryError::Git(format!("parse from oid: {e}")))?;
 
-        // Fall back to a bounded net diff when `from` is not a strict ancestor
-        // of `to` — otherwise the walk below would re-emit every commit back to
-        // the root.
-        let from_is_ancestor = repo.find_commit(from_oid).is_ok()
-            && repo.graph_descendant_of(to_oid, from_oid).unwrap_or(false);
-        if !from_is_ancestor {
-            let from_tree = repo.find_commit(from_oid).ok().and_then(|c| c.tree().ok());
-            return Self::tree_diff_deltas(repo, from_tree.as_ref(), Some(&to_tree));
-        }
+        // A missing checkpoint commit (GC'd, or a tip that was force-pushed
+        // away) must FAIL the tick — not silently resync. Diffing from an empty
+        // tree would drop every deletion since the lost commit yet still advance
+        // the checkpoint, diverging DB from git. Erroring keeps the checkpoint
+        // so the next tick retries (matches the pre-walk `changes_since`).
+        repo.find_commit(from_oid)
+            .map_err(|e| LibraryError::Git(format!("checkpoint commit {from} missing: {e}")))?;
+
+        // Bound the walk by the merge-base so a force-updated `main` (where
+        // `from` is not a strict ancestor of `to`) doesn't replay history to the
+        // root — while still running every surviving commit through the
+        // projection filter below (a flat net diff would let drua's own
+        // prune/delete net-removals resurface as external `Deleted` deltas and
+        // reopen the domino). In the normal case the merge-base IS `from`.
+        let base = repo
+            .merge_base(from_oid, to_oid)
+            .map_err(|e| LibraryError::Git(format!("merge-base of checkpoint and head: {e}")))?;
 
         let mut walk = repo
             .revwalk()
@@ -345,7 +354,7 @@ impl GitEngine {
             .map_err(|e| LibraryError::Git(format!("revwalk sort: {e}")))?;
         walk.push(to_oid)
             .map_err(|e| LibraryError::Git(format!("revwalk push: {e}")))?;
-        walk.hide(from_oid)
+        walk.hide(base)
             .map_err(|e| LibraryError::Git(format!("revwalk hide: {e}")))?;
 
         let drua_suffix = format!("@{}", crate::attribution::AGENT_DOMAIN);
@@ -1391,30 +1400,54 @@ mod tests {
     }
 
     #[test]
-    fn external_deltas_net_diff_when_from_not_ancestor() {
+    fn external_deltas_force_push_bounds_by_merge_base_and_filters_projections() {
         let dir = unique_dir("forcepush");
         let repo = git2::Repository::init_bare(&dir).unwrap();
         let c0 = commit_file(&repo, None, "a.yml", b"v0", "human@example.com", "init");
-        // Two divergent children of c0 — neither is an ancestor of the other,
-        // as if `main` was force-updated under a stale checkpoint.
-        let to = commit_file(&repo, Some(c0), "b.yml", b"b", "human@example.com", "x");
-        let stale_from = commit_file(&repo, Some(c0), "c.yml", b"c", "human@example.com", "y");
+        // New `main` since divergence: a drua projection then an external edit.
+        let c1 = commit_file(
+            &repo,
+            Some(c0),
+            "proj.yml",
+            b"p",
+            LIB_BOT,
+            &projection_msg(),
+        );
+        let to = commit_file(
+            &repo,
+            Some(c1),
+            "ext.yml",
+            b"e",
+            "human@example.com",
+            "edit",
+        );
+        // Stale checkpoint on an abandoned branch — not an ancestor of `to`.
+        let stale_from = commit_file(&repo, Some(c0), "gone.yml", b"g", "human@example.com", "y");
 
         let deltas =
             GitEngine::external_deltas(&repo, Some(&stale_from.to_string()), &to.to_string())
                 .unwrap();
 
-        // Bounded net diff between the two trees (b.yml added, c.yml removed) —
-        // NOT a replay of history back to the root.
+        // Walk is bounded by the merge-base (c0), so only the new-main commits
+        // are considered; the projection is still filtered and the abandoned
+        // branch's file is not replayed.
         let paths: std::collections::BTreeSet<&str> =
             deltas.iter().map(|d| d.path.as_str()).collect();
-        assert_eq!(
-            paths,
-            ["b.yml", "c.yml"]
-                .into_iter()
-                .collect::<std::collections::BTreeSet<_>>()
-        );
+        assert_eq!(paths, ["ext.yml"].into_iter().collect());
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 
+    #[test]
+    fn external_deltas_fails_on_missing_checkpoint() {
+        let dir = unique_dir("missing");
+        let repo = git2::Repository::init_bare(&dir).unwrap();
+        let c0 = commit_file(&repo, None, "a.yml", b"v0", "human@example.com", "init");
+        // Checkpoint OID that doesn't exist in the repo (GC'd / force-pushed
+        // away). Must error so the tick keeps the checkpoint instead of
+        // silently resyncing from an empty tree and dropping deletions.
+        let missing = "1111111111111111111111111111111111111111";
+        let res = GitEngine::external_deltas(&repo, Some(missing), &c0.to_string());
+        assert!(res.is_err(), "missing checkpoint must fail the tick");
         let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/core/crates/library/src/importer.rs
+++ b/core/crates/library/src/importer.rs
@@ -93,10 +93,17 @@ pub trait LibraryImporter: Send + Sync + 'static {
     /// Reverse of [`Self::upsert_in_op`]. Returns `Some(doc_id)` to signal
     /// the runner should also delete the search-store row (paired with
     /// [`Self::doc_type`]); `None` skips. Default: warn-and-skip.
+    ///
+    /// `content` is the removed file's old blob bytes (empty if unreadable),
+    /// so importers can make id-aware delete decisions — only delete the
+    /// entity whose file this actually was. This backstops the projection
+    /// trailer: a historical (pre-trailer) or external removal still can't
+    /// soft-delete a different generation that now owns the same path.
     async fn delete_in_op(
         &self,
         _op: &mut es_entity::DbOp<'_>,
         path: &str,
+        _content: &[u8],
     ) -> Result<Option<uuid::Uuid>, UpsertError> {
         tracing::warn!(%path, doc_type = self.doc_type().as_str(), "delete_in_op not implemented; skipping");
         Ok(None)

--- a/core/crates/library/src/importer.rs
+++ b/core/crates/library/src/importer.rs
@@ -78,6 +78,15 @@ pub trait LibraryImporter: Send + Sync + 'static {
         false
     }
 
+    /// Is the document with this id still live (present and not soft-deleted)?
+    /// Consulted by the forward-sync write job to skip a stale, replayed write
+    /// that would resurrect a deleted entity's file. Keyed by doc id (not
+    /// path) to stay robust under path aliasing. Default: always live (no
+    /// liveness gating).
+    async fn is_doc_live(&self, _id: uuid::Uuid) -> Result<bool, UpsertError> {
+        Ok(true)
+    }
+
     /// Upsert the document into its service-specific tables. Returns
     /// `Some(SearchableFields)` when the caller should also write the
     /// search index row; `None` when the importer handled everything

--- a/core/crates/library/src/importer.rs
+++ b/core/crates/library/src/importer.rs
@@ -68,16 +68,6 @@ pub trait LibraryImporter: Send + Sync + 'static {
 
     fn doc_type(&self) -> DocType;
 
-    /// When true, reverse-sync drops deltas from drua-authored commits
-    /// (`CommitDelta::from_drua`). Set by DB-authoritative importers
-    /// (e.g. workflows) whose git files are projections of DB state, so
-    /// drua's own forward-sync writes / prune-orphans must not feed back
-    /// in. Git-authoritative importers (spaces / notes / skills are written
-    /// to git first, then imported) leave this `false`.
-    fn suppress_echo_commits(&self) -> bool {
-        false
-    }
-
     /// Is the document with this id still live (present and not soft-deleted)?
     /// Consulted by the forward-sync write job to skip a stale, replayed write
     /// that would resurrect a deleted entity's file. Keyed by doc id (not

--- a/core/crates/library/src/importer.rs
+++ b/core/crates/library/src/importer.rs
@@ -68,6 +68,16 @@ pub trait LibraryImporter: Send + Sync + 'static {
 
     fn doc_type(&self) -> DocType;
 
+    /// When true, reverse-sync drops deltas from drua-authored commits
+    /// (`CommitDelta::from_drua`). Set by DB-authoritative importers
+    /// (e.g. workflows) whose git files are projections of DB state, so
+    /// drua's own forward-sync writes / prune-orphans must not feed back
+    /// in. Git-authoritative importers (spaces / notes / skills are written
+    /// to git first, then imported) leave this `false`.
+    fn suppress_echo_commits(&self) -> bool {
+        false
+    }
+
     /// Upsert the document into its service-specific tables. Returns
     /// `Some(SearchableFields)` when the caller should also write the
     /// search index row; `None` when the importer handled everything

--- a/core/crates/library/src/job/mod.rs
+++ b/core/crates/library/src/job/mod.rs
@@ -5,4 +5,4 @@ mod write;
 pub(crate) use embed::{LibraryEmbedConfig, LibraryEmbedJobInitializer};
 pub(crate) use sync::{CommitTick, ImporterRegistry, LibrarySyncConfig, LibrarySyncJobInitializer};
 pub(crate) use write::{LibraryWriteConfig, LibraryWriteJobInitializer};
-pub use write::{LivenessGuard, LivenessKind, WriteOp};
+pub use write::{LivenessRef, WriteOp};

--- a/core/crates/library/src/job/mod.rs
+++ b/core/crates/library/src/job/mod.rs
@@ -4,5 +4,5 @@ mod write;
 
 pub(crate) use embed::{LibraryEmbedConfig, LibraryEmbedJobInitializer};
 pub(crate) use sync::{CommitTick, ImporterRegistry, LibrarySyncConfig, LibrarySyncJobInitializer};
-pub use write::WriteOp;
 pub(crate) use write::{LibraryWriteConfig, LibraryWriteJobInitializer};
+pub use write::{LivenessGuard, LivenessKind, WriteOp};

--- a/core/crates/library/src/job/sync.rs
+++ b/core/crates/library/src/job/sync.rs
@@ -106,7 +106,7 @@ impl JobRunner for LibrarySyncRunner {
                             tracing::debug!(head = %tick.head, "library.sync: processing tick");
                             // Advance `last_processed_head` only if the tick was
                             // actually processed. If `process_tick` fails before
-                            // computing deltas (e.g. `external_changes_since` errors), the
+                            // computing deltas (e.g. `changes_with_provenance` errors), the
                             // next tick must diff forward from the same start
                             // point or we'd lose every change in this commit
                             // range.
@@ -154,15 +154,16 @@ impl LibrarySyncRunner {
         from: Option<&str>,
         to: &str,
     ) -> Result<(), crate::LibraryError> {
-        // Echo-suppressed: only external (non-drua) commits are authoritative
-        // reverse-sync inputs. drua's own writes/prunes are already in the DB;
-        // re-ingesting them is what produced the spurious workflow deletes.
+        // Deltas tagged with commit provenance (`from_drua`). DB-authoritative
+        // importers (workflows) drop echoes of their own writes/prunes — that
+        // feedback is what produced the spurious workflow deletes — while
+        // git-authoritative importers (spaces/notes/skills) ingest everything.
         let deltas = self
             .git
-            .external_changes_since(from, to)
+            .changes_with_provenance(from, to)
             .await
             .map_err(|e| {
-                tracing::warn!(error = %e, ?from, to, "external_changes_since failed");
+                tracing::warn!(error = %e, ?from, to, "changes_with_provenance failed");
                 e
             })?;
 
@@ -172,6 +173,9 @@ impl LibrarySyncRunner {
                 Some(i) => i,
                 None => continue,
             };
+            if delta.from_drua && importer.suppress_echo_commits() {
+                continue;
+            }
             if let Err(e) = self.dispatch(current_job, importer.as_ref(), &delta).await {
                 tracing::warn!(error = %e, path = %delta.path, "library.sync: dispatch failed");
             }

--- a/core/crates/library/src/job/sync.rs
+++ b/core/crates/library/src/job/sync.rs
@@ -106,7 +106,7 @@ impl JobRunner for LibrarySyncRunner {
                             tracing::debug!(head = %tick.head, "library.sync: processing tick");
                             // Advance `last_processed_head` only if the tick was
                             // actually processed. If `process_tick` fails before
-                            // computing deltas (e.g. `changes_with_provenance` errors), the
+                            // computing deltas (e.g. `external_changes_since` errors), the
                             // next tick must diff forward from the same start
                             // point or we'd lose every change in this commit
                             // range.
@@ -154,16 +154,16 @@ impl LibrarySyncRunner {
         from: Option<&str>,
         to: &str,
     ) -> Result<(), crate::LibraryError> {
-        // Deltas tagged with commit provenance (`from_drua`). DB-authoritative
-        // importers (workflows) drop echoes of their own writes/prunes — that
-        // feedback is what produced the spurious workflow deletes — while
-        // git-authoritative importers (spaces/notes/skills) ingest everything.
+        // Only authoritative (non-projection) commits are reverse-sync inputs.
+        // drua's own forward-sync writes and prune-orphan deletes carry the
+        // `Drua-Projection` trailer and are dropped by `external_changes_since`
+        // — re-ingesting them is what produced the spurious workflow deletes.
         let deltas = self
             .git
-            .changes_with_provenance(from, to)
+            .external_changes_since(from, to)
             .await
             .map_err(|e| {
-                tracing::warn!(error = %e, ?from, to, "changes_with_provenance failed");
+                tracing::warn!(error = %e, ?from, to, "external_changes_since failed");
                 e
             })?;
 
@@ -173,9 +173,6 @@ impl LibrarySyncRunner {
                 Some(i) => i,
                 None => continue,
             };
-            if delta.from_drua && importer.suppress_echo_commits() {
-                continue;
-            }
             if let Err(e) = self.dispatch(current_job, importer.as_ref(), &delta).await {
                 tracing::warn!(error = %e, path = %delta.path, "library.sync: dispatch failed");
             }

--- a/core/crates/library/src/job/sync.rs
+++ b/core/crates/library/src/job/sync.rs
@@ -189,7 +189,10 @@ impl LibrarySyncRunner {
         let mut op = current_job.begin_op().await?;
         match delta.kind {
             DeltaKind::Deleted => {
-                if let Some(doc_id) = importer.delete_in_op(&mut op, &delta.path).await? {
+                if let Some(doc_id) = importer
+                    .delete_in_op(&mut op, &delta.path, &delta.content)
+                    .await?
+                {
                     self.search
                         .delete_in_op(&mut op, doc_id, importer.doc_type())
                         .await?;

--- a/core/crates/library/src/job/sync.rs
+++ b/core/crates/library/src/job/sync.rs
@@ -106,7 +106,7 @@ impl JobRunner for LibrarySyncRunner {
                             tracing::debug!(head = %tick.head, "library.sync: processing tick");
                             // Advance `last_processed_head` only if the tick was
                             // actually processed. If `process_tick` fails before
-                            // computing deltas (e.g. `changes_since` errors), the
+                            // computing deltas (e.g. `external_changes_since` errors), the
                             // next tick must diff forward from the same start
                             // point or we'd lose every change in this commit
                             // range.
@@ -154,10 +154,17 @@ impl LibrarySyncRunner {
         from: Option<&str>,
         to: &str,
     ) -> Result<(), crate::LibraryError> {
-        let deltas = self.git.changes_since(from, to).await.map_err(|e| {
-            tracing::warn!(error = %e, ?from, to, "changes_since failed");
-            e
-        })?;
+        // Echo-suppressed: only external (non-drua) commits are authoritative
+        // reverse-sync inputs. drua's own writes/prunes are already in the DB;
+        // re-ingesting them is what produced the spurious workflow deletes.
+        let deltas = self
+            .git
+            .external_changes_since(from, to)
+            .await
+            .map_err(|e| {
+                tracing::warn!(error = %e, ?from, to, "external_changes_since failed");
+                e
+            })?;
 
         let importers = self.importers.read().await;
         for delta in deltas {

--- a/core/crates/library/src/job/write.rs
+++ b/core/crates/library/src/job/write.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use job::{CurrentJob, Job, JobCompletion, JobInitializer, JobRunner, JobSpawner, JobType};
 use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
 
 use crate::attribution::CommitAttribution;
 use crate::git::GitEngine;
@@ -46,6 +47,35 @@ pub enum WriteOp {
     },
 }
 
+/// Identifies the DB row that a forward-sync write reflects, so the write
+/// job can re-check liveness at execution time. A persisted write job
+/// captures its bytes at enqueue time and may replay much later (restart,
+/// retry); if the source entity was soft-deleted in the meantime, applying
+/// the captured write would resurrect an orphan file. Carried as a tagged
+/// enum (not a closure) because the job config must be serializable; each
+/// variant maps to a fixed, injection-free `deleted` lookup.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LivenessGuard {
+    pub kind: LivenessKind,
+    pub id: uuid::Uuid,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LivenessKind {
+    WorkflowDefinition,
+}
+
+impl LivenessKind {
+    fn is_deleted_query(self) -> &'static str {
+        match self {
+            LivenessKind::WorkflowDefinition => {
+                "SELECT deleted FROM workflow_definitions WHERE id = $1"
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct LibraryWriteConfig {
     pub op: WriteOp,
@@ -54,15 +84,21 @@ pub(crate) struct LibraryWriteConfig {
     /// job is replayed across a process restart.
     #[serde(default)]
     pub attribution: CommitAttribution,
+    /// When set, the write is skipped if the referenced row is soft-deleted
+    /// (or gone) by the time the job runs — guards against a stale forward
+    /// sync resurrecting a deleted entity's file.
+    #[serde(default)]
+    pub liveness: Option<LivenessGuard>,
 }
 
 pub(crate) struct LibraryWriteJobInitializer {
     git: Arc<GitEngine>,
+    pool: PgPool,
 }
 
 impl LibraryWriteJobInitializer {
-    pub fn new(git: Arc<GitEngine>) -> Self {
-        Self { git }
+    pub fn new(git: Arc<GitEngine>, pool: PgPool) -> Self {
+        Self { git, pool }
     }
 }
 
@@ -81,16 +117,33 @@ impl JobInitializer for LibraryWriteJobInitializer {
         let config: LibraryWriteConfig = job.config()?;
         Ok(Box::new(LibraryWriteRunner {
             git: Arc::clone(&self.git),
+            pool: self.pool.clone(),
             op: config.op,
             attribution: config.attribution,
+            liveness: config.liveness,
         }))
     }
 }
 
 struct LibraryWriteRunner {
     git: Arc<GitEngine>,
+    pool: PgPool,
     op: WriteOp,
     attribution: CommitAttribution,
+    liveness: Option<LivenessGuard>,
+}
+
+impl LibraryWriteRunner {
+    /// `true` when the guarded row is soft-deleted or absent — i.e. the
+    /// captured write is stale and must be skipped. Missing row counts as
+    /// deleted (the entity is gone; writing its file would resurrect it).
+    async fn target_is_dead(&self, guard: &LivenessGuard) -> Result<bool, sqlx::Error> {
+        let deleted: Option<(bool,)> = sqlx::query_as(guard.kind.is_deleted_query())
+            .bind(guard.id)
+            .fetch_optional(&self.pool)
+            .await?;
+        Ok(deleted.map(|(d,)| d).unwrap_or(true))
+    }
 }
 
 #[async_trait::async_trait]
@@ -100,6 +153,16 @@ impl JobRunner for LibraryWriteRunner {
         &self,
         _current_job: CurrentJob,
     ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
+        if let Some(guard) = &self.liveness {
+            if self.target_is_dead(guard).await? {
+                tracing::info!(
+                    kind = ?guard.kind,
+                    id = %guard.id,
+                    "library.write: skipping stale write; sync target soft-deleted or gone"
+                );
+                return Ok(JobCompletion::Complete);
+            }
+        }
         let attribution = self.attribution.clone();
         match &self.op {
             WriteOp::WriteFile {
@@ -149,5 +212,52 @@ impl JobRunner for LibraryWriteRunner {
             }
         }
         Ok(JobCompletion::Complete)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn workflow_liveness_query_checks_deleted_column() {
+        assert_eq!(
+            LivenessKind::WorkflowDefinition.is_deleted_query(),
+            "SELECT deleted FROM workflow_definitions WHERE id = $1"
+        );
+    }
+
+    #[test]
+    fn config_predating_liveness_field_still_deserializes() {
+        // Write jobs persisted before `liveness` existed must keep loading
+        // (serde default → None), or a restart would fail to replay them.
+        let json = r#"{"op":{"kind":"delete_file","path":"a.yml","message":"m"}}"#;
+        let cfg: LibraryWriteConfig = serde_json::from_str(json).unwrap();
+        assert!(cfg.liveness.is_none());
+    }
+
+    #[test]
+    fn config_with_liveness_round_trips() {
+        let cfg = LibraryWriteConfig {
+            op: WriteOp::WriteFile {
+                path: "a.yml".into(),
+                content: b"x".to_vec(),
+                message: "m".into(),
+            },
+            attribution: CommitAttribution::default(),
+            liveness: Some(LivenessGuard {
+                kind: LivenessKind::WorkflowDefinition,
+                id: uuid::Uuid::nil(),
+            }),
+        };
+        let back: LibraryWriteConfig =
+            serde_json::from_str(&serde_json::to_string(&cfg).unwrap()).unwrap();
+        assert!(matches!(
+            back.liveness,
+            Some(LivenessGuard {
+                kind: LivenessKind::WorkflowDefinition,
+                ..
+            })
+        ));
     }
 }

--- a/core/crates/library/src/job/write.rs
+++ b/core/crates/library/src/job/write.rs
@@ -2,10 +2,11 @@ use std::sync::Arc;
 
 use job::{CurrentJob, Job, JobCompletion, JobInitializer, JobRunner, JobSpawner, JobType};
 use serde::{Deserialize, Serialize};
-use sqlx::PgPool;
 
+use super::sync::ImporterRegistry;
 use crate::attribution::CommitAttribution;
 use crate::git::GitEngine;
+use crate::importer::DocType;
 
 pub(crate) const LIBRARY_WRITE_JOB: &str = "library.write";
 
@@ -47,33 +48,19 @@ pub enum WriteOp {
     },
 }
 
-/// Identifies the DB row that a forward-sync write reflects, so the write
-/// job can re-check liveness at execution time. A persisted write job
-/// captures its bytes at enqueue time and may replay much later (restart,
-/// retry); if the source entity was soft-deleted in the meantime, applying
-/// the captured write would resurrect an orphan file. Carried as a tagged
-/// enum (not a closure) because the job config must be serializable; each
-/// variant maps to a fixed, injection-free `deleted` lookup.
+/// Identifies the DB row a forward-sync write reflects, so the write job can
+/// re-check liveness at execution time. A persisted write job captures its
+/// bytes at enqueue time and may replay much later (restart, retry); if the
+/// source entity was soft-deleted in the meantime, applying the captured
+/// write would resurrect an orphan file.
+///
+/// Opaque to this crate: just `(doc_type, id)`. The matching
+/// [`crate::LibraryImporter::is_doc_live`] owns the actual liveness query, so
+/// the generic library crate stays decoupled from concrete entity tables.
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct LivenessGuard {
-    pub kind: LivenessKind,
+pub struct LivenessRef {
+    pub doc_type: DocType,
     pub id: uuid::Uuid,
-}
-
-#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
-#[serde(rename_all = "snake_case")]
-pub enum LivenessKind {
-    WorkflowDefinition,
-}
-
-impl LivenessKind {
-    fn is_deleted_query(self) -> &'static str {
-        match self {
-            LivenessKind::WorkflowDefinition => {
-                "SELECT deleted FROM workflow_definitions WHERE id = $1"
-            }
-        }
-    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -84,21 +71,21 @@ pub(crate) struct LibraryWriteConfig {
     /// job is replayed across a process restart.
     #[serde(default)]
     pub attribution: CommitAttribution,
-    /// When set, the write is skipped if the referenced row is soft-deleted
-    /// (or gone) by the time the job runs — guards against a stale forward
-    /// sync resurrecting a deleted entity's file.
+    /// When set, the write is skipped if its source row is soft-deleted (or
+    /// gone) by the time the job runs — guards against a stale forward sync
+    /// resurrecting a deleted entity's file.
     #[serde(default)]
-    pub liveness: Option<LivenessGuard>,
+    pub liveness: Option<LivenessRef>,
 }
 
 pub(crate) struct LibraryWriteJobInitializer {
     git: Arc<GitEngine>,
-    pool: PgPool,
+    importers: ImporterRegistry,
 }
 
 impl LibraryWriteJobInitializer {
-    pub fn new(git: Arc<GitEngine>, pool: PgPool) -> Self {
-        Self { git, pool }
+    pub fn new(git: Arc<GitEngine>, importers: ImporterRegistry) -> Self {
+        Self { git, importers }
     }
 }
 
@@ -117,7 +104,7 @@ impl JobInitializer for LibraryWriteJobInitializer {
         let config: LibraryWriteConfig = job.config()?;
         Ok(Box::new(LibraryWriteRunner {
             git: Arc::clone(&self.git),
-            pool: self.pool.clone(),
+            importers: Arc::clone(&self.importers),
             op: config.op,
             attribution: config.attribution,
             liveness: config.liveness,
@@ -127,22 +114,34 @@ impl JobInitializer for LibraryWriteJobInitializer {
 
 struct LibraryWriteRunner {
     git: Arc<GitEngine>,
-    pool: PgPool,
+    importers: ImporterRegistry,
     op: WriteOp,
     attribution: CommitAttribution,
-    liveness: Option<LivenessGuard>,
+    liveness: Option<LivenessRef>,
 }
 
 impl LibraryWriteRunner {
-    /// `true` when the guarded row is soft-deleted or absent — i.e. the
-    /// captured write is stale and must be skipped. Missing row counts as
-    /// deleted (the entity is gone; writing its file would resurrect it).
-    async fn target_is_dead(&self, guard: &LivenessGuard) -> Result<bool, sqlx::Error> {
-        let deleted: Option<(bool,)> = sqlx::query_as(guard.kind.is_deleted_query())
-            .bind(guard.id)
-            .fetch_optional(&self.pool)
-            .await?;
-        Ok(deleted.map(|(d,)| d).unwrap_or(true))
+    /// `true` when the write's source entity is soft-deleted or gone, so the
+    /// captured (possibly replayed) write should be skipped. The actual check
+    /// is delegated to the registered [`crate::LibraryImporter`] for the doc
+    /// type. On a missing importer or a lookup error, treats the source as
+    /// live and proceeds — matching the no-guard default.
+    async fn source_is_dead(&self, lr: &LivenessRef) -> bool {
+        let importers = self.importers.read().await;
+        let Some(importer) = importers.iter().find(|i| i.doc_type() == lr.doc_type) else {
+            tracing::warn!(
+                doc_type = %lr.doc_type,
+                "library.write: no importer for liveness check; proceeding"
+            );
+            return false;
+        };
+        match importer.is_doc_live(lr.id).await {
+            Ok(live) => !live,
+            Err(e) => {
+                tracing::warn!(error = %e, id = %lr.id, "library.write: liveness check failed; proceeding");
+                false
+            }
+        }
     }
 }
 
@@ -153,12 +152,12 @@ impl JobRunner for LibraryWriteRunner {
         &self,
         _current_job: CurrentJob,
     ) -> Result<JobCompletion, Box<dyn std::error::Error>> {
-        if let Some(guard) = &self.liveness {
-            if self.target_is_dead(guard).await? {
+        if let Some(lr) = &self.liveness {
+            if self.source_is_dead(lr).await {
                 tracing::info!(
-                    kind = ?guard.kind,
-                    id = %guard.id,
-                    "library.write: skipping stale write; sync target soft-deleted or gone"
+                    doc_type = %lr.doc_type,
+                    id = %lr.id,
+                    "library.write: skipping stale write; source soft-deleted or gone"
                 );
                 return Ok(JobCompletion::Complete);
             }
@@ -220,14 +219,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn workflow_liveness_query_checks_deleted_column() {
-        assert_eq!(
-            LivenessKind::WorkflowDefinition.is_deleted_query(),
-            "SELECT deleted FROM workflow_definitions WHERE id = $1"
-        );
-    }
-
-    #[test]
     fn config_predating_liveness_field_still_deserializes() {
         // Write jobs persisted before `liveness` existed must keep loading
         // (serde default → None), or a restart would fail to replay them.
@@ -245,19 +236,14 @@ mod tests {
                 message: "m".into(),
             },
             attribution: CommitAttribution::default(),
-            liveness: Some(LivenessGuard {
-                kind: LivenessKind::WorkflowDefinition,
+            liveness: Some(LivenessRef {
+                doc_type: DocType::new("workflow"),
                 id: uuid::Uuid::nil(),
             }),
         };
         let back: LibraryWriteConfig =
             serde_json::from_str(&serde_json::to_string(&cfg).unwrap()).unwrap();
-        assert!(matches!(
-            back.liveness,
-            Some(LivenessGuard {
-                kind: LivenessKind::WorkflowDefinition,
-                ..
-            })
-        ));
+        let lr = back.liveness.expect("liveness present");
+        assert_eq!(lr.doc_type, DocType::new("workflow"));
     }
 }

--- a/core/crates/library/src/lib.rs
+++ b/core/crates/library/src/lib.rs
@@ -240,13 +240,19 @@ impl Library {
         if !new_events.any(|p| E::is_content_event(&p.event)) {
             return Ok(());
         }
+        // A forward-sync write only projects already-persisted DB state into
+        // git, so mark it: reverse-sync drops it instead of re-ingesting (the
+        // workflow-delete domino). Direct authoring writes (`spaces edit`) go
+        // through their own path unmarked and still import.
+        let mut attribution = CommitAttribution::from_event_context();
+        attribution.mark_projection();
         self.enqueue_in_op(
             op,
             HookEntry {
                 fields: Some(entity.searchable_fields()),
                 deletes: entity.extra_search_deletes(),
                 write_op: Some(entity.write_op()),
-                attribution: CommitAttribution::from_event_context(),
+                attribution,
                 liveness: entity.liveness_guard(),
             },
         )

--- a/core/crates/library/src/lib.rs
+++ b/core/crates/library/src/lib.rs
@@ -20,7 +20,7 @@ pub use config::LibraryConfig;
 pub use error::LibraryError;
 pub use github_app::GitHubAppTokenProvider;
 pub use importer::{DocType, GitFileHash, LibraryImporter, UpsertError};
-pub use job::{LivenessGuard, LivenessKind, WriteOp};
+pub use job::{LivenessRef, WriteOp};
 pub use primitives::SpaceId;
 pub use search::{SearchHit, SearchStore, SearchableFields};
 pub use space::{NewSpace, Space, SpaceError, SpaceEvent, Spaces, SPACE_DOC_TYPE};
@@ -80,9 +80,18 @@ impl Library {
             Arc::clone(&embedder),
         ));
 
+        // Importers registry is shared with the write job so it can delegate
+        // liveness checks to the domain (per doc type). Built before the write
+        // initializer; importers registered later via `register_importer` are
+        // visible through the shared `Arc<RwLock<…>>`.
+        let importers: ImporterRegistry =
+            Arc::new(tokio::sync::RwLock::new(vec![
+                Arc::new(spaces.clone()) as Arc<dyn LibraryImporter>
+            ]));
+
         let write_spawner = jobs.add_initializer(LibraryWriteJobInitializer::new(
             Arc::clone(&git),
-            pool.clone(),
+            Arc::clone(&importers),
         ));
 
         let (tick_tx, tick_rx) = mpsc::channel::<CommitTick>(64);
@@ -92,11 +101,6 @@ impl Library {
             Duration::from_millis(config.fetch_interval_ms),
             git.local_commit_notify(),
         );
-
-        let importers: ImporterRegistry =
-            Arc::new(tokio::sync::RwLock::new(vec![
-                Arc::new(spaces.clone()) as Arc<dyn LibraryImporter>
-            ]));
 
         let spawner = jobs.add_initializer(LibrarySyncJobInitializer::new(
             tick_rx,

--- a/core/crates/library/src/lib.rs
+++ b/core/crates/library/src/lib.rs
@@ -20,7 +20,7 @@ pub use config::LibraryConfig;
 pub use error::LibraryError;
 pub use github_app::GitHubAppTokenProvider;
 pub use importer::{DocType, GitFileHash, LibraryImporter, UpsertError};
-pub use job::WriteOp;
+pub use job::{LivenessGuard, LivenessKind, WriteOp};
 pub use primitives::SpaceId;
 pub use search::{SearchHit, SearchStore, SearchableFields};
 pub use space::{NewSpace, Space, SpaceError, SpaceEvent, Spaces, SPACE_DOC_TYPE};
@@ -62,7 +62,15 @@ impl Library {
         github_app: Option<Arc<GitHubAppTokenProvider>>,
     ) -> Result<Self, LibraryError> {
         let repo_path = PathBuf::from(&config.data_dir);
-        let git = Arc::new(GitEngine::init(&config.repo_url, repo_path, github_app.clone()).await?);
+        let git = Arc::new(
+            GitEngine::init(
+                &config.repo_url,
+                repo_path,
+                github_app.clone(),
+                pool.clone(),
+            )
+            .await?,
+        );
 
         let search = SearchStore::new(pool, Arc::clone(&embedder));
         let spaces = Spaces::new(&git, pool);
@@ -72,7 +80,10 @@ impl Library {
             Arc::clone(&embedder),
         ));
 
-        let write_spawner = jobs.add_initializer(LibraryWriteJobInitializer::new(Arc::clone(&git)));
+        let write_spawner = jobs.add_initializer(LibraryWriteJobInitializer::new(
+            Arc::clone(&git),
+            pool.clone(),
+        ));
 
         let (tick_tx, tick_rx) = mpsc::channel::<CommitTick>(64);
         let fetcher = Self::spawn_fetcher(
@@ -232,6 +243,7 @@ impl Library {
                 deletes: entity.extra_search_deletes(),
                 write_op: Some(entity.write_op()),
                 attribution: CommitAttribution::from_event_context(),
+                liveness: entity.liveness_guard(),
             },
         )
         .await
@@ -254,6 +266,7 @@ impl Library {
                 deletes: Vec::new(),
                 write_op: Some(write_op),
                 attribution,
+                liveness: None,
             },
         )
         .await
@@ -281,6 +294,7 @@ impl Library {
                 deletes,
                 write_op,
                 attribution,
+                liveness: None,
             },
         )
         .await

--- a/core/crates/library/src/space/mod.rs
+++ b/core/crates/library/src/space/mod.rs
@@ -439,6 +439,7 @@ impl LibraryImporter for Spaces {
         &self,
         _op: &mut es_entity::DbOp<'_>,
         path: &str,
+        _content: &[u8],
     ) -> Result<Option<uuid::Uuid>, UpsertError> {
         if path.ends_with("/.gitkeep") {
             return Ok(None);

--- a/core/crates/library/src/synced.rs
+++ b/core/crates/library/src/synced.rs
@@ -3,7 +3,7 @@ use job::{JobId, JobSpawner};
 
 use crate::attribution::CommitAttribution;
 use crate::importer::DocType;
-use crate::job::{LibraryEmbedConfig, LibraryWriteConfig, LivenessGuard, WriteOp};
+use crate::job::{LibraryEmbedConfig, LibraryWriteConfig, LivenessRef, WriteOp};
 use crate::search::{SearchStore, SearchableFields};
 
 /// Implemented on entity types whose mutations should sync to the
@@ -35,11 +35,12 @@ pub trait LibrarySynced: Sized + Send + Sync + 'static {
         Vec::new()
     }
 
-    /// Optional liveness target re-checked when the upstream write job
+    /// Optional liveness reference re-checked when the upstream write job
     /// runs. Return `Some` so a forward-sync write that replays after the
-    /// entity was soft-deleted is skipped instead of resurrecting its
-    /// file. Default: no re-check.
-    fn liveness_guard(&self) -> Option<LivenessGuard> {
+    /// entity was soft-deleted is skipped instead of resurrecting its file.
+    /// The check itself is delegated to the matching importer's
+    /// [`crate::LibraryImporter::is_doc_live`]. Default: no re-check.
+    fn liveness_guard(&self) -> Option<LivenessRef> {
         None
     }
 }
@@ -50,7 +51,7 @@ pub(crate) struct HookEntry {
     pub deletes: Vec<(uuid::Uuid, DocType)>,
     pub write_op: Option<WriteOp>,
     pub attribution: CommitAttribution,
-    pub liveness: Option<LivenessGuard>,
+    pub liveness: Option<LivenessRef>,
 }
 
 /// Batches per-transaction library writes. On the per-transaction

--- a/core/crates/library/src/synced.rs
+++ b/core/crates/library/src/synced.rs
@@ -3,7 +3,7 @@ use job::{JobId, JobSpawner};
 
 use crate::attribution::CommitAttribution;
 use crate::importer::DocType;
-use crate::job::{LibraryEmbedConfig, LibraryWriteConfig, WriteOp};
+use crate::job::{LibraryEmbedConfig, LibraryWriteConfig, LivenessGuard, WriteOp};
 use crate::search::{SearchStore, SearchableFields};
 
 /// Implemented on entity types whose mutations should sync to the
@@ -34,6 +34,14 @@ pub trait LibrarySynced: Sized + Send + Sync + 'static {
     fn extra_search_deletes(&self) -> Vec<(uuid::Uuid, DocType)> {
         Vec::new()
     }
+
+    /// Optional liveness target re-checked when the upstream write job
+    /// runs. Return `Some` so a forward-sync write that replays after the
+    /// entity was soft-deleted is skipped instead of resurrecting its
+    /// file. Default: no re-check.
+    fn liveness_guard(&self) -> Option<LivenessGuard> {
+        None
+    }
 }
 
 /// Single entry in the per-transaction batch.
@@ -42,6 +50,7 @@ pub(crate) struct HookEntry {
     pub deletes: Vec<(uuid::Uuid, DocType)>,
     pub write_op: Option<WriteOp>,
     pub attribution: CommitAttribution,
+    pub liveness: Option<LivenessGuard>,
 }
 
 /// Batches per-transaction library writes. On the per-transaction
@@ -111,6 +120,7 @@ impl CommitHook for LibrarySyncHook {
                 let config = LibraryWriteConfig {
                     op: write_op.clone(),
                     attribution: entry.attribution.clone(),
+                    liveness: entry.liveness.clone(),
                 };
                 if let Err(e) = self
                     .write_spawner

--- a/core/src/note/importer.rs
+++ b/core/src/note/importer.rs
@@ -135,6 +135,7 @@ impl LibraryImporter for NotesImporter {
         &self,
         op: &mut es_entity::DbOp<'_>,
         path: &str,
+        _content: &[u8],
     ) -> Result<Option<uuid::Uuid>, UpsertError> {
         let deleted = self
             .notes

--- a/core/src/skill/importer.rs
+++ b/core/src/skill/importer.rs
@@ -140,6 +140,7 @@ impl LibraryImporter for SkillsImporter {
         &self,
         op: &mut es_entity::DbOp<'_>,
         path: &str,
+        _content: &[u8],
     ) -> Result<Option<uuid::Uuid>, UpsertError> {
         let deleted = self
             .skills

--- a/core/src/workflow/entity.rs
+++ b/core/src/workflow/entity.rs
@@ -1,5 +1,5 @@
 use derive_builder::Builder;
-use drua_library::{GitFileHash, LivenessGuard, LivenessKind, SearchableFields, WriteOp};
+use drua_library::{GitFileHash, LivenessRef, SearchableFields, WriteOp};
 use llm::ModelChain;
 use serde::{Deserialize, Serialize};
 
@@ -315,9 +315,9 @@ impl drua_library::LibrarySynced for WorkflowDefinition {
         }
     }
 
-    fn liveness_guard(&self) -> Option<LivenessGuard> {
-        Some(LivenessGuard {
-            kind: LivenessKind::WorkflowDefinition,
+    fn liveness_guard(&self) -> Option<LivenessRef> {
+        Some(LivenessRef {
+            doc_type: crate::workflow::WORKFLOW_DOC_TYPE,
             id: self.id.into(),
         })
     }

--- a/core/src/workflow/entity.rs
+++ b/core/src/workflow/entity.rs
@@ -1,5 +1,5 @@
 use derive_builder::Builder;
-use drua_library::{GitFileHash, SearchableFields, WriteOp};
+use drua_library::{GitFileHash, LivenessGuard, LivenessKind, SearchableFields, WriteOp};
 use llm::ModelChain;
 use serde::{Deserialize, Serialize};
 
@@ -313,6 +313,13 @@ impl drua_library::LibrarySynced for WorkflowDefinition {
                 message,
             },
         }
+    }
+
+    fn liveness_guard(&self) -> Option<LivenessGuard> {
+        Some(LivenessGuard {
+            kind: LivenessKind::WorkflowDefinition,
+            id: self.id.into(),
+        })
     }
 }
 

--- a/core/src/workflow/importer.rs
+++ b/core/src/workflow/importer.rs
@@ -42,14 +42,6 @@ impl LibraryImporter for WorkflowsImporter {
         DruaDocType::new("workflow")
     }
 
-    /// Workflows are DB-authoritative: the git YAML is a projection of the
-    /// definition. drua's own forward-sync writes and prune-orphan deletes
-    /// must not reverse-sync back in (re-ingesting a prune-orphan as a
-    /// `Deleted` delta is what soft-deleted live workflows).
-    fn suppress_echo_commits(&self) -> bool {
-        true
-    }
-
     async fn is_doc_live(&self, id: uuid::Uuid) -> Result<bool, UpsertError> {
         self.workflows
             .is_live(crate::primitives::WorkflowDefinitionId::from(id))

--- a/core/src/workflow/importer.rs
+++ b/core/src/workflow/importer.rs
@@ -102,6 +102,7 @@ impl LibraryImporter for WorkflowsImporter {
         &self,
         op: &mut es_entity::DbOp<'_>,
         path: &str,
+        content: &[u8],
     ) -> Result<Option<uuid::Uuid>, UpsertError> {
         let Some(project_name) = crate::workflow::yaml::project_name_from_workflow_path(path)
         else {
@@ -123,9 +124,19 @@ impl LibraryImporter for WorkflowsImporter {
                 )))
             }
         };
+        // Id-aware backstop to the projection trailer: only soft-delete when
+        // the removed blob's embedded id matches the live workflow at this
+        // (project, name) path. A historical (pre-trailer) prune-orphan or an
+        // external removal of a stale generation's file thus can't take down a
+        // freshly recreated workflow sharing the path. Unparseable content →
+        // `None` → skip (fail-safe).
+        let removed_id = std::str::from_utf8(content)
+            .ok()
+            .and_then(|c| parse_workflow_yaml(c, path))
+            .map(|p| p.workflow_id);
         let deleted = self
             .workflows
-            .delete_by_path_in_op(op, project.id, path)
+            .delete_by_path_in_op(op, project.id, path, removed_id)
             .await
             .map_err(|e| UpsertError::Other(format!("workflow reverse-delete: {e}")))?;
         Ok(deleted.map(uuid::Uuid::from))

--- a/core/src/workflow/importer.rs
+++ b/core/src/workflow/importer.rs
@@ -50,6 +50,13 @@ impl LibraryImporter for WorkflowsImporter {
         true
     }
 
+    async fn is_doc_live(&self, id: uuid::Uuid) -> Result<bool, UpsertError> {
+        self.workflows
+            .is_live(crate::primitives::WorkflowDefinitionId::from(id))
+            .await
+            .map_err(|e| UpsertError::Other(format!("workflow liveness check: {e}")))
+    }
+
     async fn upsert_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,

--- a/core/src/workflow/importer.rs
+++ b/core/src/workflow/importer.rs
@@ -42,6 +42,14 @@ impl LibraryImporter for WorkflowsImporter {
         DruaDocType::new("workflow")
     }
 
+    /// Workflows are DB-authoritative: the git YAML is a projection of the
+    /// definition. drua's own forward-sync writes and prune-orphan deletes
+    /// must not reverse-sync back in (re-ingesting a prune-orphan as a
+    /// `Deleted` delta is what soft-deleted live workflows).
+    fn suppress_echo_commits(&self) -> bool {
+        true
+    }
+
     async fn upsert_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -254,6 +254,13 @@ impl Workflows {
         }
     }
 
+    /// Liveness probe for the library forward-sync write job: `true` when
+    /// the definition is present and not soft-deleted. Owns the SQL so the
+    /// generic library crate stays decoupled from `workflow_definitions`.
+    pub(crate) async fn is_live(&self, id: WorkflowDefinitionId) -> Result<bool, WorkflowError> {
+        Ok(self.repo.is_live(id).await?)
+    }
+
     /// Reverse-sync entry point: persist a `ParsedWorkflow` produced
     /// by the library importer. Creates or updates depending on
     /// whether the workflow already exists. `Ok(None)` signals

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -304,6 +304,8 @@ impl Workflows {
                 slugify(&name),
                 &id_uuid.to_string()[..8]
             );
+            let mut attribution = CommitAttribution::system();
+            attribution.mark_projection();
             self.library
                 .enqueue_write_in_op(
                     op,
@@ -311,7 +313,7 @@ impl Workflows {
                         path: original_path.clone(),
                         message,
                     },
-                    CommitAttribution::system(),
+                    attribution,
                 )
                 .await?;
             tracing::info!(
@@ -757,7 +759,7 @@ impl Workflows {
         &self,
         op: &mut es_entity::DbOp<'_>,
         workflow: &WorkflowDefinition,
-        attribution: CommitAttribution,
+        mut attribution: CommitAttribution,
     ) -> Result<(), WorkflowError> {
         let path = canonical_workflow_path(&workflow.name, workflow.project_name.as_deref());
         let id_uuid: uuid::Uuid = workflow.id.into();
@@ -766,6 +768,8 @@ impl Workflows {
             slugify(&workflow.name),
             &id_uuid.to_string()[..8]
         );
+        // DB→git projection of the deletion — reverse-sync must skip it.
+        attribution.mark_projection();
         self.library
             .enqueue_full_in_op(
                 op,

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -1256,6 +1256,7 @@ impl Workflows {
         op: &mut es_entity::DbOp<'_>,
         project_id: ProjectId,
         path: &str,
+        expected_id: Option<WorkflowDefinitionId>,
     ) -> Result<Option<WorkflowDefinitionId>, WorkflowError> {
         let Some(workflow) = self
             .repo
@@ -1264,6 +1265,19 @@ impl Workflows {
         else {
             return Ok(None);
         };
+        // Only delete the workflow whose file was actually removed. A stale
+        // generation's file removal (e.g. an untrailered historical prune,
+        // replayed on deploy) must not take down the live workflow that now
+        // owns this (project, name) path.
+        if expected_id != Some(workflow.id) {
+            tracing::info!(
+                %path,
+                ?expected_id,
+                live_id = %workflow.id,
+                "library reverse-delete skipped: removed file id does not match live workflow at path"
+            );
+            return Ok(None);
+        }
         let id = workflow.id;
         self.library
             .search()

--- a/core/src/workflow/repo.rs
+++ b/core/src/workflow/repo.rs
@@ -68,6 +68,18 @@ impl WorkflowDefinitionRepo {
         Ok(row.map(|(d,)| d).unwrap_or(false))
     }
 
+    /// Standalone liveness read (no op): `true` when the row is present and
+    /// not soft-deleted. A missing row reads as not-live. Used by the library
+    /// forward-sync write job's liveness check.
+    pub async fn is_live(&self, id: WorkflowDefinitionId) -> Result<bool, sqlx::Error> {
+        let row: Option<(bool,)> =
+            sqlx::query_as("SELECT deleted FROM workflow_definitions WHERE id = $1")
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?;
+        Ok(matches!(row, Some((false,))))
+    }
+
     pub async fn maybe_find_by_canonical_path_in_op(
         &self,
         op: &mut es_entity::DbOp<'_>,


### PR DESCRIPTION
## Background

Workflow YAMLs in `GaloyMoney/drua-library` were getting deleted/recreated "by no one." Investigation traced **three distinct bugs** in the bidirectional library↔drua sync, amplified by prod HA (2 pods). Concrete cases:

- **Wrongful deletion (domino):** [`e2f9efe`](https://github.com/GaloyMoney/drua-library/commit/e2f9efe49efed40fa3c8a189eeab64476648c046) — `prune orphan lana-bank-review-v1`
- **Phantom create→delete pair:** [`6e2875a`](https://github.com/GaloyMoney/drua-library/commit/6e2875aaff208d11f2c15acd83c0c8f87dc1f1d3) + [`146d59a`](https://github.com/GaloyMoney/drua-library/commit/146d59a8bc42d619e15188503698ce82a1081fd4), 3s apart, both bot-authored
- **Write-amplification / flap:** ~30 rewrites of one file in 70s; 92 git mutations across both pods in a 15s window (Honeycomb)

DB evidence: project `lana-bank-alerts` is **not** deleted yet 13/15 of its workflows are `deleted=true`; `Prabhat1308-2` has 5 generations of `lana-bank-review-v1`, all `deleted=true`. The git path is reused across delete+recreate, each time with a fresh UUIDv7.

### Root causes
1. **Reverse-sync re-ingested drua's own commits.** A `system[bot]` prune-orphan (cleaning up an already-deleted workflow's orphan file), re-read as a `Deleted` delta, drove `delete_by_path` — which resolves the victim by `(project, name)`, not the UUID — and soft-deleted whichever **live** generation now owned the path. Each prune toppled the next live workflow, draining whole projects.
2. **Stale forward-sync writes resurrected files.** A persisted `library.write` job captures its bytes at enqueue time and can replay much later (restart/retry); if the workflow was deleted in the meantime, it re-created an orphan file → which prune-orphan then deleted (the "by no one" pair).
3. **Divergent ephemeral clones.** `library.write` jobs are distributed across pods by the DB poller, but each pod has its own emptyDir clone, so two pods pushed to `main` from divergent trees → non-ff retries, write amplification, oscillation.

## The fix — a layered defense

Each layer addresses one failure mode; together they make the sync converge.

### 1. Projection trailer (primary echo-suppression)
DB→git projections — forward-sync writes (`Library::sync_entity_in_op`) and workflow delete/prune-orphan — now stamp a **`Drua-Projection`** commit trailer (`CommitAttribution::mark_projection`). Reverse-sync (`external_changes_since`) skips a commit iff it carries the trailer **and** was committed by a drua bot (the committer gate stops an external actor forging the trailer). Direct authoring writes — `spaces edit`, human commits — lack the trailer and import normally, so **space-authored notes/skills still land**.

The echo signal lives *in the commit*: self-describing, atomic, no side table, no GC, no DB/git drift. It replaced an earlier per-importer `suppress_echo_commits` flag that rested on a fragile invariant ("a DB-authoritative type's git files are only ever drua-written as projections") — the trailer is provenance-precise and future-proof (a hypothetical "scaffold a workflow YAML directly" feature would be unmarked → imported correctly).

### 2. Id-aware reverse-delete (backstop)
`Deleted` deltas carry the removed blob, and `WorkflowsImporter` only soft-deletes when the **removed blob's embedded id matches the live workflow** at that path. This backstops the trailer for the cases it can't cover: **historical (pre-trailer) prune commits replayed on deploy**, and external removals under path-aliasing. The per-commit walk (below) makes the removed-blob id exact, so this is robust. Net: a workflow soft-delete only ever targets the workflow whose file was actually removed — independent of the trailer, so **no existing commits need rewriting on rollout**.

### 3. Write-time liveness re-check (phantom create)
`LibraryWriteConfig` carries an optional, opaque `LivenessRef { doc_type, id }`. Before applying a write, the runner delegates to the matching `LibraryImporter::is_doc_live(id)` (default: live) and **skips** if the source row is soft-deleted/gone. `WorkflowDefinition` opts in; the SQL lives in the workflow repo, keeping the generic library crate decoupled from concrete tables. Backward-compatible config (`#[serde(default)]`).

### 4. Session-scoped push lock (HA serialization)
`process_batch` wraps the commit+push critical section in a Postgres **session-scoped** advisory lock (`pg_advisory_lock` on a dedicated connection — not `xact`-scoped, so `idle_in_transaction_session_timeout` can't reap it mid-push). At most one pod mutates `main` at a time; no single-writer SPOF (the lock floats), best-effort (a DB hiccup degrades to the prior unlocked behavior). Pushing to one branch is serial at the remote anyway, so this removes thrash without sacrificing throughput.

### 5. Bounded, projection-filtered, fail-safe walk
`external_deltas` walks commits per-commit (diffing each against its first parent, so a collapsed range can't mis-attribute a deletion). When the checkpoint isn't a strict ancestor of HEAD (force-push) it bounds the walk by the **merge-base** instead of replaying to the root, and still runs every commit through the projection filter. A checkpoint commit that no longer exists (GC'd/force-pushed away) **fails the tick** (keeps the checkpoint, retries) rather than silently resyncing from an empty tree and dropping deletions.

## Rollout

It "just starts working" — **no commit rewriting, no migration, no backfill.** The trailer is forward-only (existing commits are behind the sync watermark and never re-examined; new drua commits are stamped automatically). No schema changes (trailer in commit messages, `LivenessRef` in the `#[serde(default)]` job config, `is_live` reads the existing `deleted` column). The id-aware delete backstop covers the one transition gap — historical untrailered prunes in the catch-up range can't domino a recreated workflow.

## Tests

DB-free git-fixture + serde unit tests (29 lib tests):
- projection dropped / drua *authoring* kept / forged trailer ignored
- force-push bounds by merge-base + filters projections; missing checkpoint fails the tick
- `Deleted` delta carries the removed blob (id-aware decision input)
- liveness config serde round-trip + backward-compat; projection trailer render↔detect round-trip

⚠️ The end-to-end DB+git paths (reverse-delete, liveness skip, advisory lock, two-writer contention) lean on the bats/integration suites — worth adding targeted DB-backed integration cases in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)