### PR TITLE
refactor: drop parent-job usage in workflow resume

### DIFF
--- a/core/src/workflow/mod.rs
+++ b/core/src/workflow/mod.rs
@@ -1090,11 +1090,8 @@ impl Workflows {
         let queue_id = format!("workflow:{}", run.definition_id);
         // Re-spawn under a fresh JobId: the run's original ExecuteRun job (id =
         // run.id) still occupies the `jobs` row, so reusing it would hit the
-        // primary-key constraint and roll the whole resume back. Parenting on
-        // run.id keeps the lineage queryable via list_by_parent_job_id.
+        // primary-key constraint and roll the whole resume back.
         self.execute_run_spawner
-            .clone()
-            .with_parent(run.id.into())
             .spawn_with_queue_id_in_op(
                 &mut op,
                 ::job::JobId::new(),


### PR DESCRIPTION
## What

Removes the single use of the job crate's parent-job API: the `.with_parent(run.id.into())` call when re-spawning a workflow run's ExecuteRun job on resume.

## Why

job 0.8.0 removes the parent-job concept entirely (`with_parent`, `parent_job_id`, `list_by_parent_job_id`) with no backwards compat. Nothing in drua ever queried that lineage, so the call was write-only metadata. Dropping it now lets the upcoming job 0.8.0 bump land cleanly. The run id remains available in the job's `ExecuteRunConfig`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)