### PR TITLE
fix(tool-caching): parse single-doc YAML so structured k8s output walks structurally

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1646,6 +1646,7 @@ dependencies = [
  "schemars 0.8.22",
  "serde",
  "serde_json",
+ "serde_yaml",
  "sqlx",
  "thiserror 2.0.18",
  "tokio",

--- a/core/crates/tool-caching/Cargo.toml
+++ b/core/crates/tool-caching/Cargo.toml
@@ -10,6 +10,7 @@ rmcp = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+serde_yaml = "0.9"
 sqlx = { workspace = true }
 thiserror = { workspace = true }
 tracing = { workspace = true }

--- a/core/crates/tool-caching/src/primitives.rs
+++ b/core/crates/tool-caching/src/primitives.rs
@@ -13,13 +13,23 @@ pub struct QueryStructure {
 }
 
 impl QueryStructure {
-    /// Parse `original_text` into a `serde_json::Value`. JSON objects /
-    /// arrays / scalars round-trip into their native shape. Quoted-JSON
-    /// strings whose content is itself an object or array literal are
-    /// double-decoded (some upstreams wrap their JSON body inside a JSON
-    /// string in the text channel). Anything else — including bare
-    /// non-JSON text and quoted scalars like `"hello"` or `"42"` — is
-    /// kept verbatim as `Value::String`.
+    /// Parse `original_text` into a `serde_json::Value`. Tried in order:
+    ///
+    /// 1. **JSON** — objects / arrays / scalars round-trip into their
+    ///    native shape; quoted-JSON strings whose content is itself an
+    ///    object/array literal are double-decoded (some upstreams wrap
+    ///    their JSON body inside a JSON string in the text channel).
+    /// 2. **YAML** — single-document YAML whose root is a mapping or
+    ///    sequence (e.g. `kubectl get -o yaml` / `resources_get` output)
+    ///    is converted to a JSON object/array so the structural walker
+    ///    runs instead of flat line elision. Scalars, multi-document
+    ///    streams, and any non-string-keyed mapping are rejected: YAML
+    ///    folds free text (logs, diffs, tables) into plain scalars, and
+    ///    accepting those would destroy their newlines and coerce values
+    ///    (`port: 8080` → int). Anything YAML can't represent as JSON
+    ///    falls through.
+    /// 3. **String** — verbatim, including bare non-JSON/YAML text and
+    ///    quoted scalars like `"hello"` or `"42"`.
     pub fn new(original_text: &str) -> Self {
         let trimmed = original_text.trim();
         if trimmed.is_empty() {
@@ -30,9 +40,91 @@ impl QueryStructure {
         let root = match serde_json::from_str::<Value>(trimmed) {
             Ok(Value::String(inner)) => unwrap_quoted_json(inner),
             Ok(v) => v,
-            Err(_) => Value::String(original_text.to_string()),
+            Err(_) => parse_yaml_single_doc(trimmed)
+                .unwrap_or_else(|| Value::String(original_text.to_string())),
         };
         Self { root }
+    }
+}
+
+/// Parse a single YAML document into a JSON value, rejecting anything that
+/// is not a mapping or sequence at the root. See [`QueryStructure::new`]
+/// step 2 for the rationale. Returns `None` for multi-document streams,
+/// scalars/null, and any mapping that can't be represented as a JSON object
+/// (non-string keys); the caller falls back to a verbatim string.
+fn parse_yaml_single_doc(trimmed: &str) -> Option<Value> {
+    // `serde_yaml::from_str` reads only the first document of a stream.
+    // Use the Deserializer iterator to reject multi-document input up front
+    // so a YAML stream doesn't get silently truncated to its first item.
+    let mut docs = serde_yaml::Deserializer::from_str(trimmed);
+    let first = docs.next()?;
+    if docs.next().is_some() {
+        return None;
+    }
+    let yaml = serde_yaml::Value::deserialize(first).ok()?;
+    // Reject scalar/null roots: YAML folds free text (logs, diffs, tables)
+    // into a single plain scalar, joining lines with spaces. Accepting
+    // would destroy the newlines and coerce values. Only mappings and
+    // sequences are structured documents worth walking structurally.
+    // (`yaml_to_json` stays total for nested values, where a string is
+    // legitimately a mapping value.)
+    match &yaml {
+        serde_yaml::Value::Mapping(_) | serde_yaml::Value::Sequence(_) => {}
+        _ => return None,
+    }
+    yaml_to_json(yaml)
+}
+
+/// Convert a YAML value to JSON, returning `None` for any construct with no
+/// JSON equivalent (non-string object keys; NaN/Infinity floats). Scalars and
+/// null at the root are rejected by the caller's intent — but this helper is
+/// total for nested values, so a `null` *inside* an accepted mapping becomes
+/// `Value::Null` rather than rejecting the whole document.
+fn yaml_to_json(yaml: serde_yaml::Value) -> Option<Value> {
+    Some(match yaml {
+        serde_yaml::Value::Null => Value::Null,
+        serde_yaml::Value::Bool(b) => Value::Bool(b),
+        serde_yaml::Value::Number(n) => yaml_number_to_json(n)?,
+        serde_yaml::Value::String(s) => Value::String(s),
+        serde_yaml::Value::Sequence(seq) => Value::Array(
+            seq.into_iter()
+                .map(yaml_to_json)
+                .collect::<Option<Vec<_>>>()?,
+        ),
+        serde_yaml::Value::Mapping(m) => {
+            let mut obj = serde_json::Map::with_capacity(m.len());
+            for (k, v) in m {
+                let key = yaml_scalar_key_to_string(k)?;
+                obj.insert(key, yaml_to_json(v)?);
+            }
+            Value::Object(obj)
+        }
+        serde_yaml::Value::Tagged(t) => yaml_to_json(t.value)?,
+    })
+}
+
+/// JSON object keys must be strings. Coerce a YAML scalar key to its string
+/// form; reject mapping/sequence keys (valid in YAML, no JSON equivalent).
+fn yaml_scalar_key_to_string(k: serde_yaml::Value) -> Option<String> {
+    match k {
+        serde_yaml::Value::String(s) => Some(s),
+        serde_yaml::Value::Bool(b) => Some(b.to_string()),
+        serde_yaml::Value::Number(n) => Some(n.to_string()),
+        serde_yaml::Value::Null => Some("null".to_string()),
+        serde_yaml::Value::Sequence(_) | serde_yaml::Value::Mapping(_) => None,
+        serde_yaml::Value::Tagged(t) => yaml_scalar_key_to_string(t.value),
+    }
+}
+
+fn yaml_number_to_json(n: serde_yaml::Number) -> Option<Value> {
+    if let Some(i) = n.as_i64() {
+        Some(Value::Number(i.into()))
+    } else if let Some(u) = n.as_u64() {
+        Some(Value::Number(u.into()))
+    } else if let Some(f) = n.as_f64() {
+        serde_json::Number::from_f64(f).map(Value::Number)
+    } else {
+        None
     }
 }
 
@@ -324,4 +416,148 @@ pub struct ToolCacheResponse {
     pub invocation_id: Option<ToolInvocationId>,
     pub summary_fetch_info: Option<SummaryFetchInfo>,
     pub root_path: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn root_is_string(s: &str) -> bool {
+        matches!(QueryStructure::new(s).root, Value::String(_))
+    }
+
+    #[test]
+    fn json_object_still_parses() {
+        let qs = QueryStructure::new(r#"{"a": 1, "b": [2, 3]}"#);
+        assert_eq!(qs.root, json!({"a": 1, "b": [2, 3]}));
+    }
+
+    #[test]
+    fn quoted_json_inner_is_double_decoded() {
+        let qs = QueryStructure::new(r#""{\"x\": 1}""#);
+        assert_eq!(qs.root, json!({"x": 1}));
+    }
+
+    #[test]
+    fn yaml_mapping_parses_to_object() {
+        let qs = QueryStructure::new(
+            "apiVersion: v1\nkind: ConfigMap\nmetadata:\n  name: test\ndata:\n  key: value\n",
+        );
+        assert_eq!(
+            qs.root,
+            json!({
+                "apiVersion": "v1",
+                "kind": "ConfigMap",
+                "metadata": {"name": "test"},
+                "data": {"key": "value"},
+            })
+        );
+    }
+
+    #[test]
+    fn yaml_sequence_parses_to_array() {
+        let qs = QueryStructure::new("- one\n- two\n- 3\n");
+        assert_eq!(qs.root, json!(["one", "two", 3]));
+    }
+
+    #[test]
+    fn yaml_nested_numbers_and_bools_coerce() {
+        let qs = QueryStructure::new("port: 8080\nready: true\nratio: 0.5\n");
+        assert_eq!(qs.root, json!({"port": 8080, "ready": true, "ratio": 0.5}));
+    }
+
+    #[test]
+    fn yaml_scalar_root_rejected_newlines_preserved() {
+        // YAML folds free text into plain scalars (joining lines with
+        // spaces); rejecting must return the ORIGINAL text verbatim so
+        // line-mode elision still works downstream. A folded scalar
+        // would collapse this to one space-joined line — assert that
+        // does NOT happen.
+        let log = "just a plain line of text\nand another line\n";
+        let qs = QueryStructure::new(log);
+        match qs.root {
+            Value::String(ref s) => {
+                assert_eq!(
+                    s, log,
+                    "original text must be preserved verbatim, not folded"
+                );
+                assert_eq!(s.matches('\n').count(), 2, "newlines must survive");
+            }
+            other => panic!("expected verbatim string, got {other:?}"),
+        }
+        assert!(matches!(
+            QueryStructure::new("the build succeeded in 42 seconds.").root,
+            Value::String(_)
+        ));
+    }
+
+    #[test]
+    fn yaml_null_root_rejected_as_string() {
+        assert!(root_is_string("   \n  "));
+    }
+
+    #[test]
+    fn yaml_multi_document_stream_rejected_as_string() {
+        // `serde_yaml::from_str` silently truncates to the first document;
+        // the iterator guard must reject so a stream isn't lost.
+        assert!(root_is_string(
+            "---\napiVersion: v1\nkind: A\n---\napiVersion: v1\nkind: B\n"
+        ));
+    }
+
+    #[test]
+    fn kubectl_style_log_lines_stay_a_string() {
+        // Real log output: not `key: value`, so YAML folds to a scalar.
+        let log = "INFO 2024-06-29 starting galoy-core\nlistening on :8080\nrequest handled\n";
+        assert!(root_is_string(log));
+    }
+
+    #[test]
+    fn bash_ls_output_stays_a_string() {
+        let ls = "total 32\ndrwxr-xr-x  5 user staff  160 Jun 29 12:00 .\n-rw-r--r--  1 user staff 1024 Jun 29 12:00 file.txt\n";
+        assert!(root_is_string(ls));
+    }
+
+    #[test]
+    fn git_diff_hunk_stays_a_string() {
+        let diff = "--- a/main.rs\n+++ b/main.rs\n@@ -1,3 +1,4 @@\n fn main() {\n-    old();\n+    new();\n }\n";
+        assert!(root_is_string(diff));
+    }
+
+    #[test]
+    fn kubectl_table_stays_a_string() {
+        let table =
+            "NAME              READY   STATUS    AGE\napp-7b8f-x2k      1/1     Running   3d\n";
+        assert!(root_is_string(table));
+    }
+
+    #[test]
+    fn json_takes_precedence_over_yaml() {
+        // Valid JSON must not fall through to the YAML branch.
+        let qs = QueryStructure::new(r#"{"a": 1}"#);
+        assert_eq!(qs.root, json!({"a": 1}));
+    }
+
+    #[test]
+    fn empty_and_whitespace_stay_string() {
+        assert!(root_is_string(""));
+        assert!(root_is_string("   \n\t  "));
+    }
+
+    #[test]
+    fn numeric_yaml_key_coerced_to_string() {
+        // Integer-keyed mapping: valid YAML. JSON has only string keys, so
+        // coerce losslessly (`1` -> `"1"`) rather than rejecting the doc —
+        // this is the standard JSON-library behaviour and keeps numeric-key
+        // mappings structured for the walker.
+        let qs = QueryStructure::new("1: one\n2: two\n");
+        assert_eq!(qs.root, json!({"1": "one", "2": "two"}));
+    }
+
+    #[test]
+    fn mapping_as_yaml_key_rejected_as_string() {
+        // A mapping/sequence as a key has no JSON equivalent; reject the doc.
+        assert!(root_is_string("? a: b\n: value\n"));
+    }
 }


### PR DESCRIPTION
## Problem

Text-channel tools that emit **YAML** were treated as opaque strings. `QueryStructure::new` only tried JSON; on failure it fell back to `Value::String`. The walker then ran **flat head/tail line elision** over the whole document.

Concrete impact (from debugging the galoy-staging canary): the k8s MCP server's `resources_get` returns resources as YAML text. A 17 KB CRD got `<head lines="126">` + `<bulk-elided lines="210">` + `<tail lines="127">` — and those 210 elided lines were exactly `spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.*`, the schema body an agent needs. Recoverable only via an extra `tool_output_fetch` round-trip the agent has to *know* to make, with no hint that the schema lived in the elided middle.

Same class of problem hits any YAML-emitting tool: CompositionRevisions (108 KB), composite-resource dumps, `kubectl get -o yaml`. If the upstream had emitted JSON, the **structural walker** would have run instead — proportional per-key budgeting, elision on key boundaries, every key name stays visible. YAML outputs were silently denied that path.

## Fix

Add a **JSON → YAML → string** fallback in `QueryStructure::new`. The YAML branch accepts only single-document mappings/sequences; everything else falls through to the existing verbatim-string behaviour unchanged.

### Why YAML needs guards (this was the interesting part)

YAML is **not** a safe detector the way JSON is — random free text often *parses* as valid YAML, destructively. A real-world spot-check (libyaml, the same engine `serde_yaml` binds to) of text that reaches `QueryStructure::new`:

| input | YAML result | damage if accepted |
|---|---|---|
| multi-line pod log | **scalar (folded)** | 🔴 newlines → spaces |
| `ls` output | scalar (folded) | 🔴 newlines destroyed |
| git diff hunk | scalar (folded) | 🔴 `---`/`+++` consumed |
| kubectl table | scalar (folded) | 🔴 table → one space-joined line |
| markdown | scalar (folded) | 🔴 newlines destroyed |
| kv-log (`port: 8080`) | mapping | 🔴 `8080`→int, `yes`→bool |
| stack trace | mapping | 🔴 restructured into nonsense |
| k8s ConfigMap / CRD | **mapping** | ✅ the win |

The dominant failure mode is the **folded plain scalar**: YAML joins multi-line free text into a single space-joined scalar. So three guards:

1. **Reject scalar/null roots** — eliminates the folded-scalar catastrophe (logs, diffs, tables, ls, markdown). The rejection returns the **original** text verbatim, preserving newlines so line-mode elision still works downstream.
2. **Reject multi-document streams** — `serde_yaml::from_str` silently truncates to the first document; the `Deserializer` iterator detects and rejects streams so a YAML stream isn't lost.
3. **Reject mapping/sequence keys** (no JSON equivalent); numeric keys coerce losslessly to strings, matching standard JSON-library behaviour.

### Persistence/recovery contract is unchanged

Parsed-object roots already flow through the system today — that's the path JSON-emitting tools take. `query_structure.root` becomes the parsed object, persists as JSON, and `tool_output_fetch` navigates json-paths (`$.spec.versions[0].schema…`) against the persisted object. The original YAML stays in `raw_text`/`original_structured` for the `mode:"summary"` replay. No change to the recovery contract — it just stops being a string for single-doc YAML mappings/sequences.

### Dependency

Reuses the workspace's existing `serde_yaml = "0.9"` (already a direct dep of `core`/`server`/`images/sandbox`). No new dependency.

## Testing

16 new unit tests in `primitives::tests`, covering:
- JSON precedence and double-decode (unchanged behaviour)
- YAML mapping → object, sequence → array, nested number/bool coercion
- **Scalar root rejection with newline preservation** (the invariant — a folded scalar would collapse lines)
- Multi-document stream rejection
- Free-text cases stay verbatim: pod logs, `ls`, git diffs, kubectl tables
- Numeric keys coerce; mapping keys reject; empty/whitespace stay string

The pre-existing `multi_line_string_uses_line_mode` integration test caught a real bug during development (my first cut accepted folded scalars and destroyed newlines → the walker fell back to byte-mode). It now passes, guarding against regression.

## Validation

- `cargo test -p drua-tool-caching --lib` — 122 passed (16 new)
- `cargo test -p drua-tool-caching --test string_elision` — 3 passed (incl. the line-mode regression guard)
- `cargo clippy -p drua-tool-caching --all-targets` — clean
- `cargo fmt --check` — clean
- `cargo check --workspace` — builds
- (`tests/envelope.rs` requires Postgres via `make reset-deps`; fails identically on `main` with `PoolTimedOut`, pre-existing.)

Draft until: the DB-backed `envelope` integration suite is run locally (`make reset-deps && cargo test -p drua-tool-caching --test envelope`), and ideally a live spot-check against a real k8s `resources_get` YAML output to confirm the structural walk renders a CRD schema readably.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all text-channel tool outputs are classified before elision; incorrect YAML acceptance could mangle multi-line text, though guards and tests target that failure mode.
> 
> **Overview**
> **`QueryStructure::new`** now tries **JSON → YAML → verbatim string** instead of JSON-only then string. Single-document YAML whose root is a **mapping or sequence** (e.g. k8s `resources_get` / `kubectl get -o yaml`) is converted to JSON so the **structural elision walker** runs; large YAML resources were previously treated as one string and got blunt head/tail line elision.
> 
> The YAML path is **narrow on purpose**: reject scalar/null roots (YAML would fold logs, diffs, and tables and destroy newlines), reject multi-document streams (avoid silent truncation), and reject non-scalar mapping keys; numeric keys coerce to strings. Anything else keeps the **original text** unchanged for line-mode elision.
> 
> Adds **`serde_yaml`** to `drua-tool-caching` plus helpers (`parse_yaml_single_doc`, `yaml_to_json`, …) and **16 unit tests** for JSON precedence, k8s-style YAML, and free-text cases that must stay strings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc1ac7e1b9049ac12f4921012af997b705f9b1b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->