### PR TITLE
feat(workflow): pause/resume for all workflows

### DIFF
--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -151,7 +151,7 @@ const WORKFLOW_RUN_QUERY: &str = r#"
 const WORKFLOW_TRIGGER_MUTATION: &str = r#"
     mutation WorkflowTrigger($input: WorkflowTriggerInput!) {
         workflowTrigger(input: $input) {
-            filtered
+            disposition
             run {
                 id
                 definitionId
@@ -195,9 +195,17 @@ struct WorkflowTriggerResponse {
     workflow_trigger: WorkflowTriggerPayloadNode,
 }
 
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq)]
+#[serde(rename_all = "SCREAMING_SNAKE_CASE")]
+enum WorkflowTriggerDisposition {
+    Spawned,
+    Filtered,
+    Paused,
+}
+
 #[derive(Debug, Deserialize)]
 struct WorkflowTriggerPayloadNode {
-    filtered: bool,
+    disposition: WorkflowTriggerDisposition,
     run: Option<WorkflowRunNode>,
 }
 
@@ -641,7 +649,7 @@ enum WorkflowEvent {
 }
 
 struct WorkflowTriggerOutcome {
-    filtered: bool,
+    disposition: Option<WorkflowTriggerDisposition>,
     run_id: Option<String>,
     run_detail: Option<WorkflowRunDetail>,
     updated_runs: Option<Vec<WorkflowRunItem>>,
@@ -1550,50 +1558,32 @@ fn spawn_workflow_trigger(
     tokio::spawn(async move {
         let client = GraphqlClient::new(&base_url, &token);
         match trigger_workflow(&client, &definition_id, payload).await {
-            Ok(result) if result.filtered => {
-                let _ = tx.send(WorkflowEvent::TriggerComplete(Box::new(
-                    WorkflowTriggerOutcome {
-                        filtered: true,
-                        run_id: None,
-                        run_detail: None,
-                        updated_runs: None,
-                        error: None,
-                    },
-                )));
-            }
             Ok(result) => {
-                if let Some(run) = result.run {
+                let (run_id, run_detail, updated_runs) = if let Some(run) = result.run {
                     let run_id = run.id.clone();
                     let run_detail = match fetch_workflow_run(&client, &run_id).await {
                         Ok(detail) => detail,
                         Err(_) => workflow_run_node_to_detail(run),
                     };
                     let updated_runs = fetch_workflow_runs(&client, &definition_id).await.ok();
-                    let _ = tx.send(WorkflowEvent::TriggerComplete(Box::new(
-                        WorkflowTriggerOutcome {
-                            filtered: false,
-                            run_id: Some(run_id),
-                            run_detail: Some(run_detail),
-                            updated_runs,
-                            error: None,
-                        },
-                    )));
+                    (Some(run_id), Some(run_detail), updated_runs)
                 } else {
-                    let _ = tx.send(WorkflowEvent::TriggerComplete(Box::new(
-                        WorkflowTriggerOutcome {
-                            filtered: false,
-                            run_id: None,
-                            run_detail: None,
-                            updated_runs: None,
-                            error: None,
-                        },
-                    )));
-                }
+                    (None, None, None)
+                };
+                let _ = tx.send(WorkflowEvent::TriggerComplete(Box::new(
+                    WorkflowTriggerOutcome {
+                        disposition: Some(result.disposition),
+                        run_id,
+                        run_detail,
+                        updated_runs,
+                        error: None,
+                    },
+                )));
             }
             Err(e) => {
                 let _ = tx.send(WorkflowEvent::TriggerComplete(Box::new(
                     WorkflowTriggerOutcome {
-                        filtered: false,
+                        disposition: None,
                         run_id: None,
                         run_detail: None,
                         updated_runs: None,
@@ -1689,10 +1679,18 @@ fn handle_workflow_event(
                 state.set_workflow_error(error);
                 return;
             }
-            if outcome.filtered {
-                state.status_message =
-                    Some("Trigger condition filtered; no run created".to_string());
-                return;
+            match outcome.disposition {
+                Some(WorkflowTriggerDisposition::Filtered) => {
+                    state.status_message =
+                        Some("Trigger condition filtered; no run created".to_string());
+                    return;
+                }
+                Some(WorkflowTriggerDisposition::Paused) => {
+                    state.status_message =
+                        Some("Workflow is paused; resume it to trigger runs".to_string());
+                    return;
+                }
+                _ => {}
             }
             if let Some(ref run_id) = outcome.run_id {
                 state.status_message = Some(format!("Workflow run {run_id} created"));

--- a/client/src/commands/dashboard.rs
+++ b/client/src/commands/dashboard.rs
@@ -91,6 +91,7 @@ const WORKFLOW_DEFINITIONS_QUERY: &str = r#"
             id
             name
             description
+            paused
             trigger { kind provider cronSchedule cronTimezone nextRunAt condition webhookUrl }
             steps { name stepType skill tool sandbox sandboxMode condition provider resumeCondition }
             recentRuns(first: 1) {
@@ -111,6 +112,7 @@ const WORKFLOW_DEFINITION_QUERY: &str = r#"
             name
             description
             yaml
+            paused
             trigger { kind provider cronSchedule cronTimezone nextRunAt condition webhookUrl }
             steps { name stepType skill tool sandbox sandboxMode condition provider resumeCondition }
             sandboxes { name kind branch repoUrl }
@@ -144,6 +146,14 @@ const WORKFLOW_RUN_QUERY: &str = r#"
             stepsSnapshot { name stepType skill tool sandbox sandboxMode condition provider resumeCondition }
             stepResults { name state output error skipped completedAt }
             agents { id name role session { model } attachedSandbox { name mode } }
+        }
+    }
+"#;
+
+const WORKFLOW_SET_PAUSED_MUTATION: &str = r#"
+    mutation WorkflowSetPaused($input: WorkflowSetPausedInput!) {
+        workflowSetPaused(input: $input) {
+            workflow { id paused yaml }
         }
     }
 "#;
@@ -211,12 +221,32 @@ struct WorkflowTriggerPayloadNode {
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
+struct WorkflowSetPausedResponse {
+    workflow_set_paused: WorkflowSetPausedPayloadNode,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkflowSetPausedPayloadNode {
+    workflow: WorkflowSetPausedWorkflowNode,
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkflowSetPausedWorkflowNode {
+    paused: bool,
+    #[serde(default)]
+    yaml: String,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
 struct WorkflowDefinitionNode {
     id: String,
     name: String,
     description: Option<String>,
     #[serde(default)]
     yaml: String,
+    #[serde(default)]
+    paused: bool,
     trigger: WorkflowTriggerNode,
     #[serde(default)]
     steps: Vec<WorkflowStepNode>,
@@ -637,6 +667,12 @@ enum WorkflowEvent {
         is_poll: bool,
     },
     TriggerComplete(Box<WorkflowTriggerOutcome>),
+    SetPausedComplete {
+        definition_id: String,
+        paused: bool,
+        yaml: Option<String>,
+        error: Option<String>,
+    },
     ConversationLoaded {
         agent_id: String,
         agent_name: String,
@@ -857,6 +893,7 @@ fn workflow_definition_node_to_item(d: WorkflowDefinitionNode) -> WorkflowDefini
         name: d.name,
         description: d.description,
         trigger: workflow_trigger_node_to_info(d.trigger),
+        paused: d.paused,
         steps: d
             .steps
             .into_iter()
@@ -877,6 +914,7 @@ fn workflow_definition_node_to_detail(d: WorkflowDefinitionNode) -> WorkflowDefi
         description: d.description,
         yaml: d.yaml,
         trigger: workflow_trigger_node_to_info(d.trigger),
+        paused: d.paused,
         steps: d
             .steps
             .into_iter()
@@ -997,6 +1035,25 @@ async fn trigger_workflow(
         )
         .await?;
     Ok(resp.workflow_trigger)
+}
+
+async fn set_workflow_paused(
+    client: &GraphqlClient,
+    definition_id: &str,
+    paused: bool,
+) -> Result<WorkflowSetPausedWorkflowNode> {
+    let resp: WorkflowSetPausedResponse = client
+        .query(
+            WORKFLOW_SET_PAUSED_MUTATION,
+            serde_json::json!({
+                "input": {
+                    "definitionId": definition_id,
+                    "paused": paused,
+                }
+            }),
+        )
+        .await?;
+    Ok(resp.workflow_set_paused.workflow)
 }
 
 async fn fetch_user_name(client: &GraphqlClient) -> Result<String> {
@@ -1595,6 +1652,33 @@ fn spawn_workflow_trigger(
     });
 }
 
+fn spawn_workflow_set_paused(
+    base_url: String,
+    token: String,
+    definition_id: String,
+    paused: bool,
+    tx: mpsc::UnboundedSender<WorkflowEvent>,
+) {
+    tokio::spawn(async move {
+        let client = GraphqlClient::new(&base_url, &token);
+        let (resulting_paused, yaml, error) =
+            match set_workflow_paused(&client, &definition_id, paused).await {
+                Ok(w) => (w.paused, Some(w.yaml), None),
+                Err(e) => (
+                    paused,
+                    None,
+                    Some(format!("Failed to update workflow: {e}")),
+                ),
+            };
+        let _ = tx.send(WorkflowEvent::SetPausedComplete {
+            definition_id,
+            paused: resulting_paused,
+            yaml,
+            error,
+        });
+    });
+}
+
 fn spawn_step_conversation_fetch(
     base_url: String,
     token: String,
@@ -1706,6 +1790,26 @@ fn handle_workflow_event(
             } else {
                 state.status_message = Some("Workflow trigger returned no run".to_string());
             }
+        }
+        WorkflowEvent::SetPausedComplete {
+            definition_id,
+            paused,
+            yaml,
+            error,
+        } => {
+            if let Some(error) = error {
+                state.set_workflow_error(error);
+                return;
+            }
+            state.set_workflow_definition_paused(&definition_id, paused, yaml);
+            state.status_message = Some(
+                if paused {
+                    "Workflow paused"
+                } else {
+                    "Workflow resumed"
+                }
+                .to_string(),
+            );
         }
         WorkflowEvent::ConversationLoaded {
             agent_id,
@@ -1996,6 +2100,19 @@ async fn run_event_loop(
                                     config.auth_token.clone(),
                                     definition_id,
                                     payload,
+                                    workflow_tx.clone(),
+                                );
+                            }
+                            handlers::Action::SetWorkflowPaused { definition_id, paused } => {
+                                state.status_message = Some(
+                                    if paused { "Pausing workflow…" } else { "Resuming workflow…" }
+                                        .to_string(),
+                                );
+                                spawn_workflow_set_paused(
+                                    config.server_url.clone(),
+                                    config.auth_token.clone(),
+                                    definition_id,
+                                    paused,
                                     workflow_tx.clone(),
                                 );
                             }

--- a/client/src/tui/handlers.rs
+++ b/client/src/tui/handlers.rs
@@ -23,6 +23,10 @@ pub enum Action {
         definition_id: String,
         payload: serde_json::Value,
     },
+    SetWorkflowPaused {
+        definition_id: String,
+        paused: bool,
+    },
     ExportThread {
         agent_id: String,
         path: String,
@@ -136,6 +140,7 @@ fn handle_workflow_definitions_key(state: &mut ScreenState, key: KeyEvent) -> Ac
             Action::None
         }
         KeyCode::Char('r') => Action::RefreshWorkflows,
+        KeyCode::Char('p') => set_paused_for_selected_workflow(state),
         KeyCode::Esc => {
             state.focus = Focus::Chat;
             Action::None
@@ -285,6 +290,16 @@ fn enter_trigger_for_selected_workflow(state: &mut ScreenState) -> Action {
             state.enter_trigger_workflow(definition_id, name);
             Action::None
         }
+        None => Action::None,
+    }
+}
+
+fn set_paused_for_selected_workflow(state: &ScreenState) -> Action {
+    match state.selected_workflow_definition() {
+        Some(def) => Action::SetWorkflowPaused {
+            definition_id: def.id.clone(),
+            paused: !def.paused,
+        },
         None => Action::None,
     }
 }

--- a/client/src/tui/state/mod.rs
+++ b/client/src/tui/state/mod.rs
@@ -507,6 +507,33 @@ impl ScreenState {
         self.workflows.loading = false;
     }
 
+    pub fn set_workflow_definition_paused(
+        &mut self,
+        definition_id: &str,
+        paused: bool,
+        yaml: Option<String>,
+    ) {
+        if let Some(item) = self
+            .workflows
+            .definitions
+            .iter_mut()
+            .find(|d| d.id == definition_id)
+        {
+            item.paused = paused;
+        }
+        if let Some(detail) = self
+            .workflows
+            .selected_definition
+            .as_mut()
+            .filter(|d| d.id == definition_id)
+        {
+            detail.paused = paused;
+            if let Some(yaml) = yaml {
+                detail.yaml = yaml;
+            }
+        }
+    }
+
     pub fn replace_workflow_runs(&mut self, runs: Vec<WorkflowRunItem>) {
         self.workflows.runs = runs;
         if self.workflows.run_cursor >= self.workflows.runs.len() {
@@ -1314,6 +1341,7 @@ mod tests {
                 name: "first".into(),
                 description: None,
                 trigger: WorkflowTriggerInfo::default(),
+                paused: false,
                 steps: vec![],
                 recent_runs: vec![],
             },
@@ -1322,6 +1350,7 @@ mod tests {
                 name: "second".into(),
                 description: None,
                 trigger: WorkflowTriggerInfo::default(),
+                paused: false,
                 steps: vec![],
                 recent_runs: vec![],
             },

--- a/client/src/tui/state/workflow.rs
+++ b/client/src/tui/state/workflow.rs
@@ -43,6 +43,7 @@ pub struct WorkflowDefinitionItem {
     pub name: String,
     pub description: Option<String>,
     pub trigger: WorkflowTriggerInfo,
+    pub paused: bool,
     pub steps: Vec<WorkflowStepItem>,
     pub recent_runs: Vec<WorkflowRunItem>,
 }
@@ -54,6 +55,7 @@ pub struct WorkflowDefinitionDetail {
     pub description: Option<String>,
     pub yaml: String,
     pub trigger: WorkflowTriggerInfo,
+    pub paused: bool,
     pub steps: Vec<WorkflowStepItem>,
     pub sandboxes: Vec<WorkflowSandboxItem>,
     pub recent_runs: Vec<WorkflowRunItem>,

--- a/client/src/tui/ui/workflows.rs
+++ b/client/src/tui/ui/workflows.rs
@@ -30,7 +30,7 @@ pub fn draw_workflows(frame: &mut Frame, state: &mut ScreenState, area: Rect) {
 pub fn status_keys(state: &ScreenState) -> &'static str {
     match state.workflows.focus {
         MillerFocus::Definitions => {
-            " │ ↑/↓:nav  Enter:yaml  →:runs  ^R:trigger  r:refresh  Esc:chat "
+            " │ ↑/↓:nav  Enter:yaml  →:runs  ^R:trigger  p:pause/resume  r:refresh  Esc:chat "
         }
         MillerFocus::YamlDetail => " │ ↑/↓:scroll  →:runs  ←/Esc:back ",
         MillerFocus::Runs => {
@@ -85,7 +85,7 @@ fn draw_col_definitions(frame: &mut Frame, state: &ScreenState, area: Rect) {
                 .first()
                 .map(|r| (state_label(&r.state), state_color(&r.state)))
                 .unwrap_or(("—", Color::DarkGray));
-            let line = Line::from(vec![
+            let mut spans = vec![
                 Span::styled(marker, Style::default().fg(Color::Yellow)),
                 Span::raw(" "),
                 Span::styled(
@@ -98,8 +98,11 @@ fn draw_col_definitions(frame: &mut Frame, state: &ScreenState, area: Rect) {
                 ),
                 Span::raw(" "),
                 Span::styled(run_indicator.0, Style::default().fg(run_indicator.1)),
-            ]);
-            items.push(ListItem::new(line));
+            ];
+            if definition.paused {
+                spans.push(Span::styled(" ⏸", Style::default().fg(Color::Yellow)));
+            }
+            items.push(ListItem::new(Line::from(spans)));
         }
     }
 
@@ -156,7 +159,13 @@ fn draw_definition_detail(frame: &mut Frame, state: &ScreenState, area: Rect) {
         .workflows
         .selected_definition
         .as_ref()
-        .map(|d| format!(" {} ", d.name))
+        .map(|d| {
+            if d.paused {
+                format!(" {} (paused) ", d.name)
+            } else {
+                format!(" {} ", d.name)
+            }
+        })
         .unwrap_or_else(|| " Definition ".to_string());
     let focused = state.workflows.focus == MillerFocus::YamlDetail;
     let border_color = if focused {

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -26,8 +26,8 @@ use crate::sandbox::{Sandbox, SandboxAgentMode, SandboxMode, SandboxSpecs, Sandb
 use crate::skill::{ScopedSkill, Skill, SkillSource, Skills};
 use crate::space_fs::SpaceFs;
 use crate::workflow::{
-    WorkflowDefinition, WorkflowRun, WorkflowRunState, WorkflowSandboxDecl, WorkflowStepDef,
-    WorkflowTrigger, Workflows,
+    TriggerOutcome, WorkflowDefinition, WorkflowRun, WorkflowRunState, WorkflowSandboxDecl,
+    WorkflowStepDef, WorkflowTrigger, Workflows,
 };
 
 use super::super::error::ToolSetsError;
@@ -1461,14 +1461,19 @@ impl AdminToolSet {
                 let payload = params
                     .payload
                     .unwrap_or_else(|| serde_json::Value::Object(Default::default()));
-                let maybe_run = self
+                let outcome = self
                     .workflows
                     .trigger_run(subject, definition_id, payload)
                     .await
                     .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
-                let body = match maybe_run {
-                    Some(run) => format_run(&run),
-                    None => "Trigger condition evaluated to false; no run created.".to_string(),
+                let body = match outcome {
+                    TriggerOutcome::Spawned(run) => format_run(&run),
+                    TriggerOutcome::Filtered => {
+                        "Trigger condition evaluated to false; no run created.".to_string()
+                    }
+                    TriggerOutcome::Paused => {
+                        "Workflow is paused; no run created. Resume it to trigger runs.".to_string()
+                    }
                 };
                 Ok(CallToolResult::success(vec![Content::text(body)]))
             }

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -945,10 +945,10 @@ impl TopLevelTool for WorkflowTool {
             WorkflowParams::Pause { definition_id } => {
                 let definition = self
                     .workflows
-                    .set_cron_paused(subject, definition_id, true)
+                    .pause(subject, definition_id)
                     .await
                     .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
-                let text = format!("Workflow paused (id {definition_id}). Schedule is suspended; runs will not fire until resumed.");
+                let text = format!("Workflow paused (id {definition_id}). The schedule is retained; runs will not fire until resumed.");
                 let out = WorkflowOutput {
                     command: "pause".to_string(),
                     definition: Some(definition_to_output(&definition)),
@@ -960,12 +960,12 @@ impl TopLevelTool for WorkflowTool {
             WorkflowParams::Resume { definition_id } => {
                 let definition = self
                     .workflows
-                    .set_cron_paused(subject, definition_id, false)
+                    .resume(subject, definition_id)
                     .await
                     .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
-                let next = match definition.trigger.next_fire_at(chrono::Utc::now()) {
-                    Ok(Some(t)) => format!(" Next run at {}.", t.to_rfc3339()),
-                    _ => String::new(),
+                let next = match definition.trigger.next_run_at(chrono::Utc::now()) {
+                    Some(t) => format!(" Next scheduled run: {}.", t.to_rfc3339()),
+                    None => String::new(),
                 };
                 let text = format!("Workflow resumed (id {definition_id}).{next}");
                 let out = WorkflowOutput {
@@ -998,9 +998,7 @@ fn definition_to_output(d: &WorkflowDefinition) -> WorkflowDefinitionOutput {
             cron_timezone = timezone.clone();
             next_run_at = d
                 .trigger
-                .next_fire_at(chrono::Utc::now())
-                .ok()
-                .flatten()
+                .next_run_at(chrono::Utc::now())
                 .map(|t| t.to_rfc3339());
             ("cron".to_string(), None)
         }
@@ -1257,14 +1255,10 @@ fn format_get_text(d: &WorkflowDefinition) -> String {
             let mut s = format!("cron\n  schedule:    {schedule}");
             let tz_label = timezone.as_deref().unwrap_or("UTC");
             s.push_str(&format!("\n  timezone:    {tz_label}"));
-            s.push_str(&format!(
-                "\n  status:      {}",
-                if *paused { "paused" } else { "active" }
-            ));
-            if !*paused {
-                if let Ok(Some(next)) = trigger.next_fire_at(chrono::Utc::now()) {
-                    s.push_str(&format!("\n  next_run_at: {}", next.to_rfc3339()));
-                }
+            if *paused {
+                s.push_str("\n  status:      paused");
+            } else if let Some(next) = trigger.next_run_at(chrono::Utc::now()) {
+                s.push_str(&format!("\n  next_run_at: {}", next.to_rfc3339()));
             }
             s
         }

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -115,6 +115,14 @@ enum WorkflowParams {
     Delete {
         definition_id: WorkflowDefinitionId,
     },
+    /// Temporarily stop a cron workflow without deleting it. The
+    /// schedule survives and is restored by `resume`.
+    Pause {
+        definition_id: WorkflowDefinitionId,
+    },
+    Resume {
+        definition_id: WorkflowDefinitionId,
+    },
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -309,6 +317,8 @@ impl WorkflowParams {
             Self::Run { .. } => "workflow.run",
             Self::Update { .. } => "workflow.update",
             Self::Delete { .. } => "workflow.delete",
+            Self::Pause { .. } => "workflow.pause",
+            Self::Resume { .. } => "workflow.resume",
         }
     }
 }
@@ -354,6 +364,10 @@ struct WorkflowDefinitionOutput {
     /// RFC3339 timestamp of the next scheduled fire for cron triggers.
     #[serde(skip_serializing_if = "Option::is_none")]
     next_run_at: Option<String>,
+    /// `true` when a cron workflow is paused (schedule retained, runs
+    /// suspended). Omitted for non-cron and unpaused workflows.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    paused: bool,
     steps: Vec<WorkflowStepOutput>,
     sandboxes: Vec<WorkflowSandboxOutput>,
 }
@@ -471,8 +485,8 @@ static WORKFLOW_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
         "properties": {
             "command": {
                 "type": "string",
-                "enum": ["create", "list", "get", "trigger", "runs", "run", "update", "delete"],
-                "description": "Which workflow operation to perform. `trigger` returns immediately with the freshly-spawned run. `runs` lists runs (truncated outputs); `run` returns a single run with full per-step output."
+                "enum": ["create", "list", "get", "trigger", "runs", "run", "update", "delete", "pause", "resume"],
+                "description": "Which workflow operation to perform. `trigger` returns immediately with the freshly-spawned run. `runs` lists runs (truncated outputs); `run` returns a single run with full per-step output. `pause`/`resume` temporarily stop/restart a cron workflow without deleting it."
             },
             "name": {
                 "type": "string",
@@ -622,7 +636,9 @@ impl TopLevelTool for WorkflowTool {
          `provider`/`manual`/`trigger_condition`+`update_trigger`, \
          `model_chain`+`clear_model_chain`), \
          `delete` (requires `definition_id`; cascades to runs and queues \
-         a `DeleteFile` on the canonical YAML)."
+         a `DeleteFile` on the canonical YAML), \
+         `pause`/`resume` (requires `definition_id`; cron workflows only — \
+         temporarily stop the schedule without deleting it, then restart it)."
     }
 
     fn input_schema(&self) -> &serde_json::Value {
@@ -925,6 +941,40 @@ impl TopLevelTool for WorkflowTool {
                 };
                 (text, out)
             }
+
+            WorkflowParams::Pause { definition_id } => {
+                let definition = self
+                    .workflows
+                    .set_cron_paused(subject, definition_id, true)
+                    .await
+                    .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
+                let text = format!("Workflow paused (id {definition_id}). Schedule is suspended; runs will not fire until resumed.");
+                let out = WorkflowOutput {
+                    command: "pause".to_string(),
+                    definition: Some(definition_to_output(&definition)),
+                    ..Default::default()
+                };
+                (text, out)
+            }
+
+            WorkflowParams::Resume { definition_id } => {
+                let definition = self
+                    .workflows
+                    .set_cron_paused(subject, definition_id, false)
+                    .await
+                    .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
+                let next = match definition.trigger.next_fire_at(chrono::Utc::now()) {
+                    Ok(Some(t)) => format!(" Next run at {}.", t.to_rfc3339()),
+                    _ => String::new(),
+                };
+                let text = format!("Workflow resumed (id {definition_id}).{next}");
+                let out = WorkflowOutput {
+                    command: "resume".to_string(),
+                    definition: Some(definition_to_output(&definition)),
+                    ..Default::default()
+                };
+                (text, out)
+            }
         };
 
         let structured = serde_json::to_value(&out).expect("WorkflowOutput serialization");
@@ -965,6 +1015,7 @@ fn definition_to_output(d: &WorkflowDefinition) -> WorkflowDefinitionOutput {
         cron_schedule,
         cron_timezone,
         next_run_at,
+        paused: d.trigger.is_paused(),
         steps: d.steps.iter().map(step_to_output).collect(),
         sandboxes: d.sandboxes.iter().map(sandbox_to_output).collect(),
     }
@@ -1164,7 +1215,15 @@ fn format_list_text(defs: &[WorkflowDefinition]) -> String {
                 Some(p) => format!("webhook:{p}"),
                 None => "webhook".to_string(),
             },
-            WorkflowTrigger::Cron { schedule, .. } => format!("cron:{schedule}"),
+            WorkflowTrigger::Cron {
+                schedule, paused, ..
+            } => {
+                if *paused {
+                    format!("cron:{schedule} (paused)")
+                } else {
+                    format!("cron:{schedule}")
+                }
+            }
         };
         lines.push(format!(
             "{:<38} {:<24} {:<14} {}",
@@ -1190,13 +1249,22 @@ fn format_get_text(d: &WorkflowDefinition) -> String {
             format!("{label}\n  webhook_secret: {secret}")
         }
         trigger @ WorkflowTrigger::Cron {
-            schedule, timezone, ..
+            schedule,
+            timezone,
+            paused,
+            ..
         } => {
             let mut s = format!("cron\n  schedule:    {schedule}");
             let tz_label = timezone.as_deref().unwrap_or("UTC");
             s.push_str(&format!("\n  timezone:    {tz_label}"));
-            if let Ok(Some(next)) = trigger.next_fire_at(chrono::Utc::now()) {
-                s.push_str(&format!("\n  next_run_at: {}", next.to_rfc3339()));
+            s.push_str(&format!(
+                "\n  status:      {}",
+                if *paused { "paused" } else { "active" }
+            ));
+            if !*paused {
+                if let Ok(Some(next)) = trigger.next_fire_at(chrono::Utc::now()) {
+                    s.push_str(&format!("\n  next_run_at: {}", next.to_rfc3339()));
+                }
             }
             s
         }

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -533,7 +533,7 @@ static WORKFLOW_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
             },
             "definition_id": {
                 "type": "string",
-                "description": "Workflow definition ID — UUID for `get`/`runs`/`update`, UUID-or-name for `trigger` (the project-scoped workflow name resolves identically)."
+                "description": "Workflow definition ID — UUID for `get`/`runs`/`update`/`pause`/`resume`, UUID-or-name for `trigger` (the project-scoped workflow name resolves identically)."
             },
             "run_id": {
                 "type": "string",

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -9,8 +9,8 @@ use crate::primitives::{WorkflowDefinitionId, WorkflowRunId};
 use crate::project::Projects;
 use crate::sandbox::{SandboxAgentMode, SandboxMode, SandboxSpecs};
 use crate::workflow::{
-    StepResult, WorkflowDefinition, WorkflowRun, WorkflowRunState, WorkflowSandboxDecl,
-    WorkflowStepDef, WorkflowTrigger, Workflows,
+    StepResult, TriggerOutcome, WorkflowDefinition, WorkflowRun, WorkflowRunState,
+    WorkflowSandboxDecl, WorkflowStepDef, WorkflowTrigger, Workflows,
 };
 
 use super::super::error::ToolSetsError;
@@ -117,8 +117,8 @@ enum WorkflowParams {
     },
     /// Temporarily stop a workflow without deleting it. No runs fire
     /// while paused — cron fires are skipped (the schedule survives),
-    /// webhook deliveries are suppressed, manual triggers error —
-    /// until `resume` restores it.
+    /// webhook deliveries and manual triggers are suppressed with a
+    /// paused disposition (no run) — until `resume` restores it.
     Pause {
         definition_id: WorkflowDefinitionId,
     },
@@ -641,7 +641,8 @@ impl TopLevelTool for WorkflowTool {
          a `DeleteFile` on the canonical YAML), \
          `pause`/`resume` (requires `definition_id`; temporarily stop any \
          workflow without deleting it — cron fires are skipped, webhook \
-         deliveries suppressed, manual triggers error — then restart it)."
+         deliveries and manual triggers are suppressed with a paused \
+         disposition (no run) — then restart it)."
     }
 
     fn input_schema(&self) -> &serde_json::Value {
@@ -805,15 +806,22 @@ impl TopLevelTool for WorkflowTool {
                 .await?;
                 let payload =
                     payload.unwrap_or_else(|| serde_json::Value::Object(Default::default()));
-                let maybe_run = self
+                let outcome = self
                     .workflows
                     .trigger_run(subject, resolved_id, payload)
                     .await
                     .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
-                let (text, run_out) = match &maybe_run {
-                    Some(run) => (format_run_text(run), Some(run_to_output(run))),
-                    None => (
+                let (text, run_out) = match &outcome {
+                    TriggerOutcome::Spawned(run) => {
+                        (format_run_text(run), Some(run_to_output(run)))
+                    }
+                    TriggerOutcome::Filtered => (
                         "Trigger condition evaluated to false; no run created.".to_string(),
+                        None,
+                    ),
+                    TriggerOutcome::Paused => (
+                        "Workflow is paused; no run created. Resume it to trigger runs."
+                            .to_string(),
                         None,
                     ),
                 };

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -115,8 +115,10 @@ enum WorkflowParams {
     Delete {
         definition_id: WorkflowDefinitionId,
     },
-    /// Temporarily stop a cron workflow without deleting it. The
-    /// schedule survives and is restored by `resume`.
+    /// Temporarily stop a workflow without deleting it. No runs fire
+    /// while paused — cron fires are skipped (the schedule survives),
+    /// webhook deliveries are suppressed, manual triggers error —
+    /// until `resume` restores it.
     Pause {
         definition_id: WorkflowDefinitionId,
     },
@@ -364,8 +366,8 @@ struct WorkflowDefinitionOutput {
     /// RFC3339 timestamp of the next scheduled fire for cron triggers.
     #[serde(skip_serializing_if = "Option::is_none")]
     next_run_at: Option<String>,
-    /// `true` when a cron workflow is paused (schedule retained, runs
-    /// suspended). Omitted for non-cron and unpaused workflows.
+    /// `true` when the workflow is paused (no runs fire until
+    /// resumed; cron schedules are retained). Omitted when unpaused.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     paused: bool,
     steps: Vec<WorkflowStepOutput>,
@@ -486,7 +488,7 @@ static WORKFLOW_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
             "command": {
                 "type": "string",
                 "enum": ["create", "list", "get", "trigger", "runs", "run", "update", "delete", "pause", "resume"],
-                "description": "Which workflow operation to perform. `trigger` returns immediately with the freshly-spawned run. `runs` lists runs (truncated outputs); `run` returns a single run with full per-step output. `pause`/`resume` temporarily stop/restart a cron workflow without deleting it."
+                "description": "Which workflow operation to perform. `trigger` returns immediately with the freshly-spawned run. `runs` lists runs (truncated outputs); `run` returns a single run with full per-step output. `pause`/`resume` temporarily stop/restart a workflow without deleting it."
             },
             "name": {
                 "type": "string",
@@ -637,8 +639,9 @@ impl TopLevelTool for WorkflowTool {
          `model_chain`+`clear_model_chain`), \
          `delete` (requires `definition_id`; cascades to runs and queues \
          a `DeleteFile` on the canonical YAML), \
-         `pause`/`resume` (requires `definition_id`; cron workflows only — \
-         temporarily stop the schedule without deleting it, then restart it)."
+         `pause`/`resume` (requires `definition_id`; temporarily stop any \
+         workflow without deleting it — cron fires are skipped, webhook \
+         deliveries suppressed, manual triggers error — then restart it)."
     }
 
     fn input_schema(&self) -> &serde_json::Value {
@@ -948,7 +951,7 @@ impl TopLevelTool for WorkflowTool {
                     .set_paused(subject, definition_id, true)
                     .await
                     .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
-                let text = format!("Workflow paused (id {definition_id}). The schedule is retained; runs will not fire until resumed.");
+                let text = format!("Workflow paused (id {definition_id}). No runs will fire until resumed; cron schedules are retained.");
                 let out = WorkflowOutput {
                     command: "pause".to_string(),
                     definition: Some(definition_to_output(&definition)),
@@ -963,7 +966,7 @@ impl TopLevelTool for WorkflowTool {
                     .set_paused(subject, definition_id, false)
                     .await
                     .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
-                let next = match definition.trigger.next_run_at(chrono::Utc::now()) {
+                let next = match definition.next_run_at(chrono::Utc::now()) {
                     Some(t) => format!(" Next scheduled run: {}.", t.to_rfc3339()),
                     None => String::new(),
                 };
@@ -996,10 +999,7 @@ fn definition_to_output(d: &WorkflowDefinition) -> WorkflowDefinitionOutput {
         } => {
             cron_schedule = Some(schedule.clone());
             cron_timezone = timezone.clone();
-            next_run_at = d
-                .trigger
-                .next_run_at(chrono::Utc::now())
-                .map(|t| t.to_rfc3339());
+            next_run_at = d.next_run_at(chrono::Utc::now()).map(|t| t.to_rfc3339());
             ("cron".to_string(), None)
         }
     };
@@ -1013,7 +1013,7 @@ fn definition_to_output(d: &WorkflowDefinition) -> WorkflowDefinitionOutput {
         cron_schedule,
         cron_timezone,
         next_run_at,
-        paused: d.trigger.is_paused(),
+        paused: d.paused,
         steps: d.steps.iter().map(step_to_output).collect(),
         sandboxes: d.sandboxes.iter().map(sandbox_to_output).collect(),
     }
@@ -1207,22 +1207,17 @@ fn format_list_text(defs: &[WorkflowDefinition]) -> String {
     lines.push("-".repeat(96));
 
     for d in defs {
-        let trigger = match &d.trigger {
+        let mut trigger = match &d.trigger {
             WorkflowTrigger::Manual { .. } => "manual".to_string(),
             WorkflowTrigger::Webhook { provider, .. } => match provider {
                 Some(p) => format!("webhook:{p}"),
                 None => "webhook".to_string(),
             },
-            WorkflowTrigger::Cron {
-                schedule, paused, ..
-            } => {
-                if *paused {
-                    format!("cron:{schedule} (paused)")
-                } else {
-                    format!("cron:{schedule}")
-                }
-            }
+            WorkflowTrigger::Cron { schedule, .. } => format!("cron:{schedule}"),
         };
+        if d.paused {
+            trigger.push_str(" (paused)");
+        }
         lines.push(format!(
             "{:<38} {:<24} {:<14} {}",
             d.id,
@@ -1246,18 +1241,13 @@ fn format_get_text(d: &WorkflowDefinition) -> String {
             };
             format!("{label}\n  webhook_secret: {secret}")
         }
-        trigger @ WorkflowTrigger::Cron {
-            schedule,
-            timezone,
-            paused,
-            ..
+        WorkflowTrigger::Cron {
+            schedule, timezone, ..
         } => {
             let mut s = format!("cron\n  schedule:    {schedule}");
             let tz_label = timezone.as_deref().unwrap_or("UTC");
             s.push_str(&format!("\n  timezone:    {tz_label}"));
-            if *paused {
-                s.push_str("\n  status:      paused");
-            } else if let Some(next) = trigger.next_run_at(chrono::Utc::now()) {
+            if let Some(next) = d.next_run_at(chrono::Utc::now()) {
                 s.push_str(&format!("\n  next_run_at: {}", next.to_rfc3339()));
             }
             s
@@ -1270,6 +1260,9 @@ fn format_get_text(d: &WorkflowDefinition) -> String {
         out.push_str(&format!("description: {desc}\n"));
     }
     out.push_str(&format!("trigger:     {trigger}\n"));
+    if d.paused {
+        out.push_str("status:      paused\n");
+    }
     if !d.sandboxes.is_empty() {
         out.push_str(&format!("sandboxes:   {}\n", d.sandboxes.len()));
         for sb in &d.sandboxes {

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -945,7 +945,7 @@ impl TopLevelTool for WorkflowTool {
             WorkflowParams::Pause { definition_id } => {
                 let definition = self
                     .workflows
-                    .pause(subject, definition_id)
+                    .set_paused(subject, definition_id, true)
                     .await
                     .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
                 let text = format!("Workflow paused (id {definition_id}). The schedule is retained; runs will not fire until resumed.");
@@ -960,7 +960,7 @@ impl TopLevelTool for WorkflowTool {
             WorkflowParams::Resume { definition_id } => {
                 let definition = self
                     .workflows
-                    .resume(subject, definition_id)
+                    .set_paused(subject, definition_id, false)
                     .await
                     .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
                 let next = match definition.trigger.next_run_at(chrono::Utc::now()) {

--- a/core/src/workflow/cron_job.rs
+++ b/core/src/workflow/cron_job.rs
@@ -6,8 +6,10 @@
 //!   2. If the definition was deleted or its trigger is no longer
 //!      `Cron`, exits without rescheduling.
 //!   3. Otherwise spawns a run via [`Workflows::trigger_run_for_definition`]
-//!      with a `triggered_by: cron` context, then schedules the next
-//!      job at the cron expression's next fire time.
+//!      with a `triggered_by: cron` context (unless the trigger is
+//!      `paused`, in which case the run is skipped), then schedules the
+//!      next job at the cron expression's next fire time. A paused
+//!      schedule keeps ticking so resume needs no re-registration.
 //!
 //! Concurrency: every cron-fired run shares the existing
 //! `workflow:{definition_id}` queue used by `ExecuteRunConfig`, and the
@@ -108,10 +110,13 @@ impl JobRunner for TriggerCronRunner {
             }
         };
 
-        let (schedule, timezone) = match &definition.trigger {
+        let (schedule, timezone, paused) = match &definition.trigger {
             WorkflowTrigger::Cron {
-                schedule, timezone, ..
-            } => (schedule.clone(), timezone.clone()),
+                schedule,
+                timezone,
+                paused,
+                ..
+            } => (schedule.clone(), timezone.clone(), *paused),
             _ => {
                 tracing::info!("trigger no longer cron; schedule terminating");
                 return Ok(JobCompletion::Complete);
@@ -121,31 +126,36 @@ impl JobRunner for TriggerCronRunner {
         let definition_id = definition.id;
         let fired_at = chrono::Utc::now();
         let next_fire = definition.trigger.next_fire_at(fired_at);
-        let trigger_context = serde_json::json!({
-            "triggered_by": "cron",
-            "fired_at": fired_at.to_rfc3339(),
-            "schedule": schedule,
-            "timezone": timezone,
-        });
 
-        match super::Workflows::spawn_run_static(
-            &self.runs,
-            &self.execute_run_spawner,
-            definition,
-            trigger_context,
-        )
-        .await
-        {
-            Ok(Some(run)) => {
-                tracing::info!(run_id = %run.id, "cron-triggered workflow run spawned");
-            }
-            Ok(None) => {
-                tracing::info!(
-                    "cron-triggered run suppressed by trigger condition; schedule continues"
-                );
-            }
-            Err(e) => {
-                tracing::warn!(error = %e, "cron-triggered run spawn failed; continuing schedule");
+        if paused {
+            tracing::info!("cron schedule paused; skipping run, rescheduling next fire");
+        } else {
+            let trigger_context = serde_json::json!({
+                "triggered_by": "cron",
+                "fired_at": fired_at.to_rfc3339(),
+                "schedule": schedule,
+                "timezone": timezone,
+            });
+
+            match super::Workflows::spawn_run_static(
+                &self.runs,
+                &self.execute_run_spawner,
+                definition,
+                trigger_context,
+            )
+            .await
+            {
+                Ok(Some(run)) => {
+                    tracing::info!(run_id = %run.id, "cron-triggered workflow run spawned");
+                }
+                Ok(None) => {
+                    tracing::info!(
+                        "cron-triggered run suppressed by trigger condition; schedule continues"
+                    );
+                }
+                Err(e) => {
+                    tracing::warn!(error = %e, "cron-triggered run spawn failed; continuing schedule");
+                }
             }
         }
 

--- a/core/src/workflow/cron_job.rs
+++ b/core/src/workflow/cron_job.rs
@@ -5,10 +5,10 @@
 //!   1. Loads the definition (no auth — system path).
 //!   2. If the definition was deleted or its trigger is no longer
 //!      `Cron`, exits without rescheduling.
-//!   3. Otherwise spawns a run via [`Workflows::trigger_run_for_definition`]
-//!      with a `triggered_by: cron` context (unless the definition is
-//!      `paused`, in which case the run is skipped), then schedules the
-//!      next job at the cron expression's next fire time. A paused
+//!   3. Otherwise attempts a run via the central spawn gate with a
+//!      `triggered_by: cron` context (a paused definition reports
+//!      `TriggerOutcome::Paused` and no run is created), then schedules
+//!      the next job at the cron expression's next fire time. A paused
 //!      schedule keeps ticking so resume needs no re-registration.
 //!
 //! Concurrency: every cron-fired run shares the existing
@@ -24,6 +24,7 @@ use crate::primitives::WorkflowDefinitionId;
 use super::definition::WorkflowTrigger;
 use super::repo::WorkflowDefinitionRepo;
 use super::run::WorkflowRunRepo;
+use super::TriggerOutcome;
 
 pub(crate) const TRIGGER_CRON_JOB: &str = "workflow.trigger-cron";
 
@@ -123,36 +124,34 @@ impl JobRunner for TriggerCronRunner {
         let definition_id = definition.id;
         let fired_at = chrono::Utc::now();
         let next_fire = definition.trigger.next_fire_at(fired_at);
+        let trigger_context = serde_json::json!({
+            "triggered_by": "cron",
+            "fired_at": fired_at.to_rfc3339(),
+            "schedule": schedule,
+            "timezone": timezone,
+        });
 
-        if definition.paused {
-            tracing::info!("cron schedule paused; skipping run, rescheduling next fire");
-        } else {
-            let trigger_context = serde_json::json!({
-                "triggered_by": "cron",
-                "fired_at": fired_at.to_rfc3339(),
-                "schedule": schedule,
-                "timezone": timezone,
-            });
-
-            match super::Workflows::spawn_run_static(
-                &self.runs,
-                &self.execute_run_spawner,
-                definition,
-                trigger_context,
-            )
-            .await
-            {
-                Ok(Some(run)) => {
-                    tracing::info!(run_id = %run.id, "cron-triggered workflow run spawned");
-                }
-                Ok(None) => {
-                    tracing::info!(
-                        "cron-triggered run suppressed by trigger condition; schedule continues"
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!(error = %e, "cron-triggered run spawn failed; continuing schedule");
-                }
+        match super::Workflows::spawn_run_static(
+            &self.runs,
+            &self.execute_run_spawner,
+            definition,
+            trigger_context,
+        )
+        .await
+        {
+            Ok(TriggerOutcome::Spawned(run)) => {
+                tracing::info!(run_id = %run.id, "cron-triggered workflow run spawned");
+            }
+            Ok(TriggerOutcome::Filtered) => {
+                tracing::info!(
+                    "cron-triggered run suppressed by trigger condition; schedule continues"
+                );
+            }
+            Ok(TriggerOutcome::Paused) => {
+                tracing::info!("definition paused; skipping fire, schedule continues");
+            }
+            Err(e) => {
+                tracing::warn!(error = %e, "cron-triggered run spawn failed; continuing schedule");
             }
         }
 

--- a/core/src/workflow/cron_job.rs
+++ b/core/src/workflow/cron_job.rs
@@ -6,7 +6,7 @@
 //!   2. If the definition was deleted or its trigger is no longer
 //!      `Cron`, exits without rescheduling.
 //!   3. Otherwise spawns a run via [`Workflows::trigger_run_for_definition`]
-//!      with a `triggered_by: cron` context (unless the trigger is
+//!      with a `triggered_by: cron` context (unless the definition is
 //!      `paused`, in which case the run is skipped), then schedules the
 //!      next job at the cron expression's next fire time. A paused
 //!      schedule keeps ticking so resume needs no re-registration.
@@ -110,13 +110,10 @@ impl JobRunner for TriggerCronRunner {
             }
         };
 
-        let (schedule, timezone, paused) = match &definition.trigger {
+        let (schedule, timezone) = match &definition.trigger {
             WorkflowTrigger::Cron {
-                schedule,
-                timezone,
-                paused,
-                ..
-            } => (schedule.clone(), timezone.clone(), *paused),
+                schedule, timezone, ..
+            } => (schedule.clone(), timezone.clone()),
             _ => {
                 tracing::info!("trigger no longer cron; schedule terminating");
                 return Ok(JobCompletion::Complete);
@@ -127,7 +124,7 @@ impl JobRunner for TriggerCronRunner {
         let fired_at = chrono::Utc::now();
         let next_fire = definition.trigger.next_fire_at(fired_at);
 
-        if paused {
+        if definition.paused {
             tracing::info!("cron schedule paused; skipping run, rescheduling next fire");
         } else {
             let trigger_context = serde_json::json!({

--- a/core/src/workflow/definition.rs
+++ b/core/src/workflow/definition.rs
@@ -175,6 +175,16 @@ impl WorkflowTrigger {
             _ => Ok(None),
         }
     }
+
+    /// Next fire to surface to a user — `None` while paused or when the
+    /// schedule has no future fire. The scheduler uses raw
+    /// [`Self::next_fire_at`], which keeps advancing even while paused.
+    pub fn next_run_at(&self, after: DateTime<Utc>) -> Option<DateTime<Utc>> {
+        if self.is_paused() {
+            return None;
+        }
+        self.next_fire_at(after).ok().flatten()
+    }
 }
 
 /// IANA name parses through `chrono_tz`; `None` → `UTC`. Surfaces a
@@ -701,6 +711,30 @@ mod tests {
         assert!(s.contains("paused: true"));
         let back: WorkflowTrigger = serde_yaml::from_str(&s).unwrap();
         assert!(back.is_paused());
+    }
+
+    #[test]
+    fn next_run_at_is_none_while_paused_but_raw_next_fire_advances() {
+        let now = chrono::Utc::now();
+        let active = WorkflowTrigger::Cron {
+            schedule: "0 0 */6 * * *".to_string(),
+            timezone: None,
+            condition: None,
+            paused: false,
+        };
+        assert!(active.next_run_at(now).is_some());
+
+        let paused = WorkflowTrigger::Cron {
+            schedule: "0 0 */6 * * *".to_string(),
+            timezone: None,
+            condition: None,
+            paused: true,
+        };
+        assert!(paused.next_run_at(now).is_none(), "paused hides next run");
+        assert!(
+            paused.next_fire_at(now).unwrap().is_some(),
+            "raw next_fire_at keeps advancing so the scheduler can reschedule"
+        );
     }
 
     /// Legacy cron triggers serialized before the `paused` field hydrate

--- a/core/src/workflow/definition.rs
+++ b/core/src/workflow/definition.rs
@@ -126,6 +126,11 @@ pub enum WorkflowTrigger {
         /// today for uniformity.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         condition: Option<String>,
+        /// Temporary stop. The self-rescheduling cron job keeps
+        /// ticking but skips firing runs while this is `true`, so the
+        /// schedule survives and resume needs no re-registration.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        paused: bool,
     },
 }
 
@@ -147,6 +152,10 @@ impl WorkflowTrigger {
             Self::Webhook { .. } => "webhook",
             Self::Cron { .. } => "cron",
         }
+    }
+
+    pub fn is_paused(&self) -> bool {
+        matches!(self, Self::Cron { paused: true, .. })
     }
 
     /// `None` when this is not a cron trigger, or when the cron
@@ -608,6 +617,7 @@ mod tests {
             schedule: "0 0 */6 * * *".to_string(),
             timezone: None,
             condition: None,
+            paused: false,
         };
         let next = trigger
             .next_fire_at(now)
@@ -622,6 +632,7 @@ mod tests {
             schedule: "0 0 */6 * * *".to_string(),
             timezone: Some("Not/AZone".to_string()),
             condition: None,
+            paused: false,
         };
         let err = trigger.next_fire_at(chrono::Utc::now()).unwrap_err();
         assert!(err.contains("invalid timezone"));
@@ -633,6 +644,7 @@ mod tests {
             schedule: "0 */6 * * * *".to_string(),
             timezone: Some("UTC".to_string()),
             condition: None,
+            paused: false,
         };
         let s = serde_yaml::to_string(&trigger).unwrap();
         assert!(s.contains("type: cron"));
@@ -645,6 +657,7 @@ mod tests {
                 schedule,
                 timezone,
                 condition,
+                ..
             } => {
                 assert_eq!(schedule, "0 */6 * * * *");
                 assert_eq!(timezone.as_deref(), Some("UTC"));
@@ -660,9 +673,43 @@ mod tests {
             schedule: "0 */6 * * * *".to_string(),
             timezone: None,
             condition: None,
+            paused: false,
         };
         let s = serde_yaml::to_string(&trigger).unwrap();
         assert!(!s.contains("timezone"));
+    }
+
+    #[test]
+    fn cron_trigger_paused_round_trips_and_omits_when_false() {
+        let active = WorkflowTrigger::Cron {
+            schedule: "0 */6 * * * *".to_string(),
+            timezone: None,
+            condition: None,
+            paused: false,
+        };
+        let s = serde_yaml::to_string(&active).unwrap();
+        assert!(!s.contains("paused"), "paused omitted when false");
+        assert!(!active.is_paused());
+
+        let paused = WorkflowTrigger::Cron {
+            schedule: "0 */6 * * * *".to_string(),
+            timezone: None,
+            condition: None,
+            paused: true,
+        };
+        let s = serde_yaml::to_string(&paused).unwrap();
+        assert!(s.contains("paused: true"));
+        let back: WorkflowTrigger = serde_yaml::from_str(&s).unwrap();
+        assert!(back.is_paused());
+    }
+
+    /// Legacy cron triggers serialized before the `paused` field hydrate
+    /// to `false` (replay-safety on `WorkflowDefinitionEvent`).
+    #[test]
+    fn legacy_cron_trigger_without_paused_hydrates_unpaused() {
+        let yaml = "type: cron\nschedule: '0 0 * * * *'\n";
+        let trigger: WorkflowTrigger = serde_yaml::from_str(yaml).unwrap();
+        assert!(!trigger.is_paused());
     }
 
     #[test]

--- a/core/src/workflow/definition.rs
+++ b/core/src/workflow/definition.rs
@@ -126,11 +126,6 @@ pub enum WorkflowTrigger {
         /// today for uniformity.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         condition: Option<String>,
-        /// Temporary stop. The self-rescheduling cron job keeps
-        /// ticking but skips firing runs while this is `true`, so the
-        /// schedule survives and resume needs no re-registration.
-        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-        paused: bool,
     },
 }
 
@@ -154,10 +149,6 @@ impl WorkflowTrigger {
         }
     }
 
-    pub fn is_paused(&self) -> bool {
-        matches!(self, Self::Cron { paused: true, .. })
-    }
-
     /// `None` when this is not a cron trigger, or when the cron
     /// schedule has no future fire after the supplied instant.
     pub fn next_fire_at(&self, after: DateTime<Utc>) -> Result<Option<DateTime<Utc>>, String> {
@@ -174,16 +165,6 @@ impl WorkflowTrigger {
             }
             _ => Ok(None),
         }
-    }
-
-    /// Next fire to surface to a user — `None` while paused or when the
-    /// schedule has no future fire. The scheduler uses raw
-    /// [`Self::next_fire_at`], which keeps advancing even while paused.
-    pub fn next_run_at(&self, after: DateTime<Utc>) -> Option<DateTime<Utc>> {
-        if self.is_paused() {
-            return None;
-        }
-        self.next_fire_at(after).ok().flatten()
     }
 }
 
@@ -627,7 +608,6 @@ mod tests {
             schedule: "0 0 */6 * * *".to_string(),
             timezone: None,
             condition: None,
-            paused: false,
         };
         let next = trigger
             .next_fire_at(now)
@@ -642,7 +622,6 @@ mod tests {
             schedule: "0 0 */6 * * *".to_string(),
             timezone: Some("Not/AZone".to_string()),
             condition: None,
-            paused: false,
         };
         let err = trigger.next_fire_at(chrono::Utc::now()).unwrap_err();
         assert!(err.contains("invalid timezone"));
@@ -654,7 +633,6 @@ mod tests {
             schedule: "0 */6 * * * *".to_string(),
             timezone: Some("UTC".to_string()),
             condition: None,
-            paused: false,
         };
         let s = serde_yaml::to_string(&trigger).unwrap();
         assert!(s.contains("type: cron"));
@@ -667,7 +645,6 @@ mod tests {
                 schedule,
                 timezone,
                 condition,
-                ..
             } => {
                 assert_eq!(schedule, "0 */6 * * * *");
                 assert_eq!(timezone.as_deref(), Some("UTC"));
@@ -683,67 +660,9 @@ mod tests {
             schedule: "0 */6 * * * *".to_string(),
             timezone: None,
             condition: None,
-            paused: false,
         };
         let s = serde_yaml::to_string(&trigger).unwrap();
         assert!(!s.contains("timezone"));
-    }
-
-    #[test]
-    fn cron_trigger_paused_round_trips_and_omits_when_false() {
-        let active = WorkflowTrigger::Cron {
-            schedule: "0 */6 * * * *".to_string(),
-            timezone: None,
-            condition: None,
-            paused: false,
-        };
-        let s = serde_yaml::to_string(&active).unwrap();
-        assert!(!s.contains("paused"), "paused omitted when false");
-        assert!(!active.is_paused());
-
-        let paused = WorkflowTrigger::Cron {
-            schedule: "0 */6 * * * *".to_string(),
-            timezone: None,
-            condition: None,
-            paused: true,
-        };
-        let s = serde_yaml::to_string(&paused).unwrap();
-        assert!(s.contains("paused: true"));
-        let back: WorkflowTrigger = serde_yaml::from_str(&s).unwrap();
-        assert!(back.is_paused());
-    }
-
-    #[test]
-    fn next_run_at_is_none_while_paused_but_raw_next_fire_advances() {
-        let now = chrono::Utc::now();
-        let active = WorkflowTrigger::Cron {
-            schedule: "0 0 */6 * * *".to_string(),
-            timezone: None,
-            condition: None,
-            paused: false,
-        };
-        assert!(active.next_run_at(now).is_some());
-
-        let paused = WorkflowTrigger::Cron {
-            schedule: "0 0 */6 * * *".to_string(),
-            timezone: None,
-            condition: None,
-            paused: true,
-        };
-        assert!(paused.next_run_at(now).is_none(), "paused hides next run");
-        assert!(
-            paused.next_fire_at(now).unwrap().is_some(),
-            "raw next_fire_at keeps advancing so the scheduler can reschedule"
-        );
-    }
-
-    /// Legacy cron triggers serialized before the `paused` field hydrate
-    /// to `false` (replay-safety on `WorkflowDefinitionEvent`).
-    #[test]
-    fn legacy_cron_trigger_without_paused_hydrates_unpaused() {
-        let yaml = "type: cron\nschedule: '0 0 * * * *'\n";
-        let trigger: WorkflowTrigger = serde_yaml::from_str(yaml).unwrap();
-        assert!(!trigger.is_paused());
     }
 
     #[test]

--- a/core/src/workflow/entity.rs
+++ b/core/src/workflow/entity.rs
@@ -31,6 +31,8 @@ pub enum WorkflowDefinitionEvent {
         /// the role/config default when unset.
         #[serde(default)]
         model_chain: Option<ModelChain>,
+        #[serde(default)]
+        paused: bool,
         /// On-disk path before sync canonicalisation; the
         /// `WriteToRuntime` job uses it to remove the old file.
         #[serde(default)]
@@ -47,6 +49,8 @@ pub enum WorkflowDefinitionEvent {
         /// `None` leaves the field untouched.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         model_chain: Option<Option<ModelChain>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        paused: Option<bool>,
     },
 }
 
@@ -67,6 +71,11 @@ pub struct WorkflowDefinition {
     /// Per-step `model_chain` wins; both fall through to role/config.
     #[builder(default)]
     pub model_chain: Option<ModelChain>,
+    /// While `true` no runs fire: cron fires are skipped (the schedule
+    /// keeps ticking), webhook deliveries are suppressed, and manual
+    /// triggers error. Resume is a data flip — no job re-registration.
+    #[builder(default)]
+    pub paused: bool,
     #[builder(default)]
     pub(crate) original_path: Option<String>,
     events: EntityEvents<WorkflowDefinitionEvent>,
@@ -106,12 +115,44 @@ impl WorkflowDefinition {
             &self.name,
             self.description.as_deref(),
             &self.trigger,
+            self.paused,
             &self.steps,
             &self.sandboxes,
             self.model_chain.as_ref(),
             &self.created_at().to_rfc3339(),
             &self.updated_at().to_rfc3339(),
         )
+    }
+
+    /// Next fire to surface to a user — `None` while paused, for
+    /// non-cron triggers, or when the schedule has no future fire. The
+    /// scheduler uses raw [`WorkflowTrigger::next_fire_at`], which
+    /// keeps advancing even while paused.
+    pub fn next_run_at(
+        &self,
+        after: chrono::DateTime<chrono::Utc>,
+    ) -> Option<chrono::DateTime<chrono::Utc>> {
+        if self.paused {
+            return None;
+        }
+        self.trigger.next_fire_at(after).ok().flatten()
+    }
+
+    pub fn set_paused(&mut self, paused: bool) -> Idempotent<()> {
+        if self.paused == paused {
+            return Idempotent::AlreadyApplied;
+        }
+        self.paused = paused;
+        self.events.push(WorkflowDefinitionEvent::Updated {
+            name: None,
+            description: None,
+            trigger: None,
+            steps: None,
+            sandboxes: None,
+            model_chain: None,
+            paused: Some(paused),
+        });
+        Idempotent::Executed(())
     }
 
     /// Computed (not stored) so it matches what `WriteToRuntime` writes;
@@ -132,6 +173,7 @@ impl WorkflowDefinition {
         steps: Option<Vec<WorkflowStepDef>>,
         sandboxes: Option<Vec<WorkflowSandboxDecl>>,
         model_chain: Option<Option<ModelChain>>,
+        paused: Option<bool>,
         incoming_file_hash: GitFileHash,
     ) -> Idempotent<()> {
         if self.file_hash() == incoming_file_hash {
@@ -173,6 +215,9 @@ impl WorkflowDefinition {
         if let Some(mc) = &model_chain {
             self.model_chain = mc.clone();
         }
+        if let Some(p) = paused {
+            self.paused = p;
+        }
 
         self.events.push(WorkflowDefinitionEvent::Updated {
             name,
@@ -181,6 +226,7 @@ impl WorkflowDefinition {
             steps,
             sandboxes,
             model_chain,
+            paused,
         });
         Idempotent::Executed(())
     }
@@ -250,6 +296,7 @@ impl WorkflowDefinition {
             steps,
             sandboxes,
             model_chain,
+            paused: None,
         });
         Idempotent::Executed(())
     }
@@ -341,6 +388,7 @@ impl TryFromEvents<WorkflowDefinitionEvent> for WorkflowDefinition {
                     steps,
                     sandboxes,
                     model_chain,
+                    paused,
                     original_path,
                     ..
                 } => {
@@ -354,6 +402,7 @@ impl TryFromEvents<WorkflowDefinitionEvent> for WorkflowDefinition {
                         .steps(steps.clone())
                         .sandboxes(sandboxes.clone())
                         .model_chain(model_chain.clone())
+                        .paused(*paused)
                         .original_path(original_path.clone());
                 }
                 WorkflowDefinitionEvent::Updated {
@@ -363,6 +412,7 @@ impl TryFromEvents<WorkflowDefinitionEvent> for WorkflowDefinition {
                     steps,
                     sandboxes,
                     model_chain,
+                    paused,
                     ..
                 } => {
                     if let Some(n) = name {
@@ -382,6 +432,9 @@ impl TryFromEvents<WorkflowDefinitionEvent> for WorkflowDefinition {
                     }
                     if let Some(mc) = model_chain {
                         builder = builder.model_chain(mc.clone());
+                    }
+                    if let Some(p) = paused {
+                        builder = builder.paused(*p);
                     }
                 }
             }
@@ -410,6 +463,8 @@ pub struct NewWorkflowDefinition {
     pub(super) sandboxes: Vec<WorkflowSandboxDecl>,
     #[builder(default)]
     pub(super) model_chain: Option<ModelChain>,
+    #[builder(default)]
+    pub(super) paused: bool,
     #[builder(default, setter(into, strip_option))]
     pub(super) original_path: Option<String>,
 }
@@ -443,6 +498,7 @@ impl IntoEvents<WorkflowDefinitionEvent> for NewWorkflowDefinition {
                 steps: self.steps,
                 sandboxes: self.sandboxes,
                 model_chain: self.model_chain,
+                paused: self.paused,
                 original_path: self.original_path,
             }],
         )
@@ -542,7 +598,6 @@ mod tests {
                 schedule: "0 */6 * * * *".to_string(),
                 timezone: Some("UTC".to_string()),
                 condition: None,
-                paused: false,
             })
             .steps(vec![sample_step()])
             .build()
@@ -592,6 +647,45 @@ mod tests {
             Some("trigger.payload.env == 'staging'"),
             "hydrated trigger should carry the condition from the Updated event"
         );
+    }
+
+    #[test]
+    fn set_paused_round_trips_through_hydration() {
+        let mut def = build();
+        assert!(!def.paused);
+        assert!(matches!(def.set_paused(true), Idempotent::Executed(())));
+        assert!(matches!(def.set_paused(true), Idempotent::AlreadyApplied));
+        assert!(def.paused);
+
+        let hydrated = WorkflowDefinition::try_from_events(def.events.clone()).unwrap();
+        assert!(hydrated.paused);
+
+        let mut def = hydrated;
+        assert!(matches!(def.set_paused(false), Idempotent::Executed(())));
+        let hydrated = WorkflowDefinition::try_from_events(def.events.clone()).unwrap();
+        assert!(!hydrated.paused);
+    }
+
+    /// Events serialized before the `paused` field hydrate to `false`
+    /// (replay-safety on the JSONB event log).
+    #[test]
+    fn legacy_events_without_paused_hydrate_unpaused() {
+        let def = build();
+        let mut raw: Vec<serde_json::Value> = def
+            .events
+            .iter_all()
+            .map(|e| serde_json::to_value(e).unwrap())
+            .collect();
+        for v in &mut raw {
+            v.as_object_mut().unwrap().remove("paused");
+        }
+        let events: Vec<WorkflowDefinitionEvent> = raw
+            .into_iter()
+            .map(|v| serde_json::from_value(v).unwrap())
+            .collect();
+        let hydrated =
+            WorkflowDefinition::try_from_events(EntityEvents::init(def.id, events)).unwrap();
+        assert!(!hydrated.paused);
     }
 
     /// Serialize a definition's events to JSON and back, then hydrate.

--- a/core/src/workflow/entity.rs
+++ b/core/src/workflow/entity.rs
@@ -72,8 +72,9 @@ pub struct WorkflowDefinition {
     #[builder(default)]
     pub model_chain: Option<ModelChain>,
     /// While `true` no runs fire: cron fires are skipped (the schedule
-    /// keeps ticking), webhook deliveries are suppressed, and manual
-    /// triggers error. Resume is a data flip — no job re-registration.
+    /// keeps ticking), and webhook deliveries and manual triggers are
+    /// suppressed with a paused disposition (no run). Resume is a data
+    /// flip — no job re-registration.
     #[builder(default)]
     pub paused: bool,
     #[builder(default)]
@@ -664,6 +665,31 @@ mod tests {
         assert!(matches!(def.set_paused(false), Idempotent::Executed(())));
         let hydrated = WorkflowDefinition::try_from_events(def.events.clone()).unwrap();
         assert!(!hydrated.paused);
+    }
+
+    #[test]
+    fn next_run_at_is_suppressed_while_paused() {
+        let new = NewWorkflowDefinition::builder()
+            .project_id(ProjectId::new())
+            .name("cron-flow")
+            .trigger(WorkflowTrigger::Cron {
+                schedule: "0 0 */6 * * *".to_string(),
+                timezone: None,
+                condition: None,
+            })
+            .steps(vec![sample_step()])
+            .build()
+            .unwrap();
+        let mut def = WorkflowDefinition::try_from_events(new.into_events()).unwrap();
+
+        let now = chrono::Utc::now();
+        assert!(def.next_run_at(now).is_some());
+
+        let _ = def.set_paused(true);
+        assert!(def.next_run_at(now).is_none());
+
+        let _ = def.set_paused(false);
+        assert!(def.next_run_at(now).is_some());
     }
 
     /// Events serialized before the `paused` field hydrate to `false`

--- a/core/src/workflow/entity.rs
+++ b/core/src/workflow/entity.rs
@@ -542,6 +542,7 @@ mod tests {
                 schedule: "0 */6 * * * *".to_string(),
                 timezone: Some("UTC".to_string()),
                 condition: None,
+                paused: false,
             })
             .steps(vec![sample_step()])
             .build()

--- a/core/src/workflow/error.rs
+++ b/core/src/workflow/error.rs
@@ -55,8 +55,8 @@ pub enum WorkflowError {
         "WorkflowError - TriggerConditionErrored: trigger condition `{body}` failed: {reason}"
     )]
     TriggerConditionErrored { body: String, reason: String },
-    #[error("WorkflowError - WorkflowPaused: workflow '{0}' is paused; resume it to trigger runs")]
-    WorkflowPaused(String),
+    #[error("WorkflowError - Paused: workflow '{0}' is paused; resume it to trigger runs")]
+    Paused(String),
     #[error("WorkflowError - ToolNotFound: {0}")]
     ToolNotFound(String),
     #[error("WorkflowError - ToolDispatch: {0}")]

--- a/core/src/workflow/error.rs
+++ b/core/src/workflow/error.rs
@@ -55,6 +55,8 @@ pub enum WorkflowError {
         "WorkflowError - TriggerConditionErrored: trigger condition `{body}` failed: {reason}"
     )]
     TriggerConditionErrored { body: String, reason: String },
+    #[error("WorkflowError - WorkflowPaused: workflow '{0}' is paused; resume it to trigger runs")]
+    WorkflowPaused(String),
     #[error("WorkflowError - ToolNotFound: {0}")]
     ToolNotFound(String),
     #[error("WorkflowError - ToolDispatch: {0}")]

--- a/core/src/workflow/error.rs
+++ b/core/src/workflow/error.rs
@@ -55,8 +55,6 @@ pub enum WorkflowError {
         "WorkflowError - TriggerConditionErrored: trigger condition `{body}` failed: {reason}"
     )]
     TriggerConditionErrored { body: String, reason: String },
-    #[error("WorkflowError - Paused: workflow '{0}' is paused; resume it to trigger runs")]
-    Paused(String),
     #[error("WorkflowError - ToolNotFound: {0}")]
     ToolNotFound(String),
     #[error("WorkflowError - ToolDispatch: {0}")]

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -41,8 +41,20 @@ pub use run::{StepResult, WorkflowRun, WorkflowRunRepo, WorkflowRunState, Workfl
 pub struct ProviderFanOutResult {
     pub triggered: usize,
     pub filtered: usize,
+    pub paused: usize,
     pub errored: usize,
     pub resumed: usize,
+}
+
+/// Disposition of a single trigger attempt. The non-`Spawned` variants
+/// are deliberate suppressions (each writes an audit row), not errors —
+/// callers decide per surface how loudly to report them.
+pub enum TriggerOutcome {
+    Spawned(Box<WorkflowRun>),
+    /// The trigger's `condition:` evaluated to false.
+    Filtered,
+    /// The definition is paused.
+    Paused,
 }
 
 use cron_job::{cron_queue_id, TriggerCronConfig, TriggerCronJobInitializer};
@@ -58,8 +70,7 @@ const AUDIT_ACTION_TRIGGER_FILTERED: &str = "workflow.trigger_filtered";
 /// runtime (compile, runtime, non-boolean result).
 const AUDIT_ACTION_TRIGGER_CONDITION_ERRORED: &str = "workflow.trigger_condition_errored";
 /// Audit action recorded when a run is suppressed because the
-/// workflow is paused (webhook paths; manual triggers error instead
-/// and the cron job skips before reaching the spawn).
+/// workflow is paused.
 const AUDIT_ACTION_TRIGGER_PAUSED: &str = "workflow.trigger_paused";
 
 /// Evaluate each output's CEL expression against the resume context.
@@ -781,8 +792,10 @@ impl Workflows {
     /// runs fire: cron fires are skipped (the in-flight cron job keeps
     /// ticking, so resume needs no re-registration and missed fires are
     /// not backfilled), webhook deliveries are suppressed with an audit
-    /// row, and manual triggers error. Returns the definition unchanged
-    /// (no event, no commit) when already in the target state.
+    /// row, and manual triggers error. Pause gates run *creation* only —
+    /// in-flight runs, including runs parked on a `Wait` step, continue.
+    /// Returns the definition unchanged (no event, no commit) when
+    /// already in the target state.
     #[instrument(name = "core.workflow.set_paused", skip_all)]
     pub async fn set_paused(
         &self,
@@ -928,9 +941,9 @@ impl Workflows {
     /// Spawns the executor as a job and returns the run synchronously.
     /// `Ok(None)` means the trigger's `condition:` evaluated to false
     /// and the run was deliberately suppressed (an audit row was
-    /// written). Errors with [`WorkflowError::WorkflowPaused`] on a
-    /// paused workflow — this is the explicit-trigger path, so the
-    /// caller deserves a loud answer rather than a silent skip.
+    /// written). A paused workflow errors with [`WorkflowError::Paused`]
+    /// — this is the explicit-trigger path, so the caller deserves a
+    /// loud answer rather than a silent skip.
     #[instrument(name = "core.workflow.trigger_run", skip_all)]
     pub async fn trigger_run(
         &self,
@@ -943,22 +956,22 @@ impl Workflows {
             AuthVerb::Use,
             AuthResource::Workflow(definition.project_id, Some(definition.id)),
         )?;
-        if definition.paused {
-            return Err(WorkflowError::WorkflowPaused(definition.name));
+        let name = definition.name.clone();
+        match self.spawn_run(definition, trigger_context).await? {
+            TriggerOutcome::Spawned(run) => Ok(Some(*run)),
+            TriggerOutcome::Filtered => Ok(None),
+            TriggerOutcome::Paused => Err(WorkflowError::Paused(name)),
         }
-        self.spawn_run(definition, trigger_context).await
     }
 
     /// No auth check — pairs with [`Self::find_by_id_unchecked`] so
     /// the webhook handler doesn't double-load the definition.
-    /// `Ok(None)` carries the same "filtered by trigger condition"
-    /// meaning as [`Self::trigger_run`].
     #[instrument(name = "core.workflow.trigger_run_for_definition", skip_all)]
     pub async fn trigger_run_for_definition(
         &self,
         definition: WorkflowDefinition,
         trigger_context: serde_json::Value,
-    ) -> Result<Option<WorkflowRun>, WorkflowError> {
+    ) -> Result<TriggerOutcome, WorkflowError> {
         self.spawn_run(definition, trigger_context).await
     }
 
@@ -970,6 +983,7 @@ impl Workflows {
     ) -> Result<ProviderFanOutResult, WorkflowError> {
         let mut triggered = 0usize;
         let mut filtered = 0usize;
+        let mut paused = 0usize;
         let mut errored = 0usize;
 
         let mut query = es_entity::PaginatedQueryArgs {
@@ -992,13 +1006,17 @@ impl Workflows {
                     .trigger_run_for_definition(defn, trigger_context.clone())
                     .await
                 {
-                    Ok(Some(run)) => {
+                    Ok(TriggerOutcome::Spawned(run)) => {
                         tracing::info!(%def_id, run_id = %run.id, "provider fan-out: run triggered");
                         triggered += 1;
                     }
-                    Ok(None) => {
+                    Ok(TriggerOutcome::Filtered) => {
                         tracing::debug!(%def_id, "provider fan-out: filtered by condition");
                         filtered += 1;
+                    }
+                    Ok(TriggerOutcome::Paused) => {
+                        tracing::debug!(%def_id, "provider fan-out: workflow paused");
+                        paused += 1;
                     }
                     Err(e) => {
                         tracing::warn!(%def_id, error = %e, "provider fan-out: trigger errored");
@@ -1016,6 +1034,7 @@ impl Workflows {
         Ok(ProviderFanOutResult {
             triggered,
             filtered,
+            paused,
             errored,
             resumed: 0,
         })
@@ -1150,7 +1169,7 @@ impl Workflows {
         &self,
         definition: WorkflowDefinition,
         trigger_context: serde_json::Value,
-    ) -> Result<Option<WorkflowRun>, WorkflowError> {
+    ) -> Result<TriggerOutcome, WorkflowError> {
         Self::spawn_run_static(
             &self.run_repo,
             &self.execute_run_spawner,
@@ -1160,15 +1179,17 @@ impl Workflows {
         .await
     }
 
+    /// The single gate every run-creation path goes through — pause and
+    /// trigger-condition suppression are enforced here, never in callers.
     pub(crate) async fn spawn_run_static(
         run_repo: &WorkflowRunRepo,
         execute_run_spawner: &::job::JobSpawner<ExecuteRunConfig>,
         definition: WorkflowDefinition,
         trigger_context: serde_json::Value,
-    ) -> Result<Option<WorkflowRun>, WorkflowError> {
+    ) -> Result<TriggerOutcome, WorkflowError> {
         if definition.paused {
             record_trigger_paused_audit(&definition, &trigger_context);
-            return Ok(None);
+            return Ok(TriggerOutcome::Paused);
         }
 
         if let Some(body) = definition.trigger.condition() {
@@ -1176,7 +1197,7 @@ impl Workflows {
                 Ok(template::ConditionOutcome::True) => {}
                 Ok(template::ConditionOutcome::False) => {
                     record_trigger_filtered_audit(&definition, body, &trigger_context);
-                    return Ok(None);
+                    return Ok(TriggerOutcome::Filtered);
                 }
                 Ok(template::ConditionOutcome::NotBoolean(rendered)) => {
                     let reason = format!("condition evaluated to non-boolean: {rendered}");
@@ -1223,7 +1244,7 @@ impl Workflows {
             .await
             .map_err(|e| WorkflowError::Job(e.to_string()))?;
 
-        Ok(Some(run))
+        Ok(TriggerOutcome::Spawned(Box::new(run)))
     }
 
     #[instrument(name = "core.workflow.list_runs", skip_all)]

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -751,33 +751,14 @@ impl Workflows {
         Ok(definition)
     }
 
-    /// Temporarily stop a cron workflow without deleting it. The
-    /// in-flight cron job observes the change on its next tick and
-    /// stops firing, while the schedule itself keeps ticking.
-    #[instrument(name = "core.workflow.pause", skip_all)]
-    pub async fn pause(
-        &self,
-        sub: &AuthSubject,
-        id: WorkflowDefinitionId,
-    ) -> Result<WorkflowDefinition, WorkflowError> {
-        self.set_paused(sub, id, true).await
-    }
-
-    /// Resume a paused cron workflow. Firing restarts at the next
-    /// scheduled tick; fires missed while paused are not backfilled.
-    #[instrument(name = "core.workflow.resume", skip_all)]
-    pub async fn resume(
-        &self,
-        sub: &AuthSubject,
-        id: WorkflowDefinitionId,
-    ) -> Result<WorkflowDefinition, WorkflowError> {
-        self.set_paused(sub, id, false).await
-    }
-
-    /// Rebuilds the `Cron` trigger with `paused` flipped. Errors if the
-    /// workflow is not cron-triggered; returns the definition unchanged
-    /// (no event, no commit) when already in the target state.
-    async fn set_paused(
+    /// Pause or resume a cron workflow without deleting it. While
+    /// paused the in-flight cron job keeps ticking but skips firing, so
+    /// resume needs no re-registration and fires missed while paused
+    /// are not backfilled. Errors if the workflow is not cron-triggered;
+    /// returns the definition unchanged (no event, no commit) when
+    /// already in the target state.
+    #[instrument(name = "core.workflow.set_paused", skip_all)]
+    pub async fn set_paused(
         &self,
         sub: &AuthSubject,
         id: WorkflowDefinitionId,

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -764,38 +764,64 @@ impl Workflows {
         id: WorkflowDefinitionId,
         paused: bool,
     ) -> Result<WorkflowDefinition, WorkflowError> {
-        let definition = self.repo.find_by_id(id).await?;
-        sub.can(
-            AuthVerb::Update,
-            AuthResource::Workflow(definition.project_id, Some(definition.id)),
-        )?;
-        let new_trigger = match &definition.trigger {
-            WorkflowTrigger::Cron {
-                schedule,
-                timezone,
-                condition,
-                paused: current,
-            } => {
-                if *current == paused {
-                    return Ok(definition);
-                }
+        Audit::record_action_if_unset(if paused {
+            "workflow.pause"
+        } else {
+            "workflow.resume"
+        });
+
+        let result: Result<WorkflowDefinition, WorkflowError> = async {
+            let mut op = self.repo.begin_op().await?;
+            let mut definition = self.repo.find_by_id_in_op(&mut op, id).await?;
+            Audit::record_project_id(definition.project_id);
+            Audit::record_workflow_id(definition.id);
+            sub.can(
+                AuthVerb::Update,
+                AuthResource::Workflow(definition.project_id, Some(definition.id)),
+            )?;
+
+            let new_trigger = match &definition.trigger {
                 WorkflowTrigger::Cron {
-                    schedule: schedule.clone(),
-                    timezone: timezone.clone(),
-                    condition: condition.clone(),
-                    paused,
+                    schedule,
+                    timezone,
+                    condition,
+                    paused: current,
+                } => {
+                    if *current == paused {
+                        return Ok(definition);
+                    }
+                    WorkflowTrigger::Cron {
+                        schedule: schedule.clone(),
+                        timezone: timezone.clone(),
+                        condition: condition.clone(),
+                        paused,
+                    }
                 }
+                other => {
+                    return Err(WorkflowError::InvalidDefinition(format!(
+                        "workflow '{}' is {}-triggered; only cron workflows can be paused/resumed",
+                        definition.name,
+                        other.kind_label()
+                    )));
+                }
+            };
+
+            Self::validate_trigger(&new_trigger)?;
+            if definition
+                .update_content(None, None, Some(new_trigger), None, None, None)
+                .did_execute()
+            {
+                self.populate_attribution().await;
+                self.repo.update_in_op(&mut op, &mut definition).await?;
+                op.commit().await?;
             }
-            other => {
-                return Err(WorkflowError::InvalidDefinition(format!(
-                    "workflow '{}' is {}-triggered; only cron workflows can be paused/resumed",
-                    definition.name,
-                    other.kind_label()
-                )));
-            }
-        };
-        self.update(sub, id, None, None, Some(new_trigger), None, None, None)
-            .await
+            Ok(definition)
+        }
+        .await;
+        if let Err(e) = &result {
+            Audit::record_error(e.to_string());
+        }
+        result
     }
 
     async fn populate_attribution(&self) -> CommitAttribution {

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -751,6 +751,46 @@ impl Workflows {
         Ok(definition)
     }
 
+    /// Temporarily stop (or resume) a cron workflow without deleting
+    /// it. Rebuilds the existing `Cron` trigger with `paused` flipped;
+    /// the in-flight cron job observes the change on its next tick.
+    /// Errors if the workflow is not cron-triggered.
+    #[instrument(name = "core.workflow.set_cron_paused", skip_all)]
+    pub async fn set_cron_paused(
+        &self,
+        sub: &AuthSubject,
+        id: WorkflowDefinitionId,
+        paused: bool,
+    ) -> Result<WorkflowDefinition, WorkflowError> {
+        let definition = self.repo.find_by_id(id).await?;
+        sub.can(
+            AuthVerb::Update,
+            AuthResource::Workflow(definition.project_id, Some(definition.id)),
+        )?;
+        let new_trigger = match &definition.trigger {
+            WorkflowTrigger::Cron {
+                schedule,
+                timezone,
+                condition,
+                ..
+            } => WorkflowTrigger::Cron {
+                schedule: schedule.clone(),
+                timezone: timezone.clone(),
+                condition: condition.clone(),
+                paused,
+            },
+            other => {
+                return Err(WorkflowError::InvalidDefinition(format!(
+                    "workflow '{}' is {}-triggered; only cron workflows can be paused/resumed",
+                    definition.name,
+                    other.kind_label()
+                )));
+            }
+        };
+        self.update(sub, id, None, None, Some(new_trigger), None, None, None)
+            .await
+    }
+
     async fn populate_attribution(&self) -> CommitAttribution {
         self.users.commit_attribution().await
     }
@@ -1318,6 +1358,7 @@ mod tests {
             schedule: "0 */6 * * * *".into(),
             timezone: Some("UTC".into()),
             condition: None,
+            paused: false,
         })
         .unwrap();
     }
@@ -1328,6 +1369,7 @@ mod tests {
             schedule: "not a cron".into(),
             timezone: None,
             condition: None,
+            paused: false,
         })
         .unwrap_err();
         assert!(matches!(err, WorkflowError::InvalidCronExpression(_)));
@@ -1339,6 +1381,7 @@ mod tests {
             schedule: "0 */6 * * * *".into(),
             timezone: Some("Mars/Olympus_Mons".into()),
             condition: None,
+            paused: false,
         })
         .unwrap_err();
         assert!(matches!(err, WorkflowError::InvalidTimezone(_)));

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -751,12 +751,33 @@ impl Workflows {
         Ok(definition)
     }
 
-    /// Temporarily stop (or resume) a cron workflow without deleting
-    /// it. Rebuilds the existing `Cron` trigger with `paused` flipped;
-    /// the in-flight cron job observes the change on its next tick.
-    /// Errors if the workflow is not cron-triggered.
-    #[instrument(name = "core.workflow.set_cron_paused", skip_all)]
-    pub async fn set_cron_paused(
+    /// Temporarily stop a cron workflow without deleting it. The
+    /// in-flight cron job observes the change on its next tick and
+    /// stops firing, while the schedule itself keeps ticking.
+    #[instrument(name = "core.workflow.pause", skip_all)]
+    pub async fn pause(
+        &self,
+        sub: &AuthSubject,
+        id: WorkflowDefinitionId,
+    ) -> Result<WorkflowDefinition, WorkflowError> {
+        self.set_paused(sub, id, true).await
+    }
+
+    /// Resume a paused cron workflow. Firing restarts at the next
+    /// scheduled tick; fires missed while paused are not backfilled.
+    #[instrument(name = "core.workflow.resume", skip_all)]
+    pub async fn resume(
+        &self,
+        sub: &AuthSubject,
+        id: WorkflowDefinitionId,
+    ) -> Result<WorkflowDefinition, WorkflowError> {
+        self.set_paused(sub, id, false).await
+    }
+
+    /// Rebuilds the `Cron` trigger with `paused` flipped. Errors if the
+    /// workflow is not cron-triggered; returns the definition unchanged
+    /// (no event, no commit) when already in the target state.
+    async fn set_paused(
         &self,
         sub: &AuthSubject,
         id: WorkflowDefinitionId,
@@ -772,13 +793,18 @@ impl Workflows {
                 schedule,
                 timezone,
                 condition,
-                ..
-            } => WorkflowTrigger::Cron {
-                schedule: schedule.clone(),
-                timezone: timezone.clone(),
-                condition: condition.clone(),
-                paused,
-            },
+                paused: current,
+            } => {
+                if *current == paused {
+                    return Ok(definition);
+                }
+                WorkflowTrigger::Cron {
+                    schedule: schedule.clone(),
+                    timezone: timezone.clone(),
+                    condition: condition.clone(),
+                    paused,
+                }
+            }
             other => {
                 return Err(WorkflowError::InvalidDefinition(format!(
                     "workflow '{}' is {}-triggered; only cron workflows can be paused/resumed",

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -764,64 +764,49 @@ impl Workflows {
         id: WorkflowDefinitionId,
         paused: bool,
     ) -> Result<WorkflowDefinition, WorkflowError> {
-        Audit::record_action_if_unset(if paused {
-            "workflow.pause"
-        } else {
-            "workflow.resume"
-        });
+        let mut op = self.repo.begin_op().await?;
+        let mut definition = self.repo.find_by_id_in_op(&mut op, id).await?;
+        sub.can(
+            AuthVerb::Update,
+            AuthResource::Workflow(definition.project_id, Some(definition.id)),
+        )?;
 
-        let result: Result<WorkflowDefinition, WorkflowError> = async {
-            let mut op = self.repo.begin_op().await?;
-            let mut definition = self.repo.find_by_id_in_op(&mut op, id).await?;
-            Audit::record_project_id(definition.project_id);
-            Audit::record_workflow_id(definition.id);
-            sub.can(
-                AuthVerb::Update,
-                AuthResource::Workflow(definition.project_id, Some(definition.id)),
-            )?;
-
-            let new_trigger = match &definition.trigger {
+        let new_trigger = match &definition.trigger {
+            WorkflowTrigger::Cron {
+                schedule,
+                timezone,
+                condition,
+                paused: current,
+            } => {
+                if *current == paused {
+                    return Ok(definition);
+                }
                 WorkflowTrigger::Cron {
-                    schedule,
-                    timezone,
-                    condition,
-                    paused: current,
-                } => {
-                    if *current == paused {
-                        return Ok(definition);
-                    }
-                    WorkflowTrigger::Cron {
-                        schedule: schedule.clone(),
-                        timezone: timezone.clone(),
-                        condition: condition.clone(),
-                        paused,
-                    }
+                    schedule: schedule.clone(),
+                    timezone: timezone.clone(),
+                    condition: condition.clone(),
+                    paused,
                 }
-                other => {
-                    return Err(WorkflowError::InvalidDefinition(format!(
-                        "workflow '{}' is {}-triggered; only cron workflows can be paused/resumed",
-                        definition.name,
-                        other.kind_label()
-                    )));
-                }
-            };
-
-            Self::validate_trigger(&new_trigger)?;
-            if definition
-                .update_content(None, None, Some(new_trigger), None, None, None)
-                .did_execute()
-            {
-                self.populate_attribution().await;
-                self.repo.update_in_op(&mut op, &mut definition).await?;
-                op.commit().await?;
             }
-            Ok(definition)
+            other => {
+                return Err(WorkflowError::InvalidDefinition(format!(
+                    "workflow '{}' is {}-triggered; only cron workflows can be paused/resumed",
+                    definition.name,
+                    other.kind_label()
+                )));
+            }
+        };
+
+        Self::validate_trigger(&new_trigger)?;
+        if definition
+            .update_content(None, None, Some(new_trigger), None, None, None)
+            .did_execute()
+        {
+            self.populate_attribution().await;
+            self.repo.update_in_op(&mut op, &mut definition).await?;
+            op.commit().await?;
         }
-        .await;
-        if let Err(e) = &result {
-            Audit::record_error(e.to_string());
-        }
-        result
+        Ok(definition)
     }
 
     async fn populate_attribution(&self) -> CommitAttribution {

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -791,11 +791,11 @@ impl Workflows {
     /// Pause or resume a workflow without deleting it. While paused no
     /// runs fire: cron fires are skipped (the in-flight cron job keeps
     /// ticking, so resume needs no re-registration and missed fires are
-    /// not backfilled), webhook deliveries are suppressed with an audit
-    /// row, and manual triggers error. Pause gates run *creation* only —
-    /// in-flight runs, including runs parked on a `Wait` step, continue.
-    /// Returns the definition unchanged (no event, no commit) when
-    /// already in the target state.
+    /// not backfilled), and webhook deliveries and manual triggers are
+    /// suppressed with a paused disposition (each writes an audit row).
+    /// Pause gates run *creation* only — in-flight runs, including runs
+    /// parked on a `Wait` step, continue. Returns the definition
+    /// unchanged (no event, no commit) when already in the target state.
     #[instrument(name = "core.workflow.set_paused", skip_all)]
     pub async fn set_paused(
         &self,
@@ -938,30 +938,24 @@ impl Workflows {
         Ok(result.entities)
     }
 
-    /// Spawns the executor as a job and returns the run synchronously.
-    /// `Ok(None)` means the trigger's `condition:` evaluated to false
-    /// and the run was deliberately suppressed (an audit row was
-    /// written). A paused workflow errors with [`WorkflowError::Paused`]
-    /// — this is the explicit-trigger path, so the caller deserves a
-    /// loud answer rather than a silent skip.
+    /// Authenticated explicit-trigger path. Returns the full
+    /// [`TriggerOutcome`] — `Spawned` with the run, or a deliberate
+    /// `Filtered`/`Paused` suppression (each writes an audit row).
+    /// `Paused` is an expected disposition, not an error; each caller
+    /// maps the outcome to its own surface.
     #[instrument(name = "core.workflow.trigger_run", skip_all)]
     pub async fn trigger_run(
         &self,
         sub: &AuthSubject,
         definition_id: WorkflowDefinitionId,
         trigger_context: serde_json::Value,
-    ) -> Result<Option<WorkflowRun>, WorkflowError> {
+    ) -> Result<TriggerOutcome, WorkflowError> {
         let definition = self.repo.find_by_id(definition_id).await?;
         sub.can(
             AuthVerb::Use,
             AuthResource::Workflow(definition.project_id, Some(definition.id)),
         )?;
-        let name = definition.name.clone();
-        match self.spawn_run(definition, trigger_context).await? {
-            TriggerOutcome::Spawned(run) => Ok(Some(*run)),
-            TriggerOutcome::Filtered => Ok(None),
-            TriggerOutcome::Paused => Err(WorkflowError::Paused(name)),
-        }
+        self.spawn_run(definition, trigger_context).await
     }
 
     /// No auth check — pairs with [`Self::find_by_id_unchecked`] so

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -57,6 +57,10 @@ const AUDIT_ACTION_TRIGGER_FILTERED: &str = "workflow.trigger_filtered";
 /// Audit action recorded when a `trigger.condition:` errors at
 /// runtime (compile, runtime, non-boolean result).
 const AUDIT_ACTION_TRIGGER_CONDITION_ERRORED: &str = "workflow.trigger_condition_errored";
+/// Audit action recorded when a run is suppressed because the
+/// workflow is paused (webhook paths; manual triggers error instead
+/// and the cron job skips before reaching the spawn).
+const AUDIT_ACTION_TRIGGER_PAUSED: &str = "workflow.trigger_paused";
 
 /// Evaluate each output's CEL expression against the resume context.
 /// Builds the CEL context once and reuses it across all expressions.
@@ -124,6 +128,25 @@ fn record_trigger_filtered_audit(
         definition_id = %definition.id,
         condition_body,
         "workflow run suppressed by trigger condition"
+    );
+}
+
+fn record_trigger_paused_audit(
+    definition: &WorkflowDefinition,
+    trigger_context: &serde_json::Value,
+) {
+    // See `record_trigger_filtered_audit` — same overwrite rationale.
+    Audit::record_action(AUDIT_ACTION_TRIGGER_PAUSED);
+    Audit::record_workflow_id(definition.id);
+    Audit::record_metadata(serde_json::json!({
+        "definition_id": definition.id.to_string(),
+        "trigger_kind": definition.trigger.kind_label(),
+        "payload_digest": payload_digest(trigger_context),
+    }));
+    Audit::record_outcome_if_unset(InteractionOutcome::Success);
+    tracing::info!(
+        definition_id = %definition.id,
+        "workflow run suppressed: workflow is paused"
     );
 }
 
@@ -279,6 +302,7 @@ impl Workflows {
             name,
             description,
             trigger,
+            paused,
             steps,
             sandboxes,
             model_chain,
@@ -342,6 +366,7 @@ impl Workflows {
                     Some(steps),
                     Some(sandboxes),
                     Some(model_chain.clone()),
+                    Some(paused),
                     file_hash,
                 )
                 .did_execute()
@@ -374,6 +399,7 @@ impl Workflows {
             .project_id(project_id)
             .name(name)
             .trigger(trigger)
+            .paused(paused)
             .steps(steps)
             .sandboxes(sandboxes)
             .model_chain(model_chain);
@@ -751,12 +777,12 @@ impl Workflows {
         Ok(definition)
     }
 
-    /// Pause or resume a cron workflow without deleting it. While
-    /// paused the in-flight cron job keeps ticking but skips firing, so
-    /// resume needs no re-registration and fires missed while paused
-    /// are not backfilled. Errors if the workflow is not cron-triggered;
-    /// returns the definition unchanged (no event, no commit) when
-    /// already in the target state.
+    /// Pause or resume a workflow without deleting it. While paused no
+    /// runs fire: cron fires are skipped (the in-flight cron job keeps
+    /// ticking, so resume needs no re-registration and missed fires are
+    /// not backfilled), webhook deliveries are suppressed with an audit
+    /// row, and manual triggers error. Returns the definition unchanged
+    /// (no event, no commit) when already in the target state.
     #[instrument(name = "core.workflow.set_paused", skip_all)]
     pub async fn set_paused(
         &self,
@@ -771,37 +797,7 @@ impl Workflows {
             AuthResource::Workflow(definition.project_id, Some(definition.id)),
         )?;
 
-        let new_trigger = match &definition.trigger {
-            WorkflowTrigger::Cron {
-                schedule,
-                timezone,
-                condition,
-                paused: current,
-            } => {
-                if *current == paused {
-                    return Ok(definition);
-                }
-                WorkflowTrigger::Cron {
-                    schedule: schedule.clone(),
-                    timezone: timezone.clone(),
-                    condition: condition.clone(),
-                    paused,
-                }
-            }
-            other => {
-                return Err(WorkflowError::InvalidDefinition(format!(
-                    "workflow '{}' is {}-triggered; only cron workflows can be paused/resumed",
-                    definition.name,
-                    other.kind_label()
-                )));
-            }
-        };
-
-        Self::validate_trigger(&new_trigger)?;
-        if definition
-            .update_content(None, None, Some(new_trigger), None, None, None)
-            .did_execute()
-        {
+        if definition.set_paused(paused).did_execute() {
             self.populate_attribution().await;
             self.repo.update_in_op(&mut op, &mut definition).await?;
             op.commit().await?;
@@ -932,7 +928,9 @@ impl Workflows {
     /// Spawns the executor as a job and returns the run synchronously.
     /// `Ok(None)` means the trigger's `condition:` evaluated to false
     /// and the run was deliberately suppressed (an audit row was
-    /// written).
+    /// written). Errors with [`WorkflowError::WorkflowPaused`] on a
+    /// paused workflow — this is the explicit-trigger path, so the
+    /// caller deserves a loud answer rather than a silent skip.
     #[instrument(name = "core.workflow.trigger_run", skip_all)]
     pub async fn trigger_run(
         &self,
@@ -945,6 +943,9 @@ impl Workflows {
             AuthVerb::Use,
             AuthResource::Workflow(definition.project_id, Some(definition.id)),
         )?;
+        if definition.paused {
+            return Err(WorkflowError::WorkflowPaused(definition.name));
+        }
         self.spawn_run(definition, trigger_context).await
     }
 
@@ -1165,6 +1166,11 @@ impl Workflows {
         definition: WorkflowDefinition,
         trigger_context: serde_json::Value,
     ) -> Result<Option<WorkflowRun>, WorkflowError> {
+        if definition.paused {
+            record_trigger_paused_audit(&definition, &trigger_context);
+            return Ok(None);
+        }
+
         if let Some(body) = definition.trigger.condition() {
             match template::evaluate_trigger_condition(body, &trigger_context) {
                 Ok(template::ConditionOutcome::True) => {}
@@ -1376,7 +1382,6 @@ mod tests {
             schedule: "0 */6 * * * *".into(),
             timezone: Some("UTC".into()),
             condition: None,
-            paused: false,
         })
         .unwrap();
     }
@@ -1387,7 +1392,6 @@ mod tests {
             schedule: "not a cron".into(),
             timezone: None,
             condition: None,
-            paused: false,
         })
         .unwrap_err();
         assert!(matches!(err, WorkflowError::InvalidCronExpression(_)));
@@ -1399,7 +1403,6 @@ mod tests {
             schedule: "0 */6 * * * *".into(),
             timezone: Some("Mars/Olympus_Mons".into()),
             condition: None,
-            paused: false,
         })
         .unwrap_err();
         assert!(matches!(err, WorkflowError::InvalidTimezone(_)));

--- a/core/src/workflow/yaml.rs
+++ b/core/src/workflow/yaml.rs
@@ -25,6 +25,8 @@ struct WorkflowYaml {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     description: Option<String>,
     trigger: WorkflowTriggerYaml,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    paused: bool,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     model_chain: Option<ModelChain>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
@@ -190,8 +192,6 @@ enum WorkflowTriggerYaml {
         timezone: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         condition: Option<String>,
-        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
-        paused: bool,
     },
 }
 
@@ -219,12 +219,10 @@ impl WorkflowTriggerYaml {
                 schedule,
                 timezone,
                 condition,
-                paused,
             } => WorkflowTriggerYaml::Cron {
                 schedule: schedule.clone(),
                 timezone: timezone.clone(),
                 condition: condition.clone(),
-                paused: *paused,
             },
         }
     }
@@ -378,6 +376,7 @@ pub fn render_workflow_yaml(
     name: &str,
     description: Option<&str>,
     trigger: &WorkflowTrigger,
+    paused: bool,
     steps: &[WorkflowStepDef],
     sandboxes: &[WorkflowSandboxDecl],
     model_chain: Option<&ModelChain>,
@@ -389,6 +388,7 @@ pub fn render_workflow_yaml(
         name: name.to_string(),
         description: description.map(|s| s.to_string()),
         trigger: WorkflowTriggerYaml::from_runtime(trigger),
+        paused,
         model_chain: model_chain.cloned(),
         sandboxes: sandboxes
             .iter()
@@ -410,6 +410,7 @@ pub struct ParsedWorkflow {
     pub name: String,
     pub description: Option<String>,
     pub trigger: WorkflowTrigger,
+    pub paused: bool,
     pub steps: Vec<WorkflowStepDef>,
     pub sandboxes: Vec<WorkflowSandboxDecl>,
     pub model_chain: Option<ModelChain>,
@@ -457,12 +458,10 @@ pub fn parse_workflow_yaml(content: &str, path: &str) -> Option<ParsedWorkflow> 
             schedule,
             timezone,
             condition,
-            paused,
         } => WorkflowTrigger::Cron {
             schedule,
             timezone,
             condition,
-            paused,
         },
     };
 
@@ -485,6 +484,7 @@ pub fn parse_workflow_yaml(content: &str, path: &str) -> Option<ParsedWorkflow> 
         &name,
         description.as_deref(),
         &trigger,
+        yaml.paused,
         &steps,
         &sandboxes,
         model_chain.as_ref(),
@@ -501,6 +501,7 @@ pub fn parse_workflow_yaml(content: &str, path: &str) -> Option<ParsedWorkflow> 
         name,
         description,
         trigger,
+        paused: yaml.paused,
         steps,
         sandboxes,
         model_chain,
@@ -572,6 +573,7 @@ mod tests {
             name,
             description,
             trigger,
+            false,
             &sample_steps(),
             sandboxes,
             None,
@@ -691,7 +693,6 @@ steps:
             schedule: "0 */6 * * * *".to_string(),
             timezone: Some("America/New_York".to_string()),
             condition: None,
-            paused: false,
         };
         let content = render(id, "scheduled", None, &trigger, &sample_sandboxes());
         assert!(content.contains("type: cron"));
@@ -712,20 +713,32 @@ steps:
     }
 
     #[test]
-    fn workflow_yaml_roundtrip_cron_trigger_paused() {
+    fn workflow_yaml_roundtrip_paused_and_omits_when_false() {
         let id = WorkflowDefinitionId::new();
-        let trigger = WorkflowTrigger::Cron {
-            schedule: "0 */6 * * * *".to_string(),
-            timezone: None,
-            condition: None,
-            paused: true,
-        };
-        let content = render(id, "scheduled", None, &trigger, &sample_sandboxes());
-        assert!(content.contains("paused: true"));
+        let trigger = WorkflowTrigger::Manual { condition: None };
 
-        let path = canonical_workflow_path("scheduled", None);
-        let parsed = parse_workflow_yaml(&content, &path).expect("parses");
-        assert!(parsed.trigger.is_paused());
+        let active = render(id, "flow", None, &trigger, &sample_sandboxes());
+        assert!(!active.contains("paused"), "paused omitted when false");
+        let path = canonical_workflow_path("flow", None);
+        let parsed = parse_workflow_yaml(&active, &path).expect("parses");
+        assert!(!parsed.paused);
+
+        let paused = render_workflow_yaml(
+            id,
+            "flow",
+            None,
+            &trigger,
+            true,
+            &sample_steps(),
+            &sample_sandboxes(),
+            None,
+            "2026-04-29T00:00:00Z",
+            "2026-04-29T00:00:00Z",
+        );
+        assert!(paused.contains("paused: true"));
+        let parsed = parse_workflow_yaml(&paused, &path).expect("parses");
+        assert!(parsed.paused);
+        assert!(!parsed.needs_rewrite, "paused round-trips canonically");
     }
 
     #[test]
@@ -784,6 +797,7 @@ steps:
             "judge-flow",
             None,
             &WorkflowTrigger::Manual { condition: None },
+            false,
             &steps,
             &[],
             None,

--- a/core/src/workflow/yaml.rs
+++ b/core/src/workflow/yaml.rs
@@ -190,6 +190,8 @@ enum WorkflowTriggerYaml {
         timezone: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         condition: Option<String>,
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        paused: bool,
     },
 }
 
@@ -217,10 +219,12 @@ impl WorkflowTriggerYaml {
                 schedule,
                 timezone,
                 condition,
+                paused,
             } => WorkflowTriggerYaml::Cron {
                 schedule: schedule.clone(),
                 timezone: timezone.clone(),
                 condition: condition.clone(),
+                paused: *paused,
             },
         }
     }
@@ -453,10 +457,12 @@ pub fn parse_workflow_yaml(content: &str, path: &str) -> Option<ParsedWorkflow> 
             schedule,
             timezone,
             condition,
+            paused,
         } => WorkflowTrigger::Cron {
             schedule,
             timezone,
             condition,
+            paused,
         },
     };
 
@@ -685,6 +691,7 @@ steps:
             schedule: "0 */6 * * * *".to_string(),
             timezone: Some("America/New_York".to_string()),
             condition: None,
+            paused: false,
         };
         let content = render(id, "scheduled", None, &trigger, &sample_sandboxes());
         assert!(content.contains("type: cron"));
@@ -702,6 +709,23 @@ steps:
             }
             _ => panic!("expected cron trigger"),
         }
+    }
+
+    #[test]
+    fn workflow_yaml_roundtrip_cron_trigger_paused() {
+        let id = WorkflowDefinitionId::new();
+        let trigger = WorkflowTrigger::Cron {
+            schedule: "0 */6 * * * *".to_string(),
+            timezone: None,
+            condition: None,
+            paused: true,
+        };
+        let content = render(id, "scheduled", None, &trigger, &sample_sandboxes());
+        assert!(content.contains("paused: true"));
+
+        let path = canonical_workflow_path("scheduled", None);
+        let parsed = parse_workflow_yaml(&content, &path).expect("parses");
+        assert!(parsed.trigger.is_paused());
     }
 
     #[test]

--- a/server/src/graphql/mutation.rs
+++ b/server/src/graphql/mutation.rs
@@ -281,6 +281,23 @@ impl Mutation {
         })
     }
 
+    /// Pause or resume a cron workflow without deleting it. Errors if
+    /// the workflow is not cron-triggered.
+    async fn workflow_set_paused(
+        &self,
+        ctx: &Context<'_>,
+        input: WorkflowSetPausedInput,
+    ) -> async_graphql::Result<WorkflowSetPausedPayload> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        let definition = app
+            .workflows()
+            .set_cron_paused(sub, input.definition_id, input.paused)
+            .await?;
+        Ok(WorkflowSetPausedPayload {
+            workflow: WorkflowDefinition::from(definition),
+        })
+    }
+
     async fn mcp_credentials_create(
         &self,
         ctx: &Context<'_>,

--- a/server/src/graphql/mutation.rs
+++ b/server/src/graphql/mutation.rs
@@ -281,8 +281,9 @@ impl Mutation {
         })
     }
 
-    /// Pause or resume a cron workflow without deleting it. Errors if
-    /// the workflow is not cron-triggered.
+    /// Pause or resume a workflow without deleting it. While paused no
+    /// runs fire: cron fires are skipped, webhook deliveries are
+    /// suppressed, and manual triggers error.
     async fn workflow_set_paused(
         &self,
         ctx: &Context<'_>,

--- a/server/src/graphql/mutation.rs
+++ b/server/src/graphql/mutation.rs
@@ -289,11 +289,10 @@ impl Mutation {
         input: WorkflowSetPausedInput,
     ) -> async_graphql::Result<WorkflowSetPausedPayload> {
         let (app, sub) = app_and_sub_from_ctx!(ctx);
-        let definition = if input.paused {
-            app.workflows().pause(sub, input.definition_id).await?
-        } else {
-            app.workflows().resume(sub, input.definition_id).await?
-        };
+        let definition = app
+            .workflows()
+            .set_paused(sub, input.definition_id, input.paused)
+            .await?;
         Ok(WorkflowSetPausedPayload {
             workflow: WorkflowDefinition::from(definition),
         })

--- a/server/src/graphql/mutation.rs
+++ b/server/src/graphql/mutation.rs
@@ -42,14 +42,11 @@ impl Mutation {
             .payload
             .map(JsonValue::into_inner)
             .unwrap_or_else(|| serde_json::json!({}));
-        let run = app
+        let outcome = app
             .workflows()
             .trigger_run(sub, input.definition_id, payload)
             .await?;
-        Ok(WorkflowTriggerPayload {
-            filtered: run.is_none(),
-            run: run.map(WorkflowRun::from),
-        })
+        Ok(WorkflowTriggerPayload::from(outcome))
     }
 
     async fn project_update(
@@ -282,8 +279,8 @@ impl Mutation {
     }
 
     /// Pause or resume a workflow without deleting it. While paused no
-    /// runs fire: cron fires are skipped, webhook deliveries are
-    /// suppressed, and manual triggers error.
+    /// runs fire: cron fires, webhook deliveries, and manual triggers
+    /// are all suppressed with a paused disposition (no run).
     async fn workflow_set_paused(
         &self,
         ctx: &Context<'_>,

--- a/server/src/graphql/mutation.rs
+++ b/server/src/graphql/mutation.rs
@@ -289,10 +289,11 @@ impl Mutation {
         input: WorkflowSetPausedInput,
     ) -> async_graphql::Result<WorkflowSetPausedPayload> {
         let (app, sub) = app_and_sub_from_ctx!(ctx);
-        let definition = app
-            .workflows()
-            .set_cron_paused(sub, input.definition_id, input.paused)
-            .await?;
+        let definition = if input.paused {
+            app.workflows().pause(sub, input.definition_id).await?
+        } else {
+            app.workflows().resume(sub, input.definition_id).await?
+        };
         Ok(WorkflowSetPausedPayload {
             workflow: WorkflowDefinition::from(definition),
         })

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -328,8 +328,8 @@ type Mutation {
 	workflowDelete(input: WorkflowDeleteInput!): WorkflowDeletePayload!
 	"""
 	Pause or resume a workflow without deleting it. While paused no
-	runs fire: cron fires are skipped, webhook deliveries are
-	suppressed, and manual triggers error.
+	runs fire: cron fires, webhook deliveries, and manual triggers
+	are all suppressed with a paused disposition (no run).
 	"""
 	workflowSetPaused(input: WorkflowSetPausedInput!): WorkflowSetPausedPayload!
 	workflowTrigger(input: WorkflowTriggerInput!): WorkflowTriggerPayload!
@@ -792,9 +792,9 @@ type WorkflowDefinition {
 	modelChain: ModelChain
 	name: String!
 	"""
-	`true` when the workflow is paused — no runs fire (cron fires
-	are skipped, webhook deliveries suppressed, manual triggers
-	error) until resumed.
+	`true` when the workflow is paused — no runs fire (cron fires,
+	webhook deliveries, and manual triggers are all suppressed with
+	a paused disposition) until resumed.
 	"""
 	paused: Boolean!
 	projectId: ProjectId!
@@ -924,6 +924,18 @@ type WorkflowTrigger {
 	webhookUrl: String
 }
 
+"""
+How an explicit `workflowTrigger` resolved: a run was `SPAWNED`, or
+it was deliberately suppressed because the trigger `condition` was
+`FILTERED` out or the workflow is `PAUSED`. Suppression is an
+expected outcome, not an error.
+"""
+enum WorkflowTriggerDisposition {
+	FILTERED
+	PAUSED
+	SPAWNED
+}
+
 input WorkflowTriggerInput {
 	definitionId: WorkflowDefinitionId!
 	payload: Json
@@ -936,7 +948,7 @@ enum WorkflowTriggerKind {
 }
 
 type WorkflowTriggerPayload {
-	filtered: Boolean!
+	disposition: WorkflowTriggerDisposition!
 	run: WorkflowRun
 }
 

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -326,6 +326,11 @@ type Mutation {
 	sandboxSuspend(input: SandboxSuspendInput!): SandboxSuspendPayload!
 	skillDelete(input: SkillDeleteInput!): SkillDeletePayload!
 	workflowDelete(input: WorkflowDeleteInput!): WorkflowDeletePayload!
+	"""
+	Pause or resume a cron workflow without deleting it. Errors if
+	the workflow is not cron-triggered.
+	"""
+	workflowSetPaused(input: WorkflowSetPausedInput!): WorkflowSetPausedPayload!
 	workflowTrigger(input: WorkflowTriggerInput!): WorkflowTriggerPayload!
 }
 
@@ -844,6 +849,15 @@ enum WorkflowSandboxKind {
 	SCRATCH
 }
 
+input WorkflowSetPausedInput {
+	definitionId: WorkflowDefinitionId!
+	paused: Boolean!
+}
+
+type WorkflowSetPausedPayload {
+	workflow: WorkflowDefinition!
+}
+
 type WorkflowStep {
 	condition: String
 	name: String!
@@ -899,6 +913,11 @@ type WorkflowTrigger {
 	cronTimezone: String
 	kind: WorkflowTriggerKind!
 	nextRunAt: Timestamp
+	"""
+	`true` when a cron workflow is paused — its schedule is retained
+	but runs are suspended. Always `false` for non-cron triggers.
+	"""
+	paused: Boolean!
 	provider: String
 	webhookUrl: String
 }

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -327,8 +327,9 @@ type Mutation {
 	skillDelete(input: SkillDeleteInput!): SkillDeletePayload!
 	workflowDelete(input: WorkflowDeleteInput!): WorkflowDeletePayload!
 	"""
-	Pause or resume a cron workflow without deleting it. Errors if
-	the workflow is not cron-triggered.
+	Pause or resume a workflow without deleting it. While paused no
+	runs fire: cron fires are skipped, webhook deliveries are
+	suppressed, and manual triggers error.
 	"""
 	workflowSetPaused(input: WorkflowSetPausedInput!): WorkflowSetPausedPayload!
 	workflowTrigger(input: WorkflowTriggerInput!): WorkflowTriggerPayload!
@@ -790,6 +791,12 @@ type WorkflowDefinition {
 	id: WorkflowDefinitionId!
 	modelChain: ModelChain
 	name: String!
+	"""
+	`true` when the workflow is paused — no runs fire (cron fires
+	are skipped, webhook deliveries suppressed, manual triggers
+	error) until resumed.
+	"""
+	paused: Boolean!
 	projectId: ProjectId!
 	recentRuns(first: Int! = 10): [WorkflowRun!]!
 	sandboxes: [WorkflowSandbox!]!
@@ -913,11 +920,6 @@ type WorkflowTrigger {
 	cronTimezone: String
 	kind: WorkflowTriggerKind!
 	nextRunAt: Timestamp
-	"""
-	`true` when a cron workflow is paused — its schedule is retained
-	but runs are suspended. Always `false` for non-cron triggers.
-	"""
-	paused: Boolean!
 	provider: String
 	webhookUrl: String
 }

--- a/server/src/graphql/workflow.rs
+++ b/server/src/graphql/workflow.rs
@@ -93,6 +93,9 @@ pub struct WorkflowTrigger {
     next_run_at: Option<Timestamp>,
     condition: Option<String>,
     webhook_url: Option<String>,
+    /// `true` when a cron workflow is paused — its schedule is retained
+    /// but runs are suspended. Always `false` for non-cron triggers.
+    paused: bool,
 }
 
 impl From<&DomainWorkflowTrigger> for WorkflowTrigger {
@@ -106,6 +109,7 @@ impl From<&DomainWorkflowTrigger> for WorkflowTrigger {
                 next_run_at: None,
                 condition: condition.clone(),
                 webhook_url: None,
+                paused: false,
             },
             DomainWorkflowTrigger::Webhook {
                 provider,
@@ -119,23 +123,30 @@ impl From<&DomainWorkflowTrigger> for WorkflowTrigger {
                 next_run_at: None,
                 condition: condition.clone(),
                 webhook_url: None,
+                paused: false,
             },
             DomainWorkflowTrigger::Cron {
                 schedule,
                 timezone,
                 condition,
+                paused,
             } => Self {
                 kind: WorkflowTriggerKind::Cron,
                 provider: None,
                 cron_schedule: Some(schedule.clone()),
                 cron_timezone: timezone.clone(),
-                next_run_at: trigger
-                    .next_fire_at(chrono::Utc::now())
-                    .ok()
-                    .flatten()
-                    .map(Into::into),
+                next_run_at: if *paused {
+                    None
+                } else {
+                    trigger
+                        .next_fire_at(chrono::Utc::now())
+                        .ok()
+                        .flatten()
+                        .map(Into::into)
+                },
                 condition: condition.clone(),
                 webhook_url: None,
+                paused: *paused,
             },
         }
     }
@@ -446,6 +457,17 @@ pub struct WorkflowTriggerInput {
 pub struct WorkflowTriggerPayload {
     pub run: Option<WorkflowRun>,
     pub filtered: bool,
+}
+
+#[derive(InputObject)]
+pub struct WorkflowSetPausedInput {
+    pub definition_id: WorkflowDefinitionId,
+    pub paused: bool,
+}
+
+#[derive(SimpleObject)]
+pub struct WorkflowSetPausedPayload {
+    pub workflow: WorkflowDefinition,
 }
 
 pub fn limit<T>(items: Vec<T>, first: i32) -> Vec<T> {

--- a/server/src/graphql/workflow.rs
+++ b/server/src/graphql/workflow.rs
@@ -7,10 +7,11 @@ use super::primitives::*;
 
 use drua_core::sandbox::{SandboxMode, SandboxSpecs};
 use drua_core::workflow::{
-    StepResult as DomainStepResult, WorkflowDefinition as DomainWorkflowDefinition,
-    WorkflowRun as DomainWorkflowRun, WorkflowRunState as DomainWorkflowRunState,
-    WorkflowSandboxDecl as DomainWorkflowSandboxDecl, WorkflowStepDef as DomainWorkflowStepDef,
-    WorkflowStepState as DomainWorkflowStepState, WorkflowTrigger as DomainWorkflowTrigger,
+    StepResult as DomainStepResult, TriggerOutcome as DomainTriggerOutcome,
+    WorkflowDefinition as DomainWorkflowDefinition, WorkflowRun as DomainWorkflowRun,
+    WorkflowRunState as DomainWorkflowRunState, WorkflowSandboxDecl as DomainWorkflowSandboxDecl,
+    WorkflowStepDef as DomainWorkflowStepDef, WorkflowStepState as DomainWorkflowStepState,
+    WorkflowTrigger as DomainWorkflowTrigger,
 };
 
 #[derive(InputObject)]
@@ -34,9 +35,9 @@ pub struct WorkflowDefinition {
     steps: Vec<WorkflowStep>,
     sandboxes: Vec<WorkflowSandbox>,
     model_chain: Option<ModelChain>,
-    /// `true` when the workflow is paused — no runs fire (cron fires
-    /// are skipped, webhook deliveries suppressed, manual triggers
-    /// error) until resumed.
+    /// `true` when the workflow is paused — no runs fire (cron fires,
+    /// webhook deliveries, and manual triggers are all suppressed with
+    /// a paused disposition) until resumed.
     paused: bool,
     created_at: Timestamp,
     updated_at: Timestamp,
@@ -446,10 +447,40 @@ pub struct WorkflowTriggerInput {
     pub payload: Option<JsonValue>,
 }
 
+/// How an explicit `workflowTrigger` resolved: a run was `SPAWNED`, or
+/// it was deliberately suppressed because the trigger `condition` was
+/// `FILTERED` out or the workflow is `PAUSED`. Suppression is an
+/// expected outcome, not an error.
+#[derive(Enum, Copy, Clone, Eq, PartialEq)]
+pub enum WorkflowTriggerDisposition {
+    Spawned,
+    Filtered,
+    Paused,
+}
+
 #[derive(SimpleObject)]
 pub struct WorkflowTriggerPayload {
     pub run: Option<WorkflowRun>,
-    pub filtered: bool,
+    pub disposition: WorkflowTriggerDisposition,
+}
+
+impl From<DomainTriggerOutcome> for WorkflowTriggerPayload {
+    fn from(outcome: DomainTriggerOutcome) -> Self {
+        match outcome {
+            DomainTriggerOutcome::Spawned(run) => Self {
+                run: Some(WorkflowRun::from(*run)),
+                disposition: WorkflowTriggerDisposition::Spawned,
+            },
+            DomainTriggerOutcome::Filtered => Self {
+                run: None,
+                disposition: WorkflowTriggerDisposition::Filtered,
+            },
+            DomainTriggerOutcome::Paused => Self {
+                run: None,
+                disposition: WorkflowTriggerDisposition::Paused,
+            },
+        }
+    }
 }
 
 #[derive(InputObject)]

--- a/server/src/graphql/workflow.rs
+++ b/server/src/graphql/workflow.rs
@@ -34,6 +34,10 @@ pub struct WorkflowDefinition {
     steps: Vec<WorkflowStep>,
     sandboxes: Vec<WorkflowSandbox>,
     model_chain: Option<ModelChain>,
+    /// `true` when the workflow is paused — no runs fire (cron fires
+    /// are skipped, webhook deliveries suppressed, manual triggers
+    /// error) until resumed.
+    paused: bool,
     created_at: Timestamp,
     updated_at: Timestamp,
     yaml: String,
@@ -66,6 +70,9 @@ impl From<DomainWorkflowDefinition> for WorkflowDefinition {
         if matches!(entity.trigger, DomainWorkflowTrigger::Webhook { .. }) {
             trigger.webhook_url = Some(format!("/webhooks/{}", entity.id));
         }
+        if entity.paused {
+            trigger.next_run_at = None;
+        }
         let yaml = entity.canonical_yaml();
         Self {
             id: entity.id,
@@ -76,6 +83,7 @@ impl From<DomainWorkflowDefinition> for WorkflowDefinition {
             steps: entity.steps.iter().map(WorkflowStep::from).collect(),
             sandboxes: entity.sandboxes.iter().map(WorkflowSandbox::from).collect(),
             model_chain: entity.model_chain.clone().map(Into::into),
+            paused: entity.paused,
             created_at: created_at.into(),
             updated_at: updated_at.into(),
             yaml,
@@ -93,9 +101,6 @@ pub struct WorkflowTrigger {
     next_run_at: Option<Timestamp>,
     condition: Option<String>,
     webhook_url: Option<String>,
-    /// `true` when a cron workflow is paused — its schedule is retained
-    /// but runs are suspended. Always `false` for non-cron triggers.
-    paused: bool,
 }
 
 impl From<&DomainWorkflowTrigger> for WorkflowTrigger {
@@ -109,7 +114,6 @@ impl From<&DomainWorkflowTrigger> for WorkflowTrigger {
                 next_run_at: None,
                 condition: condition.clone(),
                 webhook_url: None,
-                paused: false,
             },
             DomainWorkflowTrigger::Webhook {
                 provider,
@@ -123,22 +127,23 @@ impl From<&DomainWorkflowTrigger> for WorkflowTrigger {
                 next_run_at: None,
                 condition: condition.clone(),
                 webhook_url: None,
-                paused: false,
             },
             DomainWorkflowTrigger::Cron {
                 schedule,
                 timezone,
                 condition,
-                paused,
             } => Self {
                 kind: WorkflowTriggerKind::Cron,
                 provider: None,
                 cron_schedule: Some(schedule.clone()),
                 cron_timezone: timezone.clone(),
-                next_run_at: trigger.next_run_at(chrono::Utc::now()).map(Into::into),
+                next_run_at: trigger
+                    .next_fire_at(chrono::Utc::now())
+                    .ok()
+                    .flatten()
+                    .map(Into::into),
                 condition: condition.clone(),
                 webhook_url: None,
-                paused: *paused,
             },
         }
     }

--- a/server/src/graphql/workflow.rs
+++ b/server/src/graphql/workflow.rs
@@ -135,15 +135,7 @@ impl From<&DomainWorkflowTrigger> for WorkflowTrigger {
                 provider: None,
                 cron_schedule: Some(schedule.clone()),
                 cron_timezone: timezone.clone(),
-                next_run_at: if *paused {
-                    None
-                } else {
-                    trigger
-                        .next_fire_at(chrono::Utc::now())
-                        .ok()
-                        .flatten()
-                        .map(Into::into)
-                },
+                next_run_at: trigger.next_run_at(chrono::Utc::now()).map(Into::into),
                 condition: condition.clone(),
                 webhook_url: None,
                 paused: *paused,

--- a/server/src/graphql/workflow.rs
+++ b/server/src/graphql/workflow.rs
@@ -70,9 +70,7 @@ impl From<DomainWorkflowDefinition> for WorkflowDefinition {
         if matches!(entity.trigger, DomainWorkflowTrigger::Webhook { .. }) {
             trigger.webhook_url = Some(format!("/webhooks/{}", entity.id));
         }
-        if entity.paused {
-            trigger.next_run_at = None;
-        }
+        trigger.next_run_at = entity.next_run_at(chrono::Utc::now()).map(Into::into);
         let yaml = entity.canonical_yaml();
         Self {
             id: entity.id,
@@ -137,11 +135,9 @@ impl From<&DomainWorkflowTrigger> for WorkflowTrigger {
                 provider: None,
                 cron_schedule: Some(schedule.clone()),
                 cron_timezone: timezone.clone(),
-                next_run_at: trigger
-                    .next_fire_at(chrono::Utc::now())
-                    .ok()
-                    .flatten()
-                    .map(Into::into),
+                // Filled by the definition conversion, which knows the
+                // pause state (`WorkflowDefinition::next_run_at`).
+                next_run_at: None,
                 condition: condition.clone(),
                 webhook_url: None,
             },

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1708,7 +1708,7 @@ fn encode_query_value(s: &str) -> String {
 fn workflow_definition_to_view_for_list(
     d: &domain::workflow::WorkflowDefinition,
 ) -> WorkflowDefinitionView {
-    let (mut trigger_type, trigger_provider, secret) = match &d.trigger {
+    let (trigger_type, trigger_provider, secret) = match &d.trigger {
         WorkflowTrigger::Manual { .. } => ("manual".to_string(), None, None),
         WorkflowTrigger::Webhook {
             provider, secret, ..
@@ -1719,9 +1719,6 @@ fn workflow_definition_to_view_for_list(
         ),
         WorkflowTrigger::Cron { schedule, .. } => (format!("cron ({schedule})"), None, None),
     };
-    if d.paused {
-        trigger_type.push_str(" (paused)");
-    }
     // The list view never surfaces the secret — only the detail page does.
     let _ = secret;
     WorkflowDefinitionView {
@@ -1743,7 +1740,7 @@ fn workflow_definition_to_view_for_detail(
     d: &domain::workflow::WorkflowDefinition,
     public_host: Option<&str>,
 ) -> WorkflowDefinitionView {
-    let (mut trigger_type, trigger_provider, secret) = match &d.trigger {
+    let (trigger_type, trigger_provider, secret) = match &d.trigger {
         WorkflowTrigger::Manual { .. } => ("manual".to_string(), None, None),
         WorkflowTrigger::Webhook {
             provider, secret, ..
@@ -1762,9 +1759,6 @@ fn workflow_definition_to_view_for_detail(
             (label, None, None)
         }
     };
-    if d.paused {
-        trigger_type.push_str(" (paused)");
-    }
     let webhook_url = secret.as_ref().map(|_| match public_host {
         Some(host) => format!("{host}/webhooks/{}", d.id),
         None => format!("/webhooks/{}", d.id),
@@ -2109,20 +2103,24 @@ async fn project_workflow_set_paused(
     let sub = AuthSubject::User(user_id);
     let workflow_id = WorkflowDefinitionId::from(wf_id);
 
-    let msg = match state
+    let base = format!("/projects/{id}/workflows/{wf_id}");
+    match state
         .app
         .workflows()
         .set_paused(&sub, workflow_id, form.paused)
         .await
     {
-        Ok(_) if form.paused => "workflow paused; no runs will fire until resumed".to_string(),
-        Ok(_) => "workflow resumed".to_string(),
-        Err(e) => format!("failed to update workflow: {e}"),
-    };
-    Redirect::to(&format!(
-        "/projects/{id}/workflows/{wf_id}?flash={}",
-        encode_query_value(&msg)
-    ))
+        // Resume needs no banner — the page already shows the active state.
+        Ok(_) if !form.paused => Redirect::to(&base),
+        Ok(_) => Redirect::to(&format!(
+            "{base}?flash={}",
+            encode_query_value("workflow paused; no runs will fire until resumed")
+        )),
+        Err(e) => Redirect::to(&format!(
+            "{base}?flash={}",
+            encode_query_value(&format!("failed to update workflow: {e}"))
+        )),
+    }
     .into_response()
 }
 

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1704,7 +1704,7 @@ fn encode_query_value(s: &str) -> String {
 fn workflow_definition_to_view_for_list(
     d: &domain::workflow::WorkflowDefinition,
 ) -> WorkflowDefinitionView {
-    let (trigger_type, trigger_provider, secret) = match &d.trigger {
+    let (mut trigger_type, trigger_provider, secret) = match &d.trigger {
         WorkflowTrigger::Manual { .. } => ("manual".to_string(), None, None),
         WorkflowTrigger::Webhook {
             provider, secret, ..
@@ -1715,6 +1715,9 @@ fn workflow_definition_to_view_for_list(
         ),
         WorkflowTrigger::Cron { schedule, .. } => (format!("cron ({schedule})"), None, None),
     };
+    if d.paused {
+        trigger_type.push_str(" (paused)");
+    }
     // The list view never surfaces the secret — only the detail page does.
     let _ = secret;
     WorkflowDefinitionView {
@@ -1735,7 +1738,7 @@ fn workflow_definition_to_view_for_detail(
     d: &domain::workflow::WorkflowDefinition,
     public_host: Option<&str>,
 ) -> WorkflowDefinitionView {
-    let (trigger_type, trigger_provider, secret) = match &d.trigger {
+    let (mut trigger_type, trigger_provider, secret) = match &d.trigger {
         WorkflowTrigger::Manual { .. } => ("manual".to_string(), None, None),
         WorkflowTrigger::Webhook {
             provider, secret, ..
@@ -1754,6 +1757,9 @@ fn workflow_definition_to_view_for_detail(
             (label, None, None)
         }
     };
+    if d.paused {
+        trigger_type.push_str(" (paused)");
+    }
     let webhook_url = secret.as_ref().map(|_| match public_host {
         Some(host) => format!("{host}/webhooks/{}", d.id),
         None => format!("/webhooks/{}", d.id),

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -82,6 +82,10 @@ pub fn router() -> Router<AppState> {
             post(project_workflow_trigger),
         )
         .route(
+            "/projects/{id}/workflows/{wf_id}/pause",
+            post(project_workflow_set_paused),
+        )
+        .route(
             "/projects/{id}/workflows/{wf_id}/runs/{run_id}",
             get(project_workflow_run_detail),
         )
@@ -1726,6 +1730,7 @@ fn workflow_definition_to_view_for_list(
         description: d.description.clone(),
         trigger_type,
         trigger_provider,
+        paused: d.paused,
         webhook_secret: None,
         webhook_url: None,
         steps: d.steps.iter().map(workflow_step_to_view).collect(),
@@ -1770,6 +1775,7 @@ fn workflow_definition_to_view_for_detail(
         description: d.description.clone(),
         trigger_type,
         trigger_provider,
+        paused: d.paused,
         webhook_secret: secret,
         webhook_url,
         steps: d.steps.iter().map(workflow_step_to_view).collect(),
@@ -2082,6 +2088,42 @@ async fn project_workflow_trigger(
             .into_response()
         }
     }
+}
+
+#[derive(Debug, Deserialize)]
+struct WorkflowSetPausedForm {
+    paused: bool,
+}
+
+#[instrument(name = "web.project_workflow_set_paused", skip_all)]
+async fn project_workflow_set_paused(
+    State(state): State<AppState>,
+    session: Session,
+    Path((id, wf_id)): Path<(uuid::Uuid, uuid::Uuid)>,
+    Form(form): Form<WorkflowSetPausedForm>,
+) -> Response {
+    let user_id = match extract_user_id(&session).await {
+        Some(id) => id,
+        None => return Redirect::to("/").into_response(),
+    };
+    let sub = AuthSubject::User(user_id);
+    let workflow_id = WorkflowDefinitionId::from(wf_id);
+
+    let msg = match state
+        .app
+        .workflows()
+        .set_paused(&sub, workflow_id, form.paused)
+        .await
+    {
+        Ok(_) if form.paused => "workflow paused; no runs will fire until resumed".to_string(),
+        Ok(_) => "workflow resumed".to_string(),
+        Err(e) => format!("failed to update workflow: {e}"),
+    };
+    Redirect::to(&format!(
+        "/projects/{id}/workflows/{wf_id}?flash={}",
+        encode_query_value(&msg)
+    ))
+    .into_response()
 }
 
 #[instrument(name = "web.project_workflow_run_detail", skip_all)]

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -17,7 +17,7 @@ use domain::primitives::{
     AgentId, SandboxId, SkillId, SpaceId, UserId, WorkflowDefinitionId, WorkflowRunId,
 };
 use domain::sandbox::{SandboxAgentMode, SandboxMode};
-use domain::workflow::WorkflowTrigger;
+use domain::workflow::{TriggerOutcome, WorkflowTrigger};
 
 use crate::templates::*;
 use crate::AppState;
@@ -2053,10 +2053,20 @@ async fn project_workflow_trigger(
         .trigger_run(&sub, workflow_id, payload)
         .await
     {
-        Ok(Some(run)) => Redirect::to(&format!("/projects/{id}/workflows/{wf_id}/runs/{}", run.id))
-            .into_response(),
-        Ok(None) => {
+        Ok(TriggerOutcome::Spawned(run)) => {
+            Redirect::to(&format!("/projects/{id}/workflows/{wf_id}/runs/{}", run.id))
+                .into_response()
+        }
+        Ok(TriggerOutcome::Filtered) => {
             let msg = "trigger condition evaluated to false; no run created".to_string();
+            Redirect::to(&format!(
+                "/projects/{id}/workflows/{wf_id}?flash={}",
+                encode_query_value(&msg)
+            ))
+            .into_response()
+        }
+        Ok(TriggerOutcome::Paused) => {
+            let msg = "workflow is paused; no run created — resume it to trigger runs".to_string();
             Redirect::to(&format!(
                 "/projects/{id}/workflows/{wf_id}?flash={}",
                 encode_query_value(&msg)

--- a/server/src/templates.rs
+++ b/server/src/templates.rs
@@ -244,6 +244,7 @@ pub struct WorkflowDefinitionView {
     /// `"manual"` or `"webhook"`.
     pub trigger_type: String,
     pub trigger_provider: Option<String>,
+    pub paused: bool,
     /// Detail page only — never set on listings.
     pub webhook_secret: Option<String>,
     pub webhook_url: Option<String>,

--- a/server/src/webhook.rs
+++ b/server/src/webhook.rs
@@ -4,8 +4,8 @@
 //! - `POST /webhooks/{definition_id}` — per-definition endpoint (1:1).
 //! - `POST /webhooks/providers/{provider}` — fan-out: evaluates every
 //!   definition tagged with this provider and spawns runs for those
-//!   whose `trigger.condition` passes. Auth via env var
-//!   `WEBHOOK_SECRET_{PROVIDER_UPPER}`.
+//!   that aren't paused and whose `trigger.condition` passes. Auth via
+//!   env var `WEBHOOK_SECRET_{PROVIDER_UPPER}`.
 //!
 //! Provider `github_app` uses HMAC-SHA256 verification
 //! (`X-Hub-Signature-256: sha256=<hex>`) instead of bearer tokens.
@@ -34,7 +34,7 @@ use tracing::instrument;
 use drua_core as domain;
 
 use domain::primitives::WorkflowDefinitionId;
-use domain::workflow::WorkflowTrigger;
+use domain::workflow::{TriggerOutcome, WorkflowTrigger};
 
 use crate::AppState;
 
@@ -98,13 +98,17 @@ pub async fn handle_webhook(
         .trigger_run_for_definition(definition, trigger_context)
         .await
     {
-        Ok(Some(run)) => {
+        Ok(TriggerOutcome::Spawned(run)) => {
             tracing::info!(run_id = %run.id, "workflow run triggered via webhook");
             (StatusCode::OK, run.id.to_string()).into_response()
         }
-        Ok(None) => {
+        Ok(TriggerOutcome::Filtered) => {
             tracing::info!("webhook accepted; run suppressed by trigger condition");
             (StatusCode::OK, "filtered").into_response()
+        }
+        Ok(TriggerOutcome::Paused) => {
+            tracing::info!("webhook accepted; workflow is paused, run suppressed");
+            (StatusCode::OK, "paused").into_response()
         }
         Err(e) => {
             tracing::error!(error = %e, "webhook: failed to trigger run");
@@ -117,6 +121,7 @@ pub async fn handle_webhook(
 struct ProviderFanOutResponse {
     triggered: usize,
     filtered: usize,
+    paused: usize,
     errored: usize,
     resumed: usize,
 }
@@ -186,6 +191,7 @@ pub async fn handle_provider_webhook(
             Json(ProviderFanOutResponse {
                 triggered: result.triggered,
                 filtered: result.filtered,
+                paused: result.paused,
                 errored: result.errored,
                 resumed,
             }),

--- a/server/templates/project_workflow_detail.html
+++ b/server/templates/project_workflow_detail.html
@@ -133,6 +133,23 @@
 </section>
 
 <section>
+  <h4>Status</h4>
+  {% if workflow.paused %}
+  <p><strong>Paused.</strong> No runs fire — cron fires are skipped, webhook deliveries and manual triggers are suppressed — until resumed.</p>
+  <form method="post" action="/projects/{{ project.id }}/workflows/{{ workflow.id }}/pause">
+    <input type="hidden" name="paused" value="false">
+    <button type="submit">Resume workflow</button>
+  </form>
+  {% else %}
+  <p><strong>Active.</strong></p>
+  <form method="post" action="/projects/{{ project.id }}/workflows/{{ workflow.id }}/pause">
+    <input type="hidden" name="paused" value="true">
+    <button type="submit" class="secondary">Pause workflow</button>
+  </form>
+  {% endif %}
+</section>
+
+<section>
   <h4>Sandboxes</h4>
   {% if workflow.sandboxes.is_empty() %}
   <p><em>No sandboxes declared. Steps cannot reference a sandbox.</em></p>

--- a/server/templates/project_workflow_detail.html
+++ b/server/templates/project_workflow_detail.html
@@ -107,10 +107,7 @@
     <tr>
       <th>Type</th>
       <td>
-        {% if workflow.trigger_type == "manual" %}manual
-        {% else %}
-          webhook{% match workflow.trigger_provider %}{% when Some(p) %} ({{ p }}){% when None %}{% endmatch %}
-        {% endif %}
+        {{ workflow.trigger_type }}{% match workflow.trigger_provider %}{% when Some(p) %} ({{ p }}){% when None %}{% endmatch %}
       </td>
     </tr>
     {% match workflow.webhook_url %}

--- a/server/templates/project_workflows.html
+++ b/server/templates/project_workflows.html
@@ -89,14 +89,7 @@
       <tr style="cursor: pointer;" onclick="window.location='/projects/{{ project.id }}/workflows/{{ wf.id }}'">
         <td><strong>{{ wf.name }}</strong>{% match wf.description %}{% when Some(d) %}<br><small style="color: var(--pico-muted-color);">{{ d }}</small>{% when None %}{% endmatch %}</td>
         <td>
-          {% if wf.trigger_type == "manual" %}
-            <small>manual</small>
-          {% else %}
-            {% match wf.trigger_provider %}
-              {% when Some(p) %}<small>webhook ({{ p }})</small>
-              {% when None %}<small>webhook</small>
-            {% endmatch %}
-          {% endif %}
+          <small>{{ wf.trigger_type }}{% match wf.trigger_provider %}{% when Some(p) %} ({{ p }}){% when None %}{% endmatch %}{% if wf.paused %} (paused){% endif %}</small>
         </td>
         <td>{{ wf.steps.len() }}</td>
         <td><small>{{ wf.created_at }}</small></td>

--- a/server/tests/graphql.rs
+++ b/server/tests/graphql.rs
@@ -580,7 +580,7 @@ async fn workflow_definitions_query_exposes_yaml_and_structured_fields() {
 }
 
 #[tokio::test]
-async fn workflow_trigger_mutation_returns_run_or_filtered() {
+async fn workflow_trigger_mutation_reports_disposition() {
     let pool = pool().await;
     let app = test_app(&pool).await;
     let schema = drua_server::graphql::schema(Some(app.clone()));
@@ -656,7 +656,7 @@ async fn workflow_trigger_mutation_returns_run_or_filtered() {
         &sub,
         r#"mutation($input: WorkflowTriggerInput!) {
             workflowTrigger(input: $input) {
-                filtered
+                disposition
                 run { id definitionId projectId state triggerContext }
             }
         }"#,
@@ -669,7 +669,7 @@ async fn workflow_trigger_mutation_returns_run_or_filtered() {
     )
     .await;
     let data = assert_no_errors(&result);
-    assert_eq!(data["workflowTrigger"]["filtered"], false);
+    assert_eq!(data["workflowTrigger"]["disposition"], "SPAWNED");
     assert_eq!(
         data["workflowTrigger"]["run"]["definitionId"],
         runnable.id.to_string()
@@ -684,13 +684,31 @@ async fn workflow_trigger_mutation_returns_run_or_filtered() {
         &app,
         &sub,
         r#"mutation($input: WorkflowTriggerInput!) {
-            workflowTrigger(input: $input) { filtered run { id } }
+            workflowTrigger(input: $input) { disposition run { id } }
         }"#,
         serde_json::json!({ "input": { "definitionId": filtered.id.to_string() } }),
     )
     .await;
     let data = assert_no_errors(&result);
-    assert_eq!(data["workflowTrigger"]["filtered"], true);
+    assert_eq!(data["workflowTrigger"]["disposition"], "FILTERED");
+    assert!(data["workflowTrigger"]["run"].is_null());
+
+    app.workflows()
+        .set_paused(&sub, runnable.id, true)
+        .await
+        .expect("pause workflow");
+    let result = execute_graphql(
+        &schema,
+        &app,
+        &sub,
+        r#"mutation($input: WorkflowTriggerInput!) {
+            workflowTrigger(input: $input) { disposition run { id } }
+        }"#,
+        serde_json::json!({ "input": { "definitionId": runnable.id.to_string() } }),
+    )
+    .await;
+    let data = assert_no_errors(&result);
+    assert_eq!(data["workflowTrigger"]["disposition"], "PAUSED");
     assert!(data["workflowTrigger"]["run"].is_null());
 }
 


### PR DESCRIPTION
Adds a `paused` flag to every workflow so a cron, webhook, or manual workflow can be stopped without deleting its definition. While paused no runs fire — cron fires are skipped (the self-rescheduling job keeps ticking, so resume is a pure data flip: no re-registration, no backfill), and webhook deliveries and manual triggers are suppressed. Reachable from both front ends — a pause/resume button on the web workflow page and a `p` toggle in the TUI — plus the `workflowSetPaused` GraphQL mutation and MCP `pause`/`resume` commands, and the flag round-trips through the library YAML so it reverse-syncs like any other workflow edit.

Separately, the explicit-trigger path stops treating a paused workflow as a failure: triggering now returns a `TriggerOutcome` disposition — surfaced on the GraphQL payload as `disposition`, replacing the old `filtered` boolean — so a suppressed run (filtered or paused) is an expected outcome rather than a `WorkflowError`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all workflow trigger paths (cron, webhooks, GraphQL, MCP) and changes the GraphQL trigger contract (`filtered` → `disposition`), which is a breaking API change for clients.
> 
> **Overview**
> Adds a **`paused`** flag on workflow definitions so cron, webhook, and manual triggers can be stopped without deleting the workflow. While paused, **`spawn_run_static`** is the single gate: no new runs are created (cron jobs still reschedule; in-flight runs keep going). The flag persists in **library YAML**, entity events, and **`WorkflowDefinition::set_paused` / `Workflows::set_paused`**.
> 
> **Trigger API change:** `trigger_run` / webhooks / cron now return **`TriggerOutcome`** (`Spawned` | `Filtered` | `Paused`) instead of `Option<WorkflowRun>`. GraphQL **`workflowTrigger`** exposes **`disposition`** (replacing **`filtered`**). Provider fan-out and webhook responses count **`paused`** suppressions separately.
> 
> **Surfaces:** GraphQL **`workflowSetPaused`**, web pause/resume forms, TUI **`p`** toggle + paused indicators, MCP **`pause`/`resume`** commands, and updated tool/admin trigger messaging. **`next_run_at`** shown to users is hidden while paused; cron scheduling still uses raw **`next_fire_at`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57ec6669d6adb151e54fba9bdab965890fff30d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->