### PR TITLE
feat(config): allow issue_write on github_issues upstream

### DIFF
--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -158,9 +158,10 @@ galoyAgents:
         toolPrefix: github_issues
         authMode: github_app
         category: source-control-write
-        categoryDescription: "GitHub issue mutations — comments"
+        categoryDescription: "GitHub issue mutations — create + comments"
         internalOnly: true
         allowedTools:
+          - create_issue
           - add_issue_comment
   postgresMcp:
     enabled: true

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -161,7 +161,7 @@ galoyAgents:
         categoryDescription: "GitHub issue mutations — create + comments"
         internalOnly: true
         allowedTools:
-          - create_issue
+          - issue_write
           - add_issue_comment
   postgresMcp:
     enabled: true


### PR DESCRIPTION
Whitelists `issue_write` on the `github_issues` MCP upstream, which previously exposed only `add_issue_comment`. The capability is served by the same `github_app` upstream that already grants `create_pull_request`, so this is a whitelist-only change that lets agent workflows open new issues (via `issue_write` with `method: "create"`) instead of only commenting — needed for workflows that report findings as a fresh issue per run.

Note: `issue_write` is the GitHub MCP server's consolidated issue create/update tool; there is no `create_issue` tool. Exercising this also requires the shared `github_app` installation to carry the **Issues: write** permission (a GitHub-App setting, not a code change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Grants internal agents GitHub issue-creation via MCP; scope is limited by internalOnly and existing app auth, but it is still a new write capability on production agent config.
> 
> **Overview**
> Production **Drua** deploy config expands the internal-only `github_issues` MCP upstream so agents can **create** GitHub issues, not only comment on them.
> 
> The `allowedTools` list now includes **`issue_write`** (alongside `add_issue_comment`), and the category blurb reflects **create + comments**. Auth stays on the existing **`github_app`** upstream with **`internalOnly: true`** — same pattern as the PR-write upstream, just a broader tool whitelist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4aa9cbf53abcd976d393bf127b7503da6ae16dc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->