### PR TITLE
docs: add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,6 @@
+# Security Policy
+
+Only the latest release and `main` receive security fixes.
+
+Please report security vulnerabilities by email to **security@galoy.io** —
+do not report them through public GitHub issues, discussions, or pull requests.


### PR DESCRIPTION
Adds a minimal `SECURITY.md` so GitHub surfaces a security policy for this
repo, pointing reporters at **security@galoy.io**.

Part of an effort to add a consistent security policy across Galoy's open
source repositories (obix, job, es-entity, cala, bria, drua).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime or security logic modifications.
> 
> **Overview**
> Adds a **Security Policy** file so GitHub can display reporting guidance for this repository.
> 
> The policy states that only the latest release and `main` get security fixes, and directs vulnerability reports to **security@galoy.io** instead of public GitHub issues, discussions, or pull requests. This aligns Galoy open-source repos with a shared security disclosure process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f57fa5deb3057ddab4490e1e1709b4ea020da770. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->