### PR TITLE
fix(workflow): resume the same agent past an interrupted tool call on job retry

### DIFF
--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -1323,12 +1323,22 @@ impl Agents {
         Ok(rx)
     }
 
-    /// Re-drive an in-flight LLM call for a workflow agent on retry. Uses
-    /// [`Sessions::pending_prompt`] which, when the last `PromptSent` has no
-    /// matching `AssistantResponseReceived`, rebuilds the original prompt
-    /// from the persisted definition. Returns `Ok(None)` when the prior turn
-    /// closed cleanly (success or recorded error) — caller should fall back
-    /// to [`Self::send_message`] to start a fresh turn.
+    /// Re-drive a workflow agent's turn on job retry so execution continues
+    /// with the *same* agent after the prior worker died. Two interruption
+    /// points are recovered:
+    ///
+    /// 1. Killed between `PromptSent` and `AssistantResponseReceived` (mid
+    ///    LLM call): [`Sessions::pending_prompt`] rebuilds the original prompt
+    ///    from the persisted definition.
+    /// 2. Killed between `AssistantResponseReceived` (tool request) and
+    ///    `ToolResultsAdded` (mid tool call — e.g. a pod restart):
+    ///    [`Sessions::resume_interrupted_tool_use`] closes the unanswered
+    ///    tool_use and returns the continuation prompt, so the agent picks up
+    ///    regardless of which tool was in flight.
+    ///
+    /// Returns `Ok(None)` only when the prior turn closed cleanly (success or
+    /// recorded error) — caller should fall back to [`Self::send_message`] to
+    /// start a fresh turn.
     #[instrument(name = "domain.agent.resume_message", skip(self))]
     pub async fn resume_message(
         &self,
@@ -1355,8 +1365,15 @@ impl Agents {
             Audit::record_workflow_run_id(run);
         }
 
-        let Some(prompt_state) = self.sessions.pending_prompt(id).await? else {
-            return Ok(None);
+        let prompt_state = match self.sessions.pending_prompt(id).await? {
+            Some(prompt) => prompt,
+            // No half-sent prompt to replay. The prior worker may instead have
+            // died mid-tool-call: recover by closing the stuck tool_use and
+            // continuing. `None` here means nothing to resume — start fresh.
+            None => match self.sessions.resume_interrupted_tool_use(id).await? {
+                Some(prompt) => prompt,
+                None => return Ok(None),
+            },
         };
 
         let agent_subject = match subject.originating_user_id() {

--- a/core/src/agent/session/entity.rs
+++ b/core/src/agent/session/entity.rs
@@ -801,27 +801,64 @@ impl AgentSession {
         &mut self,
         thread_id: SessionThreadId,
     ) -> Result<(), AgentSessionError> {
+        if !self.is_tool_use_stale(thread_id) {
+            return Ok(());
+        }
+        let _ = self.abort_tool_use_on_thread(
+            thread_id,
+            "tool_execution_interrupted: dispatcher restarted",
+        )?;
+        Ok(())
+    }
+
+    /// Closes any unanswered tool_use on the current main thread with a
+    /// synthetic error result, flipping the thread back to a user turn so the
+    /// conversation can continue. Unlike [`Self::recover_stale_tool_use`] there
+    /// is no staleness gate: the caller (a workflow job retry after the prior
+    /// worker died mid-tool-call) knows the in-flight result will never arrive,
+    /// so the turn must close now rather than after the stale window.
+    /// Idempotent: no-op when the thread isn't in a ToolUse turn (e.g. the real
+    /// result landed first).
+    pub fn abort_pending_tool_use(
+        &mut self,
+        reason: &str,
+    ) -> Result<Idempotent<()>, AgentSessionError> {
+        match self.current_main_thread {
+            Some(thread_id) => self.abort_tool_use_on_thread(thread_id, reason),
+            None => Ok(Idempotent::AlreadyApplied),
+        }
+    }
+
+    /// Shared body for [`Self::recover_stale_tool_use`] and
+    /// [`Self::abort_pending_tool_use`]: if `thread_id` is in a ToolUse turn
+    /// with unanswered tool_use ids, append an `is_error` tool result for each
+    /// carrying `reason`, flipping the thread back to a user turn.
+    fn abort_tool_use_on_thread(
+        &mut self,
+        thread_id: SessionThreadId,
+        reason: &str,
+    ) -> Result<Idempotent<()>, AgentSessionError> {
         let is_tool_use = self
             .threads
             .get_persisted(&thread_id)
             .is_some_and(|t| t.is_tool_use_turn());
-        if !is_tool_use || !self.is_tool_use_stale(thread_id) {
-            return Ok(());
+        if !is_tool_use {
+            return Ok(Idempotent::AlreadyApplied);
         }
         let tool_use_ids = self.pending_tool_use_ids(thread_id);
         if tool_use_ids.is_empty() {
-            return Ok(());
+            return Ok(Idempotent::AlreadyApplied);
         }
         let results = tool_use_ids
             .into_iter()
             .map(|id| ToolResultInput {
                 tool_use_id: id,
-                content: "tool_execution_interrupted: dispatcher restarted".into(),
+                content: reason.to_string(),
                 is_error: true,
             })
             .collect();
         let _ = self.add_tool_results(thread_id, results)?;
-        Ok(())
+        Ok(Idempotent::Executed(()))
     }
 
     pub fn assistant_response_received(
@@ -1594,6 +1631,117 @@ mod tests {
             }
             _ => panic!("expected User message with tool results and queued text"),
         }
+    }
+
+    /// Drives a session into a ToolUse turn (assistant issued `tool_1`, no
+    /// result yet) — the exact state a mid-tool-call worker restart strands.
+    fn session_awaiting_tool_result() -> (AgentSession, SessionThreadId) {
+        let mut session = new_session();
+        session
+            .add_user_input(TargetThread::Main, user_source(), "Use the tool".into())
+            .unwrap();
+        let _ = session.next_prompt(TargetThread::Main).unwrap();
+        let thread_id = session.current_main_thread.unwrap();
+        hydrate_threads(&mut session);
+        session
+            .assistant_response_received(
+                thread_id,
+                vec![
+                    AssistantBlock::Text {
+                        text: "Let me check.".into(),
+                    },
+                    AssistantBlock::ToolUse {
+                        id: "tool_1".into(),
+                        name: "get_weather".into(),
+                        input: serde_json::json!({"city": "NYC"}),
+                    },
+                ],
+                StopReason::ToolUse,
+                None,
+                dummy_metadata(),
+            )
+            .unwrap();
+        (session, thread_id)
+    }
+
+    #[test]
+    fn abort_pending_tool_use_closes_dangling_tool_use() {
+        let (mut session, thread_id) = session_awaiting_tool_result();
+
+        // Job retry after a mid-tool-call restart: close the unanswered
+        // tool_use so execution can continue with the same agent.
+        assert!(session
+            .abort_pending_tool_use("interrupted on retry")
+            .unwrap()
+            .did_execute());
+
+        // Second call is a no-op — the turn already flipped back to the user.
+        assert!(!session
+            .abort_pending_tool_use("interrupted on retry")
+            .unwrap()
+            .did_execute());
+
+        // The turn is no longer ToolUse: a late real result (from a stale
+        // worker whose tool call finally returned) is rejected rather than
+        // double-appended.
+        let late = session.add_tool_results(
+            thread_id,
+            vec![ToolResultInput {
+                tool_use_id: "tool_1".into(),
+                content: "72F".into(),
+                is_error: false,
+            }],
+        );
+        assert!(matches!(late, Err(AgentSessionError::NotToolUseTurn)));
+
+        // The continuation prompt is valid: the assistant tool_use is answered
+        // by a synthetic is_error tool_result, so the model can resume.
+        let prompt = session.next_prompt(TargetThread::Main).unwrap();
+        assert_eq!(prompt.messages.len(), 3);
+        match &prompt.messages[2] {
+            Message::User { content } => match &content[0] {
+                UserBlock::ToolResult {
+                    tool_use_id,
+                    content: blocks,
+                    is_error,
+                } => {
+                    assert_eq!(tool_use_id, "tool_1");
+                    assert!(is_error);
+                    assert!(
+                        matches!(&blocks[0], ToolResultBlock::Text { text } if text == "interrupted on retry")
+                    );
+                }
+                other => panic!("expected ToolResult block, got {other:?}"),
+            },
+            other => panic!("expected User message, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn abort_pending_tool_use_noops_outside_tool_use_turn() {
+        // No thread yet.
+        let mut session = new_session();
+        assert!(!session.abort_pending_tool_use("x").unwrap().did_execute());
+
+        // After a plain text turn the thread is a user turn — nothing pending.
+        session
+            .add_user_input(TargetThread::Main, user_source(), "Hi".into())
+            .unwrap();
+        let _ = session.next_prompt(TargetThread::Main).unwrap();
+        let thread_id = session.current_main_thread.unwrap();
+        hydrate_threads(&mut session);
+        session
+            .assistant_response_received(
+                thread_id,
+                vec![AssistantBlock::Text {
+                    text: "hello".into(),
+                }],
+                StopReason::Stop,
+                None,
+                dummy_metadata(),
+            )
+            .unwrap();
+        assert!(!session.abort_pending_tool_use("x").unwrap().did_execute());
     }
 
     #[test]

--- a/core/src/agent/session/mod.rs
+++ b/core/src/agent/session/mod.rs
@@ -27,6 +27,17 @@ pub use thread::SessionThreadId;
 
 es_entity::entity_id! { AgentSessionId }
 
+/// Synthetic tool-result content injected when a workflow step is retried at
+/// the job level (e.g. a pod restart) while a tool call was still in flight.
+/// The previous execution died before recording the result, so the reused
+/// agent picks the conversation back up with this note in place of the lost
+/// result.
+const TOOL_INTERRUPTED_ON_RETRY: &str =
+    "tool_execution_interrupted: the previous execution of this \
+    step was interrupted before this tool call returned (e.g. the worker restarted). Its result is \
+    lost and any side effects are unconfirmed. Re-verify the relevant state before relying on it, \
+    then continue.";
+
 #[derive(Clone)]
 pub struct Sessions {
     repo: AgentSessionRepo,
@@ -157,6 +168,33 @@ impl Sessions {
     ) -> Result<Option<llm::Prompt>, AgentSessionError> {
         let session = self.repo.find_by_agent_id(agent_id).await?;
         Ok(session.pending_prompt()?.map(Into::into))
+    }
+
+    /// Resume-after-restart primitive for the workflow runner. When the prior
+    /// execution died *after* the assistant requested tools but *before* their
+    /// results were recorded (a pod restart mid-tool-call), the turn is stuck
+    /// in a ToolUse state that [`Self::pending_prompt`] cannot rebuild. Close
+    /// the unanswered tool_use with a synthetic interrupted-result and return
+    /// the continuation prompt so the same agent picks up where it left off,
+    /// regardless of which tool was in flight. `Ok(None)` when the session is
+    /// not stuck in a ToolUse turn (caller falls back to a fresh turn).
+    #[instrument(name = "domain.agent_session.resume_interrupted_tool_use", skip(self))]
+    pub async fn resume_interrupted_tool_use(
+        &self,
+        agent_id: AgentId,
+    ) -> Result<Option<llm::Prompt>, AgentSessionError> {
+        let mut op = self.repo.begin_op().await?;
+        let mut session = self.repo.find_by_agent_id_in_op(&mut op, agent_id).await?;
+        if !session
+            .abort_pending_tool_use(TOOL_INTERRUPTED_ON_RETRY)?
+            .did_execute()
+        {
+            return Ok(None);
+        }
+        let prompt = session.next_prompt(TargetThread::Main)?;
+        self.repo.update_in_op(&mut op, &mut session).await?;
+        op.commit().await?;
+        Ok(Some(prompt.into()))
     }
 
     #[instrument(

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -461,6 +461,217 @@ async fn send_message_dispatches_registered_tool_call() {
     }
 }
 
+/// A registered top-level tool whose call never returns — it signals entry
+/// then parks forever. Lets a test freeze an agent in a persisted ToolUse
+/// turn (assistant requested the tool, no result recorded), the exact state a
+/// worker killed mid-tool-call leaves behind.
+struct HangingTool {
+    schema: serde_json::Value,
+    entered: std::sync::Mutex<Option<tokio::sync::oneshot::Sender<()>>>,
+}
+
+impl HangingTool {
+    fn new(entered: tokio::sync::oneshot::Sender<()>) -> Self {
+        Self {
+            schema: serde_json::json!({
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false,
+            }),
+            entered: std::sync::Mutex::new(Some(entered)),
+        }
+    }
+}
+
+#[async_trait::async_trait]
+impl TopLevelTool for HangingTool {
+    fn name(&self) -> &str {
+        "hang"
+    }
+    fn description(&self) -> &str {
+        "Never returns. Test-only tool."
+    }
+    fn input_schema(&self) -> &serde_json::Value {
+        &self.schema
+    }
+    async fn call(
+        &self,
+        _subject: &AuthSubject,
+        _arguments: Option<JsonObject>,
+    ) -> Result<CallToolResult, ToolSetsError> {
+        if let Some(tx) = self.entered.lock().unwrap().take() {
+            let _ = tx.send(());
+        }
+        std::future::pending::<()>().await;
+        unreachable!("hang tool never resolves")
+    }
+}
+
+/// A worker that dies mid-tool-call leaves the session in a ToolUse turn with
+/// no result. On job retry the executor re-drives the *same* agent via
+/// `resume_message`, which must close the interrupted tool_use and continue —
+/// regardless of which tool was in flight — rather than dead-end.
+#[tokio::test]
+async fn resume_message_continues_past_interrupted_tool_call() {
+    use std::time::Duration;
+
+    let pool = pool().await;
+    let (prompt_tx, mut prompt_rx) = mpsc::channel::<PromptRequest>(64);
+
+    let model_name = "claude-haiku-4-5-20251001".to_string();
+    let mut builtin_roles = HashMap::new();
+    builtin_roles.insert(
+        AgentRole::ProjectLead,
+        RoleConfig {
+            chain: Some(llm::ModelChain::new(model_name.clone())),
+            compaction: Default::default(),
+        },
+    );
+    let mut models = HashMap::new();
+    models.insert(
+        model_name.clone(),
+        ModelDefaults {
+            model: model_name,
+            max_tokens_per_response: 1024,
+            context_window_tokens: 200_000,
+            effort: ReasoningEffort::Low,
+        },
+    );
+    let config = AgentsConfig {
+        builtin_roles,
+        models,
+        ..Default::default()
+    };
+
+    let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+    let toolsets = ToolSets::init(ToolSetsConfig::default(), None, None, None)
+        .await
+        .expect("init toolsets");
+    toolsets.register_top_level(HangingTool::new(entered_tx));
+    let toolsets = Arc::new(toolsets);
+
+    let sandboxes = Arc::new(
+        Sandboxes::init(
+            &pool,
+            SandboxConfig::default(),
+            std::sync::Arc::new(drua_git_proxy::Allowlist::default()),
+        )
+        .await
+        .expect("init sandboxes"),
+    );
+    let skills = Arc::new(drua_core::skill::Skills::new_without_library(
+        &pool,
+        Arc::clone(&sandboxes),
+    ));
+    let agents = Agents::new(
+        &pool,
+        config,
+        toolsets,
+        prompt_tx,
+        Arc::clone(&sandboxes),
+        Arc::clone(&skills),
+        None,
+        ContextGeneration::new(),
+        Arc::new(drua_core::library::SpaceMounts::empty()),
+    );
+
+    let sub = AuthSubject::User(UserId::new());
+    let agent = agents
+        .create_project_lead(&sub, ProjectId::new(), "lead", "test-project")
+        .await
+        .expect("create agent");
+
+    // First turn: the model asks to call `hang`.
+    let _events_rx = agents
+        .send_message(sub, agent.id, "Call hang".to_string())
+        .await
+        .expect("send_message");
+    let request = tokio::time::timeout(Duration::from_secs(5), prompt_rx.recv())
+        .await
+        .expect("first prompt timed out")
+        .expect("first prompt request");
+    request
+        .response_channel
+        .send(Ok(PromptResult::Complete(PromptResponse {
+            content: vec![AssistantBlock::ToolUse {
+                id: "tu_1".to_string(),
+                name: "hang".to_string(),
+                input: serde_json::json!({}),
+            }],
+            usage: Usage {
+                input_tokens: 7,
+                output_tokens: 4,
+                ..Default::default()
+            },
+            stop_reason: Some(StopReason::ToolUse),
+            model_used: None,
+        })))
+        .expect("send first response");
+
+    // Dispatch is now parked inside `hang`: the assistant response is
+    // committed but no tool result will ever land — the session is frozen in a
+    // ToolUse turn, exactly like a worker killed mid-tool-call.
+    tokio::time::timeout(Duration::from_secs(5), entered_rx)
+        .await
+        .expect("hang tool not entered")
+        .expect("entered signal");
+
+    // Simulate the job-level retry re-driving the same agent.
+    let resumed = agents
+        .resume_message(AuthSubject::User(UserId::new()), agent.id)
+        .await
+        .expect("resume_message");
+    let mut resumed_rx =
+        resumed.expect("resume must continue past the interrupted tool call, not return None");
+
+    // The continuation prompt answers the interrupted `tu_1` with an error
+    // result, so the model resumes from where it left off.
+    let request = tokio::time::timeout(Duration::from_secs(5), prompt_rx.recv())
+        .await
+        .expect("continuation prompt timed out")
+        .expect("continuation prompt request");
+    let has_interrupted_result = request.prompt.messages.iter().any(|m| match m {
+        llm::prompt::Message::User { content } => content.iter().any(|b| {
+            matches!(
+                b,
+                llm::prompt::UserBlock::ToolResult { tool_use_id, is_error, .. }
+                    if tool_use_id.as_str() == "tu_1" && *is_error
+            )
+        }),
+        _ => false,
+    });
+    assert!(
+        has_interrupted_result,
+        "continuation prompt should answer interrupted tool_use tu_1 with an error result",
+    );
+    request
+        .response_channel
+        .send(Ok(PromptResult::Complete(PromptResponse {
+            content: vec![AssistantBlock::Text {
+                text: "resumed and done".to_string(),
+            }],
+            usage: Usage {
+                input_tokens: 3,
+                output_tokens: 2,
+                ..Default::default()
+            },
+            stop_reason: None,
+            model_used: None,
+        })))
+        .expect("send continuation response");
+
+    // Draining the resumed loop reaches AssistantDone: execution continued.
+    let mut saw_done = false;
+    while let Ok(Some(event)) =
+        tokio::time::timeout(Duration::from_secs(5), resumed_rx.recv()).await
+    {
+        if matches!(event, ChatOutputEvent::AssistantDone { .. }) {
+            saw_done = true;
+        }
+    }
+    assert!(saw_done, "resumed loop should reach AssistantDone");
+}
+
 #[tokio::test]
 async fn delete_removes_agent_from_listing() {
     let pool = pool().await;


### PR DESCRIPTION
## Problem

When a workflow step's worker dies **mid-tool-call** (e.g. a pod restart), the job is reaped and re-executed. The executor already reuses the same step agent (`find_for_workflow_step_in_op`), but **resume dead-ended** and the run wedged at `workflow_runs.state='running'`, pinning the per-definition queue. Documented in the drua-dev space `workflow-run-stuck-sandbox-detach-mid-tool-2026-07-10.md`.

Why resume didn't continue: the session's last event is an `AssistantResponseReceived` that requested tools, with no matching `ToolResultsAdded` (the worker died before the tool returned). `Sessions::pending_prompt` only rebuilds a prompt that was cut off *before* the assistant response, so it returns `None`; the executor's fallback `send_message` then bounced on `AwaitingToolUsageComplete` ("waiting for tool results that will never arrive"), so the step never progressed.

This is about **job-level retry resumption**, independent of sandbox operations — it must recover regardless of which tool was in flight.

## Fix

Make resume pick the same agent back up past a stuck tool call:

- **`AgentSession::abort_pending_tool_use(reason)`** — closes any unanswered `tool_use` on the current thread with a synthetic `is_error` result, flipping the thread back to a user turn. Shares its body with the existing time-based `recover_stale_tool_use`, minus the staleness gate (a job retry is a definitive signal the prior worker died, so we don't wait for the stale window).
- **`Sessions::resume_interrupted_tool_use`** — applies the abort, then returns the continuation prompt.
- **`Agents::resume_message`** — now falls back to `resume_interrupted_tool_use` when `pending_prompt` is `None`. Since the workflow executor already calls `resume_message` on retry, both interruption points are now recovered:
  1. killed mid-LLM-call (between `PromptSent` and `AssistantResponseReceived`) → `pending_prompt` replays the prompt (existing behavior);
  2. killed mid-tool-call (between the tool request and `ToolResultsAdded`) → close the tool_use and continue (new).

The reused agent resumes its conversation with a note that the tool was interrupted and its side effects are unconfirmed, so it can re-verify and continue. Idempotent and race-safe: a late result from a resurrected worker is rejected (`NotToolUseTurn`) rather than double-appended.

## Tests

- **Entity-level** (`session/entity.rs`): `abort_pending_tool_use_closes_dangling_tool_use` (drives a session into a ToolUse turn, aborts, asserts idempotency, that a late real result is rejected, and that the rebuilt prompt is a valid continuation) + `abort_pending_tool_use_noops_outside_tool_use_turn`.
- **DB-backed end-to-end** (`tests/agent.rs`): `resume_message_continues_past_interrupted_tool_call` — a registered tool that never returns freezes an agent in a persisted ToolUse turn (exactly the mid-tool-call restart state), then asserts `resume_message` closes the interrupted tool_use, the continuation prompt carries the synthetic error result, and the resumed loop drives to `AssistantDone`.

`nix flake check` green: fmt, clippy `-D warnings`, full nextest suite (incl. the new integration test), graphql-schema, config.

## Note

The cosmetic `workflow_runs.state`-not-updated-on-reap issue (the space's third, adjacent problem — not a cause of stuck runs) is left as a follow-up.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes workflow retry and session turn state (synthetic tool errors, persisted events); wrong abort timing could confuse the model or drop in-flight results, though idempotency and `NotToolUseTurn` limit double-application.
> 
> **Overview**
> Fixes workflow steps that **wedged after a worker restart mid-tool-call**: the session stayed in a ToolUse turn with no `ToolResultsAdded`, so `pending_prompt` returned nothing and a fresh `send_message` hit `AwaitingToolUsageComplete`.
> 
> **`AgentSession::abort_pending_tool_use`** immediately closes dangling `tool_use` blocks with synthetic `is_error` results (no staleness wait), sharing logic with time-based **`recover_stale_tool_use`** via **`abort_tool_use_on_thread`**. **`Sessions::resume_interrupted_tool_use`** persists that abort and returns the continuation prompt with a fixed retry message for the model.
> 
> **`Agents::resume_message`** now tries `pending_prompt` first (mid-LLM), then **`resume_interrupted_tool_use`** (mid-tool), so job retry can re-drive the **same** agent and session. Behavior is idempotent; late tool results from a dead worker are rejected with **`NotToolUseTurn`**.
> 
> Entity and DB-backed integration tests cover abort/resume and a never-returning **`hang`** tool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83254fb6209b451077f8370a24e506cfff50db62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->