### PR TITLE
feat(sandbox): add PVC janitor to reclaim orphaned volumes

### DIFF
--- a/charts/drua/templates/configmap.yaml
+++ b/charts/drua/templates/configmap.yaml
@@ -335,4 +335,7 @@ data:
           size: {{ .nixStore.size | quote }}
         {{- end }}
         {{- end }}
+        {{- with .Values.sandbox.pvcJanitorIntervalSeconds }}
+        pvc_janitor_interval_secs: {{ . }}
+        {{- end }}
     {{- end }}

--- a/charts/drua/values.yaml
+++ b/charts/drua/values.yaml
@@ -353,6 +353,10 @@ sandbox:
   ## Whether the Helm chart should create the sandbox namespace.
   ## Set to false when the namespace is managed externally (e.g. Terraform).
   createNamespace: true
+  ## PVC-janitor sweep interval (seconds). Reclaims `managed-by=drua`
+  ## PVCs whose sandbox row is gone — the gap left when cascade teardown
+  ## swallows a transient k8s error. Empty uses the in-binary default (900s).
+  pvcJanitorIntervalSeconds: ""
   ## Install the Agent Sandbox CRDs + controller from vendored upstream manifests.
   ## Set to false if the controller is already installed (e.g. via Terraform).
   installController: true

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -42,7 +42,7 @@ use primitives::ContextGeneration;
 use project::Projects;
 use project_secret::ProjectSecrets;
 use prompt_executor::PromptExecutor;
-use sandbox::Sandboxes;
+use sandbox::{Sandboxes, SandboxBackendConfig};
 use skill::Skills;
 use toolset::{
     AdminToolSet, Bash, CodeAssistantToolSet, Delete, GlobTool, Grep, LibraryToolSet, Ls, MoveFile,
@@ -201,7 +201,17 @@ impl App {
             "git-proxy allow-list loaded"
         );
 
+        let pvc_janitor_interval = match &config.sandbox.backend {
+            SandboxBackendConfig::K8s {
+                pvc_janitor_interval_secs,
+                ..
+            } => Some(std::time::Duration::from_secs(*pvc_janitor_interval_secs)),
+            _ => None,
+        };
         let sandboxes = Arc::new(Sandboxes::init(pool, config.sandbox, allowlist.clone()).await?);
+        if let Some(interval) = pvc_janitor_interval {
+            sandboxes.spawn_pvc_janitor(interval);
+        }
 
         let mirror_root = config
             .git_proxy

--- a/core/src/sandbox/config.rs
+++ b/core/src/sandbox/config.rs
@@ -27,6 +27,11 @@ pub enum SandboxBackendConfig {
         /// binary in the sandbox image.
         #[serde(default)]
         nix_store: Option<NixStorePersistenceConfig>,
+        /// PVC-janitor sweep interval. Only meaningful on k8s; the janitor
+        /// reclaims `managed-by=drua` PVCs whose sandbox row is gone — the
+        /// gap left by best-effort cascade teardown swallowing k8s errors.
+        #[serde(default = "default_pvc_janitor_interval_secs")]
+        pvc_janitor_interval_secs: u64,
     },
 }
 
@@ -55,4 +60,8 @@ pub struct SandboxConfig {
 
 fn default_local_repo_root() -> PathBuf {
     PathBuf::from(".")
+}
+
+fn default_pvc_janitor_interval_secs() -> u64 {
+    900
 }

--- a/core/src/sandbox/mod.rs
+++ b/core/src/sandbox/mod.rs
@@ -3,6 +3,7 @@ mod entity;
 pub mod error;
 pub(crate) mod repo;
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -59,6 +60,7 @@ impl Sandboxes {
                 storage_class,
                 mount_path,
                 nix_store,
+                ..
             } => {
                 let mut client = K8sAdminClient::try_from_env(namespace, template_name).await?;
                 // PVC-backed mount; without it pods use ephemeral storage.
@@ -1049,5 +1051,56 @@ impl Sandboxes {
             self.repo.update_in_op(op, &mut sandbox).await?;
         }
         Ok(sandbox)
+    }
+
+    /// One PVC-janitor sweep: reclaim every `managed-by=drua` PVC whose
+    /// owning sandbox row is gone. Safe under HA — concurrent sweeps and
+    /// in-flight cascades race on idempotent `delete_pvcs` (404s ignored).
+    /// Returns the count of orphan owners swept.
+    #[instrument(name = "domain.sandbox.reap_orphaned_pvcs", skip(self))]
+    pub async fn reap_orphaned_pvcs(&self) -> Result<usize, SandboxError> {
+        let owners = self.admin.list_pvc_owners().await?;
+        if owners.is_empty() {
+            return Ok(0);
+        }
+        let live: HashSet<String> = self.repo.live_resource_names().await?.into_iter().collect();
+        let mut reaped = 0;
+        for owner in owners {
+            if live.contains(&owner) {
+                continue;
+            }
+            tracing::warn!(sandbox = %owner, "reaping orphaned PVC(s)");
+            if let Err(e) = self.admin.delete_pvcs(&owner).await {
+                tracing::warn!(
+                    sandbox = %owner,
+                    error = %e,
+                    "reap delete_pvcs failed; will retry next sweep"
+                );
+                continue;
+            }
+            reaped += 1;
+        }
+        Ok(reaped)
+    }
+
+    /// Runs `reap_orphaned_pvcs` on a fixed interval for the lifetime of
+    /// `App`. Skipped ticks don't pile up; each sweep is best-effort and
+    /// logs failures without aborting the loop.
+    pub fn spawn_pvc_janitor(self: &Arc<Self>, interval: Duration) {
+        let sandboxes = Arc::clone(self);
+        tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+            loop {
+                ticker.tick().await;
+                match sandboxes.reap_orphaned_pvcs().await {
+                    Ok(reaped) if reaped > 0 => {
+                        tracing::info!(reaped, "pvc janitor: reclaimed orphaned PVCs");
+                    }
+                    Ok(_) => {}
+                    Err(e) => tracing::warn!(error = %e, "pvc janitor: sweep failed"),
+                }
+            }
+        });
     }
 }

--- a/core/src/sandbox/repo.rs
+++ b/core/src/sandbox/repo.rs
@@ -54,4 +54,14 @@ impl SandboxRepo {
             .await?;
         Ok(())
     }
+
+    /// Resource names (`sb-<id>`) of every non-deleted sandbox. The PVC
+    /// janitor diffs the k8s PVC `sandbox-name` labels against this set;
+    /// any PVC owner absent here is a leaked volume. Expression must
+    /// match `Sandbox::resource_name`.
+    pub async fn live_resource_names(&self) -> Result<Vec<String>, sqlx::Error> {
+        sqlx::query_scalar("SELECT 'sb-' || id::text FROM sandboxes WHERE NOT deleted")
+            .fetch_all(&self.pool)
+            .await
+    }
 }

--- a/lib/sandbox/src/admin_client/k8s/mod.rs
+++ b/lib/sandbox/src/admin_client/k8s/mod.rs
@@ -457,6 +457,27 @@ impl K8sAdminClient {
         Ok(())
     }
 
+    /// Distinct `sandbox-name` values across PVCs labeled `managed-by=drua`.
+    /// Drives the PVC janitor's orphan detection — every owner returned
+    /// here that has no live sandbox row is a leaked PVC.
+    #[instrument(name = "sandbox.admin.k8s.list_pvc_owners", skip_all)]
+    pub async fn list_pvc_owners(&self) -> Result<Vec<String>, AdminError> {
+        let pvcs: Api<PersistentVolumeClaim> =
+            Api::namespaced(self.client.clone(), &self.namespace);
+        let lp = ListParams::default().labels(&format!("{MANAGED_BY_LABEL}={MANAGED_BY_VALUE}"));
+        let list = pvcs.list(&lp).await?;
+        let mut owners: Vec<String> = list
+            .items
+            .iter()
+            .filter_map(|p| p.metadata.labels.as_ref())
+            .filter_map(|labels| labels.get("sandbox-name").cloned())
+            .filter(|s| !s.is_empty())
+            .collect();
+        owners.sort();
+        owners.dedup();
+        Ok(owners)
+    }
+
     /// Filtered by the managed-by label.
     #[instrument(name = "sandbox.admin.k8s.list_sandboxes", skip_all)]
     pub async fn list_sandboxes(&self) -> Result<Vec<SandboxView>, AdminError> {
@@ -708,6 +729,10 @@ impl AdminClient for K8sAdminClient {
 
     async fn delete_pvcs(&self, name: &str) -> Result<(), AdminError> {
         K8sAdminClient::delete_pvcs(self, name).await
+    }
+
+    async fn list_pvc_owners(&self) -> Result<Vec<String>, AdminError> {
+        K8sAdminClient::list_pvc_owners(self).await
     }
 
     async fn get_sandbox(&self, name: &str) -> Result<SandboxView, AdminError> {

--- a/lib/sandbox/src/admin_client/local/mod.rs
+++ b/lib/sandbox/src/admin_client/local/mod.rs
@@ -245,6 +245,10 @@ impl AdminClient for LocalAdminClient {
         LocalAdminClient::delete_pvcs(self, name).await
     }
 
+    async fn list_pvc_owners(&self) -> Result<Vec<String>, AdminError> {
+        Ok(Vec::new())
+    }
+
     async fn get_sandbox(&self, name: &str) -> Result<SandboxView, AdminError> {
         LocalAdminClient::get_sandbox(self, name).await
     }

--- a/lib/sandbox/src/admin_client/trait.rs
+++ b/lib/sandbox/src/admin_client/trait.rs
@@ -23,6 +23,12 @@ pub trait AdminClient: Send + Sync {
     /// owning project goes away. Idempotent: missing storage is a no-op.
     async fn delete_pvcs(&self, name: &str) -> Result<(), AdminError>;
 
+    /// Distinct `sandbox-name` label values across every PVC this
+    /// backend owns (k8s: `managed-by=drua`). Feeds the PVC janitor,
+    /// which deletes any owner with no live DB row. Local backend has
+    /// no persistent volumes → empty.
+    async fn list_pvc_owners(&self) -> Result<Vec<String>, AdminError>;
+
     async fn get_sandbox(&self, name: &str) -> Result<Sandbox, AdminError>;
 
     async fn list_sandboxes(&self) -> Result<Vec<Sandbox>, AdminError>;


### PR DESCRIPTION
## Problem

The cluster is accumulating orphaned `managed-by=drua` PVCs (the ~60 we saw in the GCP console). Root cause is architectural, not a one-off bug:

Sandbox PVC teardown is **best-effort**. The project/workflow delete cascades (`cascade_delete_for_project_in_op`, `cascade_delete_for_workflow_id_in_op`) swallow `delete_pvcs` failures and soft-delete the DB row anyway:

```rust
if let Err(e) = self.admin.delete_pvcs(&resource_name).await {
    tracing::warn!(... "admin delete_pvcs failed during project cascade");
}
self.repo.cascade_delete_for_project_in_op(op, project_id).await?; // row gone
```

So **any transient k8s API error** during a delete orphans both PVCs permanently — the row is gone, no future cascade can retry, and there was no background sweeper. The only deletion paths are those two cascades plus `suspend` (which intentionally retains PVCs). The per-sandbox `delete` op that briefly existed was removed in `2b585b9d`.

Each sandbox owns **2 PVCs** (`workspace-<id>` via `ensure_pvc`, plus `nix-store` via the Sandbox CR `volumeClaimTemplate`), so leaks come in pairs.

## Fix

Add a k8s-only background janitor that periodically reclaims orphaned PVCs by diffing the PVC set against live (non-deleted) sandbox rows — the right direction, since orphaned rows are already soft-deleted and unrecoverable from the DB side.

- `AdminClient::list_pvc_owners` — distinct `sandbox-name` labels across `managed-by=drua` PVCs (k8s); local backend returns empty.
- `SandboxRepo::live_resource_names` — one query (`SELECT 'sb-' || id::text FROM sandboxes WHERE NOT deleted`) to diff against. Matches `Sandbox::resource_name`.
- `Sandboxes::reap_orphaned_pvcs` + `spawn_pvc_janitor(self: &Arc<Self>, interval)`, spawned from `App::init` when the backend is k8s.
- New chart value `sandbox.pvcJanitorIntervalSeconds` (default 900s via serde) + configmap render.

Safe under HA: concurrent sweeps and in-flight cascades race on idempotent `delete_pvcs` (404s ignored); resource names are unique UUID-derived and never reused, so there's no create/reap race.

## Out of scope (follow-ups worth considering)

- The cascades still swallow `delete_pvcs` errors — the janitor now recovers them, but surfacing those failures (rather than warn-and-continue) would catch them sooner.
- Verify the sandbox controller propagates `sandbox-name` from `volumeClaimTemplate.metadata` onto the actual `nix-store` PVC; today the `nix-store` PVC is reclaimed via the CR's `shutdownPolicy: Delete`, not the label. If the controller ever doesn't set the label, `delete_pvcs` can't reclaim it standalone.

## Validation

- `cargo build` + `cargo clippy` clean for `sandbox` and `drua-core`; `drua-server` builds.
- Local admin-client tests pass.
- `helm template` renders `pvc_janitor_interval_secs` when set, omits it (→ 900s default) when unset.

Draft for now — opening for review on the approach. No integration test against a live cluster yet; would appreciate thoughts on whether to add a fake-k8s sweep test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Background deletion of cluster PVCs based on DB state could remove storage if labels or `live_resource_names` drift from reality; mitigated by matching existing `sandbox-name` / `sb-<id>` naming and idempotent deletes, but still operational risk on k8s storage.
> 
> **Overview**
> Adds a **background PVC janitor** for the Kubernetes sandbox backend so `managed-by=drua` volumes are not left behind when project/workflow cascade teardown soft-deletes the sandbox row after a failed `delete_pvcs`.
> 
> On each sweep, the app lists distinct `sandbox-name` owners from labeled PVCs (`AdminClient::list_pvc_owners`), compares them to live resource names from the DB (`SandboxRepo::live_resource_names`), and calls idempotent `delete_pvcs` for owners with no non-deleted row. **`spawn_pvc_janitor`** runs this on a configurable interval from **`App::init`** when the backend is k8s; the local admin client returns an empty owner list.
> 
> **Config:** `pvc_janitor_interval_secs` on the k8s sandbox backend (serde default **900**), plus chart value **`sandbox.pvcJanitorIntervalSeconds`** rendered into the configmap when set.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3f4812f73603389bbf901b1db469cecd6ddd298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->