### PR TITLE
fix(note): allow `notes get` on space notes mounted onto the caller's project

### DIFF
--- a/core/src/note/error.rs
+++ b/core/src/note/error.rs
@@ -21,6 +21,8 @@ pub enum NoteError {
     Authorization(#[from] crate::primitives::AuthorizationError),
     #[error("NoteError - Library: {0}")]
     Library(#[from] crate::library::LibraryError),
+    #[error("NoteError - SpaceMounts: {0}")]
+    SpaceMounts(#[from] crate::library::SpaceMountsError),
     #[error("NoteError - Drua: {0}")]
     Drua(#[from] drua_library::LibraryError),
     #[error("NoteError - BuildEntity: {0}")]

--- a/core/src/note/mod.rs
+++ b/core/src/note/mod.rs
@@ -330,13 +330,23 @@ impl Notes {
             AuthResource::Note(project_id, Some(note_id)),
         )?;
         let note = self.repo.find_by_id(note_id).await?;
-        if note.project_id != Some(project_id) {
-            return Err(NoteError::Authorization(AuthorizationError::Forbidden {
-                verb: AuthVerb::Read,
-                resource: AuthResource::Project(Some(project_id)),
-            }));
+        if note.project_id == Some(project_id) {
+            return Ok(note);
         }
-        Ok(note)
+        // A note surfaced by `search` (which spans the project's mounted
+        // spaces) must also be fetchable by `get`. Space-scoped notes are
+        // readable when the note lives in a space mounted onto the
+        // caller's project — mirrors the scope filter in `search`.
+        if let Some(space_id) = note.space_id {
+            let mounted = self.space_mounts.space_ids_for_project(project_id).await?;
+            if mounted.contains(&space_id) {
+                return Ok(note);
+            }
+        }
+        Err(NoteError::Authorization(AuthorizationError::Forbidden {
+            verb: AuthVerb::Read,
+            resource: AuthResource::Project(Some(project_id)),
+        }))
     }
 
     #[instrument(name = "note.search", skip(self))]


### PR DESCRIPTION
## Summary

Fixes the `notes get` authorization bug reported in the drua-dev research note `research/notes-pinned-and-get-space-notes-bug-2026-07-08.md` (Bug 2).

`Notes::search` already spans the project's mounted spaces, but `Notes::find_by_id` (the `notes get` surface) only accepted notes whose `project_id` matched the caller. Space-scoped notes (`project_id = None`, `space_id = Some`) always hit the `Forbidden` branch — so a caller that got a note id from `notes search` then 403'd on `notes get`.

**Fix:** after the project-id fast path, if the note is space-scoped and its space is mounted onto the caller's project (`space_mounts.space_ids_for_project`), return it — mirroring the search scope. Adds `NoteError::SpaceMounts(#[from] SpaceMountsError)`.

## Scope

Reduced to the `get` fix only. The note also describes a frontmatter-parsing bug (Bug 1: `pinned`/`tags` dropped on the initial space-note write); that is intentionally **not** included here and can be addressed separately.

## Testing
- `cargo clippy --all-targets -- -D warnings` clean.
- Full `nix flake check` passes (clippy, nextest, fmt, sdl, config, graphql schema).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authorization for note reads and depends on mount resolution; mis-mount logic could expose or deny space notes incorrectly.
> 
> **Overview**
> Aligns **`notes get`** (`Notes::find_by_id`) with **`notes search`** so IDs returned from search can be fetched without a 403.
> 
> After the existing project-id match, a note with **`space_id`** is returned when that space is in **`space_mounts.space_ids_for_project(project_id)`**. Otherwise authorization still fails as before. **`NoteError`** now wraps **`SpaceMountsError`** for mount lookup failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b6097491a7e4c701d081ae6105b0eea72d6c0c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->