### PR TITLE
fix(agent): filter workflow agents in SQL in list_for_project

### DIFF
--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -54,7 +54,7 @@ use crate::sandbox::{Sandbox, SandboxAgentMode, Sandboxes};
 pub use config::{AgentsConfig, ModelChain, ModelDefaults, RoleConfig};
 pub use entity::*;
 pub use error::AgentError;
-use repo::AgentRepo;
+use repo::{AgentFilters, AgentRepo};
 use session::Sessions;
 
 /// Snapshot of dynamic system blocks (notes + skills + spaces) for one
@@ -632,20 +632,22 @@ impl Agents {
             first: 100,
             after: None,
         };
+        // `workflow_id: Some(None)` ⇒ `workflow_id IS NULL`: the page must be
+        // filtered in SQL, or workflow-spawned agents crowd out user-owned
+        // ones once a project accumulates 100 of them.
         let result = self
             .repo
-            .list_for_project_id_by_created_at(
-                project_id,
+            .list_for_filters_by_created_at(
+                AgentFilters {
+                    project_id: Some(project_id),
+                    workflow_id: Some(None),
+                    ..Default::default()
+                },
                 query,
                 es_entity::ListDirection::Descending,
             )
             .await?;
-        // Covered by the `idx_agents_project_id_user_owned` partial index.
-        Ok(result
-            .entities
-            .into_iter()
-            .filter(|a| a.workflow_id.is_none())
-            .collect())
+        Ok(result.entities)
     }
 
     #[instrument(name = "domain.agent.list_for_workflow_run", skip(self, sub))]

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -881,6 +881,48 @@ async fn detach_conflicting_writer_is_noop_when_unattached() {
 }
 
 #[tokio::test]
+async fn list_for_project_returns_lead_past_100_workflow_agents() {
+    let pool = pool().await;
+    let (agents, _sandboxes) = build_agents(&pool).await;
+    let project_id = insert_project(&pool).await;
+    let sub = AuthSubject::User(UserId::new());
+
+    let lead = agents
+        .create_project_lead(&sub, project_id, "lead", "test-project")
+        .await
+        .expect("create lead");
+
+    let (workflow_id, run_id) = seed_workflow_run(&pool, project_id).await;
+    let mut op = agents.begin_op().await.expect("begin op");
+    for i in 0..101 {
+        agents
+            .create_for_workflow_run_in_op(
+                &mut op,
+                project_id,
+                workflow_id,
+                run_id,
+                &format!("wf-step-{i}"),
+                None,
+                None,
+                drua_core::workflow::default_output_schema(),
+            )
+            .await
+            .expect("create workflow agent");
+    }
+    op.commit().await.expect("commit");
+
+    let listed = agents
+        .list_for_project(&sub, project_id)
+        .await
+        .expect("list");
+    assert_eq!(
+        listed.iter().map(|a| a.id).collect::<Vec<_>>(),
+        vec![lead.id],
+        "lead must stay visible after 100+ newer workflow agents accumulate"
+    );
+}
+
+#[tokio::test]
 async fn update_session_chain_rejects_workflow_agents() {
     let pool = pool().await;
     let (agents, _sandboxes, _sandbox_id, project_id) =


### PR DESCRIPTION
## Issue

`Agents::list_for_project` pages the first 100 agents per project ordered by `created_at` descending, then drops workflow-spawned agents in memory (`.filter(|a| a.workflow_id.is_none())`). Once a project accumulates 100 workflow-step agents newer than its lead, the page contains only workflow agents, the in-memory filter empties it, and the listing returns nothing — lead included. The comment claiming the query was covered by the `idx_agents_project_id_user_owned` partial index was aspirational: the generated query carries no `workflow_id IS NULL` predicate, so it could never match that index.

## Symptoms

Projects with active workflows lose their entire sidebar — the dashboard shows "No agents yet" / "No agents found" and no lead chat, while the lead row still exists undeleted in the DB. `Prabhat1308-2` hit this once its `lana-bank-review` runs had spawned ~150 step agents (June 2–10):

![No agents found on a project whose lead agent exists](https://github.com/GaloyMoney/drua/blob/21a5ae8a1fe72edf878c85441a54250e42d9f4d5/.github/assets/list-for-project-no-agents.png?raw=true)

- Live page load: `web.project_chat → domain.agent.list_for_project` succeeds with no error yet renders an empty sidebar — https://ui.honeycomb.io/galoymoney/environments/galoy-agents/result/t2dXE2ZvKpB/trace?trace_id=9feda82fae5109142305394ef74fbc09
- The only project-tagged spans over 90 days are 152 `domain.sandbox.attach_to_agent_in_op` calls, one per workflow step agent — https://ui.honeycomb.io/galoymoney/environments/galoy-agents/datasets/drua/result/xvx3oYRpi9T
- The lead was seeded normally at project creation (2026-05-21) and never deleted — https://ui.honeycomb.io/galoymoney/environments/galoy-agents/result/GJyLpXFQt9i/trace?trace_id=dff644bdc9d2d540f295c51f6cd0855c

## New state

`workflow_id IS NULL` is part of the query via the generated `list_for_filters_by_created_at`, so the 100-row page contains user-owned agents only and workflow agents can no longer crowd out the lead. The new regression test seeds a lead plus 101 workflow-run agents and asserts the lead survives listing; it fails against the previous implementation. Production verification deferred to deploy — the project above should render its lead on the next page load after rollout.

## Upstream

This is correct but still unindexable: es-entity's filters API emits `COALESCE(project_id = $1, $1 IS NULL)` and `(NOT $2 OR workflow_id IS NOT DISTINCT FROM $3)`, parameterized shapes Postgres cannot turn into index conditions, so the query (like the one it replaces) scans `agents` and `idx_agents_project_id_user_owned` stays unused. Fine at today's table size; cost grows linearly with total agent rows (soft-deleted included) on the hottest dashboard path. The durable fix is upstream in es-entity: emit plain `col = $n` / `col IS NOT DISTINCT FROM $n` predicates per filter combination (the macro already specializes the single-filter dispatch), after which a plain `(project_id, created_at DESC) WHERE deleted = FALSE` index makes this an index-ordered scan.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the hot dashboard listing query path; behavior fix is targeted but affects every project chat load.
> 
> **Overview**
> Fixes project agent sidebar/listing going empty when a project has **100+ newer workflow-step agents** than its lead.
> 
> **`list_for_project`** no longer loads the top 100 agents by `created_at` and drops workflow rows in Rust. It uses **`list_for_filters_by_created_at`** with **`AgentFilters`** (`project_id` + **`workflow_id: Some(None)`** → `workflow_id IS NULL`) so the paginated page is user-owned agents only.
> 
> Adds regression test **`list_for_project_returns_lead_past_100_workflow_agents`**: lead + 101 workflow agents, listing must still return the lead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2893da74e65eaa88b559d9f839a30725b7781769. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->