### PR TITLE
fix(deploy): vendor galoy-infra postgresql modules (repo is private)

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -185,6 +185,22 @@ jobs:
             cp -r repo/ci/deploy/drua deployment/tf
             cp -r repo/charts/drua deployment/tf/chart
 
+            # galoy-infra is private, so the terraform-resource below can no
+            # longer fetch its postgresql modules over anonymous HTTPS during
+            # `terraform init` (deploy-to-prod build #801). Vendor them locally
+            # here using the deploy GITHUB_PAT and rewrite the module sources
+            # to local paths so init needs no GitHub auth. The vendored tree is
+            # the same `main` the git sources previously pointed at.
+            command -v git >/dev/null 2>&1 || nix profile install nixpkgs#git
+            GALOY_INFRA_URL="https://x-access-token:${GITHUB_PAT}@github.com/GaloyMoney/galoy-infra.git"
+            if ! git clone --depth 1 --quiet "$GALOY_INFRA_URL" deployment/tf/galoy-infra-modules 2>/tmp/gi-clone.err; then
+              echo "failed to vendor galoy-infra modules:" >&2
+              sed "s#${GITHUB_PAT}#***#g" /tmp/gi-clone.err >&2
+              exit 1
+            fi
+            rm -rf deployment/tf/galoy-infra-modules/.git
+            sed -i 's#git::https://github.com/GaloyMoney/galoy-infra\.git//\([^?]*\)?ref=main#galoy-infra-modules/\1#g' deployment/tf/main.tf
+
             set +x
             cat <<EOF > deployment/tf/terraform.tfvars
             image_digest = "${DIGEST}"


### PR DESCRIPTION
## Problem

`deploy-to-prod` fails at `terraform init` (build [#801](https://ci.galoy.io/teams/galoy-agents/pipelines/galoy-agents-bin/jobs/deploy-to-prod/builds/801)):

```
Error: Failed to download module ... from
  git::https://github.com/GaloyMoney/galoy-infra.git?ref=main
fatal: could not read Username for 'https://github.com': No such device or address
```

`galoy-infra` went private, so the `tf-galoy-agents-prod` terraform-resource can no longer fetch the three postgresql modules in `ci/deploy/drua/main.tf` over anonymous HTTPS.

This is the same root cause as galoy-infra's own recent fixes, but here `terraform init` runs **inside the terraform-resource container** (not a shell task), so the in-container `git url.insteadOf` trick doesn't apply.

## Fix

Vendor the modules locally in `prepare-deployment` instead:
- shallow-clone `galoy-infra` (same `main` the sources referenced) using the deploy `GITHUB_PAT` that prepare-deployment already has,
- strip its `.git`,
- rewrite the three module sources to local relative paths via `sed`.

`terraform init` then needs no GitHub auth at all. State addresses are unchanged (terraform tracks modules by address, not source), so this is a no-op diff on the first apply.

Only `ci/pipeline.yml` changes, and only the `prepare-deployment` run script — verified the rendered pipeline diff is exactly this one block.

## To apply after merge
```bash
ci/repipe   # fly set-pipeline for team galoy-agents
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production deploy prep and pins postgresql modules to a shallow clone of main; clone or sed failures block deploy, but Terraform state/module addresses should stay unchanged on first apply.
> 
> **Overview**
> Fixes **`deploy-to-prod`** failing at **`terraform init`** after **`galoy-infra`** became private: the **`tf-galoy-agents-prod`** terraform-resource can no longer pull the three postgresql module sources over anonymous HTTPS.
> 
> The **`prepare-deployment`** task now shallow-clones **`galoy-infra`** with the existing deploy **`GITHUB_PAT`**, strips **`.git`**, and **`sed`**-rewrites **`deployment/tf/main.tf`** module sources from **`git::https://github.com/GaloyMoney/galoy-infra.git//...?ref=main`** to local **`galoy-infra-modules/...`** paths so init needs no GitHub credentials in the resource container.
> 
> Clone failures are surfaced with the PAT redacted from stderr. Only **`ci/pipeline.yml`** changes; **`ci/repipe`** is required after merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ada90846d4c5d583dee9f3590ac53be7c46399c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->