### PR TITLE
ci: avoid Cachix API lookup during deploy

### DIFF
--- a/charts/drua/templates/_helpers.tpl
+++ b/charts/drua/templates/_helpers.tpl
@@ -99,6 +99,7 @@ Sandbox NIX_CONFIG contents for configured remote substituters.
 {{- end -}}
 
 {{- define "galoyAgents.sandbox.nixConfig" -}}
+fallback = true
 substituters ={{- with (include "galoyAgents.sandbox.nixSubstituterUrls" .) }} {{ . }}{{- end }} https://cache.nixos.org/
 trusted-public-keys ={{- with (include "galoyAgents.sandbox.nixPublicKeys" .) }} {{ . }}{{- end }} cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
 {{- if .Values.sandbox.nixNetrc.enabled }}

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -175,25 +175,9 @@ jobs:
             LANA_BANK_CACHIX_ENABLED=false
             if [ -n "$LANA_BANK_CACHIX_AUTH_TOKEN" ]; then
               if [ -z "$LANA_BANK_CACHIX_PUBLIC_KEY" ]; then
-                cachix_home=$(mktemp -d)
-                CACHIX_AUTH_TOKEN="$LANA_BANK_CACHIX_AUTH_TOKEN" \
-                  HOME="$cachix_home" XDG_CONFIG_HOME="$cachix_home/.config" \
-                  cachix use lana-bank-github-actions --mode user-nixconf
-                LANA_BANK_CACHIX_PUBLIC_KEY=$(
-                  awk '
-                    /^trusted-public-keys =/ {
-                      for (i = 2; i <= NF; i++) {
-                        if ($i ~ /^lana-bank-github-actions\.cachix\.org-1:/) {
-                          print $i
-                        }
-                      }
-                    }
-                  ' "$cachix_home/.config/nix/nix.conf"
-                )
-                if [ -z "$LANA_BANK_CACHIX_PUBLIC_KEY" ]; then
-                  echo "Failed to derive lana-bank-github-actions Cachix public key" >&2
-                  exit 1
-                fi
+                echo "LANA_BANK_CACHIX_AUTH_TOKEN is set but LANA_BANK_CACHIX_PUBLIC_KEY is empty" >&2
+                echo "Set deploy_lana_bank_cachix_public_key; prepare-deployment does not contact Cachix." >&2
+                exit 1
               fi
               LANA_BANK_CACHIX_ENABLED=true
             fi

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -28,7 +28,9 @@ deploy_concourse_password: ((galoybot-concourse-creds.password))
 #! Provisioned by galoy-org-infra at
 #! concourse/galoy-agents/galoy-agents-bin/lana-bank-cachix-token.
 deploy_lana_bank_cachix_auth_token: ((lana-bank-cachix-token.token))
-deploy_lana_bank_cachix_public_key: ""
+#! Public signing key for the private cache above. This is not secret; keep it
+#! explicit so prepare-deployment does not need Cachix API access.
+deploy_lana_bank_cachix_public_key: "lana-bank-github-actions.cachix.org-1:31jDEkkTk7VarJjX1rsUEYkEoqhKtOGJeK6ZEsXvMsg="
 honeycomb_api_key: ((mcp-upstream.honeycomb_api_key))
 github_pat: ((mcp-upstream.github_pat))
 zenduty_api_token: ((zenduty.api_key))


### PR DESCRIPTION
## What changed

- Set the Lana Cachix public signing key explicitly in the Concourse values.
- Stop `prepare-deployment` from calling `cachix use lana-bank-github-actions` just to derive that public key.
- Add `fallback = true` to sandbox `NIX_CONFIG` so Nix can build from source if a substituter is unavailable.

## Why

After repiping, `deploy-to-prod` started using the previously checked-in runtime Cachix lookup. Build 792 failed before Terraform because the task contacted the private `lana-bank-github-actions` cache and the configured token could not access that cache. The deploy task only needs the public signing key, so it should not depend on Cachix API access at deploy-preparation time.

## Validation

- `ytt -f ci/values.yml -f ci/pipeline.yml -f ci/fragments.lib.yml >/tmp/galoy-agents-pipeline.yml`
- `fly -t galoy validate-pipeline -c /tmp/galoy-agents-pipeline.yml`
- `helm template drua charts/drua --set global.security.allowInsecureImages=true --set sandbox.enabled=true >/tmp/drua-rendered.yml`
- `nix develop -c tofu -chdir=ci/deploy/drua fmt -check -recursive`
