### PR TITLE
feat(llm): thread reasoning effort through model chains

### DIFF
--- a/charts/drua/templates/configmap.yaml
+++ b/charts/drua/templates/configmap.yaml
@@ -37,6 +37,9 @@ data:
           - name: {{ .name | quote }}
             max_tokens_per_response: {{ printf "%d" (int .maxTokensPerResponse) }}
             context_window_tokens: {{ printf "%d" (int .contextWindowTokens) }}
+            {{- with .effort }}
+            effort: {{ . | quote }}
+            {{- end }}
             {{- if hasKey . "cacheTtlSeconds" }}
             cache_ttl_seconds: {{ printf "%d" (int .cacheTtlSeconds) }}
             {{- end }}
@@ -51,12 +54,18 @@ data:
           {{- with .primary.maxTokens }}
           max_tokens: {{ . }}
           {{- end }}
+          {{- with .primary.effort }}
+          effort: {{ . | quote }}
+          {{- end }}
         {{- with .fallbacks }}
         fallbacks:
           {{- range . }}
           - name: {{ .name | quote }}
             {{- with .maxTokens }}
             max_tokens: {{ . }}
+            {{- end }}
+            {{- with .effort }}
+            effort: {{ . | quote }}
             {{- end }}
           {{- end }}
         {{- end }}
@@ -70,12 +79,18 @@ data:
               {{- with .primary.maxTokens }}
               max_tokens: {{ . }}
               {{- end }}
+              {{- with .primary.effort }}
+              effort: {{ . | quote }}
+              {{- end }}
             {{- with .fallbacks }}
             fallbacks:
               {{- range . }}
               - name: {{ .name | quote }}
                 {{- with .maxTokens }}
                 max_tokens: {{ . }}
+                {{- end }}
+                {{- with .effort }}
+                effort: {{ . | quote }}
                 {{- end }}
               {{- end }}
             {{- end }}
@@ -98,12 +113,18 @@ data:
               {{- with .primary.maxTokens }}
               max_tokens: {{ . }}
               {{- end }}
+              {{- with .primary.effort }}
+              effort: {{ . | quote }}
+              {{- end }}
             {{- with .fallbacks }}
             fallbacks:
               {{- range . }}
               - name: {{ .name | quote }}
                 {{- with .maxTokens }}
                 max_tokens: {{ . }}
+                {{- end }}
+                {{- with .effort }}
+                effort: {{ . | quote }}
                 {{- end }}
               {{- end }}
             {{- end }}
@@ -127,12 +148,18 @@ data:
               {{- with .primary.maxTokens }}
               max_tokens: {{ . }}
               {{- end }}
+              {{- with .primary.effort }}
+              effort: {{ . | quote }}
+              {{- end }}
             {{- with .fallbacks }}
             fallbacks:
               {{- range . }}
               - name: {{ .name | quote }}
                 {{- with .maxTokens }}
                 max_tokens: {{ . }}
+                {{- end }}
+                {{- with .effort }}
+                effort: {{ . | quote }}
                 {{- end }}
               {{- end }}
             {{- end }}

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -26,8 +26,8 @@ pub struct ModelDefaults {
     pub model: String,
     pub max_tokens_per_response: u32,
     pub context_window_tokens: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub effort: Option<ReasoningEffort>,
+    #[serde(default, skip_serializing_if = "ReasoningEffort::is_low")]
+    pub effort: ReasoningEffort,
 }
 
 impl Default for ModelDefaults {
@@ -36,7 +36,7 @@ impl Default for ModelDefaults {
             model: String::new(),
             max_tokens_per_response: 4096,
             context_window_tokens: 200_000,
-            effort: None,
+            effort: ReasoningEffort::Low,
         }
     }
 }
@@ -79,7 +79,7 @@ fn resolve_entry(
         defaults.max_tokens_per_response = mt;
     }
     if let Some(effort) = spec.effort {
-        defaults.effort = Some(effort);
+        defaults.effort = effort;
     }
     Ok(defaults)
 }
@@ -179,7 +179,7 @@ mod tests {
             model: name.to_string(),
             max_tokens_per_response: 4096,
             context_window_tokens: 100_000,
-            effort: None,
+            effort: ReasoningEffort::Low,
         }
     }
 
@@ -228,7 +228,7 @@ mod tests {
                 model: "primary".into(),
                 max_tokens_per_response: 8192,
                 context_window_tokens: 200_000,
-                effort: None,
+                effort: ReasoningEffort::Low,
             },
         );
         cfg.models.insert(
@@ -237,7 +237,7 @@ mod tests {
                 model: "backup".into(),
                 max_tokens_per_response: 4096,
                 context_window_tokens: 128_000,
-                effort: None,
+                effort: ReasoningEffort::Low,
             },
         );
         cfg.builtin_roles
@@ -268,7 +268,7 @@ mod tests {
                 model: "primary".into(),
                 max_tokens_per_response: 8192,
                 context_window_tokens: 200_000,
-                effort: None,
+                effort: ReasoningEffort::Low,
             },
         );
         cfg.models.insert(
@@ -277,7 +277,7 @@ mod tests {
                 model: "backup".into(),
                 max_tokens_per_response: 4096,
                 context_window_tokens: 128_000,
-                effort: None,
+                effort: ReasoningEffort::Low,
             },
         );
         cfg.builtin_roles
@@ -300,7 +300,7 @@ mod tests {
         cfg.builtin_roles
             .insert(AgentRole::Agent, RoleConfig::default());
         let chain = cfg.resolve_chain(AgentRole::Agent, None).unwrap();
-        assert_eq!(chain.primary.effort, Some(ReasoningEffort::High));
+        assert_eq!(chain.primary.effort, ReasoningEffort::High);
     }
 
     #[test]

--- a/core/src/agent/config.rs
+++ b/core/src/agent/config.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use llm::ModelChain as LlmModelChain;
+use llm::{ModelChain as LlmModelChain, ReasoningEffort};
 use serde::{Deserialize, Deserializer, Serialize};
 
 use super::error::AgentError;
@@ -26,6 +26,8 @@ pub struct ModelDefaults {
     pub model: String,
     pub max_tokens_per_response: u32,
     pub context_window_tokens: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<ReasoningEffort>,
 }
 
 impl Default for ModelDefaults {
@@ -34,6 +36,7 @@ impl Default for ModelDefaults {
             model: String::new(),
             max_tokens_per_response: 4096,
             context_window_tokens: 200_000,
+            effort: None,
         }
     }
 }
@@ -74,6 +77,9 @@ fn resolve_entry(
         .ok_or_else(|| AgentError::ModelNotConfigured(spec.name.clone()))?;
     if let Some(mt) = spec.max_tokens {
         defaults.max_tokens_per_response = mt;
+    }
+    if let Some(effort) = spec.effort {
+        defaults.effort = Some(effort);
     }
     Ok(defaults)
 }
@@ -173,6 +179,7 @@ mod tests {
             model: name.to_string(),
             max_tokens_per_response: 4096,
             context_window_tokens: 100_000,
+            effort: None,
         }
     }
 
@@ -221,6 +228,7 @@ mod tests {
                 model: "primary".into(),
                 max_tokens_per_response: 8192,
                 context_window_tokens: 200_000,
+                effort: None,
             },
         );
         cfg.models.insert(
@@ -229,6 +237,7 @@ mod tests {
                 model: "backup".into(),
                 max_tokens_per_response: 4096,
                 context_window_tokens: 128_000,
+                effort: None,
             },
         );
         cfg.builtin_roles
@@ -259,6 +268,7 @@ mod tests {
                 model: "primary".into(),
                 max_tokens_per_response: 8192,
                 context_window_tokens: 200_000,
+                effort: None,
             },
         );
         cfg.models.insert(
@@ -267,6 +277,7 @@ mod tests {
                 model: "backup".into(),
                 max_tokens_per_response: 4096,
                 context_window_tokens: 128_000,
+                effort: None,
             },
         );
         cfg.builtin_roles
@@ -275,6 +286,21 @@ mod tests {
         assert_eq!(chain.primary.max_tokens_per_response, 2048);
         assert_eq!(chain.fallbacks[0].max_tokens_per_response, 1024);
         assert_eq!(chain.fallbacks[1].max_tokens_per_response, 4096);
+    }
+
+    #[test]
+    fn spec_effort_overrides_registry() {
+        let mut cfg = AgentsConfig {
+            default_chain: Some(LlmModelChain::new(
+                llm::ModelSpec::new("primary").with_effort(ReasoningEffort::High),
+            )),
+            ..Default::default()
+        };
+        cfg.models.insert("primary".into(), defaults_for("primary"));
+        cfg.builtin_roles
+            .insert(AgentRole::Agent, RoleConfig::default());
+        let chain = cfg.resolve_chain(AgentRole::Agent, None).unwrap();
+        assert_eq!(chain.primary.effort, Some(ReasoningEffort::High));
     }
 
     #[test]

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -1169,6 +1169,7 @@ impl IntoEvents<AgentSessionEvent> for NewAgentSession {
 mod tests {
     use crate::agent::config::ModelDefaults;
     use crate::primitives::UserId;
+    use crate::ReasoningEffort;
     use es_entity::{IntoEvents as _, TryFromEvents as _};
 
     use super::*;
@@ -1182,7 +1183,7 @@ mod tests {
                     model: "test-model".into(),
                     max_tokens_per_response: 1024,
                     context_window_tokens: 200_000,
-                    effort: llm::ReasoningEffort::Low,
+                    effort: ReasoningEffort::Low,
                 },
                 fallbacks: Vec::new(),
             })
@@ -1672,7 +1673,7 @@ mod tests {
                     model: "test-model".into(),
                     max_tokens_per_response: 1024,
                     context_window_tokens: 100,
-                    effort: llm::ReasoningEffort::Low,
+                    effort: ReasoningEffort::Low,
                 },
                 fallbacks: Vec::new(),
             })

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -1182,7 +1182,7 @@ mod tests {
                     model: "test-model".into(),
                     max_tokens_per_response: 1024,
                     context_window_tokens: 200_000,
-                    effort: None,
+                    effort: llm::ReasoningEffort::Low,
                 },
                 fallbacks: Vec::new(),
             })
@@ -1672,7 +1672,7 @@ mod tests {
                     model: "test-model".into(),
                     max_tokens_per_response: 1024,
                     context_window_tokens: 100,
-                    effort: None,
+                    effort: llm::ReasoningEffort::Low,
                 },
                 fallbacks: Vec::new(),
             })

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -1182,6 +1182,7 @@ mod tests {
                     model: "test-model".into(),
                     max_tokens_per_response: 1024,
                     context_window_tokens: 200_000,
+                    effort: None,
                 },
                 fallbacks: Vec::new(),
             })
@@ -1671,6 +1672,7 @@ mod tests {
                     model: "test-model".into(),
                     max_tokens_per_response: 1024,
                     context_window_tokens: 100,
+                    effort: None,
                 },
                 fallbacks: Vec::new(),
             })

--- a/core/src/agent/session/message.rs
+++ b/core/src/agent/session/message.rs
@@ -197,18 +197,14 @@ impl From<Prompt> for llm::Prompt {
     fn from(p: Prompt) -> Self {
         let primary_effort = p.model_chain.primary.effort;
         let max_tokens = Some(p.model_chain.primary.max_tokens_per_response);
-        let mut primary = llm::ModelSpec::new(p.model_chain.primary.model)
-            .with_max_tokens(p.model_chain.primary.max_tokens_per_response);
-        if let Some(effort) = primary_effort {
-            primary = primary.with_effort(effort);
-        }
+        let primary = llm::ModelSpec::new(p.model_chain.primary.model)
+            .with_max_tokens(p.model_chain.primary.max_tokens_per_response)
+            .with_effort(primary_effort);
         let mut chain = llm::ModelChain::new(primary);
         for fallback in p.model_chain.fallbacks {
-            let mut spec = llm::ModelSpec::new(fallback.model)
-                .with_max_tokens(fallback.max_tokens_per_response);
-            if let Some(effort) = fallback.effort {
-                spec = spec.with_effort(effort);
-            }
+            let spec = llm::ModelSpec::new(fallback.model)
+                .with_max_tokens(fallback.max_tokens_per_response)
+                .with_effort(fallback.effort);
             chain = chain.with_fallback(spec);
         }
         llm::Prompt {

--- a/core/src/agent/session/message.rs
+++ b/core/src/agent/session/message.rs
@@ -195,20 +195,26 @@ pub enum StopReason {
 
 impl From<Prompt> for llm::Prompt {
     fn from(p: Prompt) -> Self {
+        let primary_effort = p.model_chain.primary.effort;
         let max_tokens = Some(p.model_chain.primary.max_tokens_per_response);
-        let mut chain = llm::ModelChain::new(
-            llm::ModelSpec::new(p.model_chain.primary.model)
-                .with_max_tokens(p.model_chain.primary.max_tokens_per_response),
-        );
+        let mut primary = llm::ModelSpec::new(p.model_chain.primary.model)
+            .with_max_tokens(p.model_chain.primary.max_tokens_per_response);
+        if let Some(effort) = primary_effort {
+            primary = primary.with_effort(effort);
+        }
+        let mut chain = llm::ModelChain::new(primary);
         for fallback in p.model_chain.fallbacks {
-            chain = chain.with_fallback(
-                llm::ModelSpec::new(fallback.model)
-                    .with_max_tokens(fallback.max_tokens_per_response),
-            );
+            let mut spec = llm::ModelSpec::new(fallback.model)
+                .with_max_tokens(fallback.max_tokens_per_response);
+            if let Some(effort) = fallback.effort {
+                spec = spec.with_effort(effort);
+            }
+            chain = chain.with_fallback(spec);
         }
         llm::Prompt {
             chain,
             max_tokens,
+            effort: primary_effort,
             cache_key: p.cache_key,
             system: p
                 .system

--- a/core/src/agent/session/view.rs
+++ b/core/src/agent/session/view.rs
@@ -443,6 +443,7 @@ impl PromptDefinition {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ReasoningEffort;
 
     fn tool_def(name: &str) -> ToolDefinition {
         ToolDefinition {
@@ -465,7 +466,7 @@ mod tests {
                 model: "test-model".into(),
                 max_tokens_per_response: 8192,
                 context_window_tokens: 200_000,
-                effort: llm::ReasoningEffort::Low,
+                effort: ReasoningEffort::Low,
             },
             fallbacks: Vec::new(),
         }

--- a/core/src/agent/session/view.rs
+++ b/core/src/agent/session/view.rs
@@ -465,7 +465,7 @@ mod tests {
                 model: "test-model".into(),
                 max_tokens_per_response: 8192,
                 context_window_tokens: 200_000,
-                effort: None,
+                effort: llm::ReasoningEffort::Low,
             },
             fallbacks: Vec::new(),
         }

--- a/core/src/agent/session/view.rs
+++ b/core/src/agent/session/view.rs
@@ -465,6 +465,7 @@ mod tests {
                 model: "test-model".into(),
                 max_tokens_per_response: 8192,
                 context_window_tokens: 200_000,
+                effort: None,
             },
             fallbacks: Vec::new(),
         }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -25,7 +25,7 @@ pub mod workflow;
 
 pub use config::*;
 
-pub use llm::{ModelChain, ModelSpec};
+pub use llm::{ModelChain, ModelSpec, ReasoningEffort};
 
 use std::sync::Arc;
 

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -259,7 +259,7 @@ impl ExecutorState {
                 Some(model) => entries.push(ChainEntry {
                     model_id: spec.name.clone(),
                     max_tokens: spec.max_tokens.or(model.default_max_tokens),
-                    effort: spec.effort,
+                    effort: spec.effort.unwrap_or(prompt.effort),
                     provider: model.client.clone(),
                 }),
                 None => {

--- a/core/src/prompt_executor.rs
+++ b/core/src/prompt_executor.rs
@@ -259,6 +259,7 @@ impl ExecutorState {
                 Some(model) => entries.push(ChainEntry {
                     model_id: spec.name.clone(),
                     max_tokens: spec.max_tokens.or(model.default_max_tokens),
+                    effort: spec.effort,
                     provider: model.client.clone(),
                 }),
                 None => {

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -5,6 +5,7 @@ use drua_core::agent::{AgentRole, Agents, AgentsConfig, ModelDefaults, RoleConfi
 use drua_core::primitives::{AuthSubject, ChatOutputEvent, ContextGeneration, ProjectId, UserId};
 use drua_core::sandbox::{SandboxConfig, Sandboxes};
 use drua_core::toolset::{ToolSets, ToolSetsConfig, ToolSetsError, TopLevelTool};
+use drua_core::ReasoningEffort;
 use llm::prompt::AssistantBlock;
 use llm::response::StopReason;
 use llm::{PromptRequest, PromptResponse, PromptResult, Usage};
@@ -68,7 +69,7 @@ async fn build_agents(pool: &sqlx::PgPool) -> (Agents, Arc<Sandboxes>) {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
-            effort: drua_core::ReasoningEffort::Low,
+            effort: ReasoningEffort::Low,
         },
     );
     let config = AgentsConfig {
@@ -131,7 +132,7 @@ async fn send_message_round_trip_via_prompt_channel() {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
-            effort: drua_core::ReasoningEffort::Low,
+            effort: ReasoningEffort::Low,
         },
     );
     let config = AgentsConfig {
@@ -295,7 +296,7 @@ async fn send_message_dispatches_registered_tool_call() {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
-            effort: drua_core::ReasoningEffort::Low,
+            effort: ReasoningEffort::Low,
         },
     );
     let config = AgentsConfig {

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -68,7 +68,7 @@ async fn build_agents(pool: &sqlx::PgPool) -> (Agents, Arc<Sandboxes>) {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
-            effort: None,
+            effort: drua_core::ReasoningEffort::Low,
         },
     );
     let config = AgentsConfig {
@@ -131,7 +131,7 @@ async fn send_message_round_trip_via_prompt_channel() {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
-            effort: None,
+            effort: drua_core::ReasoningEffort::Low,
         },
     );
     let config = AgentsConfig {
@@ -295,7 +295,7 @@ async fn send_message_dispatches_registered_tool_call() {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
-            effort: None,
+            effort: drua_core::ReasoningEffort::Low,
         },
     );
     let config = AgentsConfig {

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -68,6 +68,7 @@ async fn build_agents(pool: &sqlx::PgPool) -> (Agents, Arc<Sandboxes>) {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
+            effort: None,
         },
     );
     let config = AgentsConfig {
@@ -130,6 +131,7 @@ async fn send_message_round_trip_via_prompt_channel() {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
+            effort: None,
         },
     );
     let config = AgentsConfig {
@@ -293,6 +295,7 @@ async fn send_message_dispatches_registered_tool_call() {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
+            effort: None,
         },
     );
     let config = AgentsConfig {

--- a/core/tests/prompt_executor.rs
+++ b/core/tests/prompt_executor.rs
@@ -35,6 +35,7 @@ async fn anthropic_round_trip_via_executor() {
         tools: Vec::new(),
         tool_choice: None,
         max_tokens: None, // executor should fill this in from default_max_tokens
+        effort: None,
         cache_key: None,
     };
 

--- a/core/tests/prompt_executor.rs
+++ b/core/tests/prompt_executor.rs
@@ -35,7 +35,7 @@ async fn anthropic_round_trip_via_executor() {
         tools: Vec::new(),
         tool_choice: None,
         max_tokens: None, // executor should fill this in from default_max_tokens
-        effort: None,
+        effort: llm::ReasoningEffort::Low,
         cache_key: None,
     };
 

--- a/core/tests/prompt_executor.rs
+++ b/core/tests/prompt_executor.rs
@@ -1,4 +1,5 @@
 use drua_core::prompt_executor::{ModelConfig, PromptExecutor, PromptExecutorConfig, Provider};
+use drua_core::ReasoningEffort;
 use llm::prompt::{Message, UserBlock};
 use llm::{Prompt, PromptRequest};
 
@@ -35,7 +36,7 @@ async fn anthropic_round_trip_via_executor() {
         tools: Vec::new(),
         tool_choice: None,
         max_tokens: None, // executor should fill this in from default_max_tokens
-        effort: llm::ReasoningEffort::Low,
+        effort: ReasoningEffort::Low,
         cache_key: None,
     };
 

--- a/core/tests/skill_e2e.rs
+++ b/core/tests/skill_e2e.rs
@@ -146,6 +146,7 @@ fn agents_config_for_tests() -> AgentsConfig {
             model,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
+            effort: None,
         },
     );
     AgentsConfig {

--- a/core/tests/skill_e2e.rs
+++ b/core/tests/skill_e2e.rs
@@ -146,7 +146,7 @@ fn agents_config_for_tests() -> AgentsConfig {
             model,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
-            effort: None,
+            effort: drua_core::ReasoningEffort::Low,
         },
     );
     AgentsConfig {

--- a/core/tests/skill_e2e.rs
+++ b/core/tests/skill_e2e.rs
@@ -27,7 +27,7 @@ use drua_core::agent::{AgentRole, AgentsConfig, ModelDefaults, RoleConfig};
 use drua_core::library::LibraryConfig;
 use drua_core::primitives::{AuthSubject, UserId};
 use drua_core::skill::SKILL_DOC_TYPE;
-use drua_core::{App, AppConfig};
+use drua_core::{App, AppConfig, ReasoningEffort};
 
 const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
 
@@ -146,7 +146,7 @@ fn agents_config_for_tests() -> AgentsConfig {
             model,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
-            effort: drua_core::ReasoningEffort::Low,
+            effort: ReasoningEffort::Low,
         },
     );
     AgentsConfig {

--- a/lib/anthropic-client/src/convert.rs
+++ b/lib/anthropic-client/src/convert.rs
@@ -54,12 +54,11 @@ pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> AnthropicRequest {
     let tool_choice = prompt.tool_choice.as_ref().map(convert_tool_choice);
 
     let max_tokens = prompt.max_tokens.unwrap_or(8192);
-    let thinking = prompt.effort.and_then(|e| {
-        thinking_budget(e, max_tokens).map(|budget_tokens| AnthropicThinking {
+    let thinking =
+        thinking_budget(prompt.effort, max_tokens).map(|budget_tokens| AnthropicThinking {
             r#type: "enabled",
             budget_tokens,
-        })
-    });
+        });
 
     let mut request = AnthropicRequest {
         model: prompt.chain.primary.name.clone(),
@@ -85,10 +84,10 @@ fn thinking_budget(effort: llm::ReasoningEffort, max_tokens: u32) -> Option<u32>
         return None;
     }
     let frac = match effort {
-        llm::ReasoningEffort::Minimal => 0.1,
         llm::ReasoningEffort::Low => 0.25,
         llm::ReasoningEffort::Medium => 0.5,
         llm::ReasoningEffort::High => 0.75,
+        llm::ReasoningEffort::XHigh => 0.9,
     };
     let budget = (max_tokens as f32 * frac) as u32;
     Some(budget.clamp(1024, max_tokens - 1))
@@ -421,7 +420,7 @@ mod tests {
     fn base_prompt() -> Prompt {
         Prompt {
             chain: ModelChain::new("claude-sonnet-4"),
-            effort: None,
+            effort: llm::ReasoningEffort::Low,
             system: vec![SystemBlock::Text { text: "sys".into() }],
             messages: vec![Message::User {
                 content: vec![UserBlock::Text { text: "hi".into() }],

--- a/lib/anthropic-client/src/convert.rs
+++ b/lib/anthropic-client/src/convert.rs
@@ -13,7 +13,8 @@ use crate::stream::{AccumulatedBlock, AccumulatedResponse, AccumulatedStopReason
 use crate::types::{
     AnthropicCacheControl, AnthropicContent, AnthropicContentBlock, AnthropicDelta,
     AnthropicMessage, AnthropicRequest, AnthropicStopReason, AnthropicStreamEvent,
-    AnthropicSystemBlock, AnthropicTool, AnthropicToolChoice, AnthropicToolResultContent,
+    AnthropicSystemBlock, AnthropicThinking, AnthropicTool, AnthropicToolChoice,
+    AnthropicToolResultContent,
 };
 
 /// 5m matches Anthropic's default cache window.
@@ -52,20 +53,45 @@ pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> AnthropicRequest {
 
     let tool_choice = prompt.tool_choice.as_ref().map(convert_tool_choice);
 
+    let max_tokens = prompt.max_tokens.unwrap_or(8192);
+    let thinking = prompt.effort.and_then(|e| {
+        thinking_budget(e, max_tokens).map(|budget_tokens| AnthropicThinking {
+            r#type: "enabled",
+            budget_tokens,
+        })
+    });
+
     let mut request = AnthropicRequest {
         model: prompt.chain.primary.name.clone(),
         messages,
         system,
-        max_tokens: prompt.max_tokens.unwrap_or(8192),
+        max_tokens,
         temperature: None,
         tools,
         tool_choice,
         stream: true,
-        thinking: None,
+        thinking,
     };
 
     apply_prompt_caching(&mut request, DEFAULT_CACHE_TTL);
     request
+}
+
+/// Anthropic expresses reasoning as an explicit token budget drawn from
+/// `max_tokens`, and the API requires `1024 <= budget_tokens < max_tokens`.
+/// Returns `None` when `max_tokens` leaves no room for a valid budget.
+fn thinking_budget(effort: llm::ReasoningEffort, max_tokens: u32) -> Option<u32> {
+    if max_tokens <= 1024 {
+        return None;
+    }
+    let frac = match effort {
+        llm::ReasoningEffort::Minimal => 0.1,
+        llm::ReasoningEffort::Low => 0.25,
+        llm::ReasoningEffort::Medium => 0.5,
+        llm::ReasoningEffort::High => 0.75,
+    };
+    let budget = (max_tokens as f32 * frac) as u32;
+    Some(budget.clamp(1024, max_tokens - 1))
 }
 
 /// Anthropic auto-checks earlier breakpoints, so one marker on the
@@ -395,6 +421,7 @@ mod tests {
     fn base_prompt() -> Prompt {
         Prompt {
             chain: ModelChain::new("claude-sonnet-4"),
+            effort: None,
             system: vec![SystemBlock::Text { text: "sys".into() }],
             messages: vec![Message::User {
                 content: vec![UserBlock::Text { text: "hi".into() }],

--- a/lib/anthropic-client/tests/live_prompt_caching.rs
+++ b/lib/anthropic-client/tests/live_prompt_caching.rs
@@ -37,7 +37,7 @@ fn unique_nonce() -> String {
 fn build_prompt(model: &str, system_text: String, user_text: impl Into<String>) -> Prompt {
     Prompt {
         chain: ModelChain::new(model),
-        effort: None,
+        effort: llm::ReasoningEffort::Low,
         messages: vec![Message::User {
             content: vec![UserBlock::Text {
                 text: user_text.into(),

--- a/lib/anthropic-client/tests/live_prompt_caching.rs
+++ b/lib/anthropic-client/tests/live_prompt_caching.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use anthropic_client::AnthropicClient;
 use llm::prompt::{Message, SystemBlock, UserBlock};
-use llm::{ModelChain, Prompt};
+use llm::{ModelChain, Prompt, ReasoningEffort};
 
 const LIVE_TESTS_ENV: &str = "DRUA_LIVE_CACHE_TESTS";
 const API_KEY_ENV: &str = "ANTHROPIC_API_KEY";
@@ -37,7 +37,7 @@ fn unique_nonce() -> String {
 fn build_prompt(model: &str, system_text: String, user_text: impl Into<String>) -> Prompt {
     Prompt {
         chain: ModelChain::new(model),
-        effort: llm::ReasoningEffort::Low,
+        effort: ReasoningEffort::Low,
         messages: vec![Message::User {
             content: vec![UserBlock::Text {
                 text: user_text.into(),

--- a/lib/anthropic-client/tests/live_prompt_caching.rs
+++ b/lib/anthropic-client/tests/live_prompt_caching.rs
@@ -37,6 +37,7 @@ fn unique_nonce() -> String {
 fn build_prompt(model: &str, system_text: String, user_text: impl Into<String>) -> Prompt {
     Prompt {
         chain: ModelChain::new(model),
+        effort: None,
         messages: vec![Message::User {
             content: vec![UserBlock::Text {
                 text: user_text.into(),

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -14,7 +14,7 @@ pub use request::{
     StreamHandle, TerminalKind, TransientKind,
 };
 pub use response::{PromptResponse, RequestToolUse, StopReason, Usage};
-pub use spec::{ModelChain, ModelSpec};
+pub use spec::{ModelChain, ModelSpec, ReasoningEffort};
 pub use tool::{
     ToolUseError, ToolUseRequest, ToolUseRequestChannel, ToolUseResponseChannel, ToolUseResult,
 };

--- a/lib/llm/src/prompt.rs
+++ b/lib/llm/src/prompt.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
-use crate::spec::ModelChain;
+use crate::spec::{ModelChain, ReasoningEffort};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Prompt {
@@ -16,6 +16,8 @@ pub struct Prompt {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<ReasoningEffort>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_key: Option<String>,
 }
 
@@ -28,6 +30,7 @@ impl Default for Prompt {
             tools: Vec::new(),
             tool_choice: None,
             max_tokens: None,
+            effort: None,
             cache_key: None,
         }
     }
@@ -256,6 +259,7 @@ mod tests {
             }],
             tool_choice: None,
             max_tokens: Some(1024),
+            effort: None,
             cache_key: None,
         }
     }
@@ -299,6 +303,7 @@ mod tests {
             tools: vec![],
             tool_choice: None,
             max_tokens: None,
+            effort: None,
             cache_key: None,
         };
 

--- a/lib/llm/src/prompt.rs
+++ b/lib/llm/src/prompt.rs
@@ -15,8 +15,8 @@ pub struct Prompt {
     pub tool_choice: Option<ToolChoice>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub effort: Option<ReasoningEffort>,
+    #[serde(default, skip_serializing_if = "ReasoningEffort::is_low")]
+    pub effort: ReasoningEffort,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub cache_key: Option<String>,
 }
@@ -30,7 +30,7 @@ impl Default for Prompt {
             tools: Vec::new(),
             tool_choice: None,
             max_tokens: None,
-            effort: None,
+            effort: ReasoningEffort::Low,
             cache_key: None,
         }
     }
@@ -259,7 +259,7 @@ mod tests {
             }],
             tool_choice: None,
             max_tokens: Some(1024),
-            effort: None,
+            effort: ReasoningEffort::Low,
             cache_key: None,
         }
     }
@@ -303,7 +303,7 @@ mod tests {
             tools: vec![],
             tool_choice: None,
             max_tokens: None,
-            effort: None,
+            effort: ReasoningEffort::Low,
             cache_key: None,
         };
 

--- a/lib/llm/src/router.rs
+++ b/lib/llm/src/router.rs
@@ -14,7 +14,7 @@ use crate::{Prompt, StreamHandle};
 pub struct ChainEntry {
     pub model_id: String,
     pub max_tokens: Option<u32>,
-    pub effort: Option<ReasoningEffort>,
+    pub effort: ReasoningEffort,
     pub provider: Arc<dyn LlmProvider>,
 }
 
@@ -200,7 +200,7 @@ mod tests {
         ChainEntry {
             model_id: model_id.to_string(),
             max_tokens: None,
-            effort: None,
+            effort: ReasoningEffort::Low,
             provider,
         }
     }

--- a/lib/llm/src/router.rs
+++ b/lib/llm/src/router.rs
@@ -7,13 +7,14 @@ use std::sync::Arc;
 use crate::provider::LlmProvider;
 use crate::request::PromptError;
 use crate::response::Usage;
+use crate::spec::ReasoningEffort;
 use crate::{Prompt, StreamHandle};
 
 #[derive(Clone)]
 pub struct ChainEntry {
     pub model_id: String,
-    /// Today only `max_tokens` is plumbed through per-attempt.
     pub max_tokens: Option<u32>,
+    pub effort: Option<ReasoningEffort>,
     pub provider: Arc<dyn LlmProvider>,
 }
 
@@ -81,6 +82,9 @@ pub async fn walk(chain: &[ChainEntry], base: &Prompt) -> Result<WalkOutcome, Pr
         let mut prompt = base.clone();
         if let Some(mt) = entry.max_tokens {
             prompt.max_tokens = Some(mt);
+        }
+        if let Some(effort) = entry.effort {
+            prompt.effort = Some(effort);
         }
 
         match entry.provider.send_prompt_streaming(&prompt).await {
@@ -198,6 +202,7 @@ mod tests {
         ChainEntry {
             model_id: model_id.to_string(),
             max_tokens: None,
+            effort: None,
             provider,
         }
     }

--- a/lib/llm/src/router.rs
+++ b/lib/llm/src/router.rs
@@ -83,9 +83,7 @@ pub async fn walk(chain: &[ChainEntry], base: &Prompt) -> Result<WalkOutcome, Pr
         if let Some(mt) = entry.max_tokens {
             prompt.max_tokens = Some(mt);
         }
-        if let Some(effort) = entry.effort {
-            prompt.effort = Some(effort);
-        }
+        prompt.effort = entry.effort;
 
         match entry.provider.send_prompt_streaming(&prompt).await {
             Ok(rx) => {

--- a/lib/llm/src/spec.rs
+++ b/lib/llm/src/spec.rs
@@ -5,13 +5,23 @@ use serde::{Deserialize, Serialize};
 /// Provider-agnostic reasoning level; each client maps it to its own wire
 /// shape (OpenAI `reasoning_effort`, OpenRouter `reasoning.effort`,
 /// Anthropic thinking `budget_tokens`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema,
+)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
-    Minimal,
+    #[default]
     Low,
     Medium,
     High,
+    #[serde(rename = "xhigh")]
+    XHigh,
+}
+
+impl ReasoningEffort {
+    pub fn is_low(effort: &Self) -> bool {
+        *effort == Self::Low
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]

--- a/lib/llm/src/spec.rs
+++ b/lib/llm/src/spec.rs
@@ -2,11 +2,27 @@
 
 use serde::{Deserialize, Serialize};
 
+/// Provider-agnostic reasoning level; each client maps it to its own wire
+/// shape (OpenAI `reasoning_effort`, OpenRouter `reasoning.effort`,
+/// Anthropic thinking `budget_tokens`).
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum ReasoningEffort {
+    Minimal,
+    Low,
+    Medium,
+    High,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
 pub struct ModelSpec {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub max_tokens: Option<u32>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<ReasoningEffort>,
 }
 
 impl ModelSpec {
@@ -14,11 +30,17 @@ impl ModelSpec {
         Self {
             name: name.into(),
             max_tokens: None,
+            effort: None,
         }
     }
 
     pub fn with_max_tokens(mut self, max_tokens: u32) -> Self {
         self.max_tokens = Some(max_tokens);
+        self
+    }
+
+    pub fn with_effort(mut self, effort: ReasoningEffort) -> Self {
+        self.effort = Some(effort);
         self
     }
 }

--- a/lib/llm/src/spec.rs
+++ b/lib/llm/src/spec.rs
@@ -5,9 +5,7 @@ use serde::{Deserialize, Serialize};
 /// Provider-agnostic reasoning level; each client maps it to its own wire
 /// shape (OpenAI `reasoning_effort`, OpenRouter `reasoning.effort`,
 /// Anthropic thinking `budget_tokens`).
-#[derive(
-    Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema,
-)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, schemars::JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ReasoningEffort {
     Minimal,

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -20,10 +20,10 @@ pub(crate) enum ReasoningDialect {
 
 fn reasoning_effort_str(effort: llm::ReasoningEffort) -> &'static str {
     match effort {
-        llm::ReasoningEffort::Minimal => "minimal",
         llm::ReasoningEffort::Low => "low",
         llm::ReasoningEffort::Medium => "medium",
         llm::ReasoningEffort::High => "high",
+        llm::ReasoningEffort::XHigh => "xhigh",
     }
 }
 
@@ -64,7 +64,7 @@ pub(crate) fn prompt_to_request(
 
     let tool_choice = prompt.tool_choice.as_ref().map(convert_tool_choice);
 
-    let effort = prompt.effort.map(reasoning_effort_str);
+    let effort = reasoning_effort_str(prompt.effort);
     let mut request = OpenAiRequest {
         model: prompt.chain.primary.name.clone(),
         messages,
@@ -78,12 +78,12 @@ pub(crate) fn prompt_to_request(
             include_usage: true,
         }),
         reasoning_effort: match reasoning_dialect {
-            ReasoningDialect::OpenAi => effort,
+            ReasoningDialect::OpenAi => Some(effort),
             ReasoningDialect::OpenRouter => None,
         },
         reasoning: match reasoning_dialect {
             ReasoningDialect::OpenAi => None,
-            ReasoningDialect::OpenRouter => effort.map(|effort| ReasoningConfig { effort }),
+            ReasoningDialect::OpenRouter => Some(ReasoningConfig { effort }),
         },
     };
 
@@ -456,7 +456,7 @@ mod tests {
     fn sample_prompt() -> llm::Prompt {
         llm::Prompt {
             chain: llm::ModelChain::new("gpt-4o"),
-            effort: None,
+            effort: llm::ReasoningEffort::Low,
             system: vec![SystemBlock::Text {
                 text: "You are a helpful assistant.".to_string(),
             }],
@@ -480,7 +480,7 @@ mod tests {
     #[test]
     fn reasoning_effort_serialized_when_set() {
         let mut prompt = sample_prompt();
-        prompt.effort = Some(llm::ReasoningEffort::High);
+        prompt.effort = llm::ReasoningEffort::High;
         let req = prompt_to_request(&prompt, ReasoningDialect::OpenAi);
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["reasoning_effort"], "high");
@@ -490,7 +490,7 @@ mod tests {
     #[test]
     fn openrouter_reasoning_serialized_when_set() {
         let mut prompt = sample_prompt();
-        prompt.effort = Some(llm::ReasoningEffort::High);
+        prompt.effort = llm::ReasoningEffort::High;
         let req = prompt_to_request(&prompt, ReasoningDialect::OpenRouter);
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["reasoning"]["effort"], "high");
@@ -498,11 +498,11 @@ mod tests {
     }
 
     #[test]
-    fn reasoning_omitted_when_effort_unset() {
+    fn low_reasoning_serialized_by_default() {
         let req = prompt_to_request(&sample_prompt(), ReasoningDialect::OpenAi);
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("reasoning").is_none());
-        assert!(json.get("reasoning_effort").is_none());
+        assert_eq!(json["reasoning_effort"], "low");
     }
 
     #[test]
@@ -535,7 +535,7 @@ mod tests {
     fn prompt_with_tool_results() {
         let prompt = llm::Prompt {
             chain: llm::ModelChain::new("gpt-4o"),
-            effort: None,
+            effort: llm::ReasoningEffort::Low,
             system: vec![],
             messages: vec![
                 Message::Assistant {
@@ -574,7 +574,7 @@ mod tests {
     fn thinking_blocks_dropped() {
         let prompt = llm::Prompt {
             chain: llm::ModelChain::new("gpt-4o"),
-            effort: None,
+            effort: llm::ReasoningEffort::Low,
             system: vec![],
             messages: vec![Message::Assistant {
                 content: vec![
@@ -898,7 +898,7 @@ mod tests {
     fn anthropic_via_openrouter_prompt() -> llm::Prompt {
         llm::Prompt {
             chain: llm::ModelChain::new("anthropic/claude-sonnet-4.6"),
-            effort: None,
+            effort: llm::ReasoningEffort::Low,
             system: vec![SystemBlock::Text {
                 text: "system instructions".to_string(),
             }],

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -9,8 +9,17 @@ use llm::StopReason;
 use crate::types::{
     OpenAiCacheControl, OpenAiContentBlock, OpenAiFunction, OpenAiMessage, OpenAiMessageContent,
     OpenAiRequest, OpenAiRequestToolCall, OpenAiStreamChunk, OpenAiTool, OpenAiToolChoice,
-    OpenAiToolChoiceFunction, OpenAiToolFunction, StreamOptions,
+    OpenAiToolChoiceFunction, OpenAiToolFunction, ReasoningConfig, StreamOptions,
 };
+
+fn reasoning_effort_str(effort: llm::ReasoningEffort) -> &'static str {
+    match effort {
+        llm::ReasoningEffort::Minimal => "minimal",
+        llm::ReasoningEffort::Low => "low",
+        llm::ReasoningEffort::Medium => "medium",
+        llm::ReasoningEffort::High => "high",
+    }
+}
 
 /// OpenRouter routes any model id starting with `anthropic/` to Anthropic
 /// upstream, where prompt caching only engages on requests carrying explicit
@@ -58,6 +67,11 @@ pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> OpenAiRequest {
         stream_options: Some(StreamOptions {
             include_usage: true,
         }),
+        reasoning: prompt
+            .effort
+            .map(|e| ReasoningConfig {
+                effort: reasoning_effort_str(e),
+            }),
     };
 
     if request.model.starts_with(ANTHROPIC_MODEL_PREFIX) {
@@ -429,6 +443,7 @@ mod tests {
     fn sample_prompt() -> llm::Prompt {
         llm::Prompt {
             chain: llm::ModelChain::new("gpt-4o"),
+            effort: None,
             system: vec![SystemBlock::Text {
                 text: "You are a helpful assistant.".to_string(),
             }],
@@ -447,6 +462,22 @@ mod tests {
             max_tokens: Some(1024),
             cache_key: None,
         }
+    }
+
+    #[test]
+    fn reasoning_effort_serialized_when_set() {
+        let mut prompt = sample_prompt();
+        prompt.effort = Some(llm::ReasoningEffort::High);
+        let req = prompt_to_request(&prompt);
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["reasoning"]["effort"], "high");
+    }
+
+    #[test]
+    fn reasoning_omitted_when_effort_unset() {
+        let req = prompt_to_request(&sample_prompt());
+        let json = serde_json::to_value(&req).unwrap();
+        assert!(json.get("reasoning").is_none());
     }
 
     #[test]
@@ -479,6 +510,7 @@ mod tests {
     fn prompt_with_tool_results() {
         let prompt = llm::Prompt {
             chain: llm::ModelChain::new("gpt-4o"),
+            effort: None,
             system: vec![],
             messages: vec![
                 Message::Assistant {
@@ -517,6 +549,7 @@ mod tests {
     fn thinking_blocks_dropped() {
         let prompt = llm::Prompt {
             chain: llm::ModelChain::new("gpt-4o"),
+            effort: None,
             system: vec![],
             messages: vec![Message::Assistant {
                 content: vec![
@@ -840,6 +873,7 @@ mod tests {
     fn anthropic_via_openrouter_prompt() -> llm::Prompt {
         llm::Prompt {
             chain: llm::ModelChain::new("anthropic/claude-sonnet-4.6"),
+            effort: None,
             system: vec![SystemBlock::Text {
                 text: "system instructions".to_string(),
             }],

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -12,6 +12,12 @@ use crate::types::{
     OpenAiToolChoiceFunction, OpenAiToolFunction, ReasoningConfig, StreamOptions,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReasoningDialect {
+    OpenAi,
+    OpenRouter,
+}
+
 fn reasoning_effort_str(effort: llm::ReasoningEffort) -> &'static str {
     match effort {
         llm::ReasoningEffort::Minimal => "minimal",
@@ -27,7 +33,10 @@ fn reasoning_effort_str(effort: llm::ReasoningEffort) -> &'static str {
 /// these as a passthrough field.
 const ANTHROPIC_MODEL_PREFIX: &str = "anthropic/";
 
-pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> OpenAiRequest {
+pub(crate) fn prompt_to_request(
+    prompt: &llm::Prompt,
+    reasoning_dialect: ReasoningDialect,
+) -> OpenAiRequest {
     let mut messages: Vec<OpenAiMessage> = Vec::new();
 
     for block in &prompt.system {
@@ -55,6 +64,7 @@ pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> OpenAiRequest {
 
     let tool_choice = prompt.tool_choice.as_ref().map(convert_tool_choice);
 
+    let effort = prompt.effort.map(reasoning_effort_str);
     let mut request = OpenAiRequest {
         model: prompt.chain.primary.name.clone(),
         messages,
@@ -67,9 +77,14 @@ pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> OpenAiRequest {
         stream_options: Some(StreamOptions {
             include_usage: true,
         }),
-        reasoning: prompt.effort.map(|e| ReasoningConfig {
-            effort: reasoning_effort_str(e),
-        }),
+        reasoning_effort: match reasoning_dialect {
+            ReasoningDialect::OpenAi => effort,
+            ReasoningDialect::OpenRouter => None,
+        },
+        reasoning: match reasoning_dialect {
+            ReasoningDialect::OpenAi => None,
+            ReasoningDialect::OpenRouter => effort.map(|effort| ReasoningConfig { effort }),
+        },
     };
 
     if request.model.starts_with(ANTHROPIC_MODEL_PREFIX) {
@@ -466,22 +481,34 @@ mod tests {
     fn reasoning_effort_serialized_when_set() {
         let mut prompt = sample_prompt();
         prompt.effort = Some(llm::ReasoningEffort::High);
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, ReasoningDialect::OpenAi);
+        let json = serde_json::to_value(&req).unwrap();
+        assert_eq!(json["reasoning_effort"], "high");
+        assert!(json.get("reasoning").is_none());
+    }
+
+    #[test]
+    fn openrouter_reasoning_serialized_when_set() {
+        let mut prompt = sample_prompt();
+        prompt.effort = Some(llm::ReasoningEffort::High);
+        let req = prompt_to_request(&prompt, ReasoningDialect::OpenRouter);
         let json = serde_json::to_value(&req).unwrap();
         assert_eq!(json["reasoning"]["effort"], "high");
+        assert!(json.get("reasoning_effort").is_none());
     }
 
     #[test]
     fn reasoning_omitted_when_effort_unset() {
-        let req = prompt_to_request(&sample_prompt());
+        let req = prompt_to_request(&sample_prompt(), ReasoningDialect::OpenAi);
         let json = serde_json::to_value(&req).unwrap();
         assert!(json.get("reasoning").is_none());
+        assert!(json.get("reasoning_effort").is_none());
     }
 
     #[test]
     fn prompt_to_request_basic() {
         let prompt = sample_prompt();
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, ReasoningDialect::OpenAi);
 
         assert_eq!(req.model, "gpt-4o");
         assert!(req.stream);
@@ -500,7 +527,7 @@ mod tests {
         let mut prompt = sample_prompt();
         prompt.cache_key = Some("agent-session:test".to_string());
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, ReasoningDialect::OpenAi);
         assert_eq!(req.prompt_cache_key.as_deref(), Some("agent-session:test"));
     }
 
@@ -534,7 +561,7 @@ mod tests {
             cache_key: None,
         };
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, ReasoningDialect::OpenAi);
         assert_eq!(req.messages.len(), 2);
         assert_eq!(req.messages[0].role, "assistant");
         assert!(req.messages[0].tool_calls.is_some());
@@ -566,7 +593,7 @@ mod tests {
             cache_key: None,
         };
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, ReasoningDialect::OpenAi);
         assert_eq!(req.messages.len(), 1);
         assert_eq!(
             content_text(&req.messages[0]),
@@ -894,7 +921,10 @@ mod tests {
 
     #[test]
     fn anthropic_via_openrouter_marks_last_user_text_block() {
-        let req = prompt_to_request(&anthropic_via_openrouter_prompt());
+        let req = prompt_to_request(
+            &anthropic_via_openrouter_prompt(),
+            ReasoningDialect::OpenRouter,
+        );
 
         let last = req.messages.last().expect("messages present");
         assert_eq!(last.role, "user");
@@ -928,7 +958,7 @@ mod tests {
         let mut prompt = anthropic_via_openrouter_prompt();
         prompt.chain = llm::ModelChain::new("openai/gpt-5-mini");
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, ReasoningDialect::OpenRouter);
 
         for msg in &req.messages {
             assert!(
@@ -956,7 +986,7 @@ mod tests {
         prompt.messages.clear();
         prompt.system.clear();
 
-        let req = prompt_to_request(&prompt);
+        let req = prompt_to_request(&prompt, ReasoningDialect::OpenRouter);
 
         let tool = req
             .tools
@@ -969,7 +999,10 @@ mod tests {
 
     #[test]
     fn anthropic_serialised_request_has_cache_control_inside_content_block() {
-        let req = prompt_to_request(&anthropic_via_openrouter_prompt());
+        let req = prompt_to_request(
+            &anthropic_via_openrouter_prompt(),
+            ReasoningDialect::OpenRouter,
+        );
         let json = serde_json::to_value(&req).unwrap();
 
         // Wire-format check: the marker is nested inside a content block on

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -67,11 +67,9 @@ pub(crate) fn prompt_to_request(prompt: &llm::Prompt) -> OpenAiRequest {
         stream_options: Some(StreamOptions {
             include_usage: true,
         }),
-        reasoning: prompt
-            .effort
-            .map(|e| ReasoningConfig {
-                effort: reasoning_effort_str(e),
-            }),
+        reasoning: prompt.effort.map(|e| ReasoningConfig {
+            effort: reasoning_effort_str(e),
+        }),
     };
 
     if request.model.starts_with(ANTHROPIC_MODEL_PREFIX) {

--- a/lib/openai-client/src/convert.rs
+++ b/lib/openai-client/src/convert.rs
@@ -65,6 +65,10 @@ pub(crate) fn prompt_to_request(
     let tool_choice = prompt.tool_choice.as_ref().map(convert_tool_choice);
 
     let effort = reasoning_effort_str(prompt.effort);
+    let (reasoning_effort, reasoning) = match reasoning_dialect {
+        ReasoningDialect::OpenAi => (Some(effort), None),
+        ReasoningDialect::OpenRouter => (None, Some(ReasoningConfig { effort })),
+    };
     let mut request = OpenAiRequest {
         model: prompt.chain.primary.name.clone(),
         messages,
@@ -77,14 +81,8 @@ pub(crate) fn prompt_to_request(
         stream_options: Some(StreamOptions {
             include_usage: true,
         }),
-        reasoning_effort: match reasoning_dialect {
-            ReasoningDialect::OpenAi => Some(effort),
-            ReasoningDialect::OpenRouter => None,
-        },
-        reasoning: match reasoning_dialect {
-            ReasoningDialect::OpenAi => None,
-            ReasoningDialect::OpenRouter => Some(ReasoningConfig { effort }),
-        },
+        reasoning_effort,
+        reasoning,
     };
 
     if request.model.starts_with(ANTHROPIC_MODEL_PREFIX) {

--- a/lib/openai-client/src/lib.rs
+++ b/lib/openai-client/src/lib.rs
@@ -16,7 +16,7 @@ use llm::provider::LlmProvider;
 use llm::stream::StreamDelta;
 use llm::{Prompt, PromptError, PromptResponse};
 
-use crate::convert::{prompt_to_request, DeltaSynthesizer, EMPTY_COMPLETION_ERR};
+use crate::convert::{prompt_to_request, DeltaSynthesizer, ReasoningDialect, EMPTY_COMPLETION_ERR};
 use crate::sse::{parse_sse_stream, SseError};
 
 pub use responses::{OpenAiResponsesAuth, OpenAiResponsesClient, OpenAiResponsesError};
@@ -36,6 +36,14 @@ const DEFAULT_RETRY_DELAY_SECS: u64 = 1;
 /// the gateway appears to synthesise a stop response when its own provider
 /// times out. Retrying once usually succeeds.
 const MAX_EMPTY_COMPLETION_RETRIES: u32 = 1;
+
+fn reasoning_dialect_for_base_url(base_url: &str) -> ReasoningDialect {
+    if base_url.to_ascii_lowercase().contains("openrouter.ai") {
+        ReasoningDialect::OpenRouter
+    } else {
+        ReasoningDialect::OpenAi
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum OpenAiChatCompletionsError {
@@ -63,6 +71,7 @@ pub struct OpenAiClient {
     http: reqwest::Client,
     api_key: String,
     api_url: String,
+    reasoning_dialect: ReasoningDialect,
 }
 
 impl OpenAiClient {
@@ -71,11 +80,13 @@ impl OpenAiClient {
             http: reqwest::Client::new(),
             api_key: api_key.into(),
             api_url: DEFAULT_API_URL.to_string(),
+            reasoning_dialect: ReasoningDialect::OpenAi,
         }
     }
 
     pub fn with_base_url(mut self, base_url: Option<String>) -> Self {
         if let Some(base) = base_url {
+            self.reasoning_dialect = reasoning_dialect_for_base_url(&base);
             let base = base.trim_end_matches('/');
             self.api_url = format!("{base}{API_PATH}");
         }
@@ -178,7 +189,7 @@ impl OpenAiClient {
         tokio::sync::mpsc::Receiver<Result<StreamDelta, OpenAiChatCompletionsError>>,
         OpenAiChatCompletionsError,
     > {
-        let request_body = prompt_to_request(prompt);
+        let request_body = prompt_to_request(prompt, self.reasoning_dialect);
         let body_bytes = Arc::new(
             serde_json::to_vec(&request_body)
                 .map_err(|e| OpenAiChatCompletionsError::Stream(format!("body serialize: {e}")))?,
@@ -414,7 +425,7 @@ impl LlmProvider for OpenAiClient {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_retry_after_seconds;
+    use super::{parse_retry_after_seconds, reasoning_dialect_for_base_url, ReasoningDialect};
 
     #[test]
     fn parses_openrouter_429_metadata() {
@@ -427,5 +438,17 @@ mod tests {
         assert_eq!(parse_retry_after_seconds(r#"{"error":{"code":500}}"#), None);
         assert_eq!(parse_retry_after_seconds("not json"), None);
         assert_eq!(parse_retry_after_seconds(""), None);
+    }
+
+    #[test]
+    fn reasoning_dialect_detects_openrouter() {
+        assert_eq!(
+            reasoning_dialect_for_base_url("https://openrouter.ai/api"),
+            ReasoningDialect::OpenRouter
+        );
+        assert_eq!(
+            reasoning_dialect_for_base_url("https://api.openai.com"),
+            ReasoningDialect::OpenAi
+        );
     }
 }

--- a/lib/openai-client/src/responses.rs
+++ b/lib/openai-client/src/responses.rs
@@ -20,7 +20,6 @@ const DEFAULT_SUBSCRIPTION_API_URL: &str = "https://chatgpt.com/backend-api/code
 const RESPONSES_API_PATH: &str = "/v1/responses";
 const SUBSCRIPTION_API_PATH: &str = "/backend-api/codex/responses";
 const DEFAULT_MAX_OUTPUT_TOKENS: u32 = 4096;
-const DEFAULT_REASONING_EFFORT: &str = "low";
 const DEFAULT_TEXT_VERBOSITY: &str = "medium";
 const OPENAI_RESPONSES_SUBSCRIPTION_TOKEN_ENV: &str = "OPENAI_CODEX_ACCESS_TOKEN";
 
@@ -322,10 +321,10 @@ struct ResponsesReasoningConfig {
 
 fn responses_effort_str(effort: ReasoningEffort) -> &'static str {
     match effort {
-        ReasoningEffort::Minimal => "minimal",
         ReasoningEffort::Low => "low",
         ReasoningEffort::Medium => "medium",
         ReasoningEffort::High => "high",
+        ReasoningEffort::XHigh => "xhigh",
     }
 }
 
@@ -372,10 +371,7 @@ fn prompt_to_responses_request(prompt: &Prompt, auth: &OpenAiResponsesAuth) -> R
         },
         include: vec!["reasoning.encrypted_content"],
         reasoning: ResponsesReasoningConfig {
-            effort: prompt
-                .effort
-                .map(responses_effort_str)
-                .unwrap_or(DEFAULT_REASONING_EFFORT),
+            effort: responses_effort_str(prompt.effort),
             summary: "auto",
         },
     }
@@ -1062,7 +1058,7 @@ mod tests {
     fn sample_prompt() -> Prompt {
         Prompt {
             chain: llm::ModelChain::new("gpt-5.4-mini"),
-            effort: None,
+            effort: ReasoningEffort::Low,
             messages: vec![Message::User {
                 content: vec![UserBlock::Text {
                     text: "hello".to_string(),

--- a/lib/openai-client/src/responses.rs
+++ b/lib/openai-client/src/responses.rs
@@ -7,7 +7,7 @@ use llm::prompt::{
 };
 use llm::provider::LlmProvider;
 use llm::stream::StreamDelta;
-use llm::{Prompt, PromptError};
+use llm::{Prompt, PromptError, ReasoningEffort};
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use thiserror::Error;
@@ -320,6 +320,15 @@ struct ResponsesReasoningConfig {
     summary: &'static str,
 }
 
+fn responses_effort_str(effort: ReasoningEffort) -> &'static str {
+    match effort {
+        ReasoningEffort::Minimal => "minimal",
+        ReasoningEffort::Low => "low",
+        ReasoningEffort::Medium => "medium",
+        ReasoningEffort::High => "high",
+    }
+}
+
 fn prompt_to_responses_request(prompt: &Prompt, auth: &OpenAiResponsesAuth) -> ResponsesRequest {
     let mut input = Vec::new();
 
@@ -363,7 +372,10 @@ fn prompt_to_responses_request(prompt: &Prompt, auth: &OpenAiResponsesAuth) -> R
         },
         include: vec!["reasoning.encrypted_content"],
         reasoning: ResponsesReasoningConfig {
-            effort: DEFAULT_REASONING_EFFORT,
+            effort: prompt
+                .effort
+                .map(responses_effort_str)
+                .unwrap_or(DEFAULT_REASONING_EFFORT),
             summary: "auto",
         },
     }
@@ -1050,6 +1062,7 @@ mod tests {
     fn sample_prompt() -> Prompt {
         Prompt {
             chain: llm::ModelChain::new("gpt-5.4-mini"),
+            effort: None,
             messages: vec![Message::User {
                 content: vec![UserBlock::Text {
                     text: "hello".to_string(),

--- a/lib/openai-client/src/types.rs
+++ b/lib/openai-client/src/types.rs
@@ -20,6 +20,17 @@ pub(crate) struct OpenAiRequest {
     pub stream: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_options: Option<StreamOptions>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning: Option<ReasoningConfig>,
+}
+
+/// OpenRouter's unified reasoning param. For OpenAI models `effort` maps to
+/// `reasoning_effort`; for Anthropic models OpenRouter translates it to a
+/// thinking `budget_tokens`. Drua's `openai` provider targets OpenRouter,
+/// so this single shape covers every configured model.
+#[derive(Debug, Serialize)]
+pub(crate) struct ReasoningConfig {
+    pub effort: &'static str,
 }
 
 #[derive(Debug, Serialize)]

--- a/lib/openai-client/src/types.rs
+++ b/lib/openai-client/src/types.rs
@@ -21,13 +21,11 @@ pub(crate) struct OpenAiRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub stream_options: Option<StreamOptions>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub reasoning_effort: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub reasoning: Option<ReasoningConfig>,
 }
 
-/// OpenRouter's unified reasoning param. For OpenAI models `effort` maps to
-/// `reasoning_effort`; for Anthropic models OpenRouter translates it to a
-/// thinking `budget_tokens`. Drua's `openai` provider targets OpenRouter,
-/// so this single shape covers every configured model.
 #[derive(Debug, Serialize)]
 pub(crate) struct ReasoningConfig {
     pub effort: &'static str,

--- a/lib/openai-client/tests/live_prompt_caching.rs
+++ b/lib/openai-client/tests/live_prompt_caching.rs
@@ -42,7 +42,7 @@ fn build_prompt(
 ) -> Prompt {
     Prompt {
         chain: ModelChain::new(model),
-        effort: None,
+        effort: llm::ReasoningEffort::Low,
         messages: vec![Message::User {
             content: vec![UserBlock::Text {
                 text: user_text.into(),

--- a/lib/openai-client/tests/live_prompt_caching.rs
+++ b/lib/openai-client/tests/live_prompt_caching.rs
@@ -4,7 +4,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use llm::prompt::{Message, SystemBlock, UserBlock};
 use llm::provider::LlmProvider;
 use llm::stream::StreamAccumulator;
-use llm::{ModelChain, Prompt, PromptResponse};
+use llm::{ModelChain, Prompt, PromptResponse, ReasoningEffort};
 use openai_client::{OpenAiResponsesAuth, OpenAiResponsesClient};
 
 const LIVE_TESTS_ENV: &str = "DRUA_LIVE_CACHE_TESTS";
@@ -42,7 +42,7 @@ fn build_prompt(
 ) -> Prompt {
     Prompt {
         chain: ModelChain::new(model),
-        effort: llm::ReasoningEffort::Low,
+        effort: ReasoningEffort::Low,
         messages: vec![Message::User {
             content: vec![UserBlock::Text {
                 text: user_text.into(),

--- a/lib/openai-client/tests/live_prompt_caching.rs
+++ b/lib/openai-client/tests/live_prompt_caching.rs
@@ -42,6 +42,7 @@ fn build_prompt(
 ) -> Prompt {
     Prompt {
         chain: ModelChain::new(model),
+        effort: None,
         messages: vec![Message::User {
             content: vec![UserBlock::Text {
                 text: user_text.into(),

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -5,6 +5,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::auth::config::{AuthConfig, LoginMethod};
 use drua_core::agent::{AgentsConfig, ModelDefaults};
+use drua_core::ReasoningEffort;
 use drua_core::library::LibraryConfig;
 use drua_core::prompt_executor::{
     ModelConfig, OpenAiResponsesAuth, PromptExecutorConfig, Provider,
@@ -57,6 +58,8 @@ pub struct ProviderModelConfig {
     pub max_tokens_per_response: u32,
     #[serde(default = "default_context_window")]
     pub context_window_tokens: u64,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub effort: Option<ReasoningEffort>,
 }
 
 fn default_context_window() -> u64 {
@@ -273,6 +276,7 @@ impl Config {
                         model: model.name.clone(),
                         max_tokens_per_response: model.max_tokens_per_response,
                         context_window_tokens: model.context_window_tokens,
+                        effort: model.effort,
                     },
                 );
             }

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -5,7 +5,6 @@ use serde::{Deserialize, Serialize};
 
 use crate::auth::config::{AuthConfig, LoginMethod};
 use drua_core::agent::{AgentsConfig, ModelDefaults};
-use drua_core::ReasoningEffort;
 use drua_core::library::LibraryConfig;
 use drua_core::prompt_executor::{
     ModelConfig, OpenAiResponsesAuth, PromptExecutorConfig, Provider,
@@ -13,6 +12,7 @@ use drua_core::prompt_executor::{
 use drua_core::sandbox::SandboxConfig;
 use drua_core::toolset::ToolSetsConfig;
 use drua_core::GitProxyAppConfig;
+use drua_core::ReasoningEffort;
 
 #[derive(Clone, Default, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]

--- a/server/src/config.rs
+++ b/server/src/config.rs
@@ -58,8 +58,8 @@ pub struct ProviderModelConfig {
     pub max_tokens_per_response: u32,
     #[serde(default = "default_context_window")]
     pub context_window_tokens: u64,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub effort: Option<ReasoningEffort>,
+    #[serde(default, skip_serializing_if = "ReasoningEffort::is_low")]
+    pub effort: ReasoningEffort,
 }
 
 fn default_context_window() -> u64 {

--- a/server/src/graphql/agent.rs
+++ b/server/src/graphql/agent.rs
@@ -14,19 +14,20 @@ use drua_core::{
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
 pub enum ReasoningEffort {
-    Minimal,
     Low,
     Medium,
     High,
+    #[graphql(name = "XHIGH")]
+    XHigh,
 }
 
 impl From<DomainReasoningEffort> for ReasoningEffort {
     fn from(e: DomainReasoningEffort) -> Self {
         match e {
-            DomainReasoningEffort::Minimal => Self::Minimal,
             DomainReasoningEffort::Low => Self::Low,
             DomainReasoningEffort::Medium => Self::Medium,
             DomainReasoningEffort::High => Self::High,
+            DomainReasoningEffort::XHigh => Self::XHigh,
         }
     }
 }
@@ -34,10 +35,10 @@ impl From<DomainReasoningEffort> for ReasoningEffort {
 impl From<ReasoningEffort> for DomainReasoningEffort {
     fn from(e: ReasoningEffort) -> Self {
         match e {
-            ReasoningEffort::Minimal => Self::Minimal,
             ReasoningEffort::Low => Self::Low,
             ReasoningEffort::Medium => Self::Medium,
             ReasoningEffort::High => Self::High,
+            ReasoningEffort::XHigh => Self::XHigh,
         }
     }
 }
@@ -105,7 +106,7 @@ impl From<drua_core::agent::ModelChain> for ModelChain {
             primary: ModelSpec {
                 name: c.primary.model,
                 max_tokens: Some(c.primary.max_tokens_per_response as i32),
-                effort: c.primary.effort.map(Into::into),
+                effort: Some(c.primary.effort.into()),
             },
             fallbacks: c
                 .fallbacks
@@ -113,7 +114,7 @@ impl From<drua_core::agent::ModelChain> for ModelChain {
                 .map(|m| ModelSpec {
                     name: m.model,
                     max_tokens: Some(m.max_tokens_per_response as i32),
-                    effort: m.effort.map(Into::into),
+                    effort: Some(m.effort.into()),
                 })
                 .collect(),
         }

--- a/server/src/graphql/agent.rs
+++ b/server/src/graphql/agent.rs
@@ -13,34 +13,13 @@ use drua_core::{
 };
 
 #[derive(Enum, Copy, Clone, Eq, PartialEq)]
+#[graphql(remote = "DomainReasoningEffort")]
 pub enum ReasoningEffort {
     Low,
     Medium,
     High,
     #[graphql(name = "XHIGH")]
     XHigh,
-}
-
-impl From<DomainReasoningEffort> for ReasoningEffort {
-    fn from(e: DomainReasoningEffort) -> Self {
-        match e {
-            DomainReasoningEffort::Low => Self::Low,
-            DomainReasoningEffort::Medium => Self::Medium,
-            DomainReasoningEffort::High => Self::High,
-            DomainReasoningEffort::XHigh => Self::XHigh,
-        }
-    }
-}
-
-impl From<ReasoningEffort> for DomainReasoningEffort {
-    fn from(e: ReasoningEffort) -> Self {
-        match e {
-            ReasoningEffort::Low => Self::Low,
-            ReasoningEffort::Medium => Self::Medium,
-            ReasoningEffort::High => Self::High,
-            ReasoningEffort::XHigh => Self::XHigh,
-        }
-    }
 }
 
 #[derive(SimpleObject, InputObject, Clone)]

--- a/server/src/graphql/agent.rs
+++ b/server/src/graphql/agent.rs
@@ -7,7 +7,40 @@ use super::primitives::*;
 use drua_core::agent::Agent as DomainAgent;
 use drua_core::agent::AgentRole as DomainAgentRole;
 use drua_core::sandbox::SandboxAgentMode;
-use drua_core::{ModelChain as DomainModelChain, ModelSpec as DomainModelSpec};
+use drua_core::{
+    ModelChain as DomainModelChain, ModelSpec as DomainModelSpec,
+    ReasoningEffort as DomainReasoningEffort,
+};
+
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub enum ReasoningEffort {
+    Minimal,
+    Low,
+    Medium,
+    High,
+}
+
+impl From<DomainReasoningEffort> for ReasoningEffort {
+    fn from(e: DomainReasoningEffort) -> Self {
+        match e {
+            DomainReasoningEffort::Minimal => Self::Minimal,
+            DomainReasoningEffort::Low => Self::Low,
+            DomainReasoningEffort::Medium => Self::Medium,
+            DomainReasoningEffort::High => Self::High,
+        }
+    }
+}
+
+impl From<ReasoningEffort> for DomainReasoningEffort {
+    fn from(e: ReasoningEffort) -> Self {
+        match e {
+            ReasoningEffort::Minimal => Self::Minimal,
+            ReasoningEffort::Low => Self::Low,
+            ReasoningEffort::Medium => Self::Medium,
+            ReasoningEffort::High => Self::High,
+        }
+    }
+}
 
 #[derive(SimpleObject, InputObject, Clone)]
 #[graphql(input_name = "ModelSpecInput")]
@@ -16,6 +49,9 @@ pub struct ModelSpec {
     /// Input: optional override of the registry's `max_tokens_per_response`.
     /// Output: the effective max_tokens currently in force (registry value or override).
     pub max_tokens: Option<i32>,
+    /// Reasoning effort override; raise alongside `max_tokens` since reasoning
+    /// tokens are drawn from the output budget.
+    pub effort: Option<ReasoningEffort>,
 }
 
 impl From<DomainModelSpec> for ModelSpec {
@@ -23,6 +59,7 @@ impl From<DomainModelSpec> for ModelSpec {
         Self {
             name: s.name,
             max_tokens: s.max_tokens.map(|n| n as i32),
+            effort: s.effort.map(Into::into),
         }
     }
 }
@@ -32,6 +69,7 @@ impl From<ModelSpec> for DomainModelSpec {
         DomainModelSpec {
             name: s.name,
             max_tokens: s.max_tokens.map(|n| n.max(0) as u32),
+            effort: s.effort.map(Into::into),
         }
     }
 }
@@ -67,6 +105,7 @@ impl From<drua_core::agent::ModelChain> for ModelChain {
             primary: ModelSpec {
                 name: c.primary.model,
                 max_tokens: Some(c.primary.max_tokens_per_response as i32),
+                effort: c.primary.effort.map(Into::into),
             },
             fallbacks: c
                 .fallbacks
@@ -74,6 +113,7 @@ impl From<drua_core::agent::ModelChain> for ModelChain {
                 .map(|m| ModelSpec {
                     name: m.model,
                     max_tokens: Some(m.max_tokens_per_response as i32),
+                    effort: m.effort.map(Into::into),
                 })
                 .collect(),
         }

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -279,6 +279,11 @@ input ModelChainInput {
 
 type ModelSpec {
 	"""
+	Reasoning effort override; raise alongside `max_tokens` since reasoning
+	tokens are drawn from the output budget.
+	"""
+	effort: ReasoningEffort
+	"""
 	Input: optional override of the registry's `max_tokens_per_response`.
 	Output: the effective max_tokens currently in force (registry value or override).
 	"""
@@ -287,6 +292,11 @@ type ModelSpec {
 }
 
 input ModelSpecInput {
+	"""
+	Reasoning effort override; raise alongside `max_tokens` since reasoning
+	tokens are drawn from the output budget.
+	"""
+	effort: ReasoningEffort
 	"""
 	Input: optional override of the registry's `max_tokens_per_response`.
 	Output: the effective max_tokens currently in force (registry value or override).
@@ -482,6 +492,13 @@ type Query {
 	workflowDefinitions(projectId: ProjectId!): [WorkflowDefinition!]!
 	workflowRun(id: WorkflowRunId!): WorkflowRun
 	workflowRuns(definitionId: WorkflowDefinitionId!, first: Int! = 50): [WorkflowRun!]!
+}
+
+enum ReasoningEffort {
+	HIGH
+	LOW
+	MEDIUM
+	MINIMAL
 }
 
 type Sandbox {

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -498,7 +498,7 @@ enum ReasoningEffort {
 	HIGH
 	LOW
 	MEDIUM
-	MINIMAL
+	XHIGH
 }
 
 type Sandbox {

--- a/server/tests/graphql.rs
+++ b/server/tests/graphql.rs
@@ -7,6 +7,8 @@
 ///   DATABASE_URL=postgres://user:password@localhost:5432/drua cargo nextest run -p drua-server
 use std::collections::HashMap;
 
+use drua_core::ReasoningEffort;
+
 const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
 
 async fn pool() -> sqlx::PgPool {
@@ -96,7 +98,7 @@ async fn test_app(pool: &sqlx::PgPool) -> drua_core::App {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
-            effort: drua_core::ReasoningEffort::Low,
+            effort: ReasoningEffort::Low,
         },
     );
 

--- a/server/tests/graphql.rs
+++ b/server/tests/graphql.rs
@@ -96,6 +96,7 @@ async fn test_app(pool: &sqlx::PgPool) -> drua_core::App {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
+            effort: None,
         },
     );
 

--- a/server/tests/graphql.rs
+++ b/server/tests/graphql.rs
@@ -96,7 +96,7 @@ async fn test_app(pool: &sqlx::PgPool) -> drua_core::App {
             model: model_name,
             max_tokens_per_response: 1024,
             context_window_tokens: 200_000,
-            effort: None,
+            effort: drua_core::ReasoningEffort::Low,
         },
     );
 


### PR DESCRIPTION
Adds an `effort` field to the provider-agnostic `ModelSpec`, making reasoning level settable at every existing model-chain lever — `default_chain`, per-role chain, per-agent override, and per-workflow / per-step `model_chain` — alongside `max_tokens`. A `ReasoningEffort` enum (`low`, `medium`, `high`, `xhigh`) threads from the chain spec through the router (applied per fallback attempt) into the provider request builders: the OpenAI-compatible client emits native `reasoning_effort` or OpenRouter's `reasoning.effort` object depending on the base URL, the Anthropic client maps it to a thinking `budget_tokens` (a fraction of `max_tokens`), and the Responses client to its reasoning config. The level is exposed through GraphQL (`ReasoningEffort` on `ModelSpec` / `ModelSpecInput`), so a deep-review workflow step can request e.g. `model_chain: { primary: { name, max_tokens: 32000, effort: high } }`.

The resolved level always carries a value and **defaults to `low`** when no override is set, so every LLM request now sends an explicit reasoning level (previously none was sent). Reasoning tokens are drawn from the output budget, so effort is meant to be raised alongside `max_tokens`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how every LLM request is built (token budgets and provider-specific reasoning fields); misconfiguration could increase cost/latency or hit API limits, but defaults to low effort and follows existing chain override patterns.
> 
> **Overview**
> Introduces a provider-agnostic **`ReasoningEffort`** level (`low` through `xhigh`) that can be set on model registry entries, Helm-generated config, default/role/agent model chains, and optional per-spec overrides—same levers as **`max_tokens`**.
> 
> **`effort`** flows from agent **`ModelDefaults`** into **`llm::Prompt`**, through the prompt executor and chain router (applied per fallback attempt), and into provider requests: Anthropic **thinking `budget_tokens`** (fraction of **`max_tokens`**), OpenAI **`reasoning_effort`** / Responses API reasoning config, and OpenRouter **`reasoning.effort`** (auto-selected from base URL).
> 
> GraphQL exposes **`ReasoningEffort`** on **`ModelSpec`** / **`ModelSpecInput`**; chain resolution lets a spec **`effort`** override the registry default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c408dff695c7c786ceb299fdd929ed7bbdfde5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
