### PR TITLE
feat(server): model-chain selection via config-sourced dropdowns

### DIFF
--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -43,6 +43,9 @@ pub struct AppState {
     pub tunnel_public_keys: TunnelPublicKeys,
     pub library_repo_url: Option<String>,
     pub dev_mode_agent_tokens: bool,
+    /// Model ids from `providers[].models`, in config order; populates the
+    /// agent model-chain dropdowns.
+    pub model_options: Vec<String>,
 }
 
 impl AppState {
@@ -71,6 +74,7 @@ impl AppState {
             tunnel_public_keys,
             library_repo_url: None,
             dev_mode_agent_tokens: false,
+            model_options: Vec::new(),
         }
     }
 
@@ -226,6 +230,11 @@ pub async fn run_server(args: RunServerArgs) -> anyhow::Result<()> {
     );
     app_state.library_repo_url = config.library.repo_url.clone();
     app_state.dev_mode_agent_tokens = auth_config.dev_mode_agent_tokens;
+    app_state.model_options = config
+        .providers
+        .iter()
+        .flat_map(|p| p.models.iter().map(|m| m.name.clone()))
+        .collect();
     if app_state.dev_mode_agent_tokens {
         tracing::warn!(
             "dev_mode_agent_tokens enabled — accepting `dev-agent:<uuid>` bearer tokens. \

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1377,6 +1377,7 @@ async fn project_agent_detail(
             attached_sandbox: attached_view,
         },
         sandbox_options,
+        model_options: state.model_options.clone(),
         error: query.error,
     }
     .into_response()

--- a/server/src/templates.rs
+++ b/server/src/templates.rs
@@ -433,6 +433,8 @@ pub struct ProjectAgentDetailTemplate {
     pub agent: AgentDetailView,
     /// Empty when `agent.attached_sandbox` is `Some`.
     pub sandbox_options: Vec<SandboxOptionView>,
+    /// Configured model ids for the model-chain dropdowns.
+    pub model_options: Vec<String>,
     /// Flash message after a failed attach/detach (`?error=...` on redirect).
     pub error: Option<String>,
 }

--- a/server/templates/project_agent_detail.html
+++ b/server/templates/project_agent_detail.html
@@ -143,32 +143,59 @@
 <p><small>
   Set this agent's session chain. Empty primary ⇒ revert to the
   role's chain / <code>agents.default_chain</code>. Fallbacks are
-  comma-separated model ids tried in order on transient errors.
+  tried in priority order on transient errors.
 </small></p>
 <form data-gql-mutation="mutation($input: AgentUpdateSessionChainInput!) { agentUpdateSessionChain(input: $input) { session { chain { primary { name } fallbacks { name } } } } }"
       data-gql-build="buildAgentChain"
       data-gql-reload="true">
   <label>
     Primary model
-    <input name="primary_name" type="text" placeholder="anthropic/claude-sonnet-4-6">
+    <select name="primary_name">
+      <option value="">— use role / default chain —</option>
+      {% for m in model_options %}
+      <option value="{{ m }}">{{ m }}</option>
+      {% endfor %}
+    </select>
   </label>
-  <label>
-    Fallbacks <small>(comma-separated, in priority order)</small>
-    <input name="fallbacks" type="text" placeholder="openai/gpt-4o, anthropic/claude-haiku-4-5">
-  </label>
+  <label>Fallbacks <small>(in priority order)</small></label>
+  <div id="fallback-rows"></div>
+  <button type="button" id="add-fallback" class="secondary outline" style="margin-bottom: 1rem;">+ Add fallback</button>
   <div style="display: flex; gap: 0.5rem;">
     <button type="submit">Save chain</button>
     <button type="button" id="agent-chain-clear" class="secondary outline">Reset to default</button>
   </div>
 </form>
+<template id="fallback-row-template">
+  <div class="fallback-row" style="display: flex; gap: 0.5rem; margin-bottom: 0.5rem;">
+    <select name="fallback" style="flex: 1;">
+      <option value="">— select model —</option>
+      {% for m in model_options %}
+      <option value="{{ m }}">{{ m }}</option>
+      {% endfor %}
+    </select>
+    <button type="button" class="secondary outline remove-fallback" style="width: auto; margin: 0;">&times;</button>
+  </div>
+</template>
 <script>
+  const fallbackRows = document.getElementById('fallback-rows');
+  const fallbackTpl = document.getElementById('fallback-row-template');
+  function addFallbackRow(value) {
+    const row = fallbackTpl.content.cloneNode(true).querySelector('.fallback-row');
+    if (value) row.querySelector('select').value = value;
+    row.querySelector('.remove-fallback').addEventListener('click', () => row.remove());
+    fallbackRows.appendChild(row);
+  }
+  document.getElementById('add-fallback').addEventListener('click', () => addFallbackRow());
+
   function buildAgentChain(fd) {
-    const primary = fd.get('primary_name').trim();
+    const primary = (fd.get('primary_name') || '').trim();
     if (!primary) {
       return { agentId: "{{ agent.id }}", chain: null };
     }
-    const fbRaw = fd.get('fallbacks') || '';
-    const fallbacks = fbRaw.split(',').map(s => s.trim()).filter(Boolean).map(name => ({ name }));
+    const fallbacks = fd.getAll('fallback')
+      .map(s => s.trim())
+      .filter(Boolean)
+      .map(name => ({ name }));
     return {
       agentId: "{{ agent.id }}",
       chain: { primary: { name: primary }, fallbacks }


### PR DESCRIPTION
Replaces the free-text primary/fallback model inputs on the agent detail page with dropdowns sourced from the configured providers' models, so an agent's model chain can only be set to a model the backend actually knows about. The list is threaded through `AppState.model_options` from server config and rendered server-side: primary is a single `<select>` (empty ⇒ revert to the role / `agents.default_chain`), and fallbacks are add-as-needed `<select>` rows kept in priority order.

No GraphQL or validation change — `ModelSpecInput.name` stays a string and the runtime `ModelNotConfigured` check is unchanged; this only removes the typo surface in the UI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only constraint on model ids at edit time; no API or runtime validation changes beyond what operators pick in the form.
> 
> **Overview**
> The agent detail **Model chain** form no longer uses free-text fields for primary and fallback models. Model ids are collected at boot from `providers[].models` into **`AppState.model_options`** and passed into **`ProjectAgentDetailTemplate`** for server-rendered `<select>` options.
> 
> **Primary** is a single dropdown (empty value still means revert to the role / `agents.default_chain`). **Fallbacks** are one `<select>` per row, added with “+ Add fallback” and removed per row; `buildAgentChain` now uses `FormData.getAll('fallback')` instead of parsing a comma-separated string. The existing `agentUpdateSessionChain` mutation and payload shape are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c011e5686cd8bbbe5cbd2d233d7fb51190c839b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->