### PR TITLE
feat(workflow): add `cancel` command to abort in-flight runs

### DIFF
--- a/core/src/agent/error.rs
+++ b/core/src/agent/error.rs
@@ -1,7 +1,7 @@
 use thiserror::Error;
 
 use crate::auth::error::AuthorizationError;
-use crate::primitives::{ProjectId, SandboxId};
+use crate::primitives::{AgentId, ProjectId, SandboxId, WorkflowRunId};
 use crate::sandbox::error::SandboxError;
 use crate::skill::SkillError;
 
@@ -46,4 +46,13 @@ pub enum AgentError {
     NoLeadAgent(ProjectId),
     #[error("AgentError - workflow agents inherit their chain from the workflow definition")]
     WorkflowAgentChainImmutable,
+    #[error(
+        "AgentError - agent {agent_id} is a workflow agent (run {run_id}); \
+         use `workflow cancel run_id={run_id}` instead — deleting it directly \
+         would leave the run in a zombie `running` state"
+    )]
+    WorkflowAgentDeleteForbidden {
+        agent_id: AgentId,
+        run_id: WorkflowRunId,
+    },
 }

--- a/core/src/agent/mod.rs
+++ b/core/src/agent/mod.rs
@@ -749,6 +749,17 @@ impl Agents {
             AuthVerb::Delete,
             AuthResource::Agent(agent.project_id, Some(agent.id)),
         )?;
+        // A workflow agent's lifecycle is owned by its run. Deleting it
+        // directly stops the model burn but leaves `workflow_runs` +
+        // `job_executions` zombied at `running` with the queue locked.
+        // Route operators to `workflow cancel`, which transitions the run
+        // to a terminal state atomically alongside the agent soft-delete.
+        if let Some(run_id) = agent.workflow_run_id {
+            return Err(AgentError::WorkflowAgentDeleteForbidden {
+                agent_id: id,
+                run_id,
+            });
+        }
         Audit::record_action_if_unset("agent.delete");
         Audit::record_project_id(agent.project_id);
         Audit::record_agent_id(id);
@@ -822,6 +833,46 @@ impl Agents {
             }
         }
         Ok(())
+    }
+
+    /// Soft-delete every agent spawned by a single workflow run (as
+    /// opposed to [`Self::cascade_delete_for_workflow_id_in_op`], which
+    /// spans all runs of a definition). Returns the deleted agent ids so
+    /// the caller can invalidate their in-memory session caches after the
+    /// op commits. Used by `Workflows::cancel_run`.
+    #[instrument(
+        name = "domain.agent.cascade_delete_for_workflow_run_id_in_op",
+        skip(self, op)
+    )]
+    pub async fn cascade_delete_for_workflow_run_id_in_op(
+        &self,
+        op: &mut es_entity::DbOp<'_>,
+        run_id: WorkflowRunId,
+    ) -> Result<Vec<AgentId>, AgentError> {
+        const PAGE_SIZE: usize = 100;
+        let mut deleted = Vec::new();
+        loop {
+            let result = self
+                .repo
+                .list_for_workflow_run_id_by_created_at_in_op(
+                    &mut *op,
+                    Some(run_id),
+                    es_entity::PaginatedQueryArgs {
+                        first: PAGE_SIZE,
+                        after: None,
+                    },
+                    es_entity::ListDirection::Ascending,
+                )
+                .await?;
+            if result.entities.is_empty() {
+                break;
+            }
+            for agent in result.entities {
+                self.delete_in_op(op, agent.id).await?;
+                deleted.push(agent.id);
+            }
+        }
+        Ok(deleted)
     }
 
     /// Re-attach with a different mode: downgrade unconditional; upgrade to

--- a/core/src/toolset/searchable/admin.rs
+++ b/core/src/toolset/searchable/admin.rs
@@ -313,6 +313,9 @@ enum WorkflowCommand {
     Trigger,
     /// Read a single run with full per-step outputs.
     Run,
+    /// Abort an in-flight run: terminal `cancelled` state, agents
+    /// soft-deleted, queue freed. Requires `run_id`; optional `reason`.
+    Cancel,
 }
 
 /// Tagged step input. `type: agent_step` (the historical default,
@@ -526,9 +529,14 @@ struct WorkflowParams {
     #[schemars(with = "Option<uuid::Uuid>")]
     definition_id: Option<WorkflowDefinitionId>,
 
-    /// Required for `run`.
+    /// Required for `run`, `cancel`.
     #[schemars(with = "Option<uuid::Uuid>")]
     run_id: Option<WorkflowRunId>,
+
+    /// `cancel`: optional free-text audit note recorded on the
+    /// `run_cancelled` event.
+    #[serde(default)]
+    reason: Option<String>,
 
     /// `trigger`: webhook-equivalent payload bound to the run's
     /// `trigger.*` template namespace. Defaults to `{}`.
@@ -1487,6 +1495,25 @@ impl AdminToolSet {
                     &run,
                 ))]))
             }
+
+            WorkflowCommand::Cancel => {
+                let run_id = params.run_id.ok_or_else(|| {
+                    ToolSetsError::MissingArgument("run_id is required for cancel".to_string())
+                })?;
+                Audit::record_action("workflow.cancel");
+                let reason = params.reason.filter(|s| !s.is_empty());
+                let run = self
+                    .workflows
+                    .cancel_run(subject, run_id, reason)
+                    .await
+                    .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
+                Ok(CallToolResult::success(vec![Content::text(format!(
+                    "Run {} state: {}.\n{}",
+                    run.id,
+                    run_state(run.state),
+                    format_run(&run),
+                ))]))
+            }
         }
     }
 
@@ -2072,18 +2099,25 @@ fn format_workflow(d: &WorkflowDefinition, created: bool) -> String {
 /// compact JSON (one per line) so callers can read the structured
 /// payload directly without a second round-trip through the inspect
 /// MCP. Used by `trigger`, `await_run`, and `run`.
-fn format_run(r: &WorkflowRun) -> String {
-    let state = match r.state {
+fn run_state(state: WorkflowRunState) -> &'static str {
+    match state {
         WorkflowRunState::Pending => "pending",
         WorkflowRunState::Running => "running",
         WorkflowRunState::WaitingForEvent => "waiting_for_event",
         WorkflowRunState::Succeeded => "succeeded",
         WorkflowRunState::Failed => "failed",
         WorkflowRunState::Errored => "errored",
-    };
+        WorkflowRunState::Cancelled => "cancelled",
+    }
+}
+
+fn format_run(r: &WorkflowRun) -> String {
     let mut out = format!(
         "Run:\n  id: {}\n  definition_id: {}\n  project_id: {}\n  state: {}\n",
-        r.id, r.definition_id, r.project_id, state,
+        r.id,
+        r.definition_id,
+        r.project_id,
+        run_state(r.state),
     );
     if !r.step_results.is_empty() {
         out.push_str("  steps:\n");
@@ -2736,6 +2770,32 @@ mod tests {
         .expect("parse");
         assert!(matches!(p.command, WorkflowCommand::Delete));
         assert_eq!(p.definition_id.map(uuid::Uuid::from), Some(definition_id));
+    }
+
+    #[test]
+    fn workflow_cancel_takes_run_id_and_reason() {
+        let run_id = uuid::Uuid::new_v4();
+        let p: WorkflowParams = parse_params(args(serde_json::json!({
+            "command": "cancel",
+            "run_id": run_id,
+            "reason": "git-proxy connectivity broken",
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, WorkflowCommand::Cancel));
+        assert_eq!(p.run_id.map(uuid::Uuid::from), Some(run_id));
+        assert_eq!(p.reason.as_deref(), Some("git-proxy connectivity broken"));
+    }
+
+    #[test]
+    fn workflow_cancel_parses_without_reason() {
+        let run_id = uuid::Uuid::new_v4();
+        let p: WorkflowParams = parse_params(args(serde_json::json!({
+            "command": "cancel",
+            "run_id": run_id,
+        })))
+        .expect("parse");
+        assert!(matches!(p.command, WorkflowCommand::Cancel));
+        assert!(p.reason.is_none());
     }
 
     #[test]

--- a/core/src/toolset/top_level/workflow.rs
+++ b/core/src/toolset/top_level/workflow.rs
@@ -115,6 +115,13 @@ enum WorkflowParams {
     Delete {
         definition_id: WorkflowDefinitionId,
     },
+    /// Abort an in-flight run. Terminal `cancelled` state; the run's
+    /// agents are soft-deleted and the queue slot frees.
+    Cancel {
+        run_id: WorkflowRunId,
+        #[serde(default)]
+        reason: Option<String>,
+    },
 }
 
 #[derive(Deserialize, schemars::JsonSchema)]
@@ -309,6 +316,7 @@ impl WorkflowParams {
             Self::Run { .. } => "workflow.run",
             Self::Update { .. } => "workflow.update",
             Self::Delete { .. } => "workflow.delete",
+            Self::Cancel { .. } => "workflow.cancel",
         }
     }
 }
@@ -471,8 +479,8 @@ static WORKFLOW_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
         "properties": {
             "command": {
                 "type": "string",
-                "enum": ["create", "list", "get", "trigger", "runs", "run", "update", "delete"],
-                "description": "Which workflow operation to perform. `trigger` returns immediately with the freshly-spawned run. `runs` lists runs (truncated outputs); `run` returns a single run with full per-step output."
+                "enum": ["create", "list", "get", "trigger", "runs", "run", "update", "delete", "cancel"],
+                "description": "Which workflow operation to perform. `trigger` returns immediately with the freshly-spawned run. `runs` lists runs (truncated outputs); `run` returns a single run with full per-step output. `cancel` aborts an in-flight run (requires `run_id`, optional `reason`)."
             },
             "name": {
                 "type": "string",
@@ -524,7 +532,11 @@ static WORKFLOW_SCHEMA: LazyLock<serde_json::Value> = LazyLock::new(|| {
             "run_id": {
                 "type": "string",
                 "format": "uuid",
-                "description": "Workflow run ID (run)."
+                "description": "Workflow run ID (run, cancel)."
+            },
+            "reason": {
+                "type": "string",
+                "description": "Optional free-text audit note recorded on the run_cancelled event (cancel)."
             },
             "payload": {
                 "description": "Trigger context payload (trigger). Defaults to {}."
@@ -622,7 +634,9 @@ impl TopLevelTool for WorkflowTool {
          `provider`/`manual`/`trigger_condition`+`update_trigger`, \
          `model_chain`+`clear_model_chain`), \
          `delete` (requires `definition_id`; cascades to runs and queues \
-         a `DeleteFile` on the canonical YAML)."
+         a `DeleteFile` on the canonical YAML), \
+         `cancel` (requires `run_id`, optional `reason`; aborts an \
+         in-flight run to a terminal `cancelled` state and frees the queue)."
     }
 
     fn input_schema(&self) -> &serde_json::Value {
@@ -925,6 +939,26 @@ impl TopLevelTool for WorkflowTool {
                 };
                 (text, out)
             }
+
+            WorkflowParams::Cancel { run_id, reason } => {
+                let run = self
+                    .workflows
+                    .cancel_run(subject, run_id, reason.filter(|s| !s.is_empty()))
+                    .await
+                    .map_err(|e| ToolSetsError::Workflow(e.to_string()))?;
+                let text = format!(
+                    "Run {} state: {}.\n\n{}",
+                    run.id,
+                    run_state_str(run.state),
+                    format_run_text(&run),
+                );
+                let out = WorkflowOutput {
+                    command: "cancel".to_string(),
+                    run: Some(run_to_output(&run)),
+                    ..Default::default()
+                };
+                (text, out)
+            }
         };
 
         let structured = serde_json::to_value(&out).expect("WorkflowOutput serialization");
@@ -1079,6 +1113,7 @@ fn run_state_str(state: WorkflowRunState) -> &'static str {
         WorkflowRunState::Succeeded => "succeeded",
         WorkflowRunState::Failed => "failed",
         WorkflowRunState::Errored => "errored",
+        WorkflowRunState::Cancelled => "cancelled",
     }
 }
 

--- a/core/src/workflow/executor.rs
+++ b/core/src/workflow/executor.rs
@@ -16,7 +16,7 @@ use crate::toolset::ToolSets;
 use super::definition::{WorkflowSandboxDecl, WorkflowStepDef};
 use super::error::WorkflowError;
 use super::repo::WorkflowDefinitionRepo;
-use super::run::{StepResult, WorkflowRunRepo, WorkflowRunState};
+use super::run::{StepResult, WorkflowRunRepo};
 use super::template::{
     format_template_diagnostics, template_diagnostics, ConditionOutcome, TemplateContext,
 };
@@ -121,10 +121,10 @@ impl Executor {
     ) -> Result<(), WorkflowError> {
         let mut run = self.runs.find_by_id(run_id).await?;
 
-        if matches!(
-            run.state,
-            WorkflowRunState::Succeeded | WorkflowRunState::Failed | WorkflowRunState::Errored
-        ) {
+        // Terminal on load (including an externally-issued `Cancelled`):
+        // nothing left to do. A run cancelled mid-flight lands here on the
+        // job's next attempt and completes cleanly, freeing the queue slot.
+        if run.state.is_terminal() {
             return Ok(());
         }
 

--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -102,6 +102,26 @@ fn payload_digest(trigger_context: &serde_json::Value) -> String {
     hex::encode(digest)
 }
 
+/// Stable, human-readable identity for the `cancelled_by` field on a
+/// `RunCancelled` event. Mirrors the actor dimensions the audit log
+/// records, collapsed into one string so it lives on the event body.
+fn subject_label(sub: &AuthSubject) -> String {
+    match sub {
+        AuthSubject::User(id) => format!("user:{id}"),
+        AuthSubject::ExportedAgent(user_id, creds_id, _) => {
+            format!("exported_agent:{creds_id} (user:{user_id})")
+        }
+        AuthSubject::Agent(_, agent_id, _) => format!("agent:{agent_id}"),
+        AuthSubject::AgentOnBehalfOfUser(user_id, _, agent_id, _) => {
+            format!("agent:{agent_id} (on behalf of user:{user_id})")
+        }
+        AuthSubject::WorkflowExecutor(_, def_id, run_id, _) => {
+            format!("workflow_executor:run={run_id} (definition:{def_id})")
+        }
+        AuthSubject::Anonymous => "anonymous".to_string(),
+    }
+}
+
 fn record_trigger_filtered_audit(
     definition: &WorkflowDefinition,
     condition_body: &str,
@@ -1199,6 +1219,61 @@ impl Workflows {
             AuthVerb::Read,
             AuthResource::Workflow(run.project_id, Some(run.definition_id)),
         )?;
+        Ok(run)
+    }
+
+    /// Abort an in-flight run: write a terminal `Cancelled` state + a
+    /// `RunCancelled` event, then soft-delete the run's agent(s) so the
+    /// model burn stops. Idempotent — cancelling an already-terminal run
+    /// returns its current state unchanged.
+    ///
+    /// Returns as soon as the transition is committed. The executor loop
+    /// shuts down asynchronously: it observes the terminal state on its
+    /// next job attempt and exits, freeing the queue slot. Deleting the
+    /// run's agents also unblocks an executor parked on a hung agent turn
+    /// (the next `send_message` finds no agent and errors the step).
+    #[instrument(name = "core.workflow.cancel_run", skip_all)]
+    pub async fn cancel_run(
+        &self,
+        sub: &AuthSubject,
+        run_id: WorkflowRunId,
+        reason: Option<String>,
+    ) -> Result<WorkflowRun, WorkflowError> {
+        let mut run = self.run_repo.find_by_id(run_id).await?;
+        sub.can(
+            AuthVerb::Update,
+            AuthResource::Workflow(run.project_id, Some(run.definition_id)),
+        )?;
+        Audit::record_action_if_unset("workflow.cancel");
+        Audit::record_project_id(run.project_id);
+        Audit::record_workflow_id(run.definition_id);
+        Audit::record_workflow_run_id(run.id);
+
+        // Already terminal (finished on its own, or a prior cancel): no-op.
+        if run.state.is_terminal() {
+            return Ok(run);
+        }
+
+        let cancelled_by = subject_label(sub);
+        Audit::record_metadata(serde_json::json!({
+            "cancelled_by": cancelled_by,
+            "reason": reason,
+        }));
+
+        let mut op = self.run_repo.begin_op().await?;
+        let deleted_agents = if run.cancel(cancelled_by, reason).did_execute() {
+            self.run_repo.update_in_op(&mut op, &mut run).await?;
+            self.agents
+                .cascade_delete_for_workflow_run_id_in_op(&mut op, run_id)
+                .await?
+        } else {
+            Vec::new()
+        };
+        op.commit().await?;
+
+        for agent_id in deleted_agents {
+            self.agents.invalidate_agent_cache(agent_id);
+        }
         Ok(run)
     }
 

--- a/core/src/workflow/run/entity.rs
+++ b/core/src/workflow/run/entity.rs
@@ -14,6 +14,10 @@ use crate::workflow::definition::WorkflowStepDef;
 /// - `Errored`: at least one step hit an infrastructure-level error
 ///   (sandbox not ready, idle timeout, executor / agent error, etc.).
 ///   Errored takes precedence over Failed.
+/// - `Cancelled`: an operator (or a self-cancelling workflow) aborted
+///   the run via `Workflows::cancel_run` before it reached one of the
+///   above. Distinct so observability + skills can tell a deliberate
+///   abort apart from an infrastructure error.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, sqlx::Type)]
 #[serde(rename_all = "snake_case")]
 #[sqlx(type_name = "VARCHAR", rename_all = "snake_case")]
@@ -24,6 +28,22 @@ pub enum WorkflowRunState {
     Succeeded,
     Failed,
     Errored,
+    Cancelled,
+}
+
+impl WorkflowRunState {
+    /// True once the run has reached a state the executor will never
+    /// leave. `WaitingForEvent` is deliberately excluded — a parked
+    /// run resumes on a matching inbound event.
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            WorkflowRunState::Succeeded
+                | WorkflowRunState::Failed
+                | WorkflowRunState::Errored
+                | WorkflowRunState::Cancelled
+        )
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -141,6 +161,16 @@ pub enum WorkflowRunEvent {
     RunCompleted {
         state: WorkflowRunState,
         completed_at: DateTime<Utc>,
+    },
+    /// Operator- (or self-) initiated abort. Terminal, and takes
+    /// precedence over whatever step state the run was in. `cancelled_by`
+    /// is the auth-subject label of the caller; `reason` is an optional
+    /// free-text audit note.
+    RunCancelled {
+        cancelled_by: String,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        reason: Option<String>,
+        cancelled_at: DateTime<Utc>,
     },
 }
 
@@ -366,6 +396,7 @@ impl WorkflowRun {
         idempotency_guard!(
             self.events.iter_all().rev(),
             already_applied: WorkflowRunEvent::RunCompleted { .. },
+            already_applied: WorkflowRunEvent::RunCancelled { .. },
         );
         if self.state == WorkflowRunState::WaitingForEvent {
             return Idempotent::AlreadyApplied;
@@ -383,6 +414,31 @@ impl WorkflowRun {
         self.events.push(WorkflowRunEvent::RunCompleted {
             state,
             completed_at: now,
+        });
+        Idempotent::Executed(())
+    }
+
+    /// Aborts the run: records a terminal `Cancelled` state regardless
+    /// of which step was in flight. No-op if the run already reached any
+    /// terminal state (idempotent against retries and races with
+    /// `run_completed` — whichever terminal event lands first wins).
+    ///
+    /// The executor observes the persisted terminal state on its next
+    /// job attempt and exits without further work; the queue slot frees
+    /// once that attempt completes.
+    pub fn cancel(&mut self, cancelled_by: String, reason: Option<String>) -> Idempotent<()> {
+        idempotency_guard!(
+            self.events.iter_all().rev(),
+            already_applied: WorkflowRunEvent::RunCompleted { .. },
+            already_applied: WorkflowRunEvent::RunCancelled { .. },
+        );
+        let now = Utc::now();
+        self.state = WorkflowRunState::Cancelled;
+        self.completed_at = Some(now);
+        self.events.push(WorkflowRunEvent::RunCancelled {
+            cancelled_by,
+            reason,
+            cancelled_at: now,
         });
         Idempotent::Executed(())
     }
@@ -636,6 +692,10 @@ impl TryFromEvents<WorkflowRunEvent> for WorkflowRun {
                 } => {
                     state = *s;
                     completed_at = Some(*ts);
+                }
+                WorkflowRunEvent::RunCancelled { cancelled_at, .. } => {
+                    state = WorkflowRunState::Cancelled;
+                    completed_at = Some(*cancelled_at);
                 }
             }
         }
@@ -1252,5 +1312,94 @@ mod tests {
             waiting_provider: Some("github_app".into()),
         };
         assert_eq!(sr.step_state(), WorkflowStepState::WaitingForEvent);
+    }
+
+    // ── Cancel tests ──
+
+    #[test]
+    fn cancel_transitions_running_to_cancelled() {
+        let mut run = fresh_run(&["a"]);
+        start(&mut run, "a");
+        assert_eq!(run.state, WorkflowRunState::Running);
+
+        assert!(run
+            .cancel("user:abc".into(), Some("stuck".into()))
+            .did_execute());
+        assert_eq!(run.state, WorkflowRunState::Cancelled);
+        assert!(run.completed_at.is_some());
+        assert!(run.state.is_terminal());
+    }
+
+    #[test]
+    fn cancel_from_waiting_for_event() {
+        let mut run = fresh_run(&["wait_step"]);
+        run.step_waiting("wait_step".into(), "github_app".into())
+            .did_execute();
+        assert_eq!(run.state, WorkflowRunState::WaitingForEvent);
+
+        assert!(run.cancel("user:abc".into(), None).did_execute());
+        assert_eq!(run.state, WorkflowRunState::Cancelled);
+    }
+
+    #[test]
+    fn cancel_is_idempotent_against_retry() {
+        let mut run = fresh_run(&["a"]);
+        run.cancel("user:abc".into(), None).did_execute();
+        let outcome = run.cancel("user:xyz".into(), Some("again".into()));
+        assert!(matches!(outcome, Idempotent::AlreadyApplied));
+        assert_eq!(run.state, WorkflowRunState::Cancelled);
+    }
+
+    #[test]
+    fn cancel_is_noop_on_already_completed_run() {
+        let mut run = fresh_run(&["a"]);
+        start(&mut run, "a");
+        complete(&mut run, "a", json!({ "success": true }));
+        finalize(&mut run);
+        assert_eq!(run.state, WorkflowRunState::Succeeded);
+
+        let outcome = run.cancel("user:abc".into(), None);
+        assert!(matches!(outcome, Idempotent::AlreadyApplied));
+        // The earlier terminal state wins — cancel does not overwrite it.
+        assert_eq!(run.state, WorkflowRunState::Succeeded);
+    }
+
+    #[test]
+    fn run_completed_is_noop_after_cancel() {
+        let mut run = fresh_run(&["a"]);
+        run.cancel("user:abc".into(), None).did_execute();
+        let outcome = run.run_completed();
+        assert!(matches!(outcome, Idempotent::AlreadyApplied));
+        assert_eq!(run.state, WorkflowRunState::Cancelled);
+    }
+
+    #[test]
+    fn cancel_hydrates_from_events() {
+        let mut run = fresh_run(&["a"]);
+        start(&mut run, "a");
+        run.cancel("user:abc".into(), Some("git-proxy down".into()))
+            .did_execute();
+        let events = run.events;
+        let rehydrated = WorkflowRun::try_from_events(events).unwrap();
+        assert_eq!(rehydrated.state, WorkflowRunState::Cancelled);
+        assert!(rehydrated.completed_at.is_some());
+    }
+
+    #[test]
+    fn cancel_event_wire_format() {
+        let ev = WorkflowRunEvent::RunCancelled {
+            cancelled_by: "user:abc".into(),
+            reason: Some("stuck".into()),
+            cancelled_at: Utc::now(),
+        };
+        let v = serde_json::to_value(&ev).unwrap();
+        assert_eq!(
+            v.get("type").and_then(|t| t.as_str()),
+            Some("run_cancelled")
+        );
+        assert_eq!(
+            v.get("cancelled_by").and_then(|c| c.as_str()),
+            Some("user:abc")
+        );
     }
 }

--- a/core/tests/agent.rs
+++ b/core/tests/agent.rs
@@ -1163,3 +1163,38 @@ async fn update_session_chain_rejects_workflow_agents() {
         Err(drua_core::agent::AgentError::WorkflowAgentChainImmutable)
     ));
 }
+
+#[tokio::test]
+async fn delete_rejects_workflow_agents() {
+    let pool = pool().await;
+    let (agents, _sandboxes, _sandbox_id, project_id) =
+        fixture_for_detach_test(&pool, "sb-delete-wf").await;
+    let (workflow_id, run_id) = seed_workflow_run(&pool, project_id).await;
+
+    let mut op = agents.begin_op().await.expect("begin op");
+    let agent = agents
+        .create_for_workflow_run_in_op(
+            &mut op,
+            project_id,
+            workflow_id,
+            run_id,
+            "wf-step",
+            None,
+            None,
+            drua_core::workflow::default_output_schema(),
+        )
+        .await
+        .expect("create workflow agent");
+    op.commit().await.expect("commit");
+
+    let sub = AuthSubject::User(UserId::new());
+    let result = agents.delete(&sub, agent.id).await;
+    assert!(matches!(
+        result,
+        Err(drua_core::agent::AgentError::WorkflowAgentDeleteForbidden { .. })
+    ));
+
+    // The agent must survive the rejected delete.
+    let still_there = agents.find_by_id(&sub, agent.id).await;
+    assert!(still_there.is_ok(), "workflow agent should not be deleted");
+}

--- a/server/src/graphql/schema.graphql
+++ b/server/src/graphql/schema.graphql
@@ -820,6 +820,7 @@ type WorkflowRun {
 scalar WorkflowRunId
 
 enum WorkflowRunState {
+	CANCELLED
 	ERRORED
 	FAILED
 	PENDING

--- a/server/src/graphql/workflow.rs
+++ b/server/src/graphql/workflow.rs
@@ -375,6 +375,7 @@ pub enum WorkflowRunState {
     Succeeded,
     Failed,
     Errored,
+    Cancelled,
 }
 
 impl From<DomainWorkflowRunState> for WorkflowRunState {
@@ -386,6 +387,7 @@ impl From<DomainWorkflowRunState> for WorkflowRunState {
             DomainWorkflowRunState::Succeeded => Self::Succeeded,
             DomainWorkflowRunState::Failed => Self::Failed,
             DomainWorkflowRunState::Errored => Self::Errored,
+            DomainWorkflowRunState::Cancelled => Self::Cancelled,
         }
     }
 }

--- a/server/src/routes.rs
+++ b/server/src/routes.rs
@@ -1847,6 +1847,7 @@ fn workflow_run_state_str(state: domain::workflow::WorkflowRunState) -> &'static
         domain::workflow::WorkflowRunState::Succeeded => "succeeded",
         domain::workflow::WorkflowRunState::Failed => "failed",
         domain::workflow::WorkflowRunState::Errored => "errored",
+        domain::workflow::WorkflowRunState::Cancelled => "cancelled",
     }
 }
 


### PR DESCRIPTION
## What

Implements the drua-dev note `research/workflow-cancel-run-admin-command-2026-07-13.md`: a first-class way to cancel an in-flight workflow run.

Until now there was no admin path to terminate a stuck run. The stopgap — `agent delete` on the running step's agent — stopped the model burn but left `workflow_runs` + `job_executions` zombied at `running` with the queue slot locked, blocking new runs on the same queue.

## Changes

- **New terminal state `WorkflowRunState::Cancelled`** + **`RunCancelled { cancelled_by, reason, cancelled_at }`** event. No migration — the `state` column is a `VARCHAR` (resolves the note's open Q1 in favour of a distinct state).
- **`WorkflowRun::cancel(...)`** entity command — idempotent; a race with `run_completed` resolves to whichever terminal event lands first.
- **`Workflows::cancel_run(sub, run_id, reason)`** service method:
  - idempotent (already-terminal run → returns current state unchanged),
  - writes terminal state + `run_cancelled` event with `cancelled_by` (auth-subject label) + `reason`,
  - soft-deletes the run's agent(s) in the same op so the model burn stops,
  - records an audit row.
- **Executor cooperation**: recognises `Cancelled` (via `is_terminal()`) as a terminal load state and exits. A run cancelled mid-flight converges via es-entity optimistic concurrency (the `(id, sequence)` unique constraint on `workflow_run_events`) — the executor's next persist conflicts, the job retries, reloads the terminal state, and completes, freeing the queue slot. Deleting the run's agents also unblocks an executor parked on a hung agent turn (the next `send_message` finds no agent and errors the step).
- **`agent delete` now rejects workflow agents** (`workflow_run_id IS NOT NULL`) with `WorkflowAgentDeleteForbidden`, pointing operators to `workflow cancel`. `delete_in_op` (the cascade path) is unaffected, so cancellation and project/definition cascades still work.
- **Tool surfaces**: `cancel` added to both the admin `drua_admin_workflow` tool and the skill-author-facing top-level `workflow` tool (enables self-cancelling workflows). Auth mirrors the existing `update`/`delete` exposure (`AuthVerb::Update` on the workflow).
- **GraphQL**: `Cancelled` added to the `WorkflowRunState` enum; `schema.graphql` regenerated via `make sdl-rust`.

## Tests

- Entity: transitions from Running/WaitingForEvent, idempotency, no-op on already-completed, `run_completed` no-op after cancel, hydration, wire format.
- Agent: `delete` rejects a workflow agent and leaves it intact.
- Admin tool: `cancel` param parsing (with/without `reason`).
- `nix flake check` passes (fmt, clippy `-D warnings`, nextest, SDL + config checks).

## Deferred (called out in the note)

- **`delete_sandbox` opt-in teardown** — omitted. Workflow-scoped sandboxes are shared per `workflow_id` across runs, so deleting a pod/PVC on a single run's cancel risks other runs; the agent-delete cascade already detaches sandboxes. Left as a follow-up.
- **Signalling in-flight sandbox `bash` processes** (note open Q2) — deferred; not required for the terminal-state + queue-free contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches workflow run lifecycle, job queue convergence, and agent deletion in one atomic path; behavior is well-guarded and tested but incorrect cancel semantics could still strand or over-delete runs.
> 
> **Overview**
> Adds a **first-class workflow run cancel** path so operators can stop stuck runs without leaving `workflow_runs` / job queues in a zombie `running` state.
> 
> **Domain:** New terminal **`WorkflowRunState::Cancelled`**, **`RunCancelled`** event, **`WorkflowRun::cancel`**, and **`Workflows::cancel_run`** (auth, audit, idempotent on already-terminal runs). Cancel commits **`cancelled`** state and **soft-deletes all agents for that run** in one transaction via **`cascade_delete_for_workflow_run_id_in_op`**. The executor treats any terminal state (including cancelled) via **`is_terminal()`** and exits on the next job attempt.
> 
> **Guardrail:** **`agent delete`** now rejects workflow agents with **`WorkflowAgentDeleteForbidden`**, directing callers to **`workflow cancel`**; cascade **`delete_in_op`** is unchanged.
> 
> **Surfaces:** **`cancel`** on admin and top-level **`workflow`** tools (`run_id`, optional `reason`); GraphQL **`CANCELLED`** on **`WorkflowRunState`**; run text formatters include **`cancelled`**.
> 
> **Tests:** Entity cancel/idempotency/hydration, agent delete rejection, admin cancel param parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5292515d3f758c725d7275ebf44f14846b152fa1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->