### PR TITLE
fix(catalog): stop requiring output_schema in describe_tool response

### DIFF
--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -165,7 +165,17 @@ struct DescribeToolOutput {
     description: String,
     #[schemars(schema_with = "crate::toolset::any_json_schema")]
     input_schema: serde_json::Value,
+    // `#[schemars(default)]` is required, not redundant with `Option`: when
+    // `schema_with` overrides a field's type schema, schemars 0.8 loses track
+    // of the `Option` and marks the field `required`. Strict MCP clients
+    // (pi ships @modelcontextprotocol/sdk 1.29.0) validate `structuredContent`
+    // against this schema and reject responses missing a `required` field —
+    // which is why `describe_tool` failed for every tool that has no upstream
+    // `output_schema`. `schemars(default)` restores the not-required semantics
+    // while `schema_with` keeps the field an any-schema object (not a boolean
+    // schema, which strict clients also reject).
     #[serde(skip_serializing_if = "Option::is_none")]
+    #[schemars(default)]
     #[schemars(schema_with = "crate::toolset::any_json_schema")]
     output_schema: Option<serde_json::Value>,
 }
@@ -1175,6 +1185,39 @@ mod tests {
             assert!(
                 !matches!(schema, serde_json::Value::Bool(_)),
                 "property `{name}` is a boolean schema, MCP validators reject it"
+            );
+        }
+    }
+
+    /// `output_schema` is `Option<_>` and omitted when a tool has no upstream
+    /// output schema (the common case). It MUST NOT appear in the schema's
+    /// `required`, or strict MCP clients reject the `structuredContent` of
+    /// every such describe_tool call with "data must have required property
+    /// 'output_schema'". `schema_with` on an `Option` field defeats schemars
+    /// 0.8's Option-detection, so `#[schemars(default)]` restores it.
+    #[test]
+    fn describe_output_schema_does_not_require_output_schema_field() {
+        let required = DESCRIBE_OUTPUT_SCHEMA
+            .get("required")
+            .and_then(|v| v.as_array())
+            .expect("describe outputSchema has a required array");
+        let required_names: Vec<&str> = required.iter().filter_map(|v| v.as_str()).collect();
+        assert!(
+            !required_names.contains(&"output_schema"),
+            "`output_schema` must not be required (it is Option and omitted for \
+             most tools), but schema requires: {required_names:?}"
+        );
+        // Sanity: the always-present fields are still required.
+        for always in [
+            "name",
+            "upstream",
+            "category",
+            "description",
+            "input_schema",
+        ] {
+            assert!(
+                required_names.contains(&always),
+                "`{always}` should be required, got: {required_names:?}"
             );
         }
     }


### PR DESCRIPTION
## What

Fixes `describe_tool` failing with `"Structured content does not match the tool's output schema: data must have required property 'output_schema'"` for every tool that has no upstream output schema (the common case — all k8s/concourse passthrough tools).

## Root cause

`DescribeToolOutput.output_schema` is `Option<Value>` and omitted for most tools, but `#[schemars(schema_with = "any_json_schema")]` on an `Option` field defeats schemars 0.8's Option-detection, landing `output_schema` in the schema's `required` array.

Strict MCP clients validate `structuredContent` against the advertised `outputSchema`. pi ships `@modelcontextprotocol/sdk@1.29.0`, whose `Client.callTool` enforces this unconditionally when a tool declares an output schema — so any describe_tool response missing `output_schema` gets rejected.

Verified with a standalone schemars 0.8.22 repro:
- without the fix: `"required": ["input_schema", "name", "output_schema"]`
- with the fix: `"required": ["input_schema", "name"]`

## Fix

Add `#[schemars(default)]` to the `output_schema` field. This restores not-required semantics while keeping `schema_with` (which prevents the boolean-schema form `true` that strict clients like Claude Code also reject).

## Why `schema_with` can't just be dropped

The compose test suite already documents that strict clients reject boolean schemas inside `properties`. `schema_with` is what turns `"output_schema": true` into `"output_schema": {}`. The minimal fix keeps `schema_with` and adds `schemars(default)`.

## Test

New regression test `describe_output_schema_does_not_require_output_schema_field` asserts `output_schema` is absent from `required` and that the always-present fields still are. Confirmed load-bearing: the test fails when `#[schemars(default)]` is removed.

## Context

Discovered while re-testing the kubernetes-mcp-server v0.0.63 bump (galoy-deployments #3979). The server bump fixed the k8s-side findings (#2 namespaced CRD 404, #3 missing status fields), but `describe_tool` remained broken — confirming it's a drua-side schema bug, not an upstream issue.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema-generation and test-only change for catalog metadata; no runtime dispatch or auth paths touched.
> 
> **Overview**
> Fixes **`describe_tool`** responses being rejected by strict MCP clients when a catalog tool has no upstream output schema (the usual case for k8s/concourse passthrough tools).
> 
> **`DescribeToolOutput.output_schema`** keeps **`schema_with = any_json_schema`** but adds **`#[schemars(default)]`** so schemars 0.8 no longer lists **`output_schema`** in the JSON Schema **`required`** array while the field stays optional and omitted from **`structuredContent`**. Inline comments document the schemars/MCP interaction.
> 
> Adds regression test **`describe_output_schema_does_not_require_output_schema_field`**, which asserts **`output_schema`** is not required and that core fields (**`name`**, **`upstream`**, **`category`**, **`description`**, **`input_schema`**) still are.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88d42485729decd0a2afdf6fc59347a52166695e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->