### PR TITLE
fix(deploy): align PostgreSQL provider version

### DIFF
--- a/ci/deploy/drua/versions.tf
+++ b/ci/deploy/drua/versions.tf
@@ -33,7 +33,7 @@ terraform {
     }
     postgresql = {
       source  = "cyrilgdn/postgresql"
-      version = "1.24.0"
+      version = "1.27.0"
     }
     kubectl = {
       source = "alekc/kubectl"


### PR DESCRIPTION
## Summary

- align the deploy root PostgreSQL provider with the current `galoy-infra` module constraint
- fix `deploy-to-prod` build 824 failing during `tofu init` with incompatible exact constraints `1.24.0, 1.27.0`

## Validation

- `tofu init -backend=false -input=false` against the vendored current `galoy-infra` module tree
- `tofu validate` with the pipeline-generated file shape present

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single provider version pin in Terraform metadata; no application or runtime logic changes.
> 
> **Overview**
> Updates **`ci/deploy/drua/versions.tf`** so the `cyrilgdn/postgresql` provider is pinned to **`1.27.0`** instead of **`1.24.0`**.
> 
> This aligns the deploy stack with the **`galoy-infra`** module’s provider constraint and resolves **`tofu init`** failures from conflicting exact versions (`1.24.0` vs `1.27.0`) in **`deploy-to-prod`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00d4a70f9bc8ac646f33dff292c92579532742d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->