### PR TITLE
fix(tunnel-connector): install rustls crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6551,6 +6551,7 @@ dependencies = [
  "rand 0.8.6",
  "reqwest 0.13.3",
  "rmcp",
+ "rustls",
  "serde",
  "serde_json",
  "sha2",

--- a/images/tunnel-connector/Cargo.toml
+++ b/images/tunnel-connector/Cargo.toml
@@ -24,6 +24,7 @@ kube = { version = "1", features = ["runtime", "client"] }
 rand = { workspace = true }
 reqwest = { version = "0.13", default-features = false, features = ["rustls", "json"] }
 rmcp = { workspace = true }
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 serde = { workspace = true }
 serde_json = "1"
 sha2 = { workspace = true }

--- a/images/tunnel-connector/src/main.rs
+++ b/images/tunnel-connector/src/main.rs
@@ -33,6 +33,7 @@ const JITTER_MS_MAX: u64 = 1_000;
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
+    install_rustls_crypto_provider();
     tracing_subscriber::fmt::init();
 
     let cli = cli::Cli::parse();
@@ -51,6 +52,12 @@ async fn main() -> anyhow::Result<()> {
         tokio::time::sleep(delay).await;
         backoff = (backoff * 2).min(MAX_BACKOFF);
     }
+}
+
+fn install_rustls_crypto_provider() {
+    // This binary links Rustls through multiple clients, which enables both
+    // provider features and disables Rustls' automatic provider selection.
+    let _ = rustls::crypto::ring::default_provider().install_default();
 }
 
 async fn build_postgres_mcp(cli: &cli::Cli) -> anyhow::Result<Arc<ManagedPostgresMcpController>> {


### PR DESCRIPTION
## Summary
- install a process-level Rustls `ring` crypto provider at tunnel-connector startup
- add `rustls` as a direct tunnel-connector dependency so the binary owns provider selection

## Why
The staging rollout of the new tunnel-connector image failed with `Could not automatically determine the process-level CryptoProvider` because this binary enables both Rustls providers through its client stack (`reqwest`/`kube`/`sqlx`).

## Verification
- `cargo check -p tunnel-connector`
- `cargo test -p tunnel-connector registers_reconciled_postgres_mcp_tools`
- local startup smoke now exits on missing kube config instead of the Rustls provider panic