### PR TITLE
fix(deploy): install sed (and git) before vendoring galoy-infra modules

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -191,7 +191,10 @@ jobs:
             # here using the deploy GITHUB_PAT and rewrite the module sources
             # to local paths so init needs no GitHub auth. The vendored tree is
             # the same `main` the git sources previously pointed at.
-            command -v git >/dev/null 2>&1 || nix profile install nixpkgs#git
+            # The nix flake image is minimal and ships neither git nor sed by
+            # default; both are needed to vendor the modules and rewrite their
+            # sources. Install them together if either is missing.
+            { command -v git >/dev/null 2>&1 && command -v sed >/dev/null 2>&1; } || nix profile install nixpkgs#git nixpkgs#gnused
             GALOY_INFRA_URL="https://x-access-token:${GITHUB_PAT}@github.com/GaloyMoney/galoy-infra.git"
             if ! git clone --depth 1 --quiet "$GALOY_INFRA_URL" deployment/tf/galoy-infra-modules 2>/tmp/gi-clone.err; then
               echo "failed to vendor galoy-infra modules:" >&2


### PR DESCRIPTION
Follow-up to #444. The nix flake image lacks `sed` (and `git`), so the vendoring step added in #444 died with `sed: command not found` (build #802). Install both `nixpkgs#git` and `nixpkgs#gnused` together if either is missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to tool bootstrapping in the deploy pipeline; no application or infrastructure logic changes.
> 
> **Overview**
> Fixes **`deploy-to-prod`** failing during galoy-infra vendoring when the minimal nix flake image has no **`sed`** (build #802, follow-up to #444).
> 
> The **prepare-deployment** step now requires **both** `git` and `sed` before clone and `sed -i` rewrite of Terraform module sources. If either is missing, it runs **`nix profile install nixpkgs#git nixpkgs#gnused`** in one shot instead of installing only git. Comments note that the image ships neither tool by default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef27f2608650adc04d707997e55107992f6799a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->