### PR TITLE
chore: Add models to prod

### DIFF
--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -56,6 +56,18 @@ galoyAgents:
           - name: anthropic/claude-sonnet-4.6
             maxTokensPerResponse: 8192
             contextWindowTokens: 200000
+          - name: minimax/minimax-m3
+            maxTokensPerResponse: 8192
+            contextWindowTokens: 1048576
+          - name: qwen/qwen3.7-plus
+            maxTokensPerResponse: 8192
+            contextWindowTokens: 1000000
+          - name: moonshotai/kimi-k2.6:free
+            maxTokensPerResponse: 8192
+            contextWindowTokens: 262144
+          - name: moonshotai/kimi-k2.6
+            maxTokensPerResponse: 8192
+            contextWindowTokens: 262144
     ## Per-role defaults applied when an agent with that role is created.
     ## All three of `projectLead`, `agent`, and `workflowStepAgent` are
     ## REQUIRED — the binary refuses to start if any of


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Config-only additions to the provider model list with no changes to default chains or application logic.
> 
> **Overview**
> Registers **four new OpenRouter models** on the existing `openai` provider in `charts/drua/values.yaml`: `minimax/minimax-m3`, `qwen/qwen3.7-plus`, `moonshotai/kimi-k2.6:free`, and `moonshotai/kimi-k2.6`. Each entry follows the same pattern as current models—**8192** `maxTokensPerResponse` plus provider-specific `contextWindowTokens` for compaction and prompt sizing.
> 
> **Default agent chains are unchanged**; this only expands which models prod can select via overrides or the UI once the chart is deployed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b399ee916f7dfaae045105f69e83700b61c5fbad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->