### PR TITLE
fix(toolset): auto-unwrap `arguments` envelope on tool dispatch

### DIFF
--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -642,12 +642,16 @@ impl AgentSession {
         // The validated payload is the assistant's `tool_use.input` —
         // already validated provider-side (`strict: true`) and by the
         // tool itself in `SubmitOutputTool::call`.
+        // `unwrap_recorded_input` mirrors the dispatch-layer `arguments`-
+        // envelope recovery: when a model wrapped its output as
+        // `{"arguments": {…}}`, the tool succeeded on the unwrapped retry, so
+        // the persisted payload must be unwrapped to match.
         let submit_output = results
             .iter()
             .find(|r| !r.is_error)
             .and_then(|result| self.find_tool_use_input(thread_id, &result.tool_use_id))
             .filter(|(name, _)| name == SUBMIT_OUTPUT_TOOL_NAME)
-            .map(|(_, input)| input);
+            .map(|(_, input)| crate::arguments_envelope::unwrap_recorded_input(input));
 
         self.events
             .push(AgentSessionEvent::ToolResultsAdded { thread_id, results });
@@ -1662,6 +1666,54 @@ mod tests {
             result,
             Ok(AgentSessionResponse::AwaitingAssistantResponse)
         ));
+    }
+
+    #[test]
+    fn submit_output_records_unwrapped_arguments_envelope() {
+        let mut session = new_session();
+        session
+            .add_user_input(TargetThread::Main, user_source(), "Do the step".into())
+            .unwrap();
+        let _ = session.next_prompt(TargetThread::Main).unwrap();
+        let thread_id = session.current_main_thread.unwrap();
+        hydrate_threads(&mut session);
+
+        // Model wrapped its output one level too deep. The dispatch layer
+        // recovered by unwrapping and retrying, so the tool result is a
+        // success — the persisted payload must be the inner object.
+        session
+            .assistant_response_received(
+                thread_id,
+                vec![AssistantBlock::ToolUse {
+                    id: "s1".into(),
+                    name: SUBMIT_OUTPUT_TOOL_NAME.into(),
+                    input: serde_json::json!({
+                        "arguments": { "success": true, "verdict": "fix-pr" }
+                    }),
+                }],
+                StopReason::ToolUse,
+                None,
+                dummy_metadata(),
+            )
+            .unwrap();
+
+        let result = session
+            .add_tool_results(
+                thread_id,
+                vec![ToolResultInput {
+                    tool_use_id: "s1".into(),
+                    content: "output recorded".into(),
+                    is_error: false,
+                }],
+            )
+            .unwrap();
+
+        assert!(matches!(result, AgentSessionResponse::Done));
+        assert_eq!(
+            session.submitted_output(),
+            Some(&serde_json::json!({ "success": true, "verdict": "fix-pr" })),
+            "persisted output is the unwrapped inner object, not the `arguments` wrapper"
+        );
     }
 
     fn new_session_with_compaction(keep_recent: usize) -> AgentSession {

--- a/core/src/arguments_envelope.rs
+++ b/core/src/arguments_envelope.rs
@@ -1,0 +1,124 @@
+//! Recovery for a recurring model failure mode: some models (GLM family
+//! observed) emit a tool call's arguments wrapped one level too deep as
+//! `{"arguments": {…}}` instead of `{…}`. The outer object then fails the
+//! tool's schema, the error is fed back, and the model retries the same
+//! wrong shape — with no natural exit, a workflow step can loop forever.
+//!
+//! The dispatch layers (`ToolSets::call_top_level_tool` and the
+//! `call_tool` catalog for upstream MCP tools) call [`strip_for_dispatch`]
+//! *after* a call fails to recover the intended arguments and retry once.
+//! [`unwrap_recorded_input`] is the read-side mirror for the one place a
+//! tool's raw input is later read back as a value (the `submit_output`
+//! payload), so a recovered call still records the unwrapped shape.
+
+use rmcp::model::JsonObject;
+use serde_json::Value;
+
+/// Inner object when `obj` is exactly a single-key `{"arguments": {…}}`
+/// wrapper; `None` otherwise. Shared core of both entry points.
+fn lone_arguments_inner(obj: &JsonObject) -> Option<&Value> {
+    if obj.len() != 1 {
+        return None;
+    }
+    let inner = obj.get("arguments")?;
+    inner.as_object()?;
+    Some(inner)
+}
+
+/// True when `schema` (a JSON Schema object) declares its own top-level
+/// `arguments` property — such tools legitimately take an `arguments`
+/// field and must never be unwrapped.
+fn declares_arguments(schema: &Value) -> bool {
+    schema
+        .get("properties")
+        .and_then(Value::as_object)
+        .is_some_and(|props| props.contains_key("arguments"))
+}
+
+/// If `args` is a lone `{"arguments": {…}}` wrapper and `schema` does not
+/// itself declare an `arguments` property, return the inner object so the
+/// dispatch can retry with the shape the model meant. `None` leaves the
+/// original call untouched — so a well-formed call is never second-guessed
+/// and a tool that really wants `arguments` is never mangled.
+pub(crate) fn strip_for_dispatch(args: &JsonObject, schema: &Value) -> Option<JsonObject> {
+    let inner = lone_arguments_inner(args)?;
+    if declares_arguments(schema) {
+        return None;
+    }
+    inner.as_object().cloned()
+}
+
+/// Read-side mirror of [`strip_for_dispatch`] for a recorded tool-use
+/// input read back as a value (no schema in hand — the `submit_output`
+/// placeholder never declares `arguments`, matching the dispatch guard).
+/// Returns the unwrapped inner object, or `value` unchanged.
+pub(crate) fn unwrap_recorded_input(value: Value) -> Value {
+    match value.as_object().and_then(lone_arguments_inner) {
+        Some(inner) => inner.clone(),
+        None => value,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn obj(v: Value) -> JsonObject {
+        v.as_object().unwrap().clone()
+    }
+
+    #[test]
+    fn strips_lone_arguments_wrapper() {
+        let args = obj(serde_json::json!({ "arguments": { "success": true, "verdict": "x" } }));
+        let schema = serde_json::json!({ "type": "object" });
+        let inner = strip_for_dispatch(&args, &schema).expect("unwraps");
+        assert_eq!(inner.get("success"), Some(&Value::Bool(true)));
+        assert_eq!(inner.len(), 2);
+    }
+
+    #[test]
+    fn leaves_wellformed_args_untouched() {
+        let args = obj(serde_json::json!({ "success": true, "verdict": "x" }));
+        let schema = serde_json::json!({ "type": "object" });
+        assert!(strip_for_dispatch(&args, &schema).is_none());
+    }
+
+    #[test]
+    fn skips_tools_that_declare_arguments() {
+        let args = obj(serde_json::json!({ "arguments": { "success": true } }));
+        let schema = serde_json::json!({
+            "type": "object",
+            "properties": { "arguments": { "type": "object" } }
+        });
+        assert!(strip_for_dispatch(&args, &schema).is_none());
+    }
+
+    #[test]
+    fn requires_arguments_to_be_the_only_key() {
+        let args = obj(serde_json::json!({ "arguments": { "success": true }, "extra": 1 }));
+        let schema = serde_json::json!({ "type": "object" });
+        assert!(strip_for_dispatch(&args, &schema).is_none());
+    }
+
+    #[test]
+    fn requires_arguments_value_to_be_an_object() {
+        let args = obj(serde_json::json!({ "arguments": "not-an-object" }));
+        let schema = serde_json::json!({ "type": "object" });
+        assert!(strip_for_dispatch(&args, &schema).is_none());
+    }
+
+    #[test]
+    fn unwrap_recorded_input_unwraps_wrapper() {
+        let wrapped = serde_json::json!({ "arguments": { "success": true } });
+        assert_eq!(
+            unwrap_recorded_input(wrapped),
+            serde_json::json!({ "success": true })
+        );
+    }
+
+    #[test]
+    fn unwrap_recorded_input_passes_through_plain_value() {
+        let plain = serde_json::json!({ "success": true, "verdict": "x" });
+        assert_eq!(unwrap_recorded_input(plain.clone()), plain);
+    }
+}

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,6 +1,7 @@
 #![recursion_limit = "256"]
 
 pub mod agent;
+mod arguments_envelope;
 pub mod audit;
 pub mod auth;
 pub mod code_assistant;

--- a/core/src/toolset/mod.rs
+++ b/core/src/toolset/mod.rs
@@ -603,8 +603,30 @@ impl ToolSets {
             }));
 
             let default_cache = tool.default_tool_caching();
+            // Cheap to compute upfront (fast `None` unless the args are
+            // exactly a lone `{arguments: {…}}` wrapper), so `arguments` can
+            // move into the first call without a clone.
+            let recovery_inner = arguments.as_ref().and_then(|a| {
+                crate::arguments_envelope::strip_for_dispatch(a, tool.input_schema())
+            });
             let start = std::time::Instant::now();
-            let raw_result = tool.call(subject, arguments).await;
+            let mut raw_result = tool.call(subject, arguments).await;
+
+            // Recover the `{arguments: {…}}` envelope some models emit: if the
+            // call failed and the args were that wrapper, retry once with the
+            // inner object — the shape the model meant.
+            if call_failed(&raw_result) {
+                if let Some(inner) = recovery_inner {
+                    let retry = tool.call(subject, Some(inner)).await;
+                    if !call_failed(&retry) {
+                        tracing::warn!(
+                            tool = name,
+                            "recovered from `arguments` envelope; retried with unwrapped args",
+                        );
+                        raw_result = retry;
+                    }
+                }
+            }
             Audit::record_duration(start);
 
             let final_result = match raw_result {
@@ -636,6 +658,16 @@ impl ToolSets {
         }
         .with_event_context(seed)
         .await
+    }
+}
+
+/// A dispatch is "failed" for envelope-recovery purposes when it errored
+/// outright or returned an error result (`is_error: true`). Used to decide
+/// whether to retry with an unwrapped `arguments` envelope.
+pub(crate) fn call_failed(result: &Result<CallToolResult, ToolSetsError>) -> bool {
+    match result {
+        Err(_) => true,
+        Ok(r) => r.is_error.unwrap_or(false),
     }
 }
 
@@ -1163,6 +1195,80 @@ mod tests {
         toolsets.register_top_level(StubTopLevelTool::new("ok", true, true));
         let resolved = toolsets.find_for_workflow("ok").expect("accepted");
         assert_eq!(resolved.name(), "ok");
+    }
+
+    /// Fails unless its args carry a top-level `success` key — models the
+    /// class of tool (including `submit_output`) whose real schema requires
+    /// a field the model buried inside an `{"arguments": {…}}` envelope.
+    struct RequiresSuccessTool;
+
+    #[async_trait::async_trait]
+    impl TopLevelTool for RequiresSuccessTool {
+        fn name(&self) -> &str {
+            "requires_success"
+        }
+        fn description(&self) -> &str {
+            "stub"
+        }
+        fn input_schema(&self) -> &serde_json::Value {
+            static S: std::sync::OnceLock<serde_json::Value> = std::sync::OnceLock::new();
+            S.get_or_init(|| serde_json::json!({ "type": "object" }))
+        }
+        async fn call(
+            &self,
+            _subject: &AuthSubject,
+            arguments: Option<JsonObject>,
+        ) -> Result<CallToolResult, ToolSetsError> {
+            if arguments
+                .as_ref()
+                .is_some_and(|a| a.contains_key("success"))
+            {
+                Ok(CallToolResult::success(vec![rmcp::model::Content::text(
+                    "ok",
+                )]))
+            } else {
+                Ok(CallToolResult::error(vec![rmcp::model::Content::text(
+                    "missing required field `success`",
+                )]))
+            }
+        }
+    }
+
+    fn obj(v: serde_json::Value) -> JsonObject {
+        v.as_object().expect("object").clone()
+    }
+
+    #[tokio::test]
+    async fn call_top_level_tool_recovers_from_arguments_envelope() {
+        let toolsets = ToolSets::empty_for_test();
+        toolsets.register_top_level(RequiresSuccessTool);
+        let wrapped = obj(serde_json::json!({ "arguments": { "success": true } }));
+        let result = toolsets
+            .call_top_level_tool(&AuthSubject::Anonymous, "requires_success", Some(wrapped))
+            .await
+            .expect("dispatch ok");
+        assert_ne!(
+            result.is_error,
+            Some(true),
+            "wrapped args are unwrapped and the retry succeeds"
+        );
+    }
+
+    #[tokio::test]
+    async fn call_top_level_tool_surfaces_genuine_failure_unchanged() {
+        let toolsets = ToolSets::empty_for_test();
+        toolsets.register_top_level(RequiresSuccessTool);
+        // Not an `arguments` wrapper — a real bad payload must still fail.
+        let bad = obj(serde_json::json!({ "verdict": "x" }));
+        let result = toolsets
+            .call_top_level_tool(&AuthSubject::Anonymous, "requires_success", Some(bad))
+            .await
+            .expect("dispatch ok");
+        assert_eq!(
+            result.is_error,
+            Some(true),
+            "a non-wrapped failure is not masked by the recovery"
+        );
     }
 
     #[test]

--- a/core/src/toolset/top_level/catalog.rs
+++ b/core/src/toolset/top_level/catalog.rs
@@ -578,7 +578,7 @@ impl TopLevelTool for CallCatalogTool {
         // the outer call_tool envelope only declares `arguments: object`, so
         // stringified JSON inside individual upstream-arg fields wouldn't
         // otherwise be parsed.
-        let inner_args = inner_args.map(|mut a| {
+        let mut inner_args = inner_args.map(|mut a| {
             if let Some(entry) = set.tools().iter().find(|t| t.name == name) {
                 let schema =
                     serde_json::Value::Object(entry.description.input_schema.as_ref().clone());
@@ -589,7 +589,36 @@ impl TopLevelTool for CallCatalogTool {
 
         Audit::record_action(format!("catalog: {}", tool_name));
 
-        let result = set.call(subject, &name, inner_args.clone()).await;
+        let mut result = set.call(subject, &name, inner_args.clone()).await;
+
+        // Recover a double-wrapped `{arguments: {…}}` payload — some models
+        // nest the upstream args again inside call_tool's own `arguments`.
+        // If the call failed and the inner args are exactly that wrapper (and
+        // the upstream tool doesn't declare its own `arguments` field), retry
+        // once with the unwrapped object.
+        if crate::toolset::call_failed(&result) {
+            let upstream_schema = set
+                .tools()
+                .iter()
+                .find(|t| t.name == name)
+                .map(|t| serde_json::Value::Object(t.description.input_schema.as_ref().clone()))
+                .unwrap_or_else(|| serde_json::json!({}));
+            if let Some(unwrapped) = inner_args
+                .as_ref()
+                .and_then(|a| crate::arguments_envelope::strip_for_dispatch(a, &upstream_schema))
+            {
+                let retry = set.call(subject, &name, Some(unwrapped.clone())).await;
+                if !crate::toolset::call_failed(&retry) {
+                    tracing::warn!(
+                        tool = %tool_name,
+                        "recovered from `arguments` envelope; retried upstream with unwrapped args",
+                    );
+                    result = retry;
+                    inner_args = Some(unwrapped);
+                }
+            }
+        }
+
         let result = annotate_envelope_mistake(result, &tool_name, &extra_keys)?;
 
         let result = match self.tool_caching.as_ref() {


### PR DESCRIPTION
## Problem

Workflow-step runs could wedge in `workflow_runs.state='running'` **forever** — burning tokens and holding their slot in the workflow queue. Documented in `drua-dev` research space `research/workflow-run-stuck-submit-output-loop-2026-07-10.md`.

Some models (GLM-4.6 / GLM-5.2) intermittently emit a tool call's arguments **wrapped one level too deep** — `{"arguments": {"success": true, …}}` instead of `{"success": true, …}`. For `submit_output` the outer object is missing `success`, validation fails, the error is fed back, and the model retries the same wrong shape. There's no natural exit: the executor's idle timeout resets on every streamed event, so the loop looks like forward progress.

## Fix — general `arguments`-envelope recovery at the dispatch layer

Rather than special-casing `submit_output` or adding a retry cap, the shape is verified and recovered **generically for all tools** at the dispatch seam: after a call fails, if the args are *exactly* a lone `{"arguments": {…}}` wrapper **and** the tool's schema doesn't itself declare an `arguments` field, retry once with the inner object — the shape the model meant.

Applied at both dispatch seams so it covers every tool:

- **`ToolSets::call_top_level_tool`** — every top-level tool (`submit_output`, notes, skills, …).
- **the `call_tool` catalog dispatch** — upstream MCP tools that get double-wrapped inside call_tool's own `arguments` (e.g. the `zenduty_add_incident_note` variant in the report).

Shared logic lives in a small pure module, `core/src/arguments_envelope.rs`.

### Safety

- **Only fires on failure.** A call that already succeeded is never touched — zero risk to working tool calls.
- **Schema-guarded.** A tool that legitimately declares a top-level `arguments` field is skipped, so its intended shape is never mangled (this is also why `call_tool`'s own `{tool_name, arguments}` envelope is left alone).
- **Soft fallback.** If the unwrapped retry still fails, the original error is returned unchanged — the model sees exactly what it would have before.
- Every recovery emits a `tracing::warn!` with the tool name for incidence tracking.

### Correct persisted output

`submit_output` records the assistant's raw `tool_use.input` as the step's output (not the tool's `structured_content`). So `add_tool_results` applies the **same unwrap** when persisting the payload — a recovered call stores `{success, …}`, the shape downstream `steps.X.output.*` expects, not the `{arguments:{…}}` wrapper.

## Tests

- `arguments_envelope.rs`: unwraps a lone wrapper; leaves well-formed args and multi-key objects untouched; skips tools that declare `arguments`; requires the value to be an object.
- `toolset/mod.rs`: end-to-end through `call_top_level_tool` — a wrapped payload is recovered to success; a genuinely-bad (non-wrapped) payload still fails (recovery doesn't mask real errors).
- `agent/session/entity.rs`: a wrapped `submit_output` records the **unwrapped** inner object as the terminal output and reaches `Done`.

`nix flake check` green (fmt, clippy `-D warnings`, full nextest suite, graphql-schema, config).

## Note on the retry cap

An earlier revision added a consecutive-failure cap in the executor as a hard backstop; it was **dropped** per review — the general unwrap addresses the documented root cause (arguments-wrapping) directly. Trade-off: a model that repeatedly emits a *different* kind of invalid output (not a wrap) is not bounded by this change; if that class shows up in production a dispatch-level cap can be added later.

## Scope note

Sibling bug **workflow-run-stuck-sandbox-detach** (019f4b14) shares the visible symptom (`state='running'` forever) but is an independent failure mode; no code overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all top-level and catalog MCP tool dispatch plus workflow terminal output persistence; recovery is failure-only and schema-guarded, but a mistaken unwrap could change tool behavior for edge-case payloads.
> 
> **Overview**
> Adds generic recovery when models send tool args as a lone `{"arguments": {…}}` wrapper instead of the real payload—addressing workflow steps that could stay `running` forever on repeated `submit_output` validation failures.
> 
> A new `arguments_envelope` module implements **`strip_for_dispatch`** (schema-aware: skip tools that legitimately declare an `arguments` property) and **`unwrap_recorded_input`** for persisted `submit_output` values. **`ToolSets::call_top_level_tool`** and **`call_tool` catalog** dispatch now retry once with the inner object only after a failed call (`call_failed`), with a `tracing::warn!` on recovery. **`AgentSession::add_tool_results`** unwraps `submit_output` tool-use input before `OutputSubmitted` so step output matches what dispatch accepted after a successful retry.
> 
> Unit tests cover the module, top-level dispatch recovery vs genuine failures, and session persistence of unwrapped output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 559fd3fa2365f001ec84bf1c5b82c88445e9c80e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->