### PR TITLE
fix(deploy): prefix vendored module paths with ./

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -191,7 +191,10 @@ jobs:
             # here using the deploy GITHUB_PAT and rewrite the module sources
             # to local paths so init needs no GitHub auth. The vendored tree is
             # the same `main` the git sources previously pointed at.
-            command -v git >/dev/null 2>&1 || nix profile install nixpkgs#git
+            # The nix flake image is minimal and ships neither git nor sed by
+            # default; both are needed to vendor the modules and rewrite their
+            # sources. Install them together if either is missing.
+            { command -v git >/dev/null 2>&1 && command -v sed >/dev/null 2>&1; } || nix profile install nixpkgs#git nixpkgs#gnused
             GALOY_INFRA_URL="https://x-access-token:${GITHUB_PAT}@github.com/GaloyMoney/galoy-infra.git"
             if ! git clone --depth 1 --quiet "$GALOY_INFRA_URL" deployment/tf/galoy-infra-modules 2>/tmp/gi-clone.err; then
               echo "failed to vendor galoy-infra modules:" >&2


### PR DESCRIPTION
OpenTofu requires local module sources to start with `./`. The vendoring sed rewrote to `galoy-infra-modules/...` but tofu needs `./galoy-infra-modules/...` (build #803: `Invalid module source address`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to tool bootstrapping in deploy-to-prod; no runtime app or Terraform module logic changes in this diff.
> 
> **Overview**
> **deploy-to-prod** `prepare-deployment` now treats **`sed`** as a hard dependency alongside **`git`** when vendoring private **galoy-infra** Terraform modules into the deployment tree.
> 
> The minimal Nix flake image often has neither tool. The step used to install only `git` if missing; it now installs **`nixpkgs#git`** and **`nixpkgs#gnused`** when **either** `git` or `sed` is absent, so clone + `sed -i` rewrites of module sources in `main.tf` do not fail mid-job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ef27f2608650adc04d707997e55107992f6799a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->