### PR TITLE
feat(chart): add z-ai/glm-5.2 as a selectable model

### DIFF
--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -71,6 +71,9 @@ galoyAgents:
           - name: z-ai/glm-4.6
             maxTokensPerResponse: 8192
             contextWindowTokens: 200000
+          - name: z-ai/glm-5.2
+            maxTokensPerResponse: 8192
+            contextWindowTokens: 1048576
     ## Per-role defaults applied when an agent with that role is created.
     ## All three of `projectLead`, `agent`, and `workflowStepAgent` are
     ## REQUIRED — the binary refuses to start if any of


### PR DESCRIPTION
## Summary
- Adds `z-ai/glm-5.2` (via OpenRouter, 1M context) to the drua chart's LLM providers list.
- No default-chain change: `openai/gpt-5-mini` remains the default primary.

## Why
Z.ai positions GLM-5.2 as a large-scale reasoning model for long-horizon agent workflows — a closer profile match for the on-call `zenduty-investigate` step than the older `glm-4.6` we currently have. Comparison target for A/B against `deepseek-v4-pro` on the investigate step.

## Test plan
- [ ] Chart lint / helm template renders.
- [ ] Deploy to prod and confirm `z-ai/glm-5.2` shows up in the model providers list.
- [ ] Override a workflow step's `model_chain.primary.name` to `z-ai/glm-5.2` and confirm it runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Helm values-only addition to the model catalog with no default chain or runtime behavior changes.
> 
> **Overview**
> Registers **`z-ai/glm-5.2`** on the OpenAI/OpenRouter provider in `charts/drua/values.yaml` with **8192** max response tokens and a **1M** context window, alongside existing models like `z-ai/glm-4.6`.
> 
> **`agents.defaultChain`** is unchanged — **`openai/gpt-5-mini`** stays the default primary; the new model is only available via per-step or per-agent chain overrides (workflows, GraphQL, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e70b0f5af2f452b98052b265ff9f5c356f8f1068. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->