### PR TITLE
fix(tool-caching): tolerate `$.result` wire-wrapper prefix in fetch paths

### DIFF
--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -482,25 +482,60 @@ impl StoredInvocation {
 
     fn navigate(&self, path: &str) -> Result<&Value, ToolCachingError> {
         let segments = parse_path(path)?;
-        let mut cur = &self.query_structure.root;
-        for seg in &segments {
-            cur = match seg {
-                PathSegment::Key(k) => cur.get(k).ok_or_else(|| {
-                    ToolCachingError::InvalidPath(format!(
-                        "path {path}: no `{k}` — {hint}",
-                        hint = describe_available(cur)
-                    ))
-                })?,
-                PathSegment::Index(i) => cur.get(*i).ok_or_else(|| {
-                    ToolCachingError::InvalidPath(format!(
-                        "path {path}: no [{i}] — {hint}",
-                        hint = describe_available(cur)
-                    ))
-                })?,
-            };
+        let root = &self.query_structure.root;
+        match walk_segments(root, &segments, path) {
+            Ok(v) => Ok(v),
+            // Tolerate the MCP wire-wrapper assumption: models routinely send
+            // `$.result.<...>` because normal tool responses are wrapped in
+            // `{result: ...}` on the wire, but the persisted fetch root is the
+            // unwrapped upstream value. When the root has no `result` key and
+            // the `$.result`-stripped path resolves, honour that rather than
+            // failing — but only when stripping actually resolves, so genuine
+            // misses still surface the original key-listing error.
+            Err(original) => match segments.as_slice() {
+                [PathSegment::Key(first), rest @ ..]
+                    if first == "result" && !rest.is_empty() && root.get("result").is_none() =>
+                {
+                    match walk_segments(root, rest, path) {
+                        Ok(v) => {
+                            tracing::debug!(
+                                path = %path,
+                                "drua_core.tool_caching.fetch_stripped_result_wrapper"
+                            );
+                            Ok(v)
+                        }
+                        Err(_) => Err(original),
+                    }
+                }
+                _ => Err(original),
+            },
         }
-        Ok(cur)
     }
+}
+
+fn walk_segments<'a>(
+    root: &'a Value,
+    segments: &[PathSegment],
+    path: &str,
+) -> Result<&'a Value, ToolCachingError> {
+    let mut cur = root;
+    for seg in segments {
+        cur = match seg {
+            PathSegment::Key(k) => cur.get(k).ok_or_else(|| {
+                ToolCachingError::InvalidPath(format!(
+                    "path {path}: no `{k}` — {hint}",
+                    hint = describe_available(cur)
+                ))
+            })?,
+            PathSegment::Index(i) => cur.get(*i).ok_or_else(|| {
+                ToolCachingError::InvalidPath(format!(
+                    "path {path}: no [{i}] — {hint}",
+                    hint = describe_available(cur)
+                ))
+            })?,
+        };
+    }
+    Ok(cur)
 }
 
 #[derive(Debug, PartialEq)]
@@ -950,6 +985,48 @@ mod tests {
         assert!(msg.contains("no `result`"), "got: {msg}");
         assert!(msg.contains("logs"), "got: {msg}");
         assert!(msg.contains("extra"), "got: {msg}");
+    }
+
+    #[test]
+    fn navigate_tolerates_result_wrapper_prefix() {
+        // Models send `$.result.<...>` assuming the MCP wire wrapper; the
+        // persisted root is unwrapped. Strip the bogus `result` segment when
+        // it lets the rest of the path resolve.
+        let inv = stored(serde_json::json!({"issues": [{"body": "boom"}]}));
+        assert_eq!(
+            inv.navigate("$.result.issues[0].body").unwrap(),
+            &Value::String("boom".into())
+        );
+    }
+
+    #[test]
+    fn navigate_tolerates_result_wrapper_for_content_shape() {
+        let inv = stored(serde_json::json!({"content": [{"text": "hi"}]}));
+        assert_eq!(
+            inv.navigate("$.result.content[0].text").unwrap(),
+            &Value::String("hi".into())
+        );
+    }
+
+    #[test]
+    fn navigate_keeps_real_result_key() {
+        // A genuine `result` key must still resolve normally, not be stripped.
+        let inv = stored(serde_json::json!({"result": {"body": "real"}}));
+        assert_eq!(
+            inv.navigate("$.result.body").unwrap(),
+            &Value::String("real".into())
+        );
+    }
+
+    #[test]
+    fn navigate_result_strip_does_not_mask_real_miss() {
+        // Stripping `result` doesn't resolve either → surface the original
+        // error against the path the caller actually sent.
+        let inv = stored(serde_json::json!({"logs": "x"}));
+        let err = inv.navigate("$.result.missing").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("no `result`"), "got: {msg}");
+        assert!(msg.contains("logs"), "got: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
## What

When `tool_output_fetch` gets a `path` like `$.result.content[0].text` but the persisted root has no `result` key, strip the bogus leading `result` segment and retry — but only when stripping actually resolves the rest of the path.

## Why (grounded in audit data, Jun 11–17, post-#431)

Auditing the residual `tool_output_fetch` failures:

- **56% of `invalid fetch path` errors are this one shape.** Of 27 in the week, 15 were `$.result.<...>` against a root that doesn't carry a `result` key (`$.result.content[0].text`, `$.result.issues[0].body`, `$.result.diff`, …).
- **Root cause is a self-generated wrong prior, not a bad skill.** Normal tool responses are wrapped in `{result: ...}` on the wire, so models reconstruct that path for recovery. The persisted fetch root is the *unwrapped* upstream value. A library search turned up no skill/note pushing this path — every model just guesses it. The tool description and the error (`no \`result\` — available keys: [...]`) already explain it; models read neither.
- **It's where data is actually lost.** Recovery is a coin-flip: **25 of 51** errored `(agent, invocation_id)` fetch pairs were *abandoned* — the elided oversize payload is permanently dropped from that agent's context (~49%). Spread evenly across all four bot workflows (`github-lana-bank-review`, `zenduty-incident-pr`, `honeycomb-trace-scan`, `fix-github-issue`), so it's model behaviour, not one workflow.

(For contrast, the call_tool missing-`tool_name` errors were left alone: #431 already made them actionable and agents self-correct 85% of the time — low ROI.)

## How

`StoredInvocation::navigate` now splits the walk into a `walk_segments` helper. On failure, if the path is `result` + at least one more segment and the root has no `result` key, it retries against the stripped path. The retry is only honoured when it resolves, so:

- genuine misses still surface the original key-listing error against the path the caller sent (no masking),
- a real top-level `result` key resolves normally,
- a bare `$.result` (no following segment) is unchanged.

A `tracing::debug!` fires when the tolerance kicks in, mirroring the coercion middleware's observability.

## Tests

Added 4 unit tests (object-wrapped, content-wrapped, real-`result`-key preserved, no-mask-on-real-miss); existing `navigate_*` tests unchanged. `cargo test -p drua-tool-caching` unit suite: 103 passed. (The 6 `tests/envelope.rs` integration tests need a local Postgres — `PoolTimedOut` without `make reset-deps` — and are unrelated to this in-memory change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to invalid-path recovery in tool-caching fetch navigation with explicit guards and unit tests; no auth, persistence, or API contract changes.
> 
> **Overview**
> **`tool_output_fetch` path navigation** now accepts a common model mistake: paths like `$.result.content[0].text` when the stored JSON root has no top-level `result` key (wire responses are wrapped in `{result: ...}`, but the persisted fetch root is the unwrapped value).
> 
> Segment walking is moved into **`walk_segments`**. On failure, if the path starts with `result` plus more segments and the root lacks `result`, navigation **retries without that prefix** only when the stripped path resolves; otherwise the original invalid-path error is returned. A real top-level **`result`** key is unchanged, and bare **`$.result`** still errors with available keys.
> 
> A **`tracing::debug!`** event records when the strip succeeds. Four unit tests cover wrapper tolerance, real `result` keys, and no masking of genuine misses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af70749248eb557f5917595a4a8beb8a98a7948. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->