### PR TITLE
chore: Add more models

### DIFF
--- a/drua.yml
+++ b/drua.yml
@@ -32,6 +32,18 @@ providers:
       - name: anthropic/claude-sonnet-4.6
         max_tokens_per_response: 8192
         context_window_tokens: 200000
+      - name: minimax/minimax-m3
+        max_tokens_per_response: 8192
+        context_window_tokens: 1048576
+      - name: qwen/qwen3.7-plus
+        max_tokens_per_response: 8192
+        context_window_tokens: 1000000
+      - name: moonshotai/kimi-k2.6:free
+        max_tokens_per_response: 8192
+        context_window_tokens: 262144
+      - name: moonshotai/kimi-k2.6
+        max_tokens_per_response: 8192
+        context_window_tokens: 262144
 agents:
   # Resolution precedence (highest first):
   #   1. chain_override passed at the call site (workflow definition /


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only provider catalog expansion with no changes to default chains or runtime logic.
> 
> **Overview**
> Registers **four additional OpenRouter models** on the existing `openai` provider in `drua.yml`: `minimax/minimax-m3`, `qwen/qwen3.7-plus`, `moonshotai/kimi-k2.6:free`, and `moonshotai/kimi-k2.6`. Each entry uses **8192** `max_tokens_per_response` and provider-specific `context_window_tokens` (1M for MiniMax/Qwen, 262144 for both Kimi variants).
> 
> **`default_chain` and agent role chains are unchanged**—the new models are available for explicit selection via chain overrides or UI, not wired as primary/fallback defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 715d678bce3badd5a2494ab95ff43594eba99fce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->