### PR TITLE
fix(compose): emit ComposeOutput verbatim so output-schema validation passes

### DIFF
--- a/bats/fake_mcp_upstream.bats
+++ b/bats/fake_mcp_upstream.bats
@@ -422,20 +422,20 @@ assert_compose_snapshot() {
   local r1_struct
   r1_struct="$(echo "$output" | jq -r '.result.structuredContent')"
 
-  # Compose is a top-level cached tool — its structured channel is the
-  # `DruaToolResult<ComposeOutput>` wrapper. ComposeOutput fields live
-  # under `.result.` (outer wrap key).
+  # Compose owns its envelope shape (outputSchema is ComposeOutput,
+  # a flat schema — no DruaToolResult wrapper). ComposeOutput fields
+  # are at the structuredContent root.
   #
   # Structural: 2 sub_invocations expected (small obj is passthrough →
   # no recovery; large str + large arr are persisted).
   local n_subs
-  n_subs="$(echo "$r1_struct" | jq -r '.result.sub_invocations | length')"
+  n_subs="$(echo "$r1_struct" | jq -r '.sub_invocations | length')"
   [ "$n_subs" = "2" ]
 
   # Each persisted sub_invocation carries a uuid + a kind discriminator.
   local subs_summary
   subs_summary="$(echo "$r1_struct" | jq -r \
-    '.result.sub_invocations | map({tool_name, kind})')"
+    '.sub_invocations | map({tool_name, kind})')"
   echo "$subs_summary"
   [[ "$subs_summary" == *"str-large-table"* ]]
   [[ "$subs_summary" == *"arr-large-passthrough-items"* ]]
@@ -448,9 +448,9 @@ assert_compose_snapshot() {
   # recoverability of sub-call data persisted by persist_for_compose.
   local str_id arr_id
   str_id="$(echo "$r1_struct" | jq -r \
-    '.result.sub_invocations[] | select(.tool_name | endswith("str-large-table")) | .invocation_id')"
+    '.sub_invocations[] | select(.tool_name | endswith("str-large-table")) | .invocation_id')"
   arr_id="$(echo "$r1_struct" | jq -r \
-    '.result.sub_invocations[] | select(.tool_name | endswith("arr-large-passthrough-items")) | .invocation_id')"
+    '.sub_invocations[] | select(.tool_name | endswith("arr-large-passthrough-items")) | .invocation_id')"
   [[ "$str_id" =~ ^[0-9a-f-]{36}$ ]]
   [[ "$arr_id" =~ ^[0-9a-f-]{36}$ ]]
 
@@ -466,11 +466,11 @@ assert_compose_snapshot() {
   [ "$status" -eq 0 ]
 
   # The recovered slices must match the elided middle of each fixture.
-  # Outer compose wrap puts ComposeOutput at `.result`; ComposeOutput.result
-  # is the JS return — `{ str_slice: <fetched_string>, arr_slice: <fetched_array> }`.
+  # ComposeOutput.result is the JS return —
+  # `{ str_slice: <fetched_string>, arr_slice: <fetched_array> }`.
   local r2_struct r2_inner
   r2_struct="$(echo "$output" | jq -r '.result.structuredContent')"
-  r2_inner="$(echo "$r2_struct" | jq -r '.result.result')"
+  r2_inner="$(echo "$r2_struct" | jq -r '.result')"
 
   # str_slice is a JSON string; arr_slice is a JSON array.
   local str_slice arr_slice_len

--- a/bats/summarized-tool-responses/compose-roundtrip-1.json
+++ b/bats/summarized-tool-responses/compose-roundtrip-1.json
@@ -134,1620 +134,1618 @@
       }
     ]
   },
+  "console": [],
+  "execution_time_ms": "<ms>",
+  "fetch_hint": "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated `<summary>+<recovery>` envelope you'd have seen calling that tool directly. Compose includes `normal_fetch_limit_bytes`, and each sub_invocation includes `summary_envelope_bytes`, so you can size summary fetches before calling them.",
+  "normal_fetch_limit_bytes": 16384,
   "result": {
-    "console": [],
-    "execution_time_ms": "<ms>",
-    "fetch_hint": "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated `<summary>+<recovery>` envelope you'd have seen calling that tool directly. Compose includes `normal_fetch_limit_bytes`, and each sub_invocation includes `summary_envelope_bytes`, so you can size summary fetches before calling them.",
-    "normal_fetch_limit_bytes": 16384,
-    "result": {
-      "arr": [
-        {
-          "id": 0,
-          "tag": "x"
-        },
-        {
-          "id": 1,
-          "tag": "x"
-        },
-        {
-          "id": 2,
-          "tag": "x"
-        },
-        {
-          "id": 3,
-          "tag": "x"
-        },
-        {
-          "id": 4,
-          "tag": "x"
-        },
-        {
-          "id": 5,
-          "tag": "x"
-        },
-        {
-          "id": 6,
-          "tag": "x"
-        },
-        {
-          "id": 7,
-          "tag": "x"
-        },
-        {
-          "id": 8,
-          "tag": "x"
-        },
-        {
-          "id": 9,
-          "tag": "x"
-        },
-        {
-          "id": 10,
-          "tag": "x"
-        },
-        {
-          "id": 11,
-          "tag": "x"
-        },
-        {
-          "id": 12,
-          "tag": "x"
-        },
-        {
-          "id": 13,
-          "tag": "x"
-        },
-        {
-          "id": 14,
-          "tag": "x"
-        },
-        {
-          "id": 15,
-          "tag": "x"
-        },
-        {
-          "id": 16,
-          "tag": "x"
-        },
-        {
-          "id": 17,
-          "tag": "x"
-        },
-        {
-          "id": 18,
-          "tag": "x"
-        },
-        {
-          "id": 19,
-          "tag": "x"
-        },
-        {
-          "id": 20,
-          "tag": "x"
-        },
-        {
-          "id": 21,
-          "tag": "x"
-        },
-        {
-          "id": 22,
-          "tag": "x"
-        },
-        {
-          "id": 23,
-          "tag": "x"
-        },
-        {
-          "id": 24,
-          "tag": "x"
-        },
-        {
-          "id": 25,
-          "tag": "x"
-        },
-        {
-          "id": 26,
-          "tag": "x"
-        },
-        {
-          "id": 27,
-          "tag": "x"
-        },
-        {
-          "id": 28,
-          "tag": "x"
-        },
-        {
-          "id": 29,
-          "tag": "x"
-        },
-        {
-          "id": 30,
-          "tag": "x"
-        },
-        {
-          "id": 31,
-          "tag": "x"
-        },
-        {
-          "id": 32,
-          "tag": "x"
-        },
-        {
-          "id": 33,
-          "tag": "x"
-        },
-        {
-          "id": 34,
-          "tag": "x"
-        },
-        {
-          "id": 35,
-          "tag": "x"
-        },
-        {
-          "id": 36,
-          "tag": "x"
-        },
-        {
-          "id": 37,
-          "tag": "x"
-        },
-        {
-          "id": 38,
-          "tag": "x"
-        },
-        {
-          "id": 39,
-          "tag": "x"
-        },
-        {
-          "id": 40,
-          "tag": "x"
-        },
-        {
-          "id": 41,
-          "tag": "x"
-        },
-        {
-          "id": 42,
-          "tag": "x"
-        },
-        {
-          "id": 43,
-          "tag": "x"
-        },
-        {
-          "id": 44,
-          "tag": "x"
-        },
-        {
-          "id": 45,
-          "tag": "x"
-        },
-        {
-          "id": 46,
-          "tag": "x"
-        },
-        {
-          "id": 47,
-          "tag": "x"
-        },
-        {
-          "id": 48,
-          "tag": "x"
-        },
-        {
-          "id": 49,
-          "tag": "x"
-        },
-        {
-          "id": 50,
-          "tag": "x"
-        },
-        {
-          "id": 51,
-          "tag": "x"
-        },
-        {
-          "id": 52,
-          "tag": "x"
-        },
-        {
-          "id": 53,
-          "tag": "x"
-        },
-        {
-          "id": 54,
-          "tag": "x"
-        },
-        {
-          "id": 55,
-          "tag": "x"
-        },
-        {
-          "id": 56,
-          "tag": "x"
-        },
-        {
-          "id": 57,
-          "tag": "x"
-        },
-        {
-          "id": 58,
-          "tag": "x"
-        },
-        {
-          "id": 59,
-          "tag": "x"
-        },
-        {
-          "id": 60,
-          "tag": "x"
-        },
-        {
-          "id": 61,
-          "tag": "x"
-        },
-        {
-          "id": 62,
-          "tag": "x"
-        },
-        {
-          "id": 63,
-          "tag": "x"
-        },
-        {
-          "id": 64,
-          "tag": "x"
-        },
-        {
-          "id": 65,
-          "tag": "x"
-        },
-        {
-          "id": 66,
-          "tag": "x"
-        },
-        {
-          "id": 67,
-          "tag": "x"
-        },
-        {
-          "id": 68,
-          "tag": "x"
-        },
-        {
-          "id": 69,
-          "tag": "x"
-        },
-        {
-          "id": 70,
-          "tag": "x"
-        },
-        {
-          "id": 71,
-          "tag": "x"
-        },
-        {
-          "id": 72,
-          "tag": "x"
-        },
-        {
-          "id": 73,
-          "tag": "x"
-        },
-        {
-          "id": 74,
-          "tag": "x"
-        },
-        {
-          "id": 75,
-          "tag": "x"
-        },
-        {
-          "id": 76,
-          "tag": "x"
-        },
-        {
-          "id": 77,
-          "tag": "x"
-        },
-        {
-          "id": 78,
-          "tag": "x"
-        },
-        {
-          "id": 79,
-          "tag": "x"
-        },
-        {
-          "id": 80,
-          "tag": "x"
-        },
-        {
-          "id": 81,
-          "tag": "x"
-        },
-        {
-          "id": 82,
-          "tag": "x"
-        },
-        {
-          "id": 83,
-          "tag": "x"
-        },
-        {
-          "id": 84,
-          "tag": "x"
-        },
-        {
-          "id": 85,
-          "tag": "x"
-        },
-        {
-          "id": 86,
-          "tag": "x"
-        },
-        {
-          "id": 87,
-          "tag": "x"
-        },
-        {
-          "id": 88,
-          "tag": "x"
-        },
-        {
-          "id": 89,
-          "tag": "x"
-        },
-        {
-          "id": 90,
-          "tag": "x"
-        },
-        {
-          "id": 91,
-          "tag": "x"
-        },
-        {
-          "id": 92,
-          "tag": "x"
-        },
-        {
-          "id": 93,
-          "tag": "x"
-        },
-        {
-          "id": 94,
-          "tag": "x"
-        },
-        {
-          "id": 95,
-          "tag": "x"
-        },
-        {
-          "id": 96,
-          "tag": "x"
-        },
-        {
-          "id": 97,
-          "tag": "x"
-        },
-        {
-          "id": 98,
-          "tag": "x"
-        },
-        {
-          "id": 99,
-          "tag": "x"
-        },
-        {
-          "id": 100,
-          "tag": "x"
-        },
-        {
-          "id": 101,
-          "tag": "x"
-        },
-        {
-          "id": 102,
-          "tag": "x"
-        },
-        {
-          "id": 103,
-          "tag": "x"
-        },
-        {
-          "id": 104,
-          "tag": "x"
-        },
-        {
-          "id": 105,
-          "tag": "x"
-        },
-        {
-          "id": 106,
-          "tag": "x"
-        },
-        {
-          "id": 107,
-          "tag": "x"
-        },
-        {
-          "id": 108,
-          "tag": "x"
-        },
-        {
-          "id": 109,
-          "tag": "x"
-        },
-        {
-          "id": 110,
-          "tag": "x"
-        },
-        {
-          "id": 111,
-          "tag": "x"
-        },
-        {
-          "id": 112,
-          "tag": "x"
-        },
-        {
-          "id": 113,
-          "tag": "x"
-        },
-        {
-          "id": 114,
-          "tag": "x"
-        },
-        {
-          "id": 115,
-          "tag": "x"
-        },
-        {
-          "id": 116,
-          "tag": "x"
-        },
-        {
-          "id": 117,
-          "tag": "x"
-        },
-        {
-          "id": 118,
-          "tag": "x"
-        },
-        {
-          "id": 119,
-          "tag": "x"
-        },
-        {
-          "id": 120,
-          "tag": "x"
-        },
-        {
-          "id": 121,
-          "tag": "x"
-        },
-        {
-          "id": 122,
-          "tag": "x"
-        },
-        {
-          "id": 123,
-          "tag": "x"
-        },
-        {
-          "id": 124,
-          "tag": "x"
-        },
-        {
-          "id": 125,
-          "tag": "x"
-        },
-        {
-          "id": 126,
-          "tag": "x"
-        },
-        {
-          "id": 127,
-          "tag": "x"
-        },
-        {
-          "id": 128,
-          "tag": "x"
-        },
-        {
-          "id": 129,
-          "tag": "x"
-        },
-        {
-          "id": 130,
-          "tag": "x"
-        },
-        {
-          "id": 131,
-          "tag": "x"
-        },
-        {
-          "id": 132,
-          "tag": "x"
-        },
-        {
-          "id": 133,
-          "tag": "x"
-        },
-        {
-          "id": 134,
-          "tag": "x"
-        },
-        {
-          "id": 135,
-          "tag": "x"
-        },
-        {
-          "id": 136,
-          "tag": "x"
-        },
-        {
-          "id": 137,
-          "tag": "x"
-        },
-        {
-          "id": 138,
-          "tag": "x"
-        },
-        {
-          "id": 139,
-          "tag": "x"
-        },
-        {
-          "id": 140,
-          "tag": "x"
-        },
-        {
-          "id": 141,
-          "tag": "x"
-        },
-        {
-          "id": 142,
-          "tag": "x"
-        },
-        {
-          "id": 143,
-          "tag": "x"
-        },
-        {
-          "id": 144,
-          "tag": "x"
-        },
-        {
-          "id": 145,
-          "tag": "x"
-        },
-        {
-          "id": 146,
-          "tag": "x"
-        },
-        {
-          "id": 147,
-          "tag": "x"
-        },
-        {
-          "id": 148,
-          "tag": "x"
-        },
-        {
-          "id": 149,
-          "tag": "x"
-        },
-        {
-          "id": 150,
-          "tag": "x"
-        },
-        {
-          "id": 151,
-          "tag": "x"
-        },
-        {
-          "id": 152,
-          "tag": "x"
-        },
-        {
-          "id": 153,
-          "tag": "x"
-        },
-        {
-          "id": 154,
-          "tag": "x"
-        },
-        {
-          "id": 155,
-          "tag": "x"
-        },
-        {
-          "id": 156,
-          "tag": "x"
-        },
-        {
-          "id": 157,
-          "tag": "x"
-        },
-        {
-          "id": 158,
-          "tag": "x"
-        },
-        {
-          "id": 159,
-          "tag": "x"
-        },
-        {
-          "id": 160,
-          "tag": "x"
-        },
-        {
-          "id": 161,
-          "tag": "x"
-        },
-        {
-          "id": 162,
-          "tag": "x"
-        },
-        {
-          "id": 163,
-          "tag": "x"
-        },
-        {
-          "id": 164,
-          "tag": "x"
-        },
-        {
-          "id": 165,
-          "tag": "x"
-        },
-        {
-          "id": 166,
-          "tag": "x"
-        },
-        {
-          "id": 167,
-          "tag": "x"
-        },
-        {
-          "id": 168,
-          "tag": "x"
-        },
-        {
-          "id": 169,
-          "tag": "x"
-        },
-        {
-          "id": 170,
-          "tag": "x"
-        },
-        {
-          "id": 171,
-          "tag": "x"
-        },
-        {
-          "id": 172,
-          "tag": "x"
-        },
-        {
-          "id": 173,
-          "tag": "x"
-        },
-        {
-          "id": 174,
-          "tag": "x"
-        },
-        {
-          "id": 175,
-          "tag": "x"
-        },
-        {
-          "id": 176,
-          "tag": "x"
-        },
-        {
-          "id": 177,
-          "tag": "x"
-        },
-        {
-          "id": 178,
-          "tag": "x"
-        },
-        {
-          "id": 179,
-          "tag": "x"
-        },
-        {
-          "id": 180,
-          "tag": "x"
-        },
-        {
-          "id": 181,
-          "tag": "x"
-        },
-        {
-          "id": 182,
-          "tag": "x"
-        },
-        {
-          "id": 183,
-          "tag": "x"
-        },
-        {
-          "id": 184,
-          "tag": "x"
-        },
-        {
-          "id": 185,
-          "tag": "x"
-        },
-        {
-          "id": 186,
-          "tag": "x"
-        },
-        {
-          "id": 187,
-          "tag": "x"
-        },
-        {
-          "id": 188,
-          "tag": "x"
-        },
-        {
-          "id": 189,
-          "tag": "x"
-        },
-        {
-          "id": 190,
-          "tag": "x"
-        },
-        {
-          "id": 191,
-          "tag": "x"
-        },
-        {
-          "id": 192,
-          "tag": "x"
-        },
-        {
-          "id": 193,
-          "tag": "x"
-        },
-        {
-          "id": 194,
-          "tag": "x"
-        },
-        {
-          "id": 195,
-          "tag": "x"
-        },
-        {
-          "id": 196,
-          "tag": "x"
-        },
-        {
-          "id": 197,
-          "tag": "x"
-        },
-        {
-          "id": 198,
-          "tag": "x"
-        },
-        {
-          "id": 199,
-          "tag": "x"
-        },
-        {
-          "id": 200,
-          "tag": "x"
-        },
-        {
-          "id": 201,
-          "tag": "x"
-        },
-        {
-          "id": 202,
-          "tag": "x"
-        },
-        {
-          "id": 203,
-          "tag": "x"
-        },
-        {
-          "id": 204,
-          "tag": "x"
-        },
-        {
-          "id": 205,
-          "tag": "x"
-        },
-        {
-          "id": 206,
-          "tag": "x"
-        },
-        {
-          "id": 207,
-          "tag": "x"
-        },
-        {
-          "id": 208,
-          "tag": "x"
-        },
-        {
-          "id": 209,
-          "tag": "x"
-        },
-        {
-          "id": 210,
-          "tag": "x"
-        },
-        {
-          "id": 211,
-          "tag": "x"
-        },
-        {
-          "id": 212,
-          "tag": "x"
-        },
-        {
-          "id": 213,
-          "tag": "x"
-        },
-        {
-          "id": 214,
-          "tag": "x"
-        },
-        {
-          "id": 215,
-          "tag": "x"
-        },
-        {
-          "id": 216,
-          "tag": "x"
-        },
-        {
-          "id": 217,
-          "tag": "x"
-        },
-        {
-          "id": 218,
-          "tag": "x"
-        },
-        {
-          "id": 219,
-          "tag": "x"
-        },
-        {
-          "id": 220,
-          "tag": "x"
-        },
-        {
-          "id": 221,
-          "tag": "x"
-        },
-        {
-          "id": 222,
-          "tag": "x"
-        },
-        {
-          "id": 223,
-          "tag": "x"
-        },
-        {
-          "id": 224,
-          "tag": "x"
-        },
-        {
-          "id": 225,
-          "tag": "x"
-        },
-        {
-          "id": 226,
-          "tag": "x"
-        },
-        {
-          "id": 227,
-          "tag": "x"
-        },
-        {
-          "id": 228,
-          "tag": "x"
-        },
-        {
-          "id": 229,
-          "tag": "x"
-        },
-        {
-          "id": 230,
-          "tag": "x"
-        },
-        {
-          "id": 231,
-          "tag": "x"
-        },
-        {
-          "id": 232,
-          "tag": "x"
-        },
-        {
-          "id": 233,
-          "tag": "x"
-        },
-        {
-          "id": 234,
-          "tag": "x"
-        },
-        {
-          "id": 235,
-          "tag": "x"
-        },
-        {
-          "id": 236,
-          "tag": "x"
-        },
-        {
-          "id": 237,
-          "tag": "x"
-        },
-        {
-          "id": 238,
-          "tag": "x"
-        },
-        {
-          "id": 239,
-          "tag": "x"
-        },
-        {
-          "id": 240,
-          "tag": "x"
-        },
-        {
-          "id": 241,
-          "tag": "x"
-        },
-        {
-          "id": 242,
-          "tag": "x"
-        },
-        {
-          "id": 243,
-          "tag": "x"
-        },
-        {
-          "id": 244,
-          "tag": "x"
-        },
-        {
-          "id": 245,
-          "tag": "x"
-        },
-        {
-          "id": 246,
-          "tag": "x"
-        },
-        {
-          "id": 247,
-          "tag": "x"
-        },
-        {
-          "id": 248,
-          "tag": "x"
-        },
-        {
-          "id": 249,
-          "tag": "x"
-        },
-        {
-          "id": 250,
-          "tag": "x"
-        },
-        {
-          "id": 251,
-          "tag": "x"
-        },
-        {
-          "id": 252,
-          "tag": "x"
-        },
-        {
-          "id": 253,
-          "tag": "x"
-        },
-        {
-          "id": 254,
-          "tag": "x"
-        },
-        {
-          "id": 255,
-          "tag": "x"
-        },
-        {
-          "id": 256,
-          "tag": "x"
-        },
-        {
-          "id": 257,
-          "tag": "x"
-        },
-        {
-          "id": 258,
-          "tag": "x"
-        },
-        {
-          "id": 259,
-          "tag": "x"
-        },
-        {
-          "id": 260,
-          "tag": "x"
-        },
-        {
-          "id": 261,
-          "tag": "x"
-        },
-        {
-          "id": 262,
-          "tag": "x"
-        },
-        {
-          "id": 263,
-          "tag": "x"
-        },
-        {
-          "id": 264,
-          "tag": "x"
-        },
-        {
-          "id": 265,
-          "tag": "x"
-        },
-        {
-          "id": 266,
-          "tag": "x"
-        },
-        {
-          "id": 267,
-          "tag": "x"
-        },
-        {
-          "id": 268,
-          "tag": "x"
-        },
-        {
-          "id": 269,
-          "tag": "x"
-        },
-        {
-          "id": 270,
-          "tag": "x"
-        },
-        {
-          "id": 271,
-          "tag": "x"
-        },
-        {
-          "id": 272,
-          "tag": "x"
-        },
-        {
-          "id": 273,
-          "tag": "x"
-        },
-        {
-          "id": 274,
-          "tag": "x"
-        },
-        {
-          "id": 275,
-          "tag": "x"
-        },
-        {
-          "id": 276,
-          "tag": "x"
-        },
-        {
-          "id": 277,
-          "tag": "x"
-        },
-        {
-          "id": 278,
-          "tag": "x"
-        },
-        {
-          "id": 279,
-          "tag": "x"
-        },
-        {
-          "id": 280,
-          "tag": "x"
-        },
-        {
-          "id": 281,
-          "tag": "x"
-        },
-        {
-          "id": 282,
-          "tag": "x"
-        },
-        {
-          "id": 283,
-          "tag": "x"
-        },
-        {
-          "id": 284,
-          "tag": "x"
-        },
-        {
-          "id": 285,
-          "tag": "x"
-        },
-        {
-          "id": 286,
-          "tag": "x"
-        },
-        {
-          "id": 287,
-          "tag": "x"
-        },
-        {
-          "id": 288,
-          "tag": "x"
-        },
-        {
-          "id": 289,
-          "tag": "x"
-        },
-        {
-          "id": 290,
-          "tag": "x"
-        },
-        {
-          "id": 291,
-          "tag": "x"
-        },
-        {
-          "id": 292,
-          "tag": "x"
-        },
-        {
-          "id": 293,
-          "tag": "x"
-        },
-        {
-          "id": 294,
-          "tag": "x"
-        },
-        {
-          "id": 295,
-          "tag": "x"
-        },
-        {
-          "id": 296,
-          "tag": "x"
-        },
-        {
-          "id": 297,
-          "tag": "x"
-        },
-        {
-          "id": 298,
-          "tag": "x"
-        },
-        {
-          "id": 299,
-          "tag": "x"
-        },
-        {
-          "id": 300,
-          "tag": "x"
-        },
-        {
-          "id": 301,
-          "tag": "x"
-        },
-        {
-          "id": 302,
-          "tag": "x"
-        },
-        {
-          "id": 303,
-          "tag": "x"
-        },
-        {
-          "id": 304,
-          "tag": "x"
-        },
-        {
-          "id": 305,
-          "tag": "x"
-        },
-        {
-          "id": 306,
-          "tag": "x"
-        },
-        {
-          "id": 307,
-          "tag": "x"
-        },
-        {
-          "id": 308,
-          "tag": "x"
-        },
-        {
-          "id": 309,
-          "tag": "x"
-        },
-        {
-          "id": 310,
-          "tag": "x"
-        },
-        {
-          "id": 311,
-          "tag": "x"
-        },
-        {
-          "id": 312,
-          "tag": "x"
-        },
-        {
-          "id": 313,
-          "tag": "x"
-        },
-        {
-          "id": 314,
-          "tag": "x"
-        },
-        {
-          "id": 315,
-          "tag": "x"
-        },
-        {
-          "id": 316,
-          "tag": "x"
-        },
-        {
-          "id": 317,
-          "tag": "x"
-        },
-        {
-          "id": 318,
-          "tag": "x"
-        },
-        {
-          "id": 319,
-          "tag": "x"
-        },
-        {
-          "id": 320,
-          "tag": "x"
-        },
-        {
-          "id": 321,
-          "tag": "x"
-        },
-        {
-          "id": 322,
-          "tag": "x"
-        },
-        {
-          "id": 323,
-          "tag": "x"
-        },
-        {
-          "id": 324,
-          "tag": "x"
-        },
-        {
-          "id": 325,
-          "tag": "x"
-        },
-        {
-          "id": 326,
-          "tag": "x"
-        },
-        {
-          "id": 327,
-          "tag": "x"
-        },
-        {
-          "id": 328,
-          "tag": "x"
-        },
-        {
-          "id": 329,
-          "tag": "x"
-        },
-        {
-          "id": 330,
-          "tag": "x"
-        },
-        {
-          "id": 331,
-          "tag": "x"
-        },
-        {
-          "id": 332,
-          "tag": "x"
-        },
-        {
-          "id": 333,
-          "tag": "x"
-        },
-        {
-          "id": 334,
-          "tag": "x"
-        },
-        {
-          "id": 335,
-          "tag": "x"
-        },
-        {
-          "id": 336,
-          "tag": "x"
-        },
-        {
-          "id": 337,
-          "tag": "x"
-        },
-        {
-          "id": 338,
-          "tag": "x"
-        },
-        {
-          "id": 339,
-          "tag": "x"
-        },
-        {
-          "id": 340,
-          "tag": "x"
-        },
-        {
-          "id": 341,
-          "tag": "x"
-        },
-        {
-          "id": 342,
-          "tag": "x"
-        },
-        {
-          "id": 343,
-          "tag": "x"
-        },
-        {
-          "id": 344,
-          "tag": "x"
-        },
-        {
-          "id": 345,
-          "tag": "x"
-        },
-        {
-          "id": 346,
-          "tag": "x"
-        },
-        {
-          "id": 347,
-          "tag": "x"
-        },
-        {
-          "id": 348,
-          "tag": "x"
-        },
-        {
-          "id": 349,
-          "tag": "x"
-        },
-        {
-          "id": 350,
-          "tag": "x"
-        },
-        {
-          "id": 351,
-          "tag": "x"
-        },
-        {
-          "id": 352,
-          "tag": "x"
-        },
-        {
-          "id": 353,
-          "tag": "x"
-        },
-        {
-          "id": 354,
-          "tag": "x"
-        },
-        {
-          "id": 355,
-          "tag": "x"
-        },
-        {
-          "id": 356,
-          "tag": "x"
-        },
-        {
-          "id": 357,
-          "tag": "x"
-        },
-        {
-          "id": 358,
-          "tag": "x"
-        },
-        {
-          "id": 359,
-          "tag": "x"
-        },
-        {
-          "id": 360,
-          "tag": "x"
-        },
-        {
-          "id": 361,
-          "tag": "x"
-        },
-        {
-          "id": 362,
-          "tag": "x"
-        },
-        {
-          "id": 363,
-          "tag": "x"
-        },
-        {
-          "id": 364,
-          "tag": "x"
-        },
-        {
-          "id": 365,
-          "tag": "x"
-        },
-        {
-          "id": 366,
-          "tag": "x"
-        },
-        {
-          "id": 367,
-          "tag": "x"
-        },
-        {
-          "id": 368,
-          "tag": "x"
-        },
-        {
-          "id": 369,
-          "tag": "x"
-        },
-        {
-          "id": 370,
-          "tag": "x"
-        },
-        {
-          "id": 371,
-          "tag": "x"
-        },
-        {
-          "id": 372,
-          "tag": "x"
-        },
-        {
-          "id": 373,
-          "tag": "x"
-        },
-        {
-          "id": 374,
-          "tag": "x"
-        },
-        {
-          "id": 375,
-          "tag": "x"
-        },
-        {
-          "id": 376,
-          "tag": "x"
-        },
-        {
-          "id": 377,
-          "tag": "x"
-        },
-        {
-          "id": 378,
-          "tag": "x"
-        },
-        {
-          "id": 379,
-          "tag": "x"
-        },
-        {
-          "id": 380,
-          "tag": "x"
-        },
-        {
-          "id": 381,
-          "tag": "x"
-        },
-        {
-          "id": 382,
-          "tag": "x"
-        },
-        {
-          "id": 383,
-          "tag": "x"
-        },
-        {
-          "id": 384,
-          "tag": "x"
-        },
-        {
-          "id": 385,
-          "tag": "x"
-        },
-        {
-          "id": 386,
-          "tag": "x"
-        },
-        {
-          "id": 387,
-          "tag": "x"
-        },
-        {
-          "id": 388,
-          "tag": "x"
-        },
-        {
-          "id": 389,
-          "tag": "x"
-        },
-        {
-          "id": 390,
-          "tag": "x"
-        },
-        {
-          "id": 391,
-          "tag": "x"
-        },
-        {
-          "id": 392,
-          "tag": "x"
-        },
-        {
-          "id": 393,
-          "tag": "x"
-        },
-        {
-          "id": 394,
-          "tag": "x"
-        }
-      ],
-      "small": {
-        "count": 3,
-        "ok": true
-      },
-      "str": "<head lines=\"6\">\nNAMESPACE     APIVERSION   KIND   NAME                                                             READY   STATUS    RESTARTS   AGE    IP             NODE                                                  NOMINATED NODE   READINESS GATES   LABELS\nkube-system   v1           Pod    calico-node-kxw8s                                                1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-qjjtd                                                1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-v5nmp                                                1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-vertical-autoscaler-bbb8bfb74-r76x7                  1/1     Running   0          21h    192.168.1.5    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=calico-node-autoscaler,pod-template-hash=bbb8bfb74\nkube-system   v1           Pod    calico-typha-5d84858687-2zhk7                                    1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=calico-typha,pod-template-hash=5d84858687\n</head>\n<bulk-elided lines=\"28\">\n28 lines elided\n</bulk-elided>\n<tail lines=\"7\">\nkube-system   v1           Pod    netd-k9w4z                                                       3/3     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    netd-vgs2g                                                       3/3     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    netd-xxd4r                                                       3/3     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    pdcsi-node-5tr4q                                                 2/2     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    pdcsi-node-7z9zs                                                 2/2     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    pdcsi-node-lcxtr                                                 2/2     Running   0          21h    10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    runsc-metric-server-qr24t                                        1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=6b657887d,k8s-app=runsc-metric-server,pod-template-generation=2\n</tail>"
-    },
-    "sub_invocations": [
+    "arr": [
       {
-        "args_digest": "fake_upstream_str-large-table({})",
-        "invocation_id": "<uuid>",
-        "kind": "lines",
-        "raw_size_bytes": 13093,
-        "root_path": "$",
-        "summary_envelope_bytes": 8233,
-        "tool_name": "fake_upstream_str-large-table"
+        "id": 0,
+        "tag": "x"
       },
       {
-        "args_digest": "fake_upstream_arr-large-passthrough-items({})",
-        "invocation_id": "<uuid>",
-        "kind": "json_array_slice",
-        "raw_size_bytes": 10391,
-        "root_path": "$",
-        "summary_envelope_bytes": 8566,
-        "tool_name": "fake_upstream_arr-large-passthrough-items"
+        "id": 1,
+        "tag": "x"
+      },
+      {
+        "id": 2,
+        "tag": "x"
+      },
+      {
+        "id": 3,
+        "tag": "x"
+      },
+      {
+        "id": 4,
+        "tag": "x"
+      },
+      {
+        "id": 5,
+        "tag": "x"
+      },
+      {
+        "id": 6,
+        "tag": "x"
+      },
+      {
+        "id": 7,
+        "tag": "x"
+      },
+      {
+        "id": 8,
+        "tag": "x"
+      },
+      {
+        "id": 9,
+        "tag": "x"
+      },
+      {
+        "id": 10,
+        "tag": "x"
+      },
+      {
+        "id": 11,
+        "tag": "x"
+      },
+      {
+        "id": 12,
+        "tag": "x"
+      },
+      {
+        "id": 13,
+        "tag": "x"
+      },
+      {
+        "id": 14,
+        "tag": "x"
+      },
+      {
+        "id": 15,
+        "tag": "x"
+      },
+      {
+        "id": 16,
+        "tag": "x"
+      },
+      {
+        "id": 17,
+        "tag": "x"
+      },
+      {
+        "id": 18,
+        "tag": "x"
+      },
+      {
+        "id": 19,
+        "tag": "x"
+      },
+      {
+        "id": 20,
+        "tag": "x"
+      },
+      {
+        "id": 21,
+        "tag": "x"
+      },
+      {
+        "id": 22,
+        "tag": "x"
+      },
+      {
+        "id": 23,
+        "tag": "x"
+      },
+      {
+        "id": 24,
+        "tag": "x"
+      },
+      {
+        "id": 25,
+        "tag": "x"
+      },
+      {
+        "id": 26,
+        "tag": "x"
+      },
+      {
+        "id": 27,
+        "tag": "x"
+      },
+      {
+        "id": 28,
+        "tag": "x"
+      },
+      {
+        "id": 29,
+        "tag": "x"
+      },
+      {
+        "id": 30,
+        "tag": "x"
+      },
+      {
+        "id": 31,
+        "tag": "x"
+      },
+      {
+        "id": 32,
+        "tag": "x"
+      },
+      {
+        "id": 33,
+        "tag": "x"
+      },
+      {
+        "id": 34,
+        "tag": "x"
+      },
+      {
+        "id": 35,
+        "tag": "x"
+      },
+      {
+        "id": 36,
+        "tag": "x"
+      },
+      {
+        "id": 37,
+        "tag": "x"
+      },
+      {
+        "id": 38,
+        "tag": "x"
+      },
+      {
+        "id": 39,
+        "tag": "x"
+      },
+      {
+        "id": 40,
+        "tag": "x"
+      },
+      {
+        "id": 41,
+        "tag": "x"
+      },
+      {
+        "id": 42,
+        "tag": "x"
+      },
+      {
+        "id": 43,
+        "tag": "x"
+      },
+      {
+        "id": 44,
+        "tag": "x"
+      },
+      {
+        "id": 45,
+        "tag": "x"
+      },
+      {
+        "id": 46,
+        "tag": "x"
+      },
+      {
+        "id": 47,
+        "tag": "x"
+      },
+      {
+        "id": 48,
+        "tag": "x"
+      },
+      {
+        "id": 49,
+        "tag": "x"
+      },
+      {
+        "id": 50,
+        "tag": "x"
+      },
+      {
+        "id": 51,
+        "tag": "x"
+      },
+      {
+        "id": 52,
+        "tag": "x"
+      },
+      {
+        "id": 53,
+        "tag": "x"
+      },
+      {
+        "id": 54,
+        "tag": "x"
+      },
+      {
+        "id": 55,
+        "tag": "x"
+      },
+      {
+        "id": 56,
+        "tag": "x"
+      },
+      {
+        "id": 57,
+        "tag": "x"
+      },
+      {
+        "id": 58,
+        "tag": "x"
+      },
+      {
+        "id": 59,
+        "tag": "x"
+      },
+      {
+        "id": 60,
+        "tag": "x"
+      },
+      {
+        "id": 61,
+        "tag": "x"
+      },
+      {
+        "id": 62,
+        "tag": "x"
+      },
+      {
+        "id": 63,
+        "tag": "x"
+      },
+      {
+        "id": 64,
+        "tag": "x"
+      },
+      {
+        "id": 65,
+        "tag": "x"
+      },
+      {
+        "id": 66,
+        "tag": "x"
+      },
+      {
+        "id": 67,
+        "tag": "x"
+      },
+      {
+        "id": 68,
+        "tag": "x"
+      },
+      {
+        "id": 69,
+        "tag": "x"
+      },
+      {
+        "id": 70,
+        "tag": "x"
+      },
+      {
+        "id": 71,
+        "tag": "x"
+      },
+      {
+        "id": 72,
+        "tag": "x"
+      },
+      {
+        "id": 73,
+        "tag": "x"
+      },
+      {
+        "id": 74,
+        "tag": "x"
+      },
+      {
+        "id": 75,
+        "tag": "x"
+      },
+      {
+        "id": 76,
+        "tag": "x"
+      },
+      {
+        "id": 77,
+        "tag": "x"
+      },
+      {
+        "id": 78,
+        "tag": "x"
+      },
+      {
+        "id": 79,
+        "tag": "x"
+      },
+      {
+        "id": 80,
+        "tag": "x"
+      },
+      {
+        "id": 81,
+        "tag": "x"
+      },
+      {
+        "id": 82,
+        "tag": "x"
+      },
+      {
+        "id": 83,
+        "tag": "x"
+      },
+      {
+        "id": 84,
+        "tag": "x"
+      },
+      {
+        "id": 85,
+        "tag": "x"
+      },
+      {
+        "id": 86,
+        "tag": "x"
+      },
+      {
+        "id": 87,
+        "tag": "x"
+      },
+      {
+        "id": 88,
+        "tag": "x"
+      },
+      {
+        "id": 89,
+        "tag": "x"
+      },
+      {
+        "id": 90,
+        "tag": "x"
+      },
+      {
+        "id": 91,
+        "tag": "x"
+      },
+      {
+        "id": 92,
+        "tag": "x"
+      },
+      {
+        "id": 93,
+        "tag": "x"
+      },
+      {
+        "id": 94,
+        "tag": "x"
+      },
+      {
+        "id": 95,
+        "tag": "x"
+      },
+      {
+        "id": 96,
+        "tag": "x"
+      },
+      {
+        "id": 97,
+        "tag": "x"
+      },
+      {
+        "id": 98,
+        "tag": "x"
+      },
+      {
+        "id": 99,
+        "tag": "x"
+      },
+      {
+        "id": 100,
+        "tag": "x"
+      },
+      {
+        "id": 101,
+        "tag": "x"
+      },
+      {
+        "id": 102,
+        "tag": "x"
+      },
+      {
+        "id": 103,
+        "tag": "x"
+      },
+      {
+        "id": 104,
+        "tag": "x"
+      },
+      {
+        "id": 105,
+        "tag": "x"
+      },
+      {
+        "id": 106,
+        "tag": "x"
+      },
+      {
+        "id": 107,
+        "tag": "x"
+      },
+      {
+        "id": 108,
+        "tag": "x"
+      },
+      {
+        "id": 109,
+        "tag": "x"
+      },
+      {
+        "id": 110,
+        "tag": "x"
+      },
+      {
+        "id": 111,
+        "tag": "x"
+      },
+      {
+        "id": 112,
+        "tag": "x"
+      },
+      {
+        "id": 113,
+        "tag": "x"
+      },
+      {
+        "id": 114,
+        "tag": "x"
+      },
+      {
+        "id": 115,
+        "tag": "x"
+      },
+      {
+        "id": 116,
+        "tag": "x"
+      },
+      {
+        "id": 117,
+        "tag": "x"
+      },
+      {
+        "id": 118,
+        "tag": "x"
+      },
+      {
+        "id": 119,
+        "tag": "x"
+      },
+      {
+        "id": 120,
+        "tag": "x"
+      },
+      {
+        "id": 121,
+        "tag": "x"
+      },
+      {
+        "id": 122,
+        "tag": "x"
+      },
+      {
+        "id": 123,
+        "tag": "x"
+      },
+      {
+        "id": 124,
+        "tag": "x"
+      },
+      {
+        "id": 125,
+        "tag": "x"
+      },
+      {
+        "id": 126,
+        "tag": "x"
+      },
+      {
+        "id": 127,
+        "tag": "x"
+      },
+      {
+        "id": 128,
+        "tag": "x"
+      },
+      {
+        "id": 129,
+        "tag": "x"
+      },
+      {
+        "id": 130,
+        "tag": "x"
+      },
+      {
+        "id": 131,
+        "tag": "x"
+      },
+      {
+        "id": 132,
+        "tag": "x"
+      },
+      {
+        "id": 133,
+        "tag": "x"
+      },
+      {
+        "id": 134,
+        "tag": "x"
+      },
+      {
+        "id": 135,
+        "tag": "x"
+      },
+      {
+        "id": 136,
+        "tag": "x"
+      },
+      {
+        "id": 137,
+        "tag": "x"
+      },
+      {
+        "id": 138,
+        "tag": "x"
+      },
+      {
+        "id": 139,
+        "tag": "x"
+      },
+      {
+        "id": 140,
+        "tag": "x"
+      },
+      {
+        "id": 141,
+        "tag": "x"
+      },
+      {
+        "id": 142,
+        "tag": "x"
+      },
+      {
+        "id": 143,
+        "tag": "x"
+      },
+      {
+        "id": 144,
+        "tag": "x"
+      },
+      {
+        "id": 145,
+        "tag": "x"
+      },
+      {
+        "id": 146,
+        "tag": "x"
+      },
+      {
+        "id": 147,
+        "tag": "x"
+      },
+      {
+        "id": 148,
+        "tag": "x"
+      },
+      {
+        "id": 149,
+        "tag": "x"
+      },
+      {
+        "id": 150,
+        "tag": "x"
+      },
+      {
+        "id": 151,
+        "tag": "x"
+      },
+      {
+        "id": 152,
+        "tag": "x"
+      },
+      {
+        "id": 153,
+        "tag": "x"
+      },
+      {
+        "id": 154,
+        "tag": "x"
+      },
+      {
+        "id": 155,
+        "tag": "x"
+      },
+      {
+        "id": 156,
+        "tag": "x"
+      },
+      {
+        "id": 157,
+        "tag": "x"
+      },
+      {
+        "id": 158,
+        "tag": "x"
+      },
+      {
+        "id": 159,
+        "tag": "x"
+      },
+      {
+        "id": 160,
+        "tag": "x"
+      },
+      {
+        "id": 161,
+        "tag": "x"
+      },
+      {
+        "id": 162,
+        "tag": "x"
+      },
+      {
+        "id": 163,
+        "tag": "x"
+      },
+      {
+        "id": 164,
+        "tag": "x"
+      },
+      {
+        "id": 165,
+        "tag": "x"
+      },
+      {
+        "id": 166,
+        "tag": "x"
+      },
+      {
+        "id": 167,
+        "tag": "x"
+      },
+      {
+        "id": 168,
+        "tag": "x"
+      },
+      {
+        "id": 169,
+        "tag": "x"
+      },
+      {
+        "id": 170,
+        "tag": "x"
+      },
+      {
+        "id": 171,
+        "tag": "x"
+      },
+      {
+        "id": 172,
+        "tag": "x"
+      },
+      {
+        "id": 173,
+        "tag": "x"
+      },
+      {
+        "id": 174,
+        "tag": "x"
+      },
+      {
+        "id": 175,
+        "tag": "x"
+      },
+      {
+        "id": 176,
+        "tag": "x"
+      },
+      {
+        "id": 177,
+        "tag": "x"
+      },
+      {
+        "id": 178,
+        "tag": "x"
+      },
+      {
+        "id": 179,
+        "tag": "x"
+      },
+      {
+        "id": 180,
+        "tag": "x"
+      },
+      {
+        "id": 181,
+        "tag": "x"
+      },
+      {
+        "id": 182,
+        "tag": "x"
+      },
+      {
+        "id": 183,
+        "tag": "x"
+      },
+      {
+        "id": 184,
+        "tag": "x"
+      },
+      {
+        "id": 185,
+        "tag": "x"
+      },
+      {
+        "id": 186,
+        "tag": "x"
+      },
+      {
+        "id": 187,
+        "tag": "x"
+      },
+      {
+        "id": 188,
+        "tag": "x"
+      },
+      {
+        "id": 189,
+        "tag": "x"
+      },
+      {
+        "id": 190,
+        "tag": "x"
+      },
+      {
+        "id": 191,
+        "tag": "x"
+      },
+      {
+        "id": 192,
+        "tag": "x"
+      },
+      {
+        "id": 193,
+        "tag": "x"
+      },
+      {
+        "id": 194,
+        "tag": "x"
+      },
+      {
+        "id": 195,
+        "tag": "x"
+      },
+      {
+        "id": 196,
+        "tag": "x"
+      },
+      {
+        "id": 197,
+        "tag": "x"
+      },
+      {
+        "id": 198,
+        "tag": "x"
+      },
+      {
+        "id": 199,
+        "tag": "x"
+      },
+      {
+        "id": 200,
+        "tag": "x"
+      },
+      {
+        "id": 201,
+        "tag": "x"
+      },
+      {
+        "id": 202,
+        "tag": "x"
+      },
+      {
+        "id": 203,
+        "tag": "x"
+      },
+      {
+        "id": 204,
+        "tag": "x"
+      },
+      {
+        "id": 205,
+        "tag": "x"
+      },
+      {
+        "id": 206,
+        "tag": "x"
+      },
+      {
+        "id": 207,
+        "tag": "x"
+      },
+      {
+        "id": 208,
+        "tag": "x"
+      },
+      {
+        "id": 209,
+        "tag": "x"
+      },
+      {
+        "id": 210,
+        "tag": "x"
+      },
+      {
+        "id": 211,
+        "tag": "x"
+      },
+      {
+        "id": 212,
+        "tag": "x"
+      },
+      {
+        "id": 213,
+        "tag": "x"
+      },
+      {
+        "id": 214,
+        "tag": "x"
+      },
+      {
+        "id": 215,
+        "tag": "x"
+      },
+      {
+        "id": 216,
+        "tag": "x"
+      },
+      {
+        "id": 217,
+        "tag": "x"
+      },
+      {
+        "id": 218,
+        "tag": "x"
+      },
+      {
+        "id": 219,
+        "tag": "x"
+      },
+      {
+        "id": 220,
+        "tag": "x"
+      },
+      {
+        "id": 221,
+        "tag": "x"
+      },
+      {
+        "id": 222,
+        "tag": "x"
+      },
+      {
+        "id": 223,
+        "tag": "x"
+      },
+      {
+        "id": 224,
+        "tag": "x"
+      },
+      {
+        "id": 225,
+        "tag": "x"
+      },
+      {
+        "id": 226,
+        "tag": "x"
+      },
+      {
+        "id": 227,
+        "tag": "x"
+      },
+      {
+        "id": 228,
+        "tag": "x"
+      },
+      {
+        "id": 229,
+        "tag": "x"
+      },
+      {
+        "id": 230,
+        "tag": "x"
+      },
+      {
+        "id": 231,
+        "tag": "x"
+      },
+      {
+        "id": 232,
+        "tag": "x"
+      },
+      {
+        "id": 233,
+        "tag": "x"
+      },
+      {
+        "id": 234,
+        "tag": "x"
+      },
+      {
+        "id": 235,
+        "tag": "x"
+      },
+      {
+        "id": 236,
+        "tag": "x"
+      },
+      {
+        "id": 237,
+        "tag": "x"
+      },
+      {
+        "id": 238,
+        "tag": "x"
+      },
+      {
+        "id": 239,
+        "tag": "x"
+      },
+      {
+        "id": 240,
+        "tag": "x"
+      },
+      {
+        "id": 241,
+        "tag": "x"
+      },
+      {
+        "id": 242,
+        "tag": "x"
+      },
+      {
+        "id": 243,
+        "tag": "x"
+      },
+      {
+        "id": 244,
+        "tag": "x"
+      },
+      {
+        "id": 245,
+        "tag": "x"
+      },
+      {
+        "id": 246,
+        "tag": "x"
+      },
+      {
+        "id": 247,
+        "tag": "x"
+      },
+      {
+        "id": 248,
+        "tag": "x"
+      },
+      {
+        "id": 249,
+        "tag": "x"
+      },
+      {
+        "id": 250,
+        "tag": "x"
+      },
+      {
+        "id": 251,
+        "tag": "x"
+      },
+      {
+        "id": 252,
+        "tag": "x"
+      },
+      {
+        "id": 253,
+        "tag": "x"
+      },
+      {
+        "id": 254,
+        "tag": "x"
+      },
+      {
+        "id": 255,
+        "tag": "x"
+      },
+      {
+        "id": 256,
+        "tag": "x"
+      },
+      {
+        "id": 257,
+        "tag": "x"
+      },
+      {
+        "id": 258,
+        "tag": "x"
+      },
+      {
+        "id": 259,
+        "tag": "x"
+      },
+      {
+        "id": 260,
+        "tag": "x"
+      },
+      {
+        "id": 261,
+        "tag": "x"
+      },
+      {
+        "id": 262,
+        "tag": "x"
+      },
+      {
+        "id": 263,
+        "tag": "x"
+      },
+      {
+        "id": 264,
+        "tag": "x"
+      },
+      {
+        "id": 265,
+        "tag": "x"
+      },
+      {
+        "id": 266,
+        "tag": "x"
+      },
+      {
+        "id": 267,
+        "tag": "x"
+      },
+      {
+        "id": 268,
+        "tag": "x"
+      },
+      {
+        "id": 269,
+        "tag": "x"
+      },
+      {
+        "id": 270,
+        "tag": "x"
+      },
+      {
+        "id": 271,
+        "tag": "x"
+      },
+      {
+        "id": 272,
+        "tag": "x"
+      },
+      {
+        "id": 273,
+        "tag": "x"
+      },
+      {
+        "id": 274,
+        "tag": "x"
+      },
+      {
+        "id": 275,
+        "tag": "x"
+      },
+      {
+        "id": 276,
+        "tag": "x"
+      },
+      {
+        "id": 277,
+        "tag": "x"
+      },
+      {
+        "id": 278,
+        "tag": "x"
+      },
+      {
+        "id": 279,
+        "tag": "x"
+      },
+      {
+        "id": 280,
+        "tag": "x"
+      },
+      {
+        "id": 281,
+        "tag": "x"
+      },
+      {
+        "id": 282,
+        "tag": "x"
+      },
+      {
+        "id": 283,
+        "tag": "x"
+      },
+      {
+        "id": 284,
+        "tag": "x"
+      },
+      {
+        "id": 285,
+        "tag": "x"
+      },
+      {
+        "id": 286,
+        "tag": "x"
+      },
+      {
+        "id": 287,
+        "tag": "x"
+      },
+      {
+        "id": 288,
+        "tag": "x"
+      },
+      {
+        "id": 289,
+        "tag": "x"
+      },
+      {
+        "id": 290,
+        "tag": "x"
+      },
+      {
+        "id": 291,
+        "tag": "x"
+      },
+      {
+        "id": 292,
+        "tag": "x"
+      },
+      {
+        "id": 293,
+        "tag": "x"
+      },
+      {
+        "id": 294,
+        "tag": "x"
+      },
+      {
+        "id": 295,
+        "tag": "x"
+      },
+      {
+        "id": 296,
+        "tag": "x"
+      },
+      {
+        "id": 297,
+        "tag": "x"
+      },
+      {
+        "id": 298,
+        "tag": "x"
+      },
+      {
+        "id": 299,
+        "tag": "x"
+      },
+      {
+        "id": 300,
+        "tag": "x"
+      },
+      {
+        "id": 301,
+        "tag": "x"
+      },
+      {
+        "id": 302,
+        "tag": "x"
+      },
+      {
+        "id": 303,
+        "tag": "x"
+      },
+      {
+        "id": 304,
+        "tag": "x"
+      },
+      {
+        "id": 305,
+        "tag": "x"
+      },
+      {
+        "id": 306,
+        "tag": "x"
+      },
+      {
+        "id": 307,
+        "tag": "x"
+      },
+      {
+        "id": 308,
+        "tag": "x"
+      },
+      {
+        "id": 309,
+        "tag": "x"
+      },
+      {
+        "id": 310,
+        "tag": "x"
+      },
+      {
+        "id": 311,
+        "tag": "x"
+      },
+      {
+        "id": 312,
+        "tag": "x"
+      },
+      {
+        "id": 313,
+        "tag": "x"
+      },
+      {
+        "id": 314,
+        "tag": "x"
+      },
+      {
+        "id": 315,
+        "tag": "x"
+      },
+      {
+        "id": 316,
+        "tag": "x"
+      },
+      {
+        "id": 317,
+        "tag": "x"
+      },
+      {
+        "id": 318,
+        "tag": "x"
+      },
+      {
+        "id": 319,
+        "tag": "x"
+      },
+      {
+        "id": 320,
+        "tag": "x"
+      },
+      {
+        "id": 321,
+        "tag": "x"
+      },
+      {
+        "id": 322,
+        "tag": "x"
+      },
+      {
+        "id": 323,
+        "tag": "x"
+      },
+      {
+        "id": 324,
+        "tag": "x"
+      },
+      {
+        "id": 325,
+        "tag": "x"
+      },
+      {
+        "id": 326,
+        "tag": "x"
+      },
+      {
+        "id": 327,
+        "tag": "x"
+      },
+      {
+        "id": 328,
+        "tag": "x"
+      },
+      {
+        "id": 329,
+        "tag": "x"
+      },
+      {
+        "id": 330,
+        "tag": "x"
+      },
+      {
+        "id": 331,
+        "tag": "x"
+      },
+      {
+        "id": 332,
+        "tag": "x"
+      },
+      {
+        "id": 333,
+        "tag": "x"
+      },
+      {
+        "id": 334,
+        "tag": "x"
+      },
+      {
+        "id": 335,
+        "tag": "x"
+      },
+      {
+        "id": 336,
+        "tag": "x"
+      },
+      {
+        "id": 337,
+        "tag": "x"
+      },
+      {
+        "id": 338,
+        "tag": "x"
+      },
+      {
+        "id": 339,
+        "tag": "x"
+      },
+      {
+        "id": 340,
+        "tag": "x"
+      },
+      {
+        "id": 341,
+        "tag": "x"
+      },
+      {
+        "id": 342,
+        "tag": "x"
+      },
+      {
+        "id": 343,
+        "tag": "x"
+      },
+      {
+        "id": 344,
+        "tag": "x"
+      },
+      {
+        "id": 345,
+        "tag": "x"
+      },
+      {
+        "id": 346,
+        "tag": "x"
+      },
+      {
+        "id": 347,
+        "tag": "x"
+      },
+      {
+        "id": 348,
+        "tag": "x"
+      },
+      {
+        "id": 349,
+        "tag": "x"
+      },
+      {
+        "id": 350,
+        "tag": "x"
+      },
+      {
+        "id": 351,
+        "tag": "x"
+      },
+      {
+        "id": 352,
+        "tag": "x"
+      },
+      {
+        "id": 353,
+        "tag": "x"
+      },
+      {
+        "id": 354,
+        "tag": "x"
+      },
+      {
+        "id": 355,
+        "tag": "x"
+      },
+      {
+        "id": 356,
+        "tag": "x"
+      },
+      {
+        "id": 357,
+        "tag": "x"
+      },
+      {
+        "id": 358,
+        "tag": "x"
+      },
+      {
+        "id": 359,
+        "tag": "x"
+      },
+      {
+        "id": 360,
+        "tag": "x"
+      },
+      {
+        "id": 361,
+        "tag": "x"
+      },
+      {
+        "id": 362,
+        "tag": "x"
+      },
+      {
+        "id": 363,
+        "tag": "x"
+      },
+      {
+        "id": 364,
+        "tag": "x"
+      },
+      {
+        "id": 365,
+        "tag": "x"
+      },
+      {
+        "id": 366,
+        "tag": "x"
+      },
+      {
+        "id": 367,
+        "tag": "x"
+      },
+      {
+        "id": 368,
+        "tag": "x"
+      },
+      {
+        "id": 369,
+        "tag": "x"
+      },
+      {
+        "id": 370,
+        "tag": "x"
+      },
+      {
+        "id": 371,
+        "tag": "x"
+      },
+      {
+        "id": 372,
+        "tag": "x"
+      },
+      {
+        "id": 373,
+        "tag": "x"
+      },
+      {
+        "id": 374,
+        "tag": "x"
+      },
+      {
+        "id": 375,
+        "tag": "x"
+      },
+      {
+        "id": 376,
+        "tag": "x"
+      },
+      {
+        "id": 377,
+        "tag": "x"
+      },
+      {
+        "id": 378,
+        "tag": "x"
+      },
+      {
+        "id": 379,
+        "tag": "x"
+      },
+      {
+        "id": 380,
+        "tag": "x"
+      },
+      {
+        "id": 381,
+        "tag": "x"
+      },
+      {
+        "id": 382,
+        "tag": "x"
+      },
+      {
+        "id": 383,
+        "tag": "x"
+      },
+      {
+        "id": 384,
+        "tag": "x"
+      },
+      {
+        "id": 385,
+        "tag": "x"
+      },
+      {
+        "id": 386,
+        "tag": "x"
+      },
+      {
+        "id": 387,
+        "tag": "x"
+      },
+      {
+        "id": 388,
+        "tag": "x"
+      },
+      {
+        "id": 389,
+        "tag": "x"
+      },
+      {
+        "id": 390,
+        "tag": "x"
+      },
+      {
+        "id": 391,
+        "tag": "x"
+      },
+      {
+        "id": 392,
+        "tag": "x"
+      },
+      {
+        "id": 393,
+        "tag": "x"
+      },
+      {
+        "id": 394,
+        "tag": "x"
       }
     ],
-    "tool_calls": 3
-  }
+    "small": {
+      "count": 3,
+      "ok": true
+    },
+    "str": "<head lines=\"6\">\nNAMESPACE     APIVERSION   KIND   NAME                                                             READY   STATUS    RESTARTS   AGE    IP             NODE                                                  NOMINATED NODE   READINESS GATES   LABELS\nkube-system   v1           Pod    calico-node-kxw8s                                                1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-qjjtd                                                1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-v5nmp                                                1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=75869d67,k8s-app=calico-node,pod-template-generation=2\nkube-system   v1           Pod    calico-node-vertical-autoscaler-bbb8bfb74-r76x7                  1/1     Running   0          21h    192.168.1.5    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=calico-node-autoscaler,pod-template-hash=bbb8bfb74\nkube-system   v1           Pod    calico-typha-5d84858687-2zhk7                                    1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=calico-typha,pod-template-hash=5d84858687\n</head>\n<bulk-elided lines=\"28\">\n28 lines elided\n</bulk-elided>\n<tail lines=\"7\">\nkube-system   v1           Pod    netd-k9w4z                                                       3/3     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    netd-vgs2g                                                       3/3     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    netd-xxd4r                                                       3/3     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=db7d5f7f8,k8s-app=netd,pod-template-generation=3\nkube-system   v1           Pod    pdcsi-node-5tr4q                                                 2/2     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    pdcsi-node-7z9zs                                                 2/2     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    pdcsi-node-lcxtr                                                 2/2     Running   0          21h    10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=6b568d99d5,k8s-app=gcp-compute-persistent-disk-csi-driver,pod-template-generation=6\nkube-system   v1           Pod    runsc-metric-server-qr24t                                        1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=6b657887d,k8s-app=runsc-metric-server,pod-template-generation=2\n</tail>"
+  },
+  "sub_invocations": [
+    {
+      "args_digest": "fake_upstream_str-large-table({})",
+      "invocation_id": "<uuid>",
+      "kind": "lines",
+      "raw_size_bytes": 13093,
+      "root_path": "$",
+      "summary_envelope_bytes": 8233,
+      "tool_name": "fake_upstream_str-large-table"
+    },
+    {
+      "args_digest": "fake_upstream_arr-large-passthrough-items({})",
+      "invocation_id": "<uuid>",
+      "kind": "json_array_slice",
+      "raw_size_bytes": 10391,
+      "root_path": "$",
+      "summary_envelope_bytes": 8566,
+      "tool_name": "fake_upstream_arr-large-passthrough-items"
+    }
+  ],
+  "tool_calls": 3
 }

--- a/bats/summarized-tool-responses/compose-roundtrip-2.json
+++ b/bats/summarized-tool-responses/compose-roundtrip-2.json
@@ -1,451 +1,449 @@
 {
+  "console": [],
+  "execution_time_ms": "<ms>",
+  "fetch_hint": "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated `<summary>+<recovery>` envelope you'd have seen calling that tool directly. Compose includes `normal_fetch_limit_bytes`, and each sub_invocation includes `summary_envelope_bytes`, so you can size summary fetches before calling them.",
+  "normal_fetch_limit_bytes": 16384,
   "result": {
-    "console": [],
-    "execution_time_ms": "<ms>",
-    "fetch_hint": "Use any `sub_invocations[].invocation_id` with `tool_output_fetch` to fetch a sub-call's persisted output; `query: {mode: \"summary\"}` returns the curated `<summary>+<recovery>` envelope you'd have seen calling that tool directly. Compose includes `normal_fetch_limit_bytes`, and each sub_invocation includes `summary_envelope_bytes`, so you can size summary fetches before calling them.",
-    "normal_fetch_limit_bytes": 16384,
-    "result": {
-      "arr_slice": [
-        {
-          "id": 195,
-          "tag": "x"
-        },
-        {
-          "id": 196,
-          "tag": "x"
-        },
-        {
-          "id": 197,
-          "tag": "x"
-        },
-        {
-          "id": 198,
-          "tag": "x"
-        },
-        {
-          "id": 199,
-          "tag": "x"
-        },
-        {
-          "id": 200,
-          "tag": "x"
-        },
-        {
-          "id": 201,
-          "tag": "x"
-        },
-        {
-          "id": 202,
-          "tag": "x"
-        },
-        {
-          "id": 203,
-          "tag": "x"
-        },
-        {
-          "id": 204,
-          "tag": "x"
-        },
-        {
-          "id": 205,
-          "tag": "x"
-        },
-        {
-          "id": 206,
-          "tag": "x"
-        },
-        {
-          "id": 207,
-          "tag": "x"
-        },
-        {
-          "id": 208,
-          "tag": "x"
-        },
-        {
-          "id": 209,
-          "tag": "x"
-        },
-        {
-          "id": 210,
-          "tag": "x"
-        },
-        {
-          "id": 211,
-          "tag": "x"
-        },
-        {
-          "id": 212,
-          "tag": "x"
-        },
-        {
-          "id": 213,
-          "tag": "x"
-        },
-        {
-          "id": 214,
-          "tag": "x"
-        },
-        {
-          "id": 215,
-          "tag": "x"
-        },
-        {
-          "id": 216,
-          "tag": "x"
-        },
-        {
-          "id": 217,
-          "tag": "x"
-        },
-        {
-          "id": 218,
-          "tag": "x"
-        },
-        {
-          "id": 219,
-          "tag": "x"
-        },
-        {
-          "id": 220,
-          "tag": "x"
-        },
-        {
-          "id": 221,
-          "tag": "x"
-        },
-        {
-          "id": 222,
-          "tag": "x"
-        },
-        {
-          "id": 223,
-          "tag": "x"
-        },
-        {
-          "id": 224,
-          "tag": "x"
-        },
-        {
-          "id": 225,
-          "tag": "x"
-        },
-        {
-          "id": 226,
-          "tag": "x"
-        },
-        {
-          "id": 227,
-          "tag": "x"
-        },
-        {
-          "id": 228,
-          "tag": "x"
-        },
-        {
-          "id": 229,
-          "tag": "x"
-        },
-        {
-          "id": 230,
-          "tag": "x"
-        },
-        {
-          "id": 231,
-          "tag": "x"
-        },
-        {
-          "id": 232,
-          "tag": "x"
-        },
-        {
-          "id": 233,
-          "tag": "x"
-        },
-        {
-          "id": 234,
-          "tag": "x"
-        },
-        {
-          "id": 235,
-          "tag": "x"
-        },
-        {
-          "id": 236,
-          "tag": "x"
-        },
-        {
-          "id": 237,
-          "tag": "x"
-        },
-        {
-          "id": 238,
-          "tag": "x"
-        },
-        {
-          "id": 239,
-          "tag": "x"
-        },
-        {
-          "id": 240,
-          "tag": "x"
-        },
-        {
-          "id": 241,
-          "tag": "x"
-        },
-        {
-          "id": 242,
-          "tag": "x"
-        },
-        {
-          "id": 243,
-          "tag": "x"
-        },
-        {
-          "id": 244,
-          "tag": "x"
-        },
-        {
-          "id": 245,
-          "tag": "x"
-        },
-        {
-          "id": 246,
-          "tag": "x"
-        },
-        {
-          "id": 247,
-          "tag": "x"
-        },
-        {
-          "id": 248,
-          "tag": "x"
-        },
-        {
-          "id": 249,
-          "tag": "x"
-        },
-        {
-          "id": 250,
-          "tag": "x"
-        },
-        {
-          "id": 251,
-          "tag": "x"
-        },
-        {
-          "id": 252,
-          "tag": "x"
-        },
-        {
-          "id": 253,
-          "tag": "x"
-        },
-        {
-          "id": 254,
-          "tag": "x"
-        },
-        {
-          "id": 255,
-          "tag": "x"
-        },
-        {
-          "id": 256,
-          "tag": "x"
-        },
-        {
-          "id": 257,
-          "tag": "x"
-        },
-        {
-          "id": 258,
-          "tag": "x"
-        },
-        {
-          "id": 259,
-          "tag": "x"
-        },
-        {
-          "id": 260,
-          "tag": "x"
-        },
-        {
-          "id": 261,
-          "tag": "x"
-        },
-        {
-          "id": 262,
-          "tag": "x"
-        },
-        {
-          "id": 263,
-          "tag": "x"
-        },
-        {
-          "id": 264,
-          "tag": "x"
-        },
-        {
-          "id": 265,
-          "tag": "x"
-        },
-        {
-          "id": 266,
-          "tag": "x"
-        },
-        {
-          "id": 267,
-          "tag": "x"
-        },
-        {
-          "id": 268,
-          "tag": "x"
-        },
-        {
-          "id": 269,
-          "tag": "x"
-        },
-        {
-          "id": 270,
-          "tag": "x"
-        },
-        {
-          "id": 271,
-          "tag": "x"
-        },
-        {
-          "id": 272,
-          "tag": "x"
-        },
-        {
-          "id": 273,
-          "tag": "x"
-        },
-        {
-          "id": 274,
-          "tag": "x"
-        },
-        {
-          "id": 275,
-          "tag": "x"
-        },
-        {
-          "id": 276,
-          "tag": "x"
-        },
-        {
-          "id": 277,
-          "tag": "x"
-        },
-        {
-          "id": 278,
-          "tag": "x"
-        },
-        {
-          "id": 279,
-          "tag": "x"
-        },
-        {
-          "id": 280,
-          "tag": "x"
-        },
-        {
-          "id": 281,
-          "tag": "x"
-        },
-        {
-          "id": 282,
-          "tag": "x"
-        },
-        {
-          "id": 283,
-          "tag": "x"
-        },
-        {
-          "id": 284,
-          "tag": "x"
-        },
-        {
-          "id": 285,
-          "tag": "x"
-        },
-        {
-          "id": 286,
-          "tag": "x"
-        },
-        {
-          "id": 287,
-          "tag": "x"
-        },
-        {
-          "id": 288,
-          "tag": "x"
-        },
-        {
-          "id": 289,
-          "tag": "x"
-        },
-        {
-          "id": 290,
-          "tag": "x"
-        },
-        {
-          "id": 291,
-          "tag": "x"
-        },
-        {
-          "id": 292,
-          "tag": "x"
-        },
-        {
-          "id": 293,
-          "tag": "x"
-        },
-        {
-          "id": 294,
-          "tag": "x"
-        },
-        {
-          "id": 295,
-          "tag": "x"
-        },
-        {
-          "id": 296,
-          "tag": "x"
-        },
-        {
-          "id": 297,
-          "tag": "x"
-        },
-        {
-          "id": 298,
-          "tag": "x"
-        },
-        {
-          "id": 299,
-          "tag": "x"
-        },
-        {
-          "id": 300,
-          "tag": "x"
-        },
-        {
-          "id": 301,
-          "tag": "x"
-        },
-        {
-          "id": 302,
-          "tag": "x"
-        },
-        {
-          "id": 303,
-          "tag": "x"
-        }
-      ],
-      "str_slice": "kube-system   v1           Pod    fluentbit-gke-vdjth                                              3/3     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            component=fluentbit-gke,controller-revision-hash=55dd6c6454,k8s-app=fluentbit-gke,kubernetes.io/cluster-service=true,pod-template-generation=3\nkube-system   v1           Pod    gke-metadata-server-2djzv                                        1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            addonmanager.kubernetes.io/mode=Reconcile,controller-revision-hash=6dcfdfb77d,k8s-app=gke-metadata-server,pod-template-generation=2\nkube-system   v1           Pod    gke-metadata-server-dhlhp                                        1/1     Running   0          21h    10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            addonmanager.kubernetes.io/mode=Reconcile,controller-revision-hash=6dcfdfb77d,k8s-app=gke-metadata-server,pod-template-generation=2\nkube-system   v1           Pod    gke-metadata-server-kx2sb                                        1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            addonmanager.kubernetes.io/mode=Reconcile,controller-revision-hash=6dcfdfb77d,k8s-app=gke-metadata-server,pod-template-generation=2\nkube-system   v1           Pod    gke-metrics-agent-2p2xn                                          2/2     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            component=gke-metrics-agent,controller-revision-hash=5b595f7969,k8s-app=gke-metrics-agent,pod-template-generation=2\nkube-system   v1           Pod    gke-metrics-agent-kqq22                                          2/2     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            component=gke-metrics-agent,controller-revision-hash=5b595f7969,k8s-app=gke-metrics-agent,pod-template-generation=2\nkube-system   v1           Pod    gke-metrics-agent-nczml                                          2/2     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            component=gke-metrics-agent,controller-revision-hash=5b595f7969,k8s-app=gke-metrics-agent,pod-template-generation=2\nkube-system   v1           Pod    ip-masq-agent-4r6cf                                              1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=7cbdb6bd86,k8s-app=ip-masq-agent,pod-template-generation=3\nkube-system   v1           Pod    ip-masq-agent-nj4qv                                              1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=7cbdb6bd86,k8s-app=ip-masq-agent,pod-template-generation=3\nkube-system   v1           Pod    ip-masq-agent-svtk6                                              1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=7cbdb6bd86,k8s-app=ip-masq-agent,pod-template-generation=3\nkube-system   v1           Pod    konnectivity-agent-6857bb85bd-jr9sc                              2/2     Running   0          21h    192.168.1.8    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=konnectivity-agent,pod-template-hash=6857bb85bd\nkube-system   v1           Pod    konnectivity-agent-6857bb85bd-wjpw6                              2/2     Running   0          21h    192.168.0.8    gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            k8s-app=konnectivity-agent,pod-template-hash=6857bb85bd\nkube-system   v1           Pod    konnectivity-agent-6857bb85bd-x4ml9                              2/2     Running   0          21h    192.168.2.13   gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            k8s-app=konnectivity-agent,pod-template-hash=6857bb85bd\nkube-system   v1           Pod    konnectivity-agent-autoscaler-d67c74bb7-f6c29                    1/1     Running   0          21h    192.168.1.13   gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=konnectivity-agent-autoscaler,pod-template-hash=d67c74bb7\nkube-system   v1           Pod    kube-dns-6f8c46f48b-4nksr                                        4/4     Running   0          21h    192.168.2.14   gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            k8s-app=kube-dns,pod-template-hash=6f8c46f48b\nkube-system   v1           Pod    kube-dns-6f8c46f48b-jqvhn                                        4/4     Running   0          21h    192.168.1.7    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=kube-dns,pod-template-hash=6f8c46f48b"
-    },
-    "sub_invocations": [],
-    "tool_calls": 2
-  }
+    "arr_slice": [
+      {
+        "id": 195,
+        "tag": "x"
+      },
+      {
+        "id": 196,
+        "tag": "x"
+      },
+      {
+        "id": 197,
+        "tag": "x"
+      },
+      {
+        "id": 198,
+        "tag": "x"
+      },
+      {
+        "id": 199,
+        "tag": "x"
+      },
+      {
+        "id": 200,
+        "tag": "x"
+      },
+      {
+        "id": 201,
+        "tag": "x"
+      },
+      {
+        "id": 202,
+        "tag": "x"
+      },
+      {
+        "id": 203,
+        "tag": "x"
+      },
+      {
+        "id": 204,
+        "tag": "x"
+      },
+      {
+        "id": 205,
+        "tag": "x"
+      },
+      {
+        "id": 206,
+        "tag": "x"
+      },
+      {
+        "id": 207,
+        "tag": "x"
+      },
+      {
+        "id": 208,
+        "tag": "x"
+      },
+      {
+        "id": 209,
+        "tag": "x"
+      },
+      {
+        "id": 210,
+        "tag": "x"
+      },
+      {
+        "id": 211,
+        "tag": "x"
+      },
+      {
+        "id": 212,
+        "tag": "x"
+      },
+      {
+        "id": 213,
+        "tag": "x"
+      },
+      {
+        "id": 214,
+        "tag": "x"
+      },
+      {
+        "id": 215,
+        "tag": "x"
+      },
+      {
+        "id": 216,
+        "tag": "x"
+      },
+      {
+        "id": 217,
+        "tag": "x"
+      },
+      {
+        "id": 218,
+        "tag": "x"
+      },
+      {
+        "id": 219,
+        "tag": "x"
+      },
+      {
+        "id": 220,
+        "tag": "x"
+      },
+      {
+        "id": 221,
+        "tag": "x"
+      },
+      {
+        "id": 222,
+        "tag": "x"
+      },
+      {
+        "id": 223,
+        "tag": "x"
+      },
+      {
+        "id": 224,
+        "tag": "x"
+      },
+      {
+        "id": 225,
+        "tag": "x"
+      },
+      {
+        "id": 226,
+        "tag": "x"
+      },
+      {
+        "id": 227,
+        "tag": "x"
+      },
+      {
+        "id": 228,
+        "tag": "x"
+      },
+      {
+        "id": 229,
+        "tag": "x"
+      },
+      {
+        "id": 230,
+        "tag": "x"
+      },
+      {
+        "id": 231,
+        "tag": "x"
+      },
+      {
+        "id": 232,
+        "tag": "x"
+      },
+      {
+        "id": 233,
+        "tag": "x"
+      },
+      {
+        "id": 234,
+        "tag": "x"
+      },
+      {
+        "id": 235,
+        "tag": "x"
+      },
+      {
+        "id": 236,
+        "tag": "x"
+      },
+      {
+        "id": 237,
+        "tag": "x"
+      },
+      {
+        "id": 238,
+        "tag": "x"
+      },
+      {
+        "id": 239,
+        "tag": "x"
+      },
+      {
+        "id": 240,
+        "tag": "x"
+      },
+      {
+        "id": 241,
+        "tag": "x"
+      },
+      {
+        "id": 242,
+        "tag": "x"
+      },
+      {
+        "id": 243,
+        "tag": "x"
+      },
+      {
+        "id": 244,
+        "tag": "x"
+      },
+      {
+        "id": 245,
+        "tag": "x"
+      },
+      {
+        "id": 246,
+        "tag": "x"
+      },
+      {
+        "id": 247,
+        "tag": "x"
+      },
+      {
+        "id": 248,
+        "tag": "x"
+      },
+      {
+        "id": 249,
+        "tag": "x"
+      },
+      {
+        "id": 250,
+        "tag": "x"
+      },
+      {
+        "id": 251,
+        "tag": "x"
+      },
+      {
+        "id": 252,
+        "tag": "x"
+      },
+      {
+        "id": 253,
+        "tag": "x"
+      },
+      {
+        "id": 254,
+        "tag": "x"
+      },
+      {
+        "id": 255,
+        "tag": "x"
+      },
+      {
+        "id": 256,
+        "tag": "x"
+      },
+      {
+        "id": 257,
+        "tag": "x"
+      },
+      {
+        "id": 258,
+        "tag": "x"
+      },
+      {
+        "id": 259,
+        "tag": "x"
+      },
+      {
+        "id": 260,
+        "tag": "x"
+      },
+      {
+        "id": 261,
+        "tag": "x"
+      },
+      {
+        "id": 262,
+        "tag": "x"
+      },
+      {
+        "id": 263,
+        "tag": "x"
+      },
+      {
+        "id": 264,
+        "tag": "x"
+      },
+      {
+        "id": 265,
+        "tag": "x"
+      },
+      {
+        "id": 266,
+        "tag": "x"
+      },
+      {
+        "id": 267,
+        "tag": "x"
+      },
+      {
+        "id": 268,
+        "tag": "x"
+      },
+      {
+        "id": 269,
+        "tag": "x"
+      },
+      {
+        "id": 270,
+        "tag": "x"
+      },
+      {
+        "id": 271,
+        "tag": "x"
+      },
+      {
+        "id": 272,
+        "tag": "x"
+      },
+      {
+        "id": 273,
+        "tag": "x"
+      },
+      {
+        "id": 274,
+        "tag": "x"
+      },
+      {
+        "id": 275,
+        "tag": "x"
+      },
+      {
+        "id": 276,
+        "tag": "x"
+      },
+      {
+        "id": 277,
+        "tag": "x"
+      },
+      {
+        "id": 278,
+        "tag": "x"
+      },
+      {
+        "id": 279,
+        "tag": "x"
+      },
+      {
+        "id": 280,
+        "tag": "x"
+      },
+      {
+        "id": 281,
+        "tag": "x"
+      },
+      {
+        "id": 282,
+        "tag": "x"
+      },
+      {
+        "id": 283,
+        "tag": "x"
+      },
+      {
+        "id": 284,
+        "tag": "x"
+      },
+      {
+        "id": 285,
+        "tag": "x"
+      },
+      {
+        "id": 286,
+        "tag": "x"
+      },
+      {
+        "id": 287,
+        "tag": "x"
+      },
+      {
+        "id": 288,
+        "tag": "x"
+      },
+      {
+        "id": 289,
+        "tag": "x"
+      },
+      {
+        "id": 290,
+        "tag": "x"
+      },
+      {
+        "id": 291,
+        "tag": "x"
+      },
+      {
+        "id": 292,
+        "tag": "x"
+      },
+      {
+        "id": 293,
+        "tag": "x"
+      },
+      {
+        "id": 294,
+        "tag": "x"
+      },
+      {
+        "id": 295,
+        "tag": "x"
+      },
+      {
+        "id": 296,
+        "tag": "x"
+      },
+      {
+        "id": 297,
+        "tag": "x"
+      },
+      {
+        "id": 298,
+        "tag": "x"
+      },
+      {
+        "id": 299,
+        "tag": "x"
+      },
+      {
+        "id": 300,
+        "tag": "x"
+      },
+      {
+        "id": 301,
+        "tag": "x"
+      },
+      {
+        "id": 302,
+        "tag": "x"
+      },
+      {
+        "id": 303,
+        "tag": "x"
+      }
+    ],
+    "str_slice": "kube-system   v1           Pod    fluentbit-gke-vdjth                                              3/3     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            component=fluentbit-gke,controller-revision-hash=55dd6c6454,k8s-app=fluentbit-gke,kubernetes.io/cluster-service=true,pod-template-generation=3\nkube-system   v1           Pod    gke-metadata-server-2djzv                                        1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            addonmanager.kubernetes.io/mode=Reconcile,controller-revision-hash=6dcfdfb77d,k8s-app=gke-metadata-server,pod-template-generation=2\nkube-system   v1           Pod    gke-metadata-server-dhlhp                                        1/1     Running   0          21h    10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            addonmanager.kubernetes.io/mode=Reconcile,controller-revision-hash=6dcfdfb77d,k8s-app=gke-metadata-server,pod-template-generation=2\nkube-system   v1           Pod    gke-metadata-server-kx2sb                                        1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            addonmanager.kubernetes.io/mode=Reconcile,controller-revision-hash=6dcfdfb77d,k8s-app=gke-metadata-server,pod-template-generation=2\nkube-system   v1           Pod    gke-metrics-agent-2p2xn                                          2/2     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            component=gke-metrics-agent,controller-revision-hash=5b595f7969,k8s-app=gke-metrics-agent,pod-template-generation=2\nkube-system   v1           Pod    gke-metrics-agent-kqq22                                          2/2     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            component=gke-metrics-agent,controller-revision-hash=5b595f7969,k8s-app=gke-metrics-agent,pod-template-generation=2\nkube-system   v1           Pod    gke-metrics-agent-nczml                                          2/2     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            component=gke-metrics-agent,controller-revision-hash=5b595f7969,k8s-app=gke-metrics-agent,pod-template-generation=2\nkube-system   v1           Pod    ip-masq-agent-4r6cf                                              1/1     Running   0          21h    10.1.0.31      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            controller-revision-hash=7cbdb6bd86,k8s-app=ip-masq-agent,pod-template-generation=3\nkube-system   v1           Pod    ip-masq-agent-nj4qv                                              1/1     Running   0          2d2h   10.1.0.29      gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            controller-revision-hash=7cbdb6bd86,k8s-app=ip-masq-agent,pod-template-generation=3\nkube-system   v1           Pod    ip-masq-agent-svtk6                                              1/1     Running   0          21h    10.1.0.30      gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            controller-revision-hash=7cbdb6bd86,k8s-app=ip-masq-agent,pod-template-generation=3\nkube-system   v1           Pod    konnectivity-agent-6857bb85bd-jr9sc                              2/2     Running   0          21h    192.168.1.8    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=konnectivity-agent,pod-template-hash=6857bb85bd\nkube-system   v1           Pod    konnectivity-agent-6857bb85bd-wjpw6                              2/2     Running   0          21h    192.168.0.8    gke-galoy-agents-clust-sandbox-gvisor-87c7278e-q9ts   <none>           <none>            k8s-app=konnectivity-agent,pod-template-hash=6857bb85bd\nkube-system   v1           Pod    konnectivity-agent-6857bb85bd-x4ml9                              2/2     Running   0          21h    192.168.2.13   gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            k8s-app=konnectivity-agent,pod-template-hash=6857bb85bd\nkube-system   v1           Pod    konnectivity-agent-autoscaler-d67c74bb7-f6c29                    1/1     Running   0          21h    192.168.1.13   gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=konnectivity-agent-autoscaler,pod-template-hash=d67c74bb7\nkube-system   v1           Pod    kube-dns-6f8c46f48b-4nksr                                        4/4     Running   0          21h    192.168.2.14   gke-galoy-agents-clu-galoy-agents-n2--46ac1569-2xv8   <none>           <none>            k8s-app=kube-dns,pod-template-hash=6f8c46f48b\nkube-system   v1           Pod    kube-dns-6f8c46f48b-jqvhn                                        4/4     Running   0          21h    192.168.1.7    gke-galoy-agents-clu-galoy-agents-n2--46ac1569-m84i   <none>           <none>            k8s-app=kube-dns,pod-template-hash=6f8c46f48b"
+  },
+  "sub_invocations": [],
+  "tool_calls": 2
 }

--- a/core/crates/tool-caching/src/fetch.rs
+++ b/core/crates/tool-caching/src/fetch.rs
@@ -370,8 +370,19 @@ impl StoredInvocation {
     /// Replay the curated `<summary>+<recovery>` envelope from the
     /// persisted `ToolCallSummary`. Summary mode is the recovery escape
     /// hatch, so it bypasses the normal fetch-size cap.
+    ///
+    /// Envelope-mode invocations (e.g. `compose`, which advertises
+    /// `ComposeOutput` as its outputSchema and has no outer `{result: …}`
+    /// wrapper) replay through `build_wire_envelope` so the replayed
+    /// shape matches what the live call emitted — agents using
+    /// `query:{mode:"summary"}` recovery see the same structured shape
+    /// they would have seen calling the tool directly.
     fn summary_view(&self, _max_bytes: usize) -> Result<FetchResult, ToolCachingError> {
-        let (result, structured) = self.summary.build_wire(self.id);
+        let (result, structured) = if self.summary.envelope_mode {
+            self.summary.build_wire_envelope(self.id)
+        } else {
+            self.summary.build_wire(self.id)
+        };
         Ok(FetchResult { result, structured })
     }
 
@@ -754,6 +765,7 @@ mod tests {
                 shown_items: None,
                 total_lines: None,
                 shown_lines: None,
+                envelope_mode: false,
             },
             original_structured: None,
         }
@@ -1055,6 +1067,58 @@ mod tests {
         assert!(hint.contains("normal_fetch_limit_bytes: 64"), "got: {hint}");
     }
 
+    /// Envelope-mode persisted summaries (e.g. `compose`) must replay
+    /// through `build_wire_envelope` on `query:{mode:"summary"}` so the
+    /// re-fetched structured shape matches the live elided call. If it
+    /// fell back to `build_wire`, agents would see `{result: <T>, ...}`
+    /// from the replay but a flat ComposeOutput from the live call.
+    #[test]
+    fn summary_query_replays_envelope_mode_through_build_wire_envelope() {
+        use crate::primitives::ElidedPath;
+        let mut inv = stored(serde_json::json!({}));
+        inv.summary = ToolCallSummary {
+            summary: Value::String("<elided body>".into()),
+            wire_result: serde_json::json!({
+                "sub_invocations": [],
+                "tool_calls": 1,
+                "execution_time_ms": 12,
+                "console": [],
+                "result": "<elided body>",
+            }),
+            elided_paths: vec![ElidedPath {
+                path: "$.result".to_string(),
+                total_bytes: 9999,
+                shown_bytes: 16,
+                total_lines: None,
+                shown_lines: None,
+                total_items: None,
+                shown_items: None,
+                recover: serde_json::json!({
+                    "tool": "tool_output_fetch",
+                    "args_template": { "invocation_id": "<id>", "path": "$.result" },
+                }),
+            }],
+            root_path: "$".to_string(),
+            total_bytes: 9999,
+            shown_bytes: 16,
+            total_items: None,
+            shown_items: None,
+            total_lines: None,
+            shown_lines: None,
+            envelope_mode: true,
+        };
+
+        let fetched = inv
+            .query("$", Some(&FetchQuery::Summary), 64)
+            .expect("summary mode bypasses the normal fetch cap");
+        // ComposeOutput fields at the root, not under a synthetic `result` key.
+        assert_eq!(fetched.structured["tool_calls"], 1);
+        assert_eq!(fetched.structured["execution_time_ms"], 12);
+        assert_eq!(fetched.structured["result"], "<elided body>");
+        assert!(fetched.structured.get("_recovery").is_some());
+        assert!(fetched.structured.get("_elided").is_some());
+    }
+
     #[test]
     fn summary_query_bypasses_fetch_cap_without_late_annotation() {
         let mut inv = stored(serde_json::json!("full"));
@@ -1069,6 +1133,7 @@ mod tests {
             shown_items: None,
             total_lines: None,
             shown_lines: None,
+            envelope_mode: false,
         };
 
         let fetched = inv
@@ -1138,6 +1203,7 @@ mod tests {
                 shown_items: None,
                 total_lines: None,
                 shown_lines: None,
+                envelope_mode: false,
             },
             original_structured: None,
         }

--- a/core/crates/tool-caching/src/lib.rs
+++ b/core/crates/tool-caching/src/lib.rs
@@ -41,6 +41,19 @@ struct Processed {
     persisted: bool,
 }
 
+/// Which wire shape the persisted summary should replay as on a later
+/// `tool_output_fetch(query:{mode:"summary"})`. Stamped onto the summary
+/// inside `process()` so the replay path can't diverge from the live
+/// caller's choice.
+#[derive(Debug, Clone, Copy)]
+enum ProcessMode {
+    /// `{result: T, _recovery, _elided}` — the default `DruaToolResult` shape.
+    Wrap,
+    /// T verbatim with `_recovery` / `_elided` merged into its root.
+    /// Used by tools that own their envelope shape (e.g. `compose`).
+    Envelope,
+}
+
 impl ToolCaching {
     pub fn new(pool: &sqlx::PgPool, config: ToolCachingConfig) -> Self {
         let walker = Walker::new(
@@ -88,7 +101,9 @@ impl ToolCaching {
             return Ok(passthrough_no_owner(result));
         }
 
-        let processed = self.process(owner_id, tool_name, args, &result).await?;
+        let processed = self
+            .process(owner_id, tool_name, args, &result, ProcessMode::Wrap)
+            .await?;
 
         if !processed.persisted {
             // Sub-threshold passthrough — keep the text channel raw,
@@ -149,7 +164,9 @@ impl ToolCaching {
             return Ok(passthrough_no_owner(result));
         }
 
-        let processed = self.process(owner_id, tool_name, args, &result).await?;
+        let processed = self
+            .process(owner_id, tool_name, args, &result, ProcessMode::Envelope)
+            .await?;
 
         if !processed.persisted {
             // Sub-threshold passthrough — emit T verbatim, no `{result: T}`
@@ -205,7 +222,14 @@ impl ToolCaching {
             return Ok(passthrough_no_owner(result));
         }
 
-        let processed = self.process(owner_id, tool_name, args, &result).await?;
+        // Sub-invocations inside compose are persisted under their own
+        // tool's wire shape (catalog tools use the `DruaToolResult` wrap;
+        // top-level envelope-owning tools are out of scope here since they
+        // can't run from compose), so the summary replay mode mirrors
+        // `cache()`'s `{result: T}` envelope.
+        let processed = self
+            .process(owner_id, tool_name, args, &result, ProcessMode::Wrap)
+            .await?;
 
         // For compose JS engine: always emit T verbatim, regardless of
         // whether the walker found anything elision-worthy.
@@ -268,12 +292,18 @@ impl ToolCaching {
     /// shape; `persist_for_compose()` discards the summary on the wire
     /// (emits T verbatim) but persists it so the agent can re-fetch
     /// with `{mode: "summary"}` later.
+    ///
+    /// `mode` controls how a later `tool_output_fetch(query:{mode:"summary"})`
+    /// replays this invocation — wrap (`{result: T, _recovery, _elided}`)
+    /// or envelope (T verbatim with recovery merged in). It is persisted
+    /// on the summary so the replay path can't drift from the live call.
     async fn process(
         &self,
         owner_id: ToolCallOwnerId,
         tool_name: &str,
         args: &serde_json::Value,
         result: &CallToolResult,
+        mode: ProcessMode,
     ) -> Result<Processed, ToolCachingError> {
         let original_structured = result.structured_content.clone();
         let upstream_t = tool_result_value(result);
@@ -292,9 +322,10 @@ impl ToolCaching {
             root: upstream_t.clone(),
         };
         let invocation_id = ToolInvocationId::new();
-        let summary = self
+        let mut summary = self
             .walker
             .summarize(&query_structure, invocation_id, tool_name);
+        summary.envelope_mode = matches!(mode, ProcessMode::Envelope);
 
         if summary.elided_paths.is_empty() {
             return Ok(Processed {
@@ -559,6 +590,7 @@ mod tests {
             shown_items: None,
             total_lines: None,
             shown_lines: None,
+            envelope_mode: true,
         };
         let id = ToolInvocationId::new();
 
@@ -618,6 +650,7 @@ mod tests {
             shown_items: None,
             total_lines: None,
             shown_lines: None,
+            envelope_mode: true,
         };
         let id = ToolInvocationId::new();
         let (_, env) = summary.clone().build_wire_envelope(id);

--- a/core/crates/tool-caching/src/lib.rs
+++ b/core/crates/tool-caching/src/lib.rs
@@ -120,6 +120,65 @@ impl ToolCaching {
         })
     }
 
+    /// Variant of [`cache`] for tools that own their envelope shape and opt
+    /// out of the `DruaToolResult` wrapper (`default_tool_caching() == false`,
+    /// e.g. `compose`). Walks and persists identically to `cache()`, but on
+    /// the structured channel emits the upstream `T` verbatim — merging
+    /// elision recovery (`_recovery` / `_elided`) into `T`'s top-level
+    /// object when the walker elides, rather than nesting under a
+    /// synthetic `result` key.
+    ///
+    /// This is what makes the returned `structuredContent` validate against
+    /// such a tool's advertised `outputSchema` (e.g. `ComposeOutput`): the
+    /// schema has no outer `{ result: ... }` wrapper, so `cache()`'s wrap
+    /// would make every persisted compose call fail strict MCP-client
+    /// output-schema validation (`@modelcontextprotocol/sdk` `callTool`
+    /// validates unconditionally when a tool declares an `outputSchema`).
+    pub async fn cache_envelope(
+        &self,
+        owner: impl Into<Option<ToolCallOwnerId>>,
+        tool_name: &str,
+        args: &serde_json::Value,
+        result: CallToolResult,
+    ) -> Result<ToolCacheResponse, ToolCachingError> {
+        let result = ensure_text_channel(result);
+        let Some(owner_id) = owner.into() else {
+            return Ok(passthrough_no_owner(result));
+        };
+        if result.is_error == Some(true) {
+            return Ok(passthrough_no_owner(result));
+        }
+
+        let processed = self.process(owner_id, tool_name, args, &result).await?;
+
+        if !processed.persisted {
+            // Sub-threshold passthrough — emit T verbatim, no `{result: T}`
+            // wrap. Matches what envelope-owning tools advertise as their
+            // outputSchema.
+            let mut passthrough = result;
+            passthrough.structured_content = Some(processed.upstream_t);
+            return Ok(ToolCacheResponse {
+                result: passthrough,
+                elided_paths: Vec::new(),
+                invocation_id: None,
+                summary_fetch_info: None,
+                root_path: None,
+            });
+        }
+
+        let elided_paths = processed.summary.elided_paths.clone();
+        let summary_fetch_info = self.summary_fetch_info(&processed.summary);
+        let root_path = processed.summary.root_path.clone();
+        let wrapped = build_elide_ctr_envelope(processed.summary, processed.invocation_id);
+        Ok(ToolCacheResponse {
+            result: wrapped,
+            elided_paths,
+            invocation_id: Some(processed.invocation_id),
+            summary_fetch_info: Some(summary_fetch_info),
+            root_path: Some(root_path),
+        })
+    }
+
     /// Compose sub-dispatch call path. The JS engine has its own size
     /// cap and scripts use the sub-tool's return directly as upstream `T`
     /// — pre-elided data would force every script to recover through
@@ -287,6 +346,16 @@ fn build_elide_ctr(summary: ToolCallSummary, invocation_id: ToolInvocationId) ->
     summary.build_wire(invocation_id).0
 }
 
+/// Envelope-owning variant (see [`ToolCallSummary::build_wire_envelope`]).
+/// Used by [`ToolCaching::cache_envelope`] for tools like `compose` whose
+/// advertised outputSchema has no outer `{ result: ... }` wrapper.
+fn build_elide_ctr_envelope(
+    summary: ToolCallSummary,
+    invocation_id: ToolInvocationId,
+) -> CallToolResult {
+    summary.build_wire_envelope(invocation_id).0
+}
+
 pub fn extract_text(result: &CallToolResult) -> String {
     result
         .content
@@ -446,5 +515,116 @@ mod tests {
             value["content"][1]["resource"]["blob"],
             "<base64 resource blob elided; 10 bytes>"
         );
+    }
+
+    /// `build_wire_envelope` keeps the walked object's own top-level shape
+    /// (no synthetic `result` wrapper) while still attaching `_recovery` /
+    /// `_elided`. This is what lets envelope-owning tools like `compose`
+    /// validate their `structuredContent` against a flat `outputSchema`
+    /// (e.g. `ComposeOutput`). Mirrored against `build_wire` to lock the
+    /// wrap-vs-merge contract.
+    #[test]
+    fn build_wire_envelope_merges_recovery_into_object_root() {
+        use crate::primitives::{ElidedPath, ToolCallSummary};
+        // `wire_result` mirrors a ComposeOutput-style envelope: a handful
+        // of always-present fields plus a big `result` the walker elided.
+        let wire_result = serde_json::json!({
+            "sub_invocations": [],
+            "tool_calls": 1,
+            "execution_time_ms": 12,
+            "console": [],
+            "result": "<elided body>"
+        });
+        let elided = ElidedPath {
+            path: "$.result".to_string(),
+            total_bytes: 9999,
+            shown_bytes: 16,
+            total_lines: None,
+            shown_lines: None,
+            total_items: None,
+            shown_items: None,
+            recover: serde_json::json!({
+                "tool": "tool_output_fetch",
+                "args_template": { "invocation_id": "<id>", "path": "$.result" }
+            }),
+        };
+        let summary = ToolCallSummary {
+            summary: serde_json::json!("<elided body>"),
+            wire_result: wire_result.clone(),
+            elided_paths: vec![elided],
+            root_path: "$".to_string(),
+            total_bytes: 9999,
+            shown_bytes: 16,
+            total_items: None,
+            shown_items: None,
+            total_lines: None,
+            shown_lines: None,
+        };
+        let id = ToolInvocationId::new();
+
+        let (wrapped_ctr, wrapped) = summary.clone().build_wire(id);
+        let (env_ctr, env) = summary.build_wire_envelope(id);
+
+        // `build_wire` nests everything under `result` (DruaToolResult).
+        assert_eq!(wrapped["result"]["tool_calls"], 1);
+        assert!(wrapped.get("_recovery").is_some());
+        assert!(wrapped.get("_elided").is_some());
+        // The envelope's own fields are NOT at the wrapped root.
+        assert!(wrapped.get("tool_calls").is_none());
+
+        // `build_wire_envelope` keeps ComposeOutput's fields at the root.
+        assert_eq!(env["tool_calls"], 1);
+        assert_eq!(env["execution_time_ms"], 12);
+        assert_eq!(env["sub_invocations"], serde_json::json!([]));
+        assert_eq!(env["result"], "<elided body>");
+        // Recovery metadata merged in alongside them, not under `result`.
+        assert_eq!(
+            env["_recovery"]["invocation_id"],
+            wrapped["_recovery"]["invocation_id"]
+        );
+        assert_eq!(env["_elided"]["paths"][0]["path"], "$.result");
+        // No synthetic `result` wrapper around the whole envelope.
+        assert!(env.get("result").is_some()); // ComposeOutput.result, present
+        assert!(env.get("_recovery").is_some());
+        assert!(env.get("_elided").is_some());
+
+        // Same text-channel envelope on both (recovery rendering is shared).
+        assert_eq!(extract_text(&wrapped_ctr), extract_text(&env_ctr));
+    }
+
+    /// When `wire_result` is not an object (array/scalar root),
+    /// `build_wire_envelope` must fall back to `build_wire` so recovery
+    /// metadata is never silently dropped.
+    #[test]
+    fn build_wire_envelope_falls_back_to_wrap_for_non_object_root() {
+        use crate::primitives::{ElidedPath, ToolCallSummary};
+        let summary = ToolCallSummary {
+            summary: serde_json::json!("x"),
+            wire_result: serde_json::json!([1, 2, 3]), // array root
+            elided_paths: vec![ElidedPath {
+                path: "$[0]".to_string(),
+                total_bytes: 10,
+                shown_bytes: 1,
+                total_lines: None,
+                shown_lines: None,
+                total_items: None,
+                shown_items: None,
+                recover: serde_json::json!({"tool": "tool_output_fetch"}),
+            }],
+            root_path: "$".to_string(),
+            total_bytes: 10,
+            shown_bytes: 1,
+            total_items: None,
+            shown_items: None,
+            total_lines: None,
+            shown_lines: None,
+        };
+        let id = ToolInvocationId::new();
+        let (_, env) = summary.clone().build_wire_envelope(id);
+        let (_, wrapped) = summary.build_wire(id);
+        // Non-object root → identical wrapped shape (recovery preserved).
+        assert_eq!(env, wrapped);
+        assert_eq!(env["result"], serde_json::json!([1, 2, 3]));
+        assert!(env.get("_recovery").is_some());
     }
 }

--- a/core/crates/tool-caching/src/primitives.rs
+++ b/core/crates/tool-caching/src/primitives.rs
@@ -76,6 +76,13 @@ pub struct ToolCallSummary {
     pub total_lines: Option<u32>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub shown_lines: Option<u32>,
+    /// True when this summary was produced by a tool that owns its
+    /// envelope shape (`default_tool_caching() == false`, e.g. `compose`)
+    /// — the live wire emits `T` verbatim via [`build_wire_envelope`],
+    /// so summary replay must do the same to keep parity. `#[serde(default)]`
+    /// keeps pre-existing persisted rows readable as wrap-mode.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub envelope_mode: bool,
 }
 
 impl ToolCallSummary {

--- a/core/crates/tool-caching/src/primitives.rs
+++ b/core/crates/tool-caching/src/primitives.rs
@@ -122,10 +122,7 @@ impl ToolCallSummary {
     /// which has no outer `{ result: ... }` wrapper. If `wire_result` is
     /// not an object (e.g. a tool returns an array or scalar root), fall
     /// back to [`build_wire`] so recovery metadata is never lost.
-    pub fn build_wire_envelope(
-        &self,
-        invocation_id: ToolInvocationId,
-    ) -> (CallToolResult, Value) {
+    pub fn build_wire_envelope(&self, invocation_id: ToolInvocationId) -> (CallToolResult, Value) {
         let envelope = self.build_envelope_text();
         let recovery = self.recovery_manifest(invocation_id);
         let mut root = self.wire_result.clone();

--- a/core/crates/tool-caching/src/primitives.rs
+++ b/core/crates/tool-caching/src/primitives.rs
@@ -108,6 +108,54 @@ impl ToolCallSummary {
         (result, structured)
     }
 
+    /// Variant of [`build_wire`] for tools that own their envelope shape
+    /// and opt out of the `DruaToolResult` wrapper (i.e.
+    /// `default_tool_caching() == false`, such as `compose`). The walker
+    /// still operates on the full structured `T` and persists it for
+    /// `tool_output_fetch` recovery, but the agent-facing structured
+    /// channel keeps `T`'s own top-level shape — merging `_recovery` /
+    /// `_elided` into `T`'s root object rather than nesting everything
+    /// under a synthetic `result` key.
+    ///
+    /// This is what makes the returned `structuredContent` validate against
+    /// such a tool's advertised `outputSchema` (e.g. `ComposeOutput`),
+    /// which has no outer `{ result: ... }` wrapper. If `wire_result` is
+    /// not an object (e.g. a tool returns an array or scalar root), fall
+    /// back to [`build_wire`] so recovery metadata is never lost.
+    pub fn build_wire_envelope(
+        &self,
+        invocation_id: ToolInvocationId,
+    ) -> (CallToolResult, Value) {
+        let envelope = self.build_envelope_text();
+        let recovery = self.recovery_manifest(invocation_id);
+        let mut root = self.wire_result.clone();
+        match &mut root {
+            Value::Object(map) => {
+                map.insert(
+                    "_recovery".to_string(),
+                    serde_json::to_value(&recovery).unwrap(),
+                );
+                if !self.elided_paths.is_empty() {
+                    map.insert(
+                        "_elided".to_string(),
+                        serde_json::json!({
+                            "invocation_id": invocation_id.to_string(),
+                            "paths": self.elided_paths.clone(),
+                        }),
+                    );
+                }
+            }
+            _ => {
+                // Non-object root — wrapping is the only way to attach
+                // recovery metadata without losing the root value.
+                return self.build_wire(invocation_id);
+            }
+        }
+        let mut result = CallToolResult::success(vec![Content::text(envelope)]);
+        result.structured_content = Some(root.clone());
+        (result, root)
+    }
+
     fn recovery_manifest(&self, invocation_id: ToolInvocationId) -> RecoveryManifest {
         RecoveryManifest {
             invocation_id: invocation_id.to_string(),

--- a/core/crates/tool-caching/src/walker.rs
+++ b/core/crates/tool-caching/src/walker.rs
@@ -146,6 +146,7 @@ impl Walker {
             shown_items,
             total_lines,
             shown_lines,
+            envelope_mode: false,
         }
     }
 

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -196,11 +196,17 @@ impl TopLevelTool for ComposeTool {
 
         let ctr = match self.tool_caching.as_ref() {
             Some(tc) => {
-                // Plain `cache()` — same path every other top-level tool
-                // takes. We hand off an empty text channel; cache() fills
-                // it from the structured payload (or replaces it with the
-                // `<summary>+<recovery>` envelope when walking elides).
-                tc.cache(subject, "compose", &recorded_args, ctr)
+                // `cache_envelope()` — compose advertises `ComposeOutput`
+                // (a flat schema with no outer `{ result: ... }` wrapper)
+                // as its outputSchema, so it must NOT go through `cache()`'s
+                // DruaToolResult wrap: strict MCP clients validate
+                // `structuredContent` against the advertised schema and
+                // reject the wrapped shape (which nests ComposeOutput under
+                // a `result` key, dropping its declared top-level fields).
+                // `cache_envelope` walks/persists identically but emits `T`
+                // verbatim, merging `_recovery`/`_elided` into the
+                // ComposeOutput root when the walker elides `result`.
+                tc.cache_envelope(subject, "compose", &recorded_args, ctr)
                     .await?
                     .result
             }

--- a/core/src/toolset/top_level/compose.rs
+++ b/core/src/toolset/top_level/compose.rs
@@ -75,8 +75,16 @@ struct ComposeOutput {
     result: serde_json::Value,
 }
 
-static COMPOSE_OUTPUT_SCHEMA: LazyLock<serde_json::Value> =
-    LazyLock::new(schema_for::<ComposeOutput>);
+/// `ComposeOutput` is generated with `additionalProperties: false` by
+/// `schema_for`, but `cache_envelope` merges `_recovery` / `_elided` into
+/// the ComposeOutput root when the walker elides. Without declaring them
+/// as optional properties here, strict MCP clients reject every elided
+/// compose response. Mirrors the recovery property shape in `wrap.rs`.
+static COMPOSE_OUTPUT_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
+    let mut schema = schema_for::<ComposeOutput>();
+    crate::toolset::wrap::merge_envelope_recovery_props(&mut schema);
+    schema
+});
 
 #[async_trait::async_trait]
 impl TopLevelTool for ComposeTool {
@@ -923,6 +931,37 @@ mod tests {
             !dts.contains("function compose("),
             "non-composable tool leaked into dts:\n{dts}"
         );
+    }
+
+    /// `cache_envelope` merges `_recovery` and `_elided` into the
+    /// ComposeOutput root when the walker elides. The schema is generated
+    /// with `additionalProperties: false`, so those keys must be declared
+    /// up front or strict MCP clients reject every elided compose call.
+    #[test]
+    fn compose_output_schema_declares_recovery_properties() {
+        let props = COMPOSE_OUTPUT_SCHEMA
+            .get("properties")
+            .and_then(|v| v.as_object())
+            .expect("compose outputSchema has properties");
+        assert!(
+            props.contains_key("_recovery"),
+            "_recovery missing — strict validators reject elided compose"
+        );
+        assert!(
+            props.contains_key("_elided"),
+            "_elided missing — strict validators reject elided compose"
+        );
+        // They MUST stay optional — non-elided compose responses don't carry them.
+        let required: Vec<&str> = COMPOSE_OUTPUT_SCHEMA
+            .get("required")
+            .and_then(|v| v.as_array())
+            .map(|a| a.iter().filter_map(|v| v.as_str()).collect())
+            .unwrap_or_default();
+        assert!(
+            !required.contains(&"_recovery"),
+            "_recovery must be optional"
+        );
+        assert!(!required.contains(&"_elided"), "_elided must be optional");
     }
 
     /// Strict MCP clients (e.g. Claude Code) reject boolean schemas inside

--- a/core/src/toolset/wrap.rs
+++ b/core/src/toolset/wrap.rs
@@ -12,6 +12,87 @@
 
 use serde_json::{json, Value};
 
+/// JSON Schema fragment for the `_elided` field that
+/// `ToolCallSummary::build_wire` / `build_wire_envelope` attach when the
+/// walker elided something. Reused by both the `DruaToolResult` wrapper
+/// schema and the envelope-owning tool augmentation so the recovery
+/// metadata shape is declared in one place.
+fn elided_property_schema() -> Value {
+    json!({
+        "type": "object",
+        "description": "Present only when something was elided. Mirror of the text-channel <recovery> section.",
+        "properties": {
+            "invocation_id": { "type": "string" },
+            "paths": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "description": "One elision point. total_/shown_ dimensions describe what was elided here; recover is the tool_output_fetch template that retrieves the withheld portion.",
+                    "properties": {
+                        "path": { "type": "string" },
+                        "total_bytes": { "type": "integer" },
+                        "shown_bytes": { "type": "integer" },
+                        "total_lines": { "type": "integer" },
+                        "shown_lines": { "type": "integer" },
+                        "total_items": { "type": "integer" },
+                        "shown_items": { "type": "integer" },
+                        "recover": {
+                            "type": "object",
+                            "description": "tool_output_fetch call template"
+                        }
+                    },
+                    "required": ["path", "total_bytes", "shown_bytes", "recover"]
+                }
+            }
+        },
+        "required": ["invocation_id", "paths"]
+    })
+}
+
+/// JSON Schema fragment for the `_recovery` field — the typed recovery
+/// manifest attached to every persisted invocation's structured channel.
+fn recovery_property_schema() -> Value {
+    json!({
+        "type": "object",
+        "description": "Typed recovery manifest for this cached invocation. Includes persisted-root semantics, recoverable paths, and compose sub-invocation handles when present.",
+        "properties": {
+            "invocation_id": { "type": "string" },
+            "root_kind": { "type": "string" },
+            "root_path": { "type": "string" },
+            "persisted_root": { "type": "string" },
+            "paths": { "type": "array" },
+            "recommended_queries": { "type": "array" },
+            "sub_invocations": { "type": "array" }
+        },
+        "required": ["invocation_id", "root_kind", "root_path", "persisted_root", "paths", "recommended_queries"]
+    })
+}
+
+/// Augment an envelope-owning tool's outputSchema (a flat object schema
+/// with no outer `{ result: ... }` wrapper) with the optional `_recovery`
+/// and `_elided` properties that `cache_envelope()` merges into the
+/// structured channel when the walker elides. Without this, strict MCP
+/// clients reject elided responses because the schema is generated with
+/// `additionalProperties: false`.
+///
+/// No-op when `schema` isn't an object schema or has no `properties` map.
+/// Existing required fields are preserved — the recovery keys are
+/// always optional.
+pub fn merge_envelope_recovery_props(schema: &mut Value) {
+    let Some(obj) = schema.as_object_mut() else {
+        return;
+    };
+    let Some(props) = obj
+        .entry("properties")
+        .or_insert_with(|| json!({}))
+        .as_object_mut()
+    else {
+        return;
+    };
+    props.insert("_recovery".to_string(), recovery_property_schema());
+    props.insert("_elided".to_string(), elided_property_schema());
+}
+
 /// Advertise the `DruaToolResult<T>` wrapper as a tool's outputSchema —
 /// matches what `cache()` actually emits on the structured
 /// channel. MCP clients that validate `structuredContent` against
@@ -21,49 +102,8 @@ pub fn wrap_output_schema(upstream: &Value) -> Value {
         "type": "object",
         "properties": {
             "result": upstream,
-            "_elided": {
-                "type": "object",
-                "description": "Present only when something was elided. Mirror of the text-channel <recovery> section.",
-                "properties": {
-                    "invocation_id": { "type": "string" },
-                    "paths": {
-                        "type": "array",
-                        "items": {
-                            "type": "object",
-                            "description": "One elision point. total_/shown_ dimensions describe what was elided here; recover is the tool_output_fetch template that retrieves the withheld portion.",
-                            "properties": {
-                                "path": { "type": "string" },
-                                "total_bytes": { "type": "integer" },
-                                "shown_bytes": { "type": "integer" },
-                                "total_lines": { "type": "integer" },
-                                "shown_lines": { "type": "integer" },
-                                "total_items": { "type": "integer" },
-                                "shown_items": { "type": "integer" },
-                                "recover": {
-                                    "type": "object",
-                                    "description": "tool_output_fetch call template"
-                                }
-                            },
-                            "required": ["path", "total_bytes", "shown_bytes", "recover"]
-                        }
-                    }
-                },
-                "required": ["invocation_id", "paths"]
-            },
-            "_recovery": {
-                "type": "object",
-                "description": "Typed recovery manifest for this cached invocation. Includes persisted-root semantics, recoverable paths, and compose sub-invocation handles when present.",
-                "properties": {
-                    "invocation_id": { "type": "string" },
-                    "root_kind": { "type": "string" },
-                    "root_path": { "type": "string" },
-                    "persisted_root": { "type": "string" },
-                    "paths": { "type": "array" },
-                    "recommended_queries": { "type": "array" },
-                    "sub_invocations": { "type": "array" }
-                },
-                "required": ["invocation_id", "root_kind", "root_path", "persisted_root", "paths", "recommended_queries"]
-            }
+            "_elided": elided_property_schema(),
+            "_recovery": recovery_property_schema(),
         },
         "required": ["result"]
     })


### PR DESCRIPTION
## What

Fixes `compose` failing for **every** call — even `return 1 + 1` — with:

```
Structured content does not match the tool's output schema:
data must have required property 'console', 'execution_time_ms',
'fetch_hint', 'sub_invocations', 'tool_calls'
```

## Root cause

Compose advertises `ComposeOutput` (a flat schema: `sub_invocations`, `fetch_hint`, `tool_calls`, `execution_time_ms`, `console`, `result`) as its `outputSchema`. But it routed its own result through `ToolCaching::cache()`, which wraps **every** structured response in a synthetic `{ result: T, _recovery, _elided }` envelope.

That nesting drops ComposeOutput's declared top-level fields below a `result` key, so the returned `structuredContent` doesn't match the advertised schema.

Strict MCP clients validate `structuredContent` against `outputSchema` unconditionally when a tool declares one (pi ships `@modelcontextprotocol/sdk@1.29.0`, whose `Client.callTool` enforces this). So every compose call fails.

This is exactly the opt-out the `wrap.rs` contract describes:
> tools that return `false` (`compose`, `call_tool`, `tool_output_fetch`) own their own envelope shape and opt out of the wrapper.

…except `cache()` never honored it. (`call_tool` has the same `default_tool_caching() == false` and also calls `cache()`, but declares **no** outputSchema, so no validation runs and the inconsistency was harmless there.)

## Fix

Add `ToolCaching::cache_envelope` — walks and persists identically to `cache()`, but emits the upstream `T` verbatim on the structured channel:

- **passthrough** (nothing elided): `structured_content = T` (no `{ result: T }` wrap)
- **persisted** (walker elided something): `structured_content = walked T` with `_recovery` / `_elided` **merged into T's root object** via the new `ToolCallSummary::build_wire_envelope`

Compose now calls `cache_envelope` instead of `cache`.

For non-object roots (array/scalar), `build_wire_envelope` falls back to `build_wire` so recovery metadata is never lost. schemars 0.8 does not emit `additionalProperties: false`, so the merged `_recovery`/`_elided` keys remain schema-valid.

## Why a new method instead of a flag on cache()

The wrap-vs-verbatim decision is a per-tool property (`default_tool_caching()`), and compose is the only tool that both owns its envelope AND needs persistence/elision of its (up to 16 MiB) `result`. `persist_for_compose` already emits T verbatim but skips on-wire elision (it's for sub-calls inside the JS sandbox). `cache_envelope` is the missing third behavior: walk + persist + elide, but keep the tool's own envelope shape.

## Tests

- `build_wire_envelope_merges_recovery_into_object_root` — locks the wrap-vs-merge contract: `build_wire` nests under `result`; `build_wire_envelope` keeps ComposeOutput's fields at root with `_recovery`/`_elided` alongside.
- `build_wire_envelope_falls_back_to_wrap_for_non_object_root` — non-object roots still get recovery (delegates to `build_wire`).
- Full tool-caching lib suite (105) and compose suite (15) pass; full workspace builds clean.

## Note

The describe_tool fix (#442) is the sibling one-liner; this is the deeper caching-core change. Both stem from the same strict-MCP-client validation that newly surfaces latent schema/shape mismatches.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MCP wire shape and tool-caching replay for compose and envelope-mode summaries; incorrect wiring would break clients or recovery, but scope is focused and covered by unit and bats tests.
> 
> **Overview**
> **Compose** now routes results through **`ToolCaching::cache_envelope`** instead of **`cache()`**, so MCP **`structuredContent`** matches the flat **`ComposeOutput`** schema instead of being nested under a synthetic **`{ result: T }`** **`DruaToolResult`** wrapper that broke strict client validation.
> 
> The caching layer adds **`ProcessMode::Envelope`**, **`ToolCallSummary::build_wire_envelope`** (merge **`_recovery`** / **`_elided`** into the tool’s root object), and persisted **`envelope_mode`** so **`tool_output_fetch`** summary replay uses the same shape as live calls. **`compose`**’s **`outputSchema`** is augmented with optional **`_recovery`** / **`_elided`** via **`merge_envelope_recovery_props`**.
> 
> Bats compose roundtrip tests and JSON snapshots are updated to assert **`sub_invocations`**, **`fetch_hint`**, etc. at **`structuredContent`** root (and **`$.result`** for the JS return payload only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f33cef8d1e145169b4e8ab2d02f2f2c610a29165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->