### PR TITLE
feat(git-proxy): allow bot/ push to galoy-deployments

### DIFF
--- a/ci/deploy/drua/prod-values.yml.tmpl
+++ b/ci/deploy/drua/prod-values.yml.tmpl
@@ -104,6 +104,11 @@ galoyAgents:
             modes: [pull, push]
             allowedPushRefs:
               - refs/heads/bot/*
+          - owner: GaloyMoney
+            repo: galoy-deployments
+            modes: [pull, push]
+            allowedPushRefs:
+              - refs/heads/bot/*
     mcpUpstreams:
       - name: honeycomb
         url: https://mcp.honeycomb.io/mcp


### PR DESCRIPTION
## Summary
- Extends the drua git-proxy allowlist (`ci/deploy/drua/prod-values.yml.tmpl`) to cover `GaloyMoney/galoy-deployments`.
- Same shape as the other entries: pull + push allowed, push restricted to `refs/heads/bot/*` — agents PR, humans / CI merge.

## Why
The on-call `investigate_novel` skill flagged deployment-config-side fixes for open Zenduty incidents:
- **#2565** Crossplane `sb-*` claim-not-ready alerts stuck open — fix in `gitops-health.sh` (add `sb-` to the claim violation jq filter, mirroring the existing `testflight-*` exclusion).
- **#2566/#2568-family** ArgoCD app health-degraded alerts on ephemeral sandbox apps — fix in `notifications.tf` (add `sb-` exclusion, mirroring `testflight-*`).

Both live in `galoy-deployments`. Without this allowlist entry the upcoming workflow step that opens draft PRs for `verdict: fix-pr` recommendations always bails with `needs-human` on deployment-config fixes.

## Test plan
- [ ] Chart values render (`helm template` from `charts/drua/`).
- [ ] Deploy to prod, then verify the drua pod's git-proxy config includes `galoy-deployments`.
- [ ] Trigger a workflow that clones `galoy-deployments` via the sandbox git-proxy — confirm 200 OK.
- [ ] Trigger a bot-branch push — confirm push succeeds for `refs/heads/bot/*` and is rejected for other refs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Prod Helm values-only change that widens git-proxy access for one repo while keeping the existing bot-branch push restriction; no auth or application logic changes.
> 
> **Overview**
> Adds **`GaloyMoney/galoy-deployments`** to the drua **git-proxy allowlist** in `ci/deploy/drua/prod-values.yml.tmpl`, using the same rules as the other repos: **pull + push**, with pushes limited to **`refs/heads/bot/*`**.
> 
> This unblocks sandbox agents from cloning and opening draft PRs against deployment-config fixes in `galoy-deployments` instead of failing with **needs-human** when the proxy rejects that repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ded8fb2a6c8fd8c09e96ae38363b71d3faa20f54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->