### PR TITLE
fix(library): wake peer replicas on push via PG NOTIFY

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1565,6 +1565,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
 ]
 

--- a/core/crates/library/Cargo.toml
+++ b/core/crates/library/Cargo.toml
@@ -24,3 +24,4 @@ chrono = { version = "0.4", features = ["clock", "serde"], default-features = fa
 [dev-dependencies]
 tokio = { workspace = true }
 serde_json = { workspace = true }
+tracing-subscriber = { workspace = true }

--- a/core/crates/library/src/git.rs
+++ b/core/crates/library/src/git.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use sqlx::PgPool;
+use sqlx::{PgConnection, PgPool};
 use tokio::sync::{mpsc, oneshot, Mutex, Notify};
 use tokio::task::JoinHandle;
 
@@ -21,6 +21,13 @@ const QUEUE_CAPACITY: usize = 256;
 /// Cluster-wide Postgres advisory-lock key for serializing pushes to the
 /// library repo's `main`. Fixed (one library repo per deployment); `0x647275616c6962` = "drualib".
 const LIBRARY_PUSH_LOCK_KEY: i64 = 0x647275616c6962;
+
+/// PG NOTIFY channel fired after a successful push. Every replica's
+/// fetcher LISTENs on it, so a write on one replica is visible
+/// cluster-wide in milliseconds instead of after each replica's fetch
+/// ticker (`fetch_interval_ms`). Payload is empty; the wake-up is
+/// purely a hint, the ticker remains the backstop.
+const LIBRARY_HEAD_NOTIFY_CHANNEL: &str = "library_head_changed";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DeltaKind {
@@ -125,9 +132,12 @@ pub struct GitEngine {
     /// in-flight commits before `push_main` lands.
     repo_mutex: Arc<Mutex<()>>,
     write_tx: mpsc::Sender<QueuedOp>,
-    local_commit_notify: Arc<Notify>,
+    /// Wakes the fetcher. Fired by the local writer after a successful
+    /// batch and by the head listener on any peer replica's push.
+    commit_notify: Arc<Notify>,
     github_app: Option<Arc<GitHubAppTokenProvider>>,
     _writer: OwnedTaskHandle,
+    _listener: OwnedTaskHandle,
 }
 
 impl GitEngine {
@@ -137,8 +147,8 @@ impl GitEngine {
         &self.repo_path
     }
 
-    pub fn local_commit_notify(&self) -> Arc<Notify> {
-        Arc::clone(&self.local_commit_notify)
+    pub fn commit_notify(&self) -> Arc<Notify> {
+        Arc::clone(&self.commit_notify)
     }
 
     #[tracing::instrument(name = "library.git.init", skip_all)]
@@ -163,24 +173,57 @@ impl GitEngine {
 
         let repo_mutex = Arc::new(Mutex::new(()));
         let (write_tx, write_rx) = mpsc::channel(QUEUE_CAPACITY);
-        let local_commit_notify = Arc::new(Notify::new());
+        let commit_notify = Arc::new(Notify::new());
         let writer = tokio::spawn(Self::run_writer(
             repo_path.clone(),
             github_app.clone(),
             Arc::clone(&repo_mutex),
-            Arc::clone(&local_commit_notify),
+            Arc::clone(&commit_notify),
             write_rx,
-            pool,
+            pool.clone(),
         ));
+        let listener = tokio::spawn(Self::run_head_listener(pool, Arc::clone(&commit_notify)));
 
         Ok(Self {
             repo_path,
             repo_mutex,
             write_tx,
-            local_commit_notify,
+            commit_notify,
             github_app,
             _writer: OwnedTaskHandle::new(writer),
+            _listener: OwnedTaskHandle::new(listener),
         })
+    }
+
+    /// Cluster-wide counterpart of the writer's local wake-up: any
+    /// replica's successful push `pg_notify`s [`LIBRARY_HEAD_NOTIFY_CHANNEL`],
+    /// waking this replica's fetcher immediately. While PG is
+    /// unreachable, sync degrades to ticker cadence.
+    async fn run_head_listener(pool: PgPool, commit_notify: Arc<Notify>) {
+        loop {
+            let mut listener = match sqlx::postgres::PgListener::connect_with(&pool).await {
+                Ok(l) => l,
+                Err(e) => {
+                    tracing::warn!(error = %e, "library head listener: connect failed; retrying");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+            };
+            if let Err(e) = listener.listen(LIBRARY_HEAD_NOTIFY_CHANNEL).await {
+                tracing::warn!(error = %e, "library head listener: LISTEN failed; retrying");
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            }
+            loop {
+                match listener.recv().await {
+                    Ok(_) => commit_notify.notify_one(),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "library head listener: recv failed; reconnecting");
+                        break;
+                    }
+                }
+            }
+        }
     }
 
     /// Diff between two commits (None `from` = walk all of `to`'s tree as Added)
@@ -692,7 +735,7 @@ impl GitEngine {
         repo_path: PathBuf,
         github_app: Option<Arc<GitHubAppTokenProvider>>,
         repo_mutex: Arc<Mutex<()>>,
-        local_commit_notify: Arc<Notify>,
+        commit_notify: Arc<Notify>,
         mut rx: mpsc::Receiver<QueuedOp>,
         pool: PgPool,
     ) {
@@ -715,7 +758,7 @@ impl GitEngine {
                 Self::process_batch(&repo_path, github_app.as_ref(), &repo_mutex, &pool, batch)
                     .await;
             if any_ok {
-                local_commit_notify.notify_waiters();
+                commit_notify.notify_one();
             }
         }
     }
@@ -774,6 +817,11 @@ impl GitEngine {
                 .collect()
         });
 
+        let any_ok = results.iter().any(|r| r.is_ok());
+        if any_ok {
+            Self::notify_cluster_push(pool, lock_conn.as_deref_mut()).await;
+        }
+
         if let Some(mut conn) = lock_conn.take() {
             if let Err(e) = sqlx::query("SELECT pg_advisory_unlock($1)")
                 .bind(LIBRARY_PUSH_LOCK_KEY)
@@ -783,12 +831,33 @@ impl GitEngine {
                 tracing::warn!(error = %e, "library push lock: release failed");
             }
         }
-
-        let any_ok = results.iter().any(|r| r.is_ok());
         for (resp, res) in responders.into_iter().zip(results) {
             let _ = resp.send(res);
         }
         any_ok
+    }
+
+    /// Wake peer replicas' fetchers after a successful push so
+    /// cross-replica reads converge in milliseconds instead of after
+    /// each replica's fetch ticker. Best effort: failure degrades to
+    /// ticker-cadence convergence. Prefers the advisory-lock connection
+    /// (already held) over a fresh pool checkout.
+    async fn notify_cluster_push(pool: &PgPool, lock_conn: Option<&mut PgConnection>) {
+        let res = match lock_conn {
+            Some(conn) => sqlx::query("SELECT pg_notify($1, '')")
+                .bind(LIBRARY_HEAD_NOTIFY_CHANNEL)
+                .execute(conn)
+                .await
+                .map(|_| ()),
+            None => sqlx::query("SELECT pg_notify($1, '')")
+                .bind(LIBRARY_HEAD_NOTIFY_CHANNEL)
+                .execute(pool)
+                .await
+                .map(|_| ()),
+        };
+        if let Err(e) = res {
+            tracing::warn!(error = %e, "library head notify failed; peers converge on ticker");
+        }
     }
 
     /// Apply N ops as N commits, then push once. On non-FF push, fetch

--- a/core/crates/library/src/lib.rs
+++ b/core/crates/library/src/lib.rs
@@ -99,7 +99,7 @@ impl Library {
             Arc::clone(&git),
             tick_tx,
             Duration::from_millis(config.fetch_interval_ms),
-            git.local_commit_notify(),
+            git.commit_notify(),
         );
 
         let spawner = jobs.add_initializer(LibrarySyncJobInitializer::new(
@@ -148,7 +148,7 @@ impl Library {
         git: Arc<GitEngine>,
         tick_tx: mpsc::Sender<CommitTick>,
         interval: Duration,
-        local_commit_notify: Arc<tokio::sync::Notify>,
+        commit_notify: Arc<tokio::sync::Notify>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             let mut ticker = tokio::time::interval(interval);
@@ -157,7 +157,7 @@ impl Library {
             loop {
                 tokio::select! {
                     _ = ticker.tick() => {}
-                    _ = local_commit_notify.notified() => {}
+                    _ = commit_notify.notified() => {}
                 }
                 match git.fetch_and_head().await {
                     Ok(Some(head)) => {

--- a/core/crates/library/tests/cross_replica_notify.rs
+++ b/core/crates/library/tests/cross_replica_notify.rs
@@ -1,0 +1,98 @@
+mod common;
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use common::{library_data_dir, reset_library_db_state, TestRepo};
+use drua_library::{CommitAttribution, Library, LibraryConfig};
+
+const PG_CON: &str = "postgres://user:password@localhost:5432/drua";
+
+/// Ticker effectively disabled: convergence can only come from the
+/// cross-replica `library_head_changed` PG NOTIFY wake-up.
+const FETCH_INTERVAL_MS: u64 = 3_600_000;
+
+async fn pool() -> sqlx::PgPool {
+    let url = std::env::var("DATABASE_URL").unwrap_or_else(|_| PG_CON.to_string());
+    sqlx::PgPool::connect(&url).await.expect("connect to pg")
+}
+
+async fn init_replica(
+    test_name: &str,
+    replica: &str,
+    repo_url: &str,
+    pool: &sqlx::PgPool,
+    start_poll: bool,
+) -> (Library, job::Jobs) {
+    let data_dir = library_data_dir(test_name).join(replica);
+    let embedder = Arc::new(code_assistant_core::embedder::Embedder::new().expect("embedder"));
+    let job_config = job::JobSvcConfig::builder()
+        .pool(pool.clone())
+        .build()
+        .expect("job config");
+    let mut jobs = job::Jobs::init(job_config).await.expect("jobs init");
+    let config = LibraryConfig {
+        data_dir: data_dir.to_string_lossy().to_string(),
+        repo_url: repo_url.to_string(),
+        fetch_interval_ms: FETCH_INTERVAL_MS,
+    };
+    let library = Library::init(pool, &config, embedder, &mut jobs, None)
+        .await
+        .expect("library init");
+    if start_poll {
+        jobs.start_poll().await.expect("start poll");
+    }
+    // `jobs` must outlive the test: dropping it drops the sync-job
+    // initializer holding the fetcher's tick receiver, and the fetcher
+    // exits on the first failed send.
+    (library, jobs)
+}
+
+#[tokio::test]
+#[ignore = "requires postgres + writes to tests/.library; run with --ignored"]
+async fn write_on_one_replica_is_visible_on_peer_without_ticker() {
+    let test_name = "write_on_one_replica_is_visible_on_peer_without_ticker";
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter("drua_library=debug,info")
+        .try_init();
+    let fixture = TestRepo::init(&[("README.md", "init\n")]);
+    let pool = pool().await;
+    reset_library_db_state(&pool).await;
+
+    // Only replica A polls jobs, so A is guaranteed to execute the
+    // library.write job; B has no poller and a disabled ticker, so it
+    // can only converge via the `library_head_changed` PG NOTIFY.
+    let repo_url = fixture.path().to_string_lossy().to_string();
+    let (replica_a, _jobs_a) = init_replica(test_name, "a", &repo_url, &pool, true).await;
+    let (replica_b, _jobs_b) = init_replica(test_name, "b", &repo_url, &pool, false).await;
+
+    let slug = "notify";
+    replica_a
+        .spaces()
+        .create(slug.into(), None, CommitAttribution::library_default())
+        .await
+        .expect("create space");
+    replica_a
+        .spaces()
+        .write_file(
+            slug,
+            "doc.md",
+            "alpha bravo\n".into(),
+            CommitAttribution::library_default(),
+        )
+        .await
+        .expect("write");
+
+    let path = format!("spaces/{slug}/doc.md");
+    let deadline = Instant::now() + Duration::from_secs(10);
+    loop {
+        if let Ok(Some(content)) = replica_b.read_blob_at_head(&path).await {
+            assert_eq!(content, b"alpha bravo\n");
+            return;
+        }
+        if Instant::now() >= deadline {
+            panic!("peer replica did not converge within timeout");
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+}


### PR DESCRIPTION
## Problem

Each drua server replica keeps its own local bare clone of the knowledge-base repo and serves **all** space reads (`ls` / `read` / `grep` / `glob`) from its local HEAD. Writes commit + push locally (serialized cluster-wide via the PG advisory lock), but peer replicas only learn about them on their fetch ticker (`fetch_interval_ms`, default **20s**) — the `local_commit_notify` wake-up only fires for commits made by *that* replica.

With N>1 replicas behind the MCP gateway, a write lands on replica A while a subsequent `ls` routed to replica B serves B's pre-fetch HEAD: a read-your-writes violation lasting up to the fetch interval (longer under missed ticks). Reproduced live: `write` → acknowledged, `ls` seconds later → file missing, `read` ~1 min later → content intact.

## Fix

Write-fanout notify over Postgres `LISTEN/NOTIFY` (replicas already share the PG used for the push advisory lock):

- After a successful batch push, the writer fires `pg_notify('library_head_changed', '')`, reusing the advisory-lock connection (falls back to a pool checkout).
- Every replica runs a `PgListener` task (auto-reconnecting) that wakes its fetcher on any peer's push, so cross-replica reads converge in **milliseconds**. The fetcher wake also drives the `CommitTick`, so the search index converges faster too.
- The wake-up `Notify` switches from `notify_waiters()` to `notify_one()`, closing the lost-wake race when a notification lands mid-fetch.

Both paths are best effort: a PG hiccup degrades to the previous ticker-cadence convergence. Cost: one extra pooled PG connection per replica (same as the existing `context_changed` listener).

## Test

New `cross_replica_notify` integration test: two `Library` replicas against one upstream + one PG. Replica A polls jobs (executes the `library.write` job); replica B has no poller and a 1-hour fetch ticker, so it can only converge via the NOTIFY. Verified the test **fails** with the notify call disabled and passes (converging in <1s) with it.

Full `drua-library` suite passes serially; `space_writes` remains flaky under parallel threads, but that's pre-existing on `main` (shared test DB), unrelated to this change.

## Not addressed (from the handoff, deliberate)

- Fetch-on-miss retry in `read_blob_at_head`/`list_dir_at_head` — subsumed by the notify for the common case.
- Head-based consistency tokens — strongest semantics, much more plumbing; can layer on later if needed.

Ref: `/tmp/drua-space-ls-staleness-handoff.md` (filed 2026-07-27 by the lana-stress-test agent session).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cluster-wide library HEAD convergence and adds a per-replica PG LISTEN connection; failures degrade to the old ticker behavior but multi-replica read consistency is on the critical path for MCP space tools.
> 
> **Overview**
> Fixes **read-your-writes** across MCP gateway replicas: each pod kept its own library clone and only learned about peer pushes on the periodic fetch ticker (often tens of seconds), so a write on replica A could be missing on replica B’s `ls`/`read` until the next tick.
> 
> After a successful push batch, the git writer now fires **`pg_notify('library_head_changed')`** (preferring the advisory-lock connection). Every replica runs a reconnecting **`PgListener`** that LISTENs on that channel and wakes the shared fetcher **`Notify`** (`commit_notify`, renamed from `local_commit_notify`). Local successful batches still wake the fetcher; notifications use **`notify_one()`** instead of **`notify_waiters()`** to avoid a lost-wake race mid-fetch. If Postgres notify fails, behavior falls back to ticker-only convergence.
> 
> Adds an ignored integration test (`cross_replica_notify`) where replica B has no job poller and a disabled fetch ticker and must see writes from replica A via NOTIFY alone.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 01eb28068d96363c4734324c8d0559f84eba960a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->