### PR TITLE
fix(toolset): tool-catalog audit fixes — arg coercion, bash authz, call_tool ergonomics, compose scope

### DIFF
--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -8,6 +8,37 @@ use serde_json::Value;
 use crate::error::ToolCachingError;
 use crate::repo::StoredInvocation;
 
+/// Liberal numeric deserialization — some models send `"200"` instead of
+/// `200`; coerce numeric strings rather than failing the whole fetch.
+mod liberal {
+    use serde::Deserialize;
+
+    #[derive(Deserialize)]
+    #[serde(untagged)]
+    enum StringOrInt {
+        Int(i64),
+        Str(String),
+    }
+
+    pub(super) fn deserialize_i64<'de, D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<i64, D::Error> {
+        match StringOrInt::deserialize(deserializer)? {
+            StringOrInt::Int(v) => Ok(v),
+            StringOrInt::Str(s) => s.trim().parse().map_err(serde::de::Error::custom),
+        }
+    }
+
+    pub(super) fn deserialize_usize<'de, D: serde::Deserializer<'de>>(
+        deserializer: D,
+    ) -> Result<usize, D::Error> {
+        match StringOrInt::deserialize(deserializer)? {
+            StringOrInt::Int(v) => usize::try_from(v).map_err(serde::de::Error::custom),
+            StringOrInt::Str(s) => s.trim().parse().map_err(serde::de::Error::custom),
+        }
+    }
+}
+
 /// Slice operation applied at the resolved json-path. When absent, the
 /// whole value at the path is returned. Mirrors the recovery template
 /// the walker emits.
@@ -23,16 +54,31 @@ pub enum FetchQuery {
     /// requested byte boundaries land inside a UTF-8 codepoint, they are
     /// moved inward to the nearest valid character boundaries instead of
     /// failing the recovery request.
-    Range { offset: i64, len: usize },
+    Range {
+        #[serde(deserialize_with = "liberal::deserialize_i64")]
+        offset: i64,
+        #[serde(deserialize_with = "liberal::deserialize_usize")]
+        len: usize,
+    },
     /// Line range on a string-typed value at `path`. `offset` is the
     /// zero-indexed first line to return; `len` is the line count.
     /// `offset` may be negative to count from the end (e.g.
     /// `offset:-80, len:80` returns the last 80 lines).
-    Lines { offset: i64, len: usize },
+    Lines {
+        #[serde(deserialize_with = "liberal::deserialize_i64")]
+        offset: i64,
+        #[serde(deserialize_with = "liberal::deserialize_usize")]
+        len: usize,
+    },
     /// Item range on an array-typed value at `path`. Returns the slice
     /// `arr[offset..offset+len]` as a `Value::Array`. `offset` may be
     /// negative to count from the end of the array.
-    JsonArraySlice { offset: i64, len: usize },
+    JsonArraySlice {
+        #[serde(deserialize_with = "liberal::deserialize_i64")]
+        offset: i64,
+        #[serde(deserialize_with = "liberal::deserialize_usize")]
+        len: usize,
+    },
     /// Return the persisted curated `<summary>+<recovery>` envelope —
     /// the same view the agent would have seen from a top-level
     /// `call_tool` invocation. Useful for inspecting a compose
@@ -676,6 +722,41 @@ mod tests {
             },
             original_structured: None,
         }
+    }
+
+    #[test]
+    fn fetch_query_coerces_numeric_strings() {
+        let q: FetchQuery = serde_json::from_value(
+            serde_json::json!({"mode": "lines", "offset": "-80", "len": "200"}),
+        )
+        .unwrap();
+        assert!(matches!(
+            q,
+            FetchQuery::Lines {
+                offset: -80,
+                len: 200
+            }
+        ));
+        let q: FetchQuery =
+            serde_json::from_value(serde_json::json!({"mode": "range", "offset": "0", "len": 64}))
+                .unwrap();
+        assert!(matches!(q, FetchQuery::Range { offset: 0, len: 64 }));
+        let q: FetchQuery = serde_json::from_value(
+            serde_json::json!({"mode": "json_array_slice", "offset": 5, "len": "10"}),
+        )
+        .unwrap();
+        assert!(matches!(
+            q,
+            FetchQuery::JsonArraySlice { offset: 5, len: 10 }
+        ));
+        assert!(serde_json::from_value::<FetchQuery>(
+            serde_json::json!({"mode": "lines", "offset": 0, "len": "abc"})
+        )
+        .is_err());
+        assert!(serde_json::from_value::<FetchQuery>(
+            serde_json::json!({"mode": "lines", "offset": 0, "len": "-5"})
+        )
+        .is_err());
     }
 
     #[test]

--- a/core/src/auth/subject.rs
+++ b/core/src/auth/subject.rs
@@ -172,6 +172,17 @@ impl AuthSubject {
         })
     }
 
+    /// First `SandboxUse` scope (writer attachment). Read-only attachments
+    /// don't qualify — mutating tools (bash, Edit, Delete, Move) must not
+    /// run against them. Entity enforces a single active attachment per
+    /// agent, but first-wins regardless.
+    pub fn writable_sandbox_id(&self) -> Option<SandboxId> {
+        self.scopes().iter().find_map(|s| match s {
+            AuthScope::SandboxUse(id) => Some(*id),
+            _ => None,
+        })
+    }
+
     /// Panics for `Anonymous` and `WorkflowExecutor` — neither sends
     /// chat messages directly (the executor dispatches top-level tools
     /// rather than driving an agent session).

--- a/core/src/toolset/auto_parse_args.rs
+++ b/core/src/toolset/auto_parse_args.rs
@@ -1,55 +1,132 @@
-//! MCP gateway middleware: schema-driven auto-parse of stringified JSON args.
+//! MCP gateway middleware: schema-driven arg coercion.
 //!
-//! Some MCP clients (Claude Code's transport, in particular) JSON-encode
-//! complex nested arg values as strings — e.g. they send `query: "{\"mode\":
-//! \"head\"}"` instead of `query: {"mode": "head"}`. Per-tool deserialization
-//! then fails with "expected internally tagged enum FetchQuery" on what
-//! looks to the caller like a correctly-shaped object.
+//! Models and some MCP transports send args that are shaped right but typed
+//! wrong: complex values JSON-encoded as strings (`query: "{\"mode\":
+//! \"head\"}"` — Claude Code's transport) and scalars as strings
+//! (`len: "200"` — observed from minimax-m3). Per-tool deserialization then
+//! fails on what looks to the caller like a correct call.
 //!
-//! This middleware walks the args once before per-tool deserialization and,
-//! for each arg whose schema declares an object/array/enum type, tries to
-//! parse a JSON-shaped string in place. Schema-driven so a `String` field
-//! containing legitimate JSON literals (e.g. `sql: "[1,2,3]"`) stays a string.
+//! This middleware walks the args against the tool's input schema before
+//! per-tool deserialization and fixes both in place, recursing into nested
+//! objects, arrays, and `oneOf`/`anyOf`/`allOf` variants. Schema-driven so a
+//! `String` field containing legitimate JSON literals (e.g. `sql: "[1,2,3]"`)
+//! or numeric text stays a string.
 
 use rmcp::model::JsonObject;
 use serde_json::Value;
 
-/// Walks `args` and replaces stringified JSON in fields where `schema` declares
-/// a non-string shape. Mutates `args` in place. No-op when `schema` doesn't
-/// expose a `properties` map. Records a `tracing::debug!` event when a field
-/// is auto-parsed so observability can show whether the workaround is firing.
-pub(crate) fn auto_parse_stringified_json_args(args: &mut JsonObject, schema: &Value) {
+/// Mutates `args` in place. No-op when `schema` doesn't expose a
+/// `properties` map. Records a `tracing::debug!` event when a field is
+/// coerced so observability can show whether the workaround is firing.
+pub(crate) fn coerce_args_to_schema(args: &mut JsonObject, schema: &Value) {
     let Some(properties) = schema.get("properties").and_then(|v| v.as_object()) else {
         return;
     };
     for (key, value) in args.iter_mut() {
-        let Some(field_schema) = properties.get(key) else {
-            continue;
-        };
-        if !schema_expects_complex(field_schema) {
-            continue;
+        if let Some(field_schema) = properties.get(key) {
+            coerce_value(value, field_schema, key);
         }
-        let Value::String(s) = value else {
-            continue;
-        };
-        let trimmed = s.trim_start();
-        if !(trimmed.starts_with('{') || trimmed.starts_with('[')) {
-            continue;
-        }
-        match serde_json::from_str::<Value>(trimmed) {
-            Ok(parsed @ (Value::Object(_) | Value::Array(_))) => {
-                tracing::debug!(
-                    field = %key,
-                    "drua_core.toolset.auto_parse_stringified_json_arg"
-                );
-                *value = parsed;
+    }
+}
+
+fn coerce_value(value: &mut Value, schema: &Value, field: &str) {
+    match value {
+        Value::String(s) => {
+            if schema_expects_complex(schema) {
+                let trimmed = s.trim_start();
+                if trimmed.starts_with('{') || trimmed.starts_with('[') {
+                    if let Ok(parsed @ (Value::Object(_) | Value::Array(_))) =
+                        serde_json::from_str::<Value>(trimmed)
+                    {
+                        tracing::debug!(
+                            field = %field,
+                            "drua_core.toolset.auto_parse_stringified_json_arg"
+                        );
+                        *value = parsed;
+                        recurse(value, schema, field);
+                        return;
+                    }
+                }
+                // Not valid JSON or not a complex shape — leave alone;
+                // per-tool deserialization surfaces a clear error.
             }
-            _ => {
-                // Not valid JSON or not a complex shape — leave alone; per-tool
-                // deserialization will surface a clear error to the caller.
+            if let Some(coerced) = coerce_scalar_string(s, schema) {
+                tracing::debug!(
+                    field = %field,
+                    "drua_core.toolset.auto_coerce_scalar_arg"
+                );
+                *value = coerced;
+            }
+        }
+        Value::Object(_) | Value::Array(_) => recurse(value, schema, field),
+        _ => {}
+    }
+}
+
+/// Descend into the parts of `schema` that describe `value`'s children.
+/// Union variants are each tried — coercion only fires where a variant's
+/// declared type is non-string, so wrong-variant visits are no-ops.
+/// `$ref`s are not resolved, which also bounds recursion.
+fn recurse(value: &mut Value, schema: &Value, field: &str) {
+    let Some(schema_obj) = schema.as_object() else {
+        return;
+    };
+    for key in ["oneOf", "anyOf", "allOf"] {
+        if let Some(variants) = schema_obj.get(key).and_then(|v| v.as_array()) {
+            for variant in variants {
+                recurse(value, variant, field);
             }
         }
     }
+    match value {
+        Value::Object(map) => {
+            if let Some(props) = schema_obj.get("properties").and_then(|v| v.as_object()) {
+                for (k, v) in map.iter_mut() {
+                    if let Some(field_schema) = props.get(k) {
+                        coerce_value(v, field_schema, k);
+                    }
+                }
+            }
+        }
+        Value::Array(items) => {
+            if let Some(item_schema) = schema_obj.get("items").filter(|v| v.is_object()) {
+                for item in items.iter_mut() {
+                    coerce_value(item, item_schema, field);
+                }
+            }
+        }
+        _ => {}
+    }
+}
+
+/// `"200"` → `200` (integer), `"1.5"` → `1.5` (number), `"true"` → `true`
+/// (boolean) — only when the schema's declared type is one of those and
+/// does NOT admit string.
+fn coerce_scalar_string(s: &str, schema: &Value) -> Option<Value> {
+    let t = schema.get("type")?;
+    if type_admits_string(t) {
+        return None;
+    }
+    let wants = |name: &str| match t {
+        Value::String(v) => v == name,
+        Value::Array(types) => types.iter().any(|v| v.as_str() == Some(name)),
+        _ => false,
+    };
+    let s = s.trim();
+    if wants("integer") {
+        return s.parse::<i64>().ok().map(Value::from);
+    }
+    if wants("number") {
+        return s
+            .parse::<f64>()
+            .ok()
+            .filter(|f| f.is_finite())
+            .map(Value::from);
+    }
+    if wants("boolean") {
+        return s.parse::<bool>().ok().map(Value::from);
+    }
+    None
 }
 
 /// True when `schema` declares an object, array, or sum-of-objects (enum)
@@ -123,6 +200,109 @@ mod tests {
     }
 
     #[test]
+    fn coerces_top_level_numeric_and_boolean_strings() {
+        let schema = json!({
+            "properties": {
+                "limit": {"type": "integer"},
+                "ratio": {"type": "number"},
+                "dry_run": {"type": "boolean"},
+                "name": {"type": "string"},
+            }
+        });
+        let mut a = args(json!({
+            "limit": "200",
+            "ratio": "1.5",
+            "dry_run": "true",
+            "name": "42",
+        }));
+        coerce_args_to_schema(&mut a, &schema);
+        assert_eq!(a.get("limit").unwrap(), &json!(200));
+        assert_eq!(a.get("ratio").unwrap(), &json!(1.5));
+        assert_eq!(a.get("dry_run").unwrap(), &json!(true));
+        assert_eq!(a.get("name").unwrap(), &json!("42"));
+    }
+
+    #[test]
+    fn coerces_inside_tagged_enum_variants() {
+        // The FetchQuery shape: query is anyOf [oneOf [variants...], null],
+        // each variant declaring integer offset/len.
+        let schema = json!({
+            "properties": {
+                "query": {
+                    "anyOf": [
+                        {
+                            "oneOf": [
+                                {"type": "object", "properties": {
+                                    "mode": {"type": "string", "enum": ["lines"]},
+                                    "offset": {"type": "integer"},
+                                    "len": {"type": "integer", "minimum": 0},
+                                }},
+                                {"type": "object", "properties": {
+                                    "mode": {"type": "string", "enum": ["range"]},
+                                    "offset": {"type": "integer"},
+                                    "len": {"type": "integer", "minimum": 0},
+                                }},
+                            ]
+                        },
+                        {"type": "null"}
+                    ]
+                }
+            }
+        });
+        let mut a = args(json!({
+            "query": {"mode": "lines", "offset": "-80", "len": "200"}
+        }));
+        coerce_args_to_schema(&mut a, &schema);
+        assert_eq!(
+            a.get("query").unwrap(),
+            &json!({"mode": "lines", "offset": -80, "len": 200})
+        );
+    }
+
+    #[test]
+    fn coerces_inside_array_items() {
+        let schema = json!({
+            "properties": {
+                "rows": {"type": "array", "items": {
+                    "type": "object",
+                    "properties": {"id": {"type": "integer"}},
+                }}
+            }
+        });
+        let mut a = args(json!({"rows": [{"id": "1"}, {"id": "2"}]}));
+        coerce_args_to_schema(&mut a, &schema);
+        assert_eq!(a.get("rows").unwrap(), &json!([{"id": 1}, {"id": 2}]));
+    }
+
+    #[test]
+    fn coerces_after_parsing_stringified_object() {
+        let schema = json!({
+            "properties": {
+                "query": {"type": "object", "properties": {"len": {"type": "integer"}}}
+            }
+        });
+        let mut a = args(json!({"query": "{\"len\":\"100\"}"}));
+        coerce_args_to_schema(&mut a, &schema);
+        assert_eq!(a.get("query").unwrap(), &json!({"len": 100}));
+    }
+
+    #[test]
+    fn leaves_non_numeric_strings_alone_for_integer_fields() {
+        let schema = json!({"properties": {"limit": {"type": "integer"}}});
+        let mut a = args(json!({"limit": "abc"}));
+        coerce_args_to_schema(&mut a, &schema);
+        assert_eq!(a.get("limit").unwrap(), &json!("abc"));
+    }
+
+    #[test]
+    fn leaves_strings_alone_when_type_admits_string() {
+        let schema = json!({"properties": {"id": {"type": ["string", "integer"]}}});
+        let mut a = args(json!({"id": "123"}));
+        coerce_args_to_schema(&mut a, &schema);
+        assert_eq!(a.get("id").unwrap(), &json!("123"));
+    }
+
+    #[test]
     fn parses_stringified_object_into_object_field() {
         let schema = json!({
             "properties": {
@@ -132,7 +312,7 @@ mod tests {
         let mut a = args(json!({
             "query": "{\"mode\":\"head\",\"lines\":5}"
         }));
-        auto_parse_stringified_json_args(&mut a, &schema);
+        coerce_args_to_schema(&mut a, &schema);
         assert_eq!(
             a.get("query").unwrap(),
             &json!({"mode": "head", "lines": 5})
@@ -143,7 +323,7 @@ mod tests {
     fn parses_stringified_array_into_array_field() {
         let schema = json!({"properties": {"ids": {"type": "array"}}});
         let mut a = args(json!({"ids": "[1,2,3]"}));
-        auto_parse_stringified_json_args(&mut a, &schema);
+        coerce_args_to_schema(&mut a, &schema);
         assert_eq!(a.get("ids").unwrap(), &json!([1, 2, 3]));
     }
 
@@ -163,7 +343,7 @@ mod tests {
         let mut a = args(json!({
             "query": "{\"mode\":\"tail\",\"lines\":3}"
         }));
-        auto_parse_stringified_json_args(&mut a, &schema);
+        coerce_args_to_schema(&mut a, &schema);
         assert_eq!(
             a.get("query").unwrap(),
             &json!({"mode": "tail", "lines": 3})
@@ -174,7 +354,7 @@ mod tests {
     fn leaves_string_field_alone_when_schema_says_string() {
         let schema = json!({"properties": {"sql": {"type": "string"}}});
         let mut a = args(json!({"sql": "[1,2,3]"})); // user-shaped string
-        auto_parse_stringified_json_args(&mut a, &schema);
+        coerce_args_to_schema(&mut a, &schema);
         assert_eq!(a.get("sql").unwrap(), &json!("[1,2,3]"));
     }
 
@@ -182,7 +362,7 @@ mod tests {
     fn leaves_string_field_alone_when_schema_admits_string_and_null() {
         let schema = json!({"properties": {"name": {"type": ["string", "null"]}}});
         let mut a = args(json!({"name": "{\"foo\":1}"}));
-        auto_parse_stringified_json_args(&mut a, &schema);
+        coerce_args_to_schema(&mut a, &schema);
         assert_eq!(a.get("name").unwrap(), &json!("{\"foo\":1}"));
     }
 
@@ -196,7 +376,7 @@ mod tests {
             }
         });
         let mut a = args(json!({"value": "{\"foo\":1}"}));
-        auto_parse_stringified_json_args(&mut a, &schema);
+        coerce_args_to_schema(&mut a, &schema);
         assert_eq!(a.get("value").unwrap(), &json!("{\"foo\":1}"));
     }
 
@@ -204,7 +384,7 @@ mod tests {
     fn leaves_invalid_json_alone() {
         let schema = json!({"properties": {"query": {"type": "object"}}});
         let mut a = args(json!({"query": "{not valid json"}));
-        auto_parse_stringified_json_args(&mut a, &schema);
+        coerce_args_to_schema(&mut a, &schema);
         assert_eq!(a.get("query").unwrap(), &json!("{not valid json"));
     }
 
@@ -212,7 +392,7 @@ mod tests {
     fn leaves_string_not_starting_with_brace_alone() {
         let schema = json!({"properties": {"query": {"type": "object"}}});
         let mut a = args(json!({"query": "plain old string"}));
-        auto_parse_stringified_json_args(&mut a, &schema);
+        coerce_args_to_schema(&mut a, &schema);
         assert_eq!(a.get("query").unwrap(), &json!("plain old string"));
     }
 
@@ -220,7 +400,7 @@ mod tests {
     fn handles_schema_without_properties() {
         let schema = json!({"type": "object"});
         let mut a = args(json!({"x": "{\"a\":1}"}));
-        auto_parse_stringified_json_args(&mut a, &schema);
+        coerce_args_to_schema(&mut a, &schema);
         // No-op — without `properties` we have no per-field schema.
         assert_eq!(a.get("x").unwrap(), &json!("{\"a\":1}"));
     }
@@ -232,7 +412,7 @@ mod tests {
             "known": "{\"a\":1}",
             "unknown": "{\"b\":2}",
         }));
-        auto_parse_stringified_json_args(&mut a, &schema);
+        coerce_args_to_schema(&mut a, &schema);
         assert_eq!(a.get("known").unwrap(), &json!({"a": 1}));
         assert_eq!(a.get("unknown").unwrap(), &json!("{\"b\":2}"));
     }
@@ -241,7 +421,7 @@ mod tests {
     fn handles_stringified_with_leading_whitespace() {
         let schema = json!({"properties": {"q": {"type": "object"}}});
         let mut a = args(json!({"q": "  \n  {\"a\":1}"}));
-        auto_parse_stringified_json_args(&mut a, &schema);
+        coerce_args_to_schema(&mut a, &schema);
         assert_eq!(a.get("q").unwrap(), &json!({"a": 1}));
     }
 
@@ -250,7 +430,7 @@ mod tests {
         // String "42" is JSON-parseable but not a complex type. Leave alone.
         let schema = json!({"properties": {"q": {"type": "object"}}});
         let mut a = args(json!({"q": "42"}));
-        auto_parse_stringified_json_args(&mut a, &schema);
+        coerce_args_to_schema(&mut a, &schema);
         assert_eq!(a.get("q").unwrap(), &json!("42"));
     }
 }

--- a/core/src/toolset/error.rs
+++ b/core/src/toolset/error.rs
@@ -50,6 +50,8 @@ pub enum ToolSetsError {
     Workflow(String),
     #[error("ToolSetsError - Unauthorized")]
     Unauthorized,
+    #[error("ToolSetsError - Unauthorized: {0}")]
+    UnauthorizedReason(String),
 }
 
 /// Why a top-level tool can't be invoked from a workflow `tool_step`.

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -203,6 +203,7 @@ impl ToolSets {
         let describe = Arc::new(DescribeCatalogTool::new(Arc::clone(&sets)));
         let call = Arc::new(CallCatalogTool::new(
             Arc::clone(&sets),
+            Arc::clone(&top_level),
             tool_caching.clone(),
         ));
         let compose = Arc::new(ComposeTool::new(

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -590,7 +590,7 @@ impl ToolSets {
             // Auto-parse them in place against the tool's input schema before
             // dispatch, so per-tool deserialization sees the intended shape.
             let arguments = arguments.map(|mut args| {
-                auto_parse_args::auto_parse_stringified_json_args(&mut args, tool.input_schema());
+                auto_parse_args::coerce_args_to_schema(&mut args, tool.input_schema());
                 args
             });
 

--- a/core/src/toolset/top_level/bash.rs
+++ b/core/src/toolset/top_level/bash.rs
@@ -8,11 +8,11 @@
 //! Visibility / authz:
 //! - Visible only to [`AuthSubject::Agent`] / [`AuthSubject::AgentOnBehalfOfUser`]
 //!   — users / exported-agent tokens / anonymous never see it.
-//! - Executable only when the subject carries a [`AuthScope::SandboxUse`]
-//!   (granted by attaching as Write). Read-only attachment isn't enough —
-//!   bash can mutate sandbox state. Visible-but-unauthorized when an agent
-//!   has no write attachment yet, so the model can ask to attach and try
-//!   again instead of being baffled by a missing tool.
+//! - Visible and executable only when the subject carries a
+//!   [`AuthScope::SandboxUse`] (granted by attaching as Write). Read-only
+//!   attachment isn't enough — bash can mutate sandbox state, and unlike
+//!   the other file tools there is no space-path fallback, so a bash
+//!   without write attachment can never succeed and is hidden entirely.
 
 use std::sync::{Arc, LazyLock};
 
@@ -21,7 +21,6 @@ use sandbox::{BashCommandInput, BashCommandOutput};
 
 use crate::audit::Audit;
 use crate::auth::AuthSubject;
-use crate::primitives::{AuthScope, SandboxId};
 use crate::sandbox::Sandboxes;
 
 use super::super::error::ToolSetsError;
@@ -64,16 +63,6 @@ static BASH_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
     })
 });
 
-/// First `SandboxUse` scope (writer attachment). Read-only attachments don't
-/// qualify because `bash` can mutate state. Entity enforces a single active
-/// attachment per agent, but first-wins regardless.
-fn sandbox_use_id(subject: &AuthSubject) -> Option<SandboxId> {
-    subject.scopes().iter().find_map(|s| match s {
-        AuthScope::SandboxUse(id) => Some(*id),
-        _ => None,
-    })
-}
-
 #[async_trait::async_trait]
 impl TopLevelTool for Bash {
     fn name(&self) -> &str {
@@ -97,8 +86,11 @@ impl TopLevelTool for Bash {
         Some(&BASH_OUTPUT_SCHEMA)
     }
 
+    // Unlike the other file tools, bash has no space-path fallback — without
+    // a write-mode sandbox it can never succeed, so don't advertise it
+    // (audit: 414 Unauthorized/week from read-only workflow agents).
     fn is_visible(&self, subject: &AuthSubject) -> bool {
-        subject.can_use_agent_file_tools()
+        subject.can_use_agent_file_tools() && subject.writable_sandbox_id().is_some()
     }
 
     async fn call(
@@ -106,7 +98,9 @@ impl TopLevelTool for Bash {
         subject: &AuthSubject,
         arguments: Option<JsonObject>,
     ) -> Result<CallToolResult, ToolSetsError> {
-        let sandbox_id = sandbox_use_id(subject).ok_or(ToolSetsError::Unauthorized)?;
+        let sandbox_id = subject
+            .writable_sandbox_id()
+            .ok_or_else(|| super::sandbox_write_denied(subject, "bash"))?;
         Audit::record_action("bash");
         Audit::record_sandbox_id(sandbox_id);
 

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -395,14 +395,15 @@ impl CallCatalogTool {
     }
 
     /// Top-level tools that models route through call_tool (audit:
-    /// tool_output_fetch, submit_output, workflow). Proxying keeps each
-    /// tool's own authz checks; only self-dispatch is refused.
-    fn find_top_level(&self, name: &str) -> Option<Arc<dyn TopLevelTool>> {
+    /// tool_output_fetch, submit_output, workflow). Hidden tools stay
+    /// hidden — the proxy must not be a side door past `is_visible`
+    /// (e.g. bash for read-only agents). Self-dispatch is refused.
+    fn find_top_level(&self, subject: &AuthSubject, name: &str) -> Option<Arc<dyn TopLevelTool>> {
         if name == "call_tool" {
             return None;
         }
         let map = self.top_level.read().expect("top_level lock poisoned");
-        map.get(name).cloned()
+        map.get(name).filter(|t| t.is_visible(subject)).cloned()
     }
 
     fn not_found(&self, subject: &AuthSubject, requested: &str) -> ToolSetsError {
@@ -547,8 +548,16 @@ impl TopLevelTool for CallCatalogTool {
         {
             Some(found) => found,
             None => {
-                if let Some(tool) = self.find_top_level(&canonical) {
+                if let Some(tool) = self.find_top_level(subject, &canonical) {
                     Audit::record_action(tool.name());
+                    // Same arg-coercion treatment as direct top-level dispatch.
+                    let inner_args = inner_args.map(|mut a| {
+                        super::super::auto_parse_args::coerce_args_to_schema(
+                            &mut a,
+                            tool.input_schema(),
+                        );
+                        a
+                    });
                     return tool.call(subject, inner_args).await;
                 }
                 return Err(self.not_found(subject, &tool_name));
@@ -1054,6 +1063,7 @@ mod tests {
 
     struct StubTopLevel {
         schema: serde_json::Value,
+        visible: bool,
     }
 
     #[async_trait::async_trait]
@@ -1067,47 +1077,89 @@ mod tests {
         fn input_schema(&self) -> &serde_json::Value {
             &self.schema
         }
+        fn is_visible(&self, _subject: &AuthSubject) -> bool {
+            self.visible
+        }
         async fn call(
             &self,
             _subject: &AuthSubject,
-            _arguments: Option<JsonObject>,
+            arguments: Option<JsonObject>,
         ) -> Result<CallToolResult, ToolSetsError> {
-            Ok(CallToolResult::success(vec![Content::text("proxied")]))
+            let echo = serde_json::to_string(&arguments.unwrap_or_default()).unwrap();
+            Ok(CallToolResult::success(vec![Content::text(echo)]))
         }
     }
 
-    #[tokio::test]
-    async fn call_tool_proxies_registered_top_level_tools() {
+    fn call_tool_with_stub_top_level(visible: bool) -> CallCatalogTool {
         let mut top_level: std::collections::HashMap<String, Arc<dyn TopLevelTool>> =
             Default::default();
         top_level.insert(
             "submit_output".to_string(),
-            Arc::new(StubTopLevel { schema: json!({}) }),
+            Arc::new(StubTopLevel {
+                schema: json!({"properties": {"len": {"type": "integer"}}}),
+                visible,
+            }),
         );
         let sets: Vec<Arc<dyn SearchableToolSet>> = vec![];
-        let call = CallCatalogTool::new(
+        CallCatalogTool::new(
             Arc::new(RwLock::new(sets)),
             Arc::new(RwLock::new(top_level)),
             None,
-        );
+        )
+    }
+
+    fn call_tool_args(tool_name: &str) -> JsonObject {
+        let mut args = JsonObject::default();
+        args.insert("tool_name".to_string(), json!(tool_name));
+        args
+    }
+
+    #[tokio::test]
+    async fn call_tool_proxies_registered_top_level_tools() {
+        let call = call_tool_with_stub_top_level(true);
 
         for requested in ["submit_output", "mcp__drua__submit_output"] {
-            let mut args = JsonObject::default();
-            args.insert("tool_name".to_string(), json!(requested));
             let result = call
-                .call(&AuthSubject::Anonymous, Some(args))
+                .call(&AuthSubject::Anonymous, Some(call_tool_args(requested)))
                 .await
                 .unwrap();
             assert_ne!(result.is_error, Some(true), "requested: {requested}");
         }
 
         // Self-dispatch is refused, not recursed.
-        let mut args = JsonObject::default();
-        args.insert("tool_name".to_string(), json!("call_tool"));
         assert!(call
-            .call(&AuthSubject::Anonymous, Some(args))
+            .call(&AuthSubject::Anonymous, Some(call_tool_args("call_tool")))
             .await
             .is_err());
+    }
+
+    #[tokio::test]
+    async fn call_tool_proxy_coerces_args_against_tool_schema() {
+        let call = call_tool_with_stub_top_level(true);
+
+        let mut args = call_tool_args("submit_output");
+        args.insert("arguments".to_string(), json!({"len": "200"}));
+        let result = call
+            .call(&AuthSubject::Anonymous, Some(args))
+            .await
+            .unwrap();
+        let echoed = result.content[0].as_text().unwrap().text.clone();
+        assert!(echoed.contains("\"len\":200"), "got: {echoed}");
+    }
+
+    #[tokio::test]
+    async fn call_tool_does_not_proxy_hidden_top_level_tools() {
+        let call = call_tool_with_stub_top_level(false);
+
+        let err = call
+            .call(
+                &AuthSubject::Anonymous,
+                Some(call_tool_args("submit_output")),
+            )
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("ToolNotFound"), "got: {err}");
     }
 
     /// Strict MCP clients (e.g. Claude Code) reject boolean schemas inside

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -438,7 +438,22 @@ impl TopLevelTool for CallCatalogTool {
         let tool_name = args
             .remove("tool_name")
             .and_then(|v| v.as_str().map(str::to_string))
-            .ok_or_else(|| ToolSetsError::ToolNotFound("missing tool_name".to_string()))?;
+            .ok_or_else(|| {
+                let received: Vec<&String> = args.keys().collect();
+                let msg = if received.is_empty() {
+                    "missing required field `tool_name` — call_tool envelope is \
+                     {tool_name: \"<prefixed name from search_tools>\", arguments: {…}}"
+                        .to_string()
+                } else {
+                    format!(
+                        "missing required field `tool_name`; received keys: {received:?}. \
+                         call_tool envelope is {{tool_name: \"<prefixed name from \
+                         search_tools>\", arguments: {{…}}}} — put the tool's own \
+                         parameters inside `arguments`."
+                    )
+                };
+                ToolSetsError::InvalidArgument(msg)
+            })?;
         let inner_args = args.remove("arguments").and_then(|v| match v {
             serde_json::Value::Object(obj) => Some(obj),
             _ => None,
@@ -873,6 +888,36 @@ mod tests {
             Ok(CallToolResult::success(vec![Content::text("ok")]));
         let out = annotate_envelope_mistake(ok, "x", &["stray".to_string()]);
         assert!(out.is_ok());
+    }
+
+    #[tokio::test]
+    async fn missing_tool_name_echoes_received_keys() {
+        let sets: Vec<Arc<dyn SearchableToolSet>> = vec![];
+        let call = CallCatalogTool::new(Arc::new(RwLock::new(sets)), None);
+
+        let err = call
+            .call(&AuthSubject::Anonymous, None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("InvalidArgument"), "got: {err}");
+        assert!(
+            err.contains("missing required field `tool_name`"),
+            "got: {err}"
+        );
+
+        let mut args = JsonObject::default();
+        args.insert("incident_id".to_string(), json!("123"));
+        let err = call
+            .call(&AuthSubject::Anonymous, Some(args))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("received keys: [\"incident_id\"]"),
+            "got: {err}"
+        );
+        assert!(err.contains("inside `arguments`"), "got: {err}");
     }
 
     /// Strict MCP clients (e.g. Claude Code) reject boolean schemas inside

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -368,15 +368,21 @@ impl TopLevelTool for DescribeCatalogTool {
 
 pub struct CallCatalogTool {
     sets: Arc<RwLock<Vec<Arc<dyn SearchableToolSet>>>>,
+    top_level: Arc<RwLock<std::collections::HashMap<String, Arc<dyn TopLevelTool>>>>,
     tool_caching: Option<Arc<ToolCaching>>,
 }
 
 impl CallCatalogTool {
     pub fn new(
         sets: Arc<RwLock<Vec<Arc<dyn SearchableToolSet>>>>,
+        top_level: Arc<RwLock<std::collections::HashMap<String, Arc<dyn TopLevelTool>>>>,
         tool_caching: Option<Arc<ToolCaching>>,
     ) -> Self {
-        Self { sets, tool_caching }
+        Self {
+            sets,
+            top_level,
+            tool_caching,
+        }
     }
 
     fn find_set(
@@ -387,6 +393,79 @@ impl CallCatalogTool {
         let sets = self.sets.read().expect("toolset lock poisoned");
         super::super::dispatch::find_searchable(sets.iter(), subject, prefixed_name)
     }
+
+    /// Top-level tools that models route through call_tool (audit:
+    /// tool_output_fetch, submit_output, workflow). Proxying keeps each
+    /// tool's own authz checks; only self-dispatch is refused.
+    fn find_top_level(&self, name: &str) -> Option<Arc<dyn TopLevelTool>> {
+        if name == "call_tool" {
+            return None;
+        }
+        let map = self.top_level.read().expect("top_level lock poisoned");
+        map.get(name).cloned()
+    }
+
+    fn not_found(&self, subject: &AuthSubject, requested: &str) -> ToolSetsError {
+        let mut candidates: Vec<String> = {
+            let sets = self.sets.read().expect("toolset lock poisoned");
+            visible_entries(subject, &sets)
+                .into_iter()
+                .map(|e| e.prefixed_name)
+                .collect()
+        };
+        {
+            let map = self.top_level.read().expect("top_level lock poisoned");
+            candidates.extend(
+                map.values()
+                    .filter(|t| t.is_visible(subject))
+                    .map(|t| t.name().to_string()),
+            );
+        }
+        let suggestions = closest_tool_names(requested, &candidates);
+        let msg = if suggestions.is_empty() {
+            format!("{requested} — no such tool; use search_tools to discover available tools")
+        } else {
+            format!(
+                "{requested} — no such tool. Did you mean: {}? \
+                 Use search_tools to discover available tools.",
+                suggestions.join(", ")
+            )
+        };
+        ToolSetsError::ToolNotFound(msg)
+    }
+}
+
+/// Models confuse naming conventions (audit: `github.pull_request_read`,
+/// `mcp__drua__tool_output_fetch`) — map those spellings back to the
+/// canonical prefixed name before declaring a miss.
+fn canonicalize_tool_name(name: &str) -> String {
+    let stripped = name.strip_prefix("mcp__drua__").unwrap_or(name);
+    stripped.replace('.', "_")
+}
+
+fn name_tokens(s: &str) -> Vec<String> {
+    s.to_lowercase()
+        .split(['_', '-', '.', ' '])
+        .filter(|t| !t.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+fn closest_tool_names(requested: &str, candidates: &[String]) -> Vec<String> {
+    let req = name_tokens(requested);
+    if req.is_empty() {
+        return Vec::new();
+    }
+    let mut scored: Vec<(usize, &String)> = candidates
+        .iter()
+        .filter_map(|c| {
+            let toks = name_tokens(c);
+            let score = req.iter().filter(|t| toks.contains(t)).count();
+            (score > 0).then_some((score, c))
+        })
+        .collect();
+    scored.sort_by(|a, b| b.0.cmp(&a.0).then_with(|| a.1.cmp(b.1)));
+    scored.into_iter().take(3).map(|(_, c)| c.clone()).collect()
 }
 
 static CALL_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
@@ -461,21 +540,19 @@ impl TopLevelTool for CallCatalogTool {
 
         let extra_keys: Vec<String> = args.keys().cloned().collect();
 
-        let (set, name) = match self.find_set(subject, &tool_name) {
+        let canonical = canonicalize_tool_name(&tool_name);
+        let (set, name) = match self
+            .find_set(subject, &tool_name)
+            .or_else(|| self.find_set(subject, &canonical))
+        {
             Some(found) => found,
-            None if tool_name == "tool_output_fetch"
-                || tool_name == "mcp__drua__tool_output_fetch" =>
-            {
-                let tc = self
-                    .tool_caching
-                    .as_ref()
-                    .ok_or_else(|| ToolSetsError::ToolNotFound(tool_name.clone()))?;
-                let fetch =
-                    super::tool_output_fetch::ToolOutputFetch::new(std::sync::Arc::clone(tc));
-                Audit::record_action("tool_output_fetch");
-                return fetch.call(subject, inner_args).await;
+            None => {
+                if let Some(tool) = self.find_top_level(&canonical) {
+                    Audit::record_action(tool.name());
+                    return tool.call(subject, inner_args).await;
+                }
+                return Err(self.not_found(subject, &tool_name));
             }
-            None => return Err(ToolSetsError::ToolNotFound(tool_name.clone())),
         };
 
         // Auto-parse inner_args against the upstream tool's input schema —
@@ -893,7 +970,11 @@ mod tests {
     #[tokio::test]
     async fn missing_tool_name_echoes_received_keys() {
         let sets: Vec<Arc<dyn SearchableToolSet>> = vec![];
-        let call = CallCatalogTool::new(Arc::new(RwLock::new(sets)), None);
+        let call = CallCatalogTool::new(
+            Arc::new(RwLock::new(sets)),
+            Arc::new(RwLock::new(Default::default())),
+            None,
+        );
 
         let err = call
             .call(&AuthSubject::Anonymous, None)
@@ -918,6 +999,115 @@ mod tests {
             "got: {err}"
         );
         assert!(err.contains("inside `arguments`"), "got: {err}");
+    }
+
+    #[test]
+    fn canonicalize_handles_dots_and_mcp_prefix() {
+        assert_eq!(
+            canonicalize_tool_name("github.pull_request_read"),
+            "github_pull_request_read"
+        );
+        assert_eq!(
+            canonicalize_tool_name("mcp__drua__tool_output_fetch"),
+            "tool_output_fetch"
+        );
+        assert_eq!(
+            canonicalize_tool_name("zenduty_get_incident"),
+            "zenduty_get_incident"
+        );
+    }
+
+    #[test]
+    fn closest_tool_names_ranks_by_shared_tokens() {
+        let candidates = vec![
+            "github_pull_request_read".to_string(),
+            "github_get_file_contents".to_string(),
+            "zenduty_get_incident".to_string(),
+        ];
+        let got = closest_tool_names("github_pull_request_review_write", &candidates);
+        assert_eq!(got[0], "github_pull_request_read");
+        assert!(!got.contains(&"zenduty_get_incident".to_string()));
+
+        assert!(closest_tool_names("xyzzy", &candidates).is_empty());
+    }
+
+    #[tokio::test]
+    async fn unknown_tool_error_suggests_close_names() {
+        let stub = StubToolSet::with_tools(vec![("pull_request_read", "Read a PR")]);
+        let sets: Vec<Arc<dyn SearchableToolSet>> = vec![Arc::new(stub)];
+        let call = CallCatalogTool::new(
+            Arc::new(RwLock::new(sets)),
+            Arc::new(RwLock::new(Default::default())),
+            None,
+        );
+
+        let mut args = JsonObject::default();
+        args.insert("tool_name".to_string(), json!("stub.pull_request_reed"));
+        let err = call
+            .call(&AuthSubject::Anonymous, Some(args))
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("Did you mean"), "got: {err}");
+        assert!(err.contains("stub_pull_request_read"), "got: {err}");
+    }
+
+    struct StubTopLevel {
+        schema: serde_json::Value,
+    }
+
+    #[async_trait::async_trait]
+    impl TopLevelTool for StubTopLevel {
+        fn name(&self) -> &str {
+            "submit_output"
+        }
+        fn description(&self) -> &str {
+            "stub"
+        }
+        fn input_schema(&self) -> &serde_json::Value {
+            &self.schema
+        }
+        async fn call(
+            &self,
+            _subject: &AuthSubject,
+            _arguments: Option<JsonObject>,
+        ) -> Result<CallToolResult, ToolSetsError> {
+            Ok(CallToolResult::success(vec![Content::text("proxied")]))
+        }
+    }
+
+    #[tokio::test]
+    async fn call_tool_proxies_registered_top_level_tools() {
+        let mut top_level: std::collections::HashMap<String, Arc<dyn TopLevelTool>> =
+            Default::default();
+        top_level.insert(
+            "submit_output".to_string(),
+            Arc::new(StubTopLevel { schema: json!({}) }),
+        );
+        let sets: Vec<Arc<dyn SearchableToolSet>> = vec![];
+        let call = CallCatalogTool::new(
+            Arc::new(RwLock::new(sets)),
+            Arc::new(RwLock::new(top_level)),
+            None,
+        );
+
+        for requested in ["submit_output", "mcp__drua__submit_output"] {
+            let mut args = JsonObject::default();
+            args.insert("tool_name".to_string(), json!(requested));
+            let result = call
+                .call(&AuthSubject::Anonymous, Some(args))
+                .await
+                .unwrap();
+            assert_ne!(result.is_error, Some(true), "requested: {requested}");
+        }
+
+        // Self-dispatch is refused, not recursed.
+        let mut args = JsonObject::default();
+        args.insert("tool_name".to_string(), json!("call_tool"));
+        assert!(call
+            .call(&AuthSubject::Anonymous, Some(args))
+            .await
+            .is_err());
     }
 
     /// Strict MCP clients (e.g. Claude Code) reject boolean schemas inside

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -563,7 +563,7 @@ impl TopLevelTool for CallCatalogTool {
             if let Some(entry) = set.tools().iter().find(|t| t.name == name) {
                 let schema =
                     serde_json::Value::Object(entry.description.input_schema.as_ref().clone());
-                super::super::auto_parse_args::auto_parse_stringified_json_args(&mut a, &schema);
+                super::super::auto_parse_args::coerce_args_to_schema(&mut a, &schema);
             }
             a
         });

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -513,7 +513,7 @@ async fn run_searchable_call(
     let inner_args = inner_args.map(|mut a| {
         if let Some(entry) = set.tools().iter().find(|t| t.name == tool_name) {
             let schema = serde_json::Value::Object(entry.description.input_schema.as_ref().clone());
-            super::super::auto_parse_args::auto_parse_stringified_json_args(&mut a, &schema);
+            super::super::auto_parse_args::coerce_args_to_schema(&mut a, &schema);
         }
         a
     });
@@ -544,10 +544,7 @@ async fn run_top_level_call(
 
     // Same defense-in-depth as searchable runner.
     let inner_args = inner_args.map(|mut a| {
-        super::super::auto_parse_args::auto_parse_stringified_json_args(
-            &mut a,
-            tool.input_schema(),
-        );
+        super::super::auto_parse_args::coerce_args_to_schema(&mut a, tool.input_schema());
         a
     });
 

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -91,7 +91,9 @@ impl TopLevelTool for ComposeTool {
          (e.g. `tools.honeycomb_list_environments({...})`). \
          Use `return` for the final value. Top-level `await` and `Promise.all()` are supported. \
          **Call `compose_types` first** to fetch exact tool signatures and parameter names \
-         — guessing leads to runtime errors that waste a round trip.\n\n\
+         — guessing leads to runtime errors that waste a round trip. \
+         Scope is plain JavaScript plus `tools`, `console`, and `setTimeout` — \
+         no Node.js builtins (`require`, `module`, `process`, `fs` are unavailable).\n\n\
          Example:\n```js\nconst envs = await tools.honeycomb.list_environments({});\n\
          const issues = await tools.github.list_issues({ repo: 'org/repo', state: 'open' });\n\
          const stale = issues.filter(i => Date.now() - Date.parse(i.updated_at) > 7*86400*1000);\n\
@@ -328,10 +330,19 @@ impl CatalogDispatcher {
     ) -> Result<serde_json::Value, String> {
         let tool = {
             let map = self.top_level.read().expect("top_level lock poisoned");
-            map.get(name)
-                .filter(|t| t.composable() && t.is_visible(&self.subject))
-                .cloned()
-                .ok_or_else(|| with_hint(name, format!("Tool not found: {name}")))?
+            match map.get(name) {
+                Some(t) if t.is_visible(&self.subject) && t.composable() => Arc::clone(t),
+                // Registered but non-composable (compose, call_tool): say so
+                // instead of "not found" + a hint that suggests the failing
+                // call itself.
+                Some(t) if t.is_visible(&self.subject) => {
+                    return Err(format!(
+                        "Tool not callable inside compose scripts: {name} is a \
+                         top-level MCP tool — call it directly, outside compose."
+                    ));
+                }
+                _ => return Err(with_hint(name, format!("Tool not found: {name}"))),
+            }
         };
 
         let action = format!("compose > top_level: {name}");

--- a/core/src/toolset/top_level/compose_types.rs
+++ b/core/src/toolset/top_level/compose_types.rs
@@ -81,10 +81,6 @@ impl TopLevelTool for ComposeTypes {
         Some(&COMPOSE_TYPES_OUTPUT_SCHEMA)
     }
 
-    fn composable(&self) -> bool {
-        false
-    }
-
     async fn call(
         &self,
         subject: &AuthSubject,

--- a/core/src/toolset/top_level/delete.rs
+++ b/core/src/toolset/top_level/delete.rs
@@ -17,7 +17,6 @@ use sandbox::DeleteInput;
 
 use crate::audit::Audit;
 use crate::auth::AuthSubject;
-use crate::primitives::{AuthScope, SandboxId};
 use crate::sandbox::Sandboxes;
 use crate::space_fs::SpaceFs;
 
@@ -41,13 +40,6 @@ impl Delete {
 
 static DELETE_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<DeleteInput>);
 static DELETE_OUTPUT: LazyLock<OutputSchema<TextOutput>> = LazyLock::new(OutputSchema::new);
-
-fn writable_sandbox_id(subject: &AuthSubject) -> Option<SandboxId> {
-    subject.scopes().iter().find_map(|s| match s {
-        AuthScope::SandboxUse(id) => Some(*id),
-        _ => None,
-    })
-}
 
 #[async_trait::async_trait]
 impl TopLevelTool for Delete {
@@ -90,7 +82,9 @@ impl TopLevelTool for Delete {
             return Ok(DELETE_OUTPUT.success(text, &out));
         }
 
-        let sandbox_id = writable_sandbox_id(subject).ok_or(ToolSetsError::Unauthorized)?;
+        let sandbox_id = subject
+            .writable_sandbox_id()
+            .ok_or_else(|| super::sandbox_write_denied(subject, "Delete"))?;
         Audit::record_sandbox_id(sandbox_id);
 
         let client = self

--- a/core/src/toolset/top_level/glob.rs
+++ b/core/src/toolset/top_level/glob.rs
@@ -84,7 +84,7 @@ impl TopLevelTool for GlobTool {
 
         let sandbox_id = subject
             .readable_sandbox_id()
-            .ok_or(ToolSetsError::Unauthorized)?;
+            .ok_or_else(|| super::sandbox_read_denied("Glob"))?;
         Audit::record_sandbox_id(sandbox_id);
 
         let client = self

--- a/core/src/toolset/top_level/grep.rs
+++ b/core/src/toolset/top_level/grep.rs
@@ -94,7 +94,7 @@ impl TopLevelTool for Grep {
 
         let sandbox_id = subject
             .readable_sandbox_id()
-            .ok_or(ToolSetsError::Unauthorized)?;
+            .ok_or_else(|| super::sandbox_read_denied("Grep"))?;
         Audit::record_sandbox_id(sandbox_id);
 
         let client = self

--- a/core/src/toolset/top_level/ls.rs
+++ b/core/src/toolset/top_level/ls.rs
@@ -90,7 +90,7 @@ impl TopLevelTool for Ls {
 
         let sandbox_id = subject
             .readable_sandbox_id()
-            .ok_or(ToolSetsError::Unauthorized)?;
+            .ok_or_else(|| super::sandbox_read_denied("LS"))?;
         Audit::record_sandbox_id(sandbox_id);
 
         let client = self

--- a/core/src/toolset/top_level/mod.rs
+++ b/core/src/toolset/top_level/mod.rs
@@ -43,6 +43,31 @@ mod liberal {
     }
 }
 
+/// Actionable denial for sandbox-mutating tools — a bare "Unauthorized"
+/// sends agents into retry loops (audit: ~4 attempts each), so name the
+/// missing capability and the alternative.
+pub(super) fn sandbox_write_denied(
+    subject: &crate::auth::AuthSubject,
+    tool: &str,
+) -> ToolSetsError {
+    let reason = if subject.readable_sandbox_id().is_some() {
+        format!(
+            "sandbox is attached read-only; {tool} requires a write-mode \
+             attachment — use the read-only tools (Read, Grep, Glob, LS, \
+             Edit view) instead"
+        )
+    } else {
+        format!("no sandbox attached; {tool} requires a write-mode sandbox attachment")
+    };
+    ToolSetsError::UnauthorizedReason(reason)
+}
+
+pub(super) fn sandbox_read_denied(tool: &str) -> ToolSetsError {
+    ToolSetsError::UnauthorizedReason(format!(
+        "no sandbox attached; {tool} requires an attached sandbox"
+    ))
+}
+
 /// Missing arguments are treated as an empty object.
 pub(super) fn parse_params<T: serde::de::DeserializeOwned>(
     arguments: Option<JsonObject>,

--- a/core/src/toolset/top_level/move_file.rs
+++ b/core/src/toolset/top_level/move_file.rs
@@ -19,7 +19,6 @@ use sandbox::MoveInput;
 
 use crate::audit::Audit;
 use crate::auth::AuthSubject;
-use crate::primitives::{AuthScope, SandboxId};
 use crate::sandbox::Sandboxes;
 use crate::space_fs::SpaceFs;
 
@@ -43,13 +42,6 @@ impl MoveFile {
 
 static MOVE_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(schema_for::<MoveInput>);
 static MOVE_OUTPUT: LazyLock<OutputSchema<TextOutput>> = LazyLock::new(OutputSchema::new);
-
-fn writable_sandbox_id(subject: &AuthSubject) -> Option<SandboxId> {
-    subject.scopes().iter().find_map(|s| match s {
-        AuthScope::SandboxUse(id) => Some(*id),
-        _ => None,
-    })
-}
 
 #[async_trait::async_trait]
 impl TopLevelTool for MoveFile {
@@ -97,7 +89,9 @@ impl TopLevelTool for MoveFile {
             return Ok(MOVE_OUTPUT.success(text, &out));
         }
 
-        let sandbox_id = writable_sandbox_id(subject).ok_or(ToolSetsError::Unauthorized)?;
+        let sandbox_id = subject
+            .writable_sandbox_id()
+            .ok_or_else(|| super::sandbox_write_denied(subject, "Move"))?;
         Audit::record_sandbox_id(sandbox_id);
 
         let client = self

--- a/core/src/toolset/top_level/read.rs
+++ b/core/src/toolset/top_level/read.rs
@@ -105,7 +105,7 @@ impl TopLevelTool for Read {
 
         let sandbox_id = subject
             .readable_sandbox_id()
-            .ok_or(ToolSetsError::Unauthorized)?;
+            .ok_or_else(|| super::sandbox_read_denied("Read"))?;
         Audit::record_sandbox_id(sandbox_id);
 
         let mut editor_input = serde_json::json!({

--- a/core/src/toolset/top_level/text_editor.rs
+++ b/core/src/toolset/top_level/text_editor.rs
@@ -23,7 +23,6 @@ use sandbox::{TextEditorAction, TextEditorInput};
 
 use crate::audit::Audit;
 use crate::auth::AuthSubject;
-use crate::primitives::{AuthScope, SandboxId};
 use crate::sandbox::Sandboxes;
 use crate::space_fs::{FileView, SpaceFs};
 
@@ -48,13 +47,6 @@ impl TextEditor {
 static TEXT_EDITOR_OUTPUT: LazyLock<OutputSchema<TextOutput>> = LazyLock::new(OutputSchema::new);
 static TEXT_EDITOR_SCHEMA: LazyLock<serde_json::Value> =
     LazyLock::new(schema_for::<TextEditorInput>);
-
-fn writable_sandbox_id(subject: &AuthSubject) -> Option<SandboxId> {
-    subject.scopes().iter().find_map(|s| match s {
-        AuthScope::SandboxUse(id) => Some(*id),
-        _ => None,
-    })
-}
 
 #[async_trait::async_trait]
 impl TopLevelTool for TextEditor {
@@ -152,11 +144,13 @@ impl TopLevelTool for TextEditor {
         }
 
         let sandbox_id = if is_mutating {
-            writable_sandbox_id(subject).ok_or(ToolSetsError::Unauthorized)?
+            subject
+                .writable_sandbox_id()
+                .ok_or_else(|| super::sandbox_write_denied(subject, "Edit"))?
         } else {
             subject
                 .readable_sandbox_id()
-                .ok_or(ToolSetsError::Unauthorized)?
+                .ok_or_else(|| super::sandbox_read_denied("Edit"))?
         };
         Audit::record_sandbox_id(sandbox_id);
 

--- a/lib/js-engine/src/lib.rs
+++ b/lib/js-engine/src/lib.rs
@@ -580,6 +580,15 @@ const tools = new Proxy({{}}, {{
     }}
 }});
 
+// ── Node-ism stubs: fail with guidance, not ReferenceError ──
+const __noNode = (name) => () => {{
+    throw new Error(name + " is not available in compose scripts — plain JavaScript \
+plus the `tools` namespace only (no Node.js builtins).");
+}};
+const require = __noNode("require");
+const module = {{ get exports() {{ return __noNode("module")(); }} }};
+const process = new Proxy({{}}, {{ get: (_, p) => __noNode("process." + String(p))() }});
+
 // ── user script (wrapped for top-level await + return) ──
 (async () => {{
 {user_script}
@@ -642,6 +651,25 @@ mod tests {
             .unwrap();
         assert_eq!(result.value, serde_json::json!(3));
         assert_eq!(result.tool_calls_made, 0);
+    }
+
+    #[tokio::test]
+    async fn node_isms_fail_with_guidance() {
+        for script in [
+            r#"const x = require("fs"); return x;"#,
+            r#"return module.exports;"#,
+            r#"return process.env.HOME;"#,
+        ] {
+            let err = engine()
+                .execute(script, Arc::new(EchoDispatcher), timeout())
+                .await
+                .unwrap_err();
+            let msg = err.to_string();
+            assert!(
+                msg.contains("not available in compose scripts"),
+                "script {script:?} got: {msg}"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Context

Audit of `audit_entries` / `tool_invocations` (30-day window, 2026-06-10) confirmed the May 27 / Jun 2 tool-caching fixes worked (fetch-too-large errors 283 → 7; `ToolNotFound: tool_output_fetch` gone), and surfaced the current top model struggles. This PR fixes all of them, one commit per fix.

## Fixes (in priority order)

1. **`fix(tool-caching)`: accept numeric strings for `offset`/`len` in `FetchQuery`** — stops the active regression: after review/scan workflow steps moved to minimax-m3 on Jun 8, `tool_output_fetch` error rate jumped ~3% → 76% (311 errors / 40 agents in 7 days) because the model emits `"len": "200"` and strict serde rejected it.

2. **`fix(toolset)`: hide bash without a write sandbox + name the reason on denial** — 446 `Unauthorized`/week (114 agents), 414 of them bash calls from read-only workflow step agents retrying a bare error ~4× each. bash is now invisible without a write-mode attachment (it has no space-path fallback, so it could never succeed), and all sandbox-tool denials now say what's missing and what to use instead. Also dedupes 4 copies of `writable_sandbox_id` into `AuthSubject`.

3. **`fix(toolset)`: actionable `call_tool` missing-`tool_name` error** — 83/month; now `InvalidArgument` echoing the received keys plus the correct `{tool_name, arguments:{…}}` envelope.

4. **`fix(toolset)`: normalize tool names, proxy top-level tools, suggest on miss** — handles `github.pull_request_read` (dots), `mcp__drua__*` prefixes, and `submit_output`/`workflow` routed through call_tool (generalizes the hard-coded `tool_output_fetch` arm from #419); real misses get up to 3 closest names by token overlap.

5. **`fix(compose)`: callable `compose_types`, non-composable-specific error, Node-ism stubs** — kills the circular "Tool not found: compose_types → Hint: call compose_types" loop, makes `require`/`module`/`process` fail with guidance instead of `ReferenceError`, documents script scope in the tool description.

6. **`feat(toolset)`: recursive schema-driven scalar coercion** — the class fix for fix 1: the auto-parse middleware (renamed `coerce_args_to_schema`) now coerces `"200"`→`200` / `"true"`→`true` wherever a tool's input schema declares a non-string scalar, recursing into nested objects, array items, and `oneOf`/`anyOf`/`allOf`. Covers every catalog and top-level tool at both dispatch points, so the next string-typing model doesn't need a per-struct patch.

## Verification

- `cargo test -p drua-core --lib` — 539 passed
- `cargo test -p drua-tool-caching --lib`, `cargo test -p js-engine --lib` — green
- `cargo clippy` clean on touched crates, `cargo check --workspace` green
- New unit tests per fix: FetchQuery string coercion, missing-tool_name echo, canonicalization + suggestions + top-level proxy (incl. self-dispatch refusal), Node-ism stubs, nested/variant/array scalar coercion

## Expected audit impact

The four biggest error classes of the last 7 days (`Unauthorized` 446, numeric-as-string 311, missing tool_name 68, compose scope ~40) should all drop to ~0 without behavior change for well-formed callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches MCP argument parsing and authorization for all tools and changes bash visibility; behavior for well-formed callers should be unchanged, but coercion could theoretically alter edge-case string args where schemas are loose.
> 
> **Overview**
> Addresses audit-driven model and transport failures across tool-caching, MCP dispatch, sandbox tools, and compose.
> 
> **Arg coercion** renames and expands gateway middleware to `coerce_args_to_schema`: besides stringified JSON objects/arrays, it now coerces string scalars to integer/number/boolean when the schema disallows strings, with recursion through nested objects, arrays, and `oneOf`/`anyOf`/`allOf`. `FetchQuery` in tool-caching also accepts numeric strings for `offset`/`len` at deserialize time. Coercion runs on direct MCP dispatch, `call_tool` proxy paths, and compose runners.
> 
> **Sandbox authz** adds `AuthSubject::writable_sandbox_id()` and shared `sandbox_write_denied` / `sandbox_read_denied` helpers that return `UnauthorizedReason` with actionable text. **bash** is hidden unless a write sandbox is attached; mutating file tools use the centralized writable check.
> 
> **call_tool** gains name canonicalization (`mcp__drua__` prefix, dots → underscores), proxies visible top-level tools (with schema coercion, no self-dispatch), richer missing-`tool_name` errors, and “did you mean” suggestions on unknown tools.
> 
> **Compose** allows `compose_types` inside scripts (drops `composable: false`), improves errors when calling non-composable top-level tools, documents JS-only scope, and stubs `require`/`module`/`process` in js-engine with guided errors instead of `ReferenceError`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc2a2a137fd21f4b3f2a514c0e0e310126d5967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->