### PR TITLE
revert: revert GitHub Actions tool exposure

### DIFF
--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -207,7 +207,7 @@ galoyAgents:
     #     - list_issues
     #     - search_issues
     # - name: github_actions
-    #   url: https://api.githubcopilot.com/mcp/x/actions
+    #   url: https://api.githubcopilot.com/mcp/x/actions/readonly
     #   toolPrefix: github_actions
     #   category: ci
     #   categoryDescription: "GitHub Actions workflows, runs, jobs, and logs"
@@ -215,7 +215,6 @@ galoyAgents:
     #     - actions_list
     #     - actions_get
     #     - get_job_logs
-    #     - actions_run_trigger
     ## GitHub App configuration for token auto-provisioning.
     ## When enabled, sandbox agents receive a `github-token` file secret.
     ## The PEM private key is read from the main drua secret (key: github-app-private-key).

--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -129,7 +129,7 @@ galoyAgents:
           - list_issues
           - search_issues
       - name: github_actions
-        url: https://api.githubcopilot.com/mcp/x/actions
+        url: https://api.githubcopilot.com/mcp/
         toolPrefix: github_actions
         authMode: github_app
         category: ci
@@ -138,7 +138,6 @@ galoyAgents:
           - actions_list
           - actions_get
           - get_job_logs
-          - actions_run_trigger
       # PR-mutation upstream — gated to internal agents (project_lead /
       # agent / workflow_step_agent) only. Users and ExportedAgents
       # don't see it. `merge_pull_request` deliberately excluded — the

--- a/drua.yml
+++ b/drua.yml
@@ -136,7 +136,7 @@ toolsets:
         - list_issues
         - search_issues
     - name: github_actions
-      url: https://api.githubcopilot.com/mcp/x/actions
+      url: https://api.githubcopilot.com/mcp/x/actions/readonly
       tool_prefix: github_actions
       category: ci
       category_description: "GitHub Actions workflows, runs, jobs, and logs"
@@ -144,7 +144,6 @@ toolsets:
         - actions_list
         - actions_get
         - get_job_logs
-        - actions_run_trigger
     # PR-mutation upstream — local-dev test of separating writes from reads.
     # Auth: GITHUB_PULL_REQUESTS_AUTH_HEADER ("Bearer <PAT>"). Same PAT as
     # the github upstream is fine for now; PAT needs `repo` (or fine-grained

--- a/lib/github-app/src/lib.rs
+++ b/lib/github-app/src/lib.rs
@@ -112,7 +112,7 @@ fn installation_token_request_body() -> serde_json::Value {
             "metadata": "read",
             "checks": "read",
             "statuses": "read",
-            "actions": "write"
+            "actions": "read"
         }
     })
 }
@@ -122,7 +122,7 @@ mod tests {
     use super::installation_token_request_body;
 
     #[test]
-    fn installation_token_requests_ci_permissions() {
+    fn installation_token_requests_ci_read_permissions() {
         let body = installation_token_request_body();
         let permissions = body
             .get("permissions")
@@ -139,7 +139,7 @@ mod tests {
         );
         assert_eq!(
             permissions.get("actions").and_then(|v| v.as_str()),
-            Some("write")
+            Some("read")
         );
     }
 


### PR DESCRIPTION
## What

Reverts PR #437, restoring the previous GitHub Actions MCP exposure and GitHub App installation token permission settings.

## Why

The image produced after PR #437 caused the production galoy-agents dashboard rollout to fail, so this restores the last known working behavior while any replacement permission model is handled separately.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and permission tightening revert; reduces agent ability to trigger Actions rather than expanding attack surface.
> 
> **Overview**
> Reverts the GitHub Actions exposure from PR #437 to unblock the production galoy-agents dashboard rollout.
> 
> **GitHub Actions MCP** is narrowed again: chart and local `drua.yml` examples point at the **readonly** Copilot MCP path (`…/mcp/x/actions/readonly`), production `github_actions` goes back to the shared `https://api.githubcopilot.com/mcp/` upstream, and **`actions_run_trigger` is removed** from allowed tools everywhere (list/get/logs only).
> 
> **GitHub App installation tokens** again request **`actions: read`** instead of `write`, with the unit test updated to match.
> 
> Net effect: agents keep CI visibility (workflows, runs, job logs) without workflow-dispatch / Actions write capability on App-provisioned tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2ff8bff2e7e1bc47ba54a81220257005e2f8036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->