### PR TITLE
feat(chart): add z-ai/glm-4.6 as a selectable model

### DIFF
--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -68,6 +68,9 @@ galoyAgents:
           - name: moonshotai/kimi-k2.6
             maxTokensPerResponse: 8192
             contextWindowTokens: 262144
+          - name: z-ai/glm-4.6
+            maxTokensPerResponse: 8192
+            contextWindowTokens: 200000
     ## Per-role defaults applied when an agent with that role is created.
     ## All three of `projectLead`, `agent`, and `workflowStepAgent` are
     ## REQUIRED — the binary refuses to start if any of


### PR DESCRIPTION
## Summary
- Adds `z-ai/glm-4.6` (via OpenRouter, 200k context) to the drua chart's LLM providers list.
- No default-chain change: `openai/gpt-5-mini` remains the default primary.

## Why
Enables per-workflow model selection for the on-call `zenduty-investigate` skill so we can A/B/C the investigation step across GLM-4.6, Sonnet 4.6, and GPT-5-mini on the same incident.

## Test plan
- [ ] Chart lint / helm template renders (`helm template` from `charts/drua/`).
- [ ] Deploy to prod and confirm `z-ai/glm-4.6` shows up in the model providers list served by drua.
- [ ] Override a workflow step's `model_chain.primary.name` to `z-ai/glm-4.6` and confirm the step runs successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm values-only addition to the model catalog; no runtime logic, auth, or default routing changes.
> 
> **Overview**
> Registers **`z-ai/glm-4.6`** on the drua chart’s OpenRouter model list with **8k** max response tokens and a **200k** context window, alongside the existing entries in `charts/drua/values.yaml`.
> 
> **`agents.defaultChain`** is unchanged — **`openai/gpt-5-mini`** stays the default primary; GLM-4.6 is only available when a workflow or step overrides `model_chain.primary.name` (e.g. on-call investigation A/B tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aae139575e32682818450a6e271f86411278ea7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->