### PR TITLE
fix(graphql): gate appConfig behind authorization

### DIFF
--- a/core/src/auth/resource.rs
+++ b/core/src/auth/resource.rs
@@ -19,6 +19,10 @@ pub enum AuthResource {
     ProjectSecret(ProjectId, Option<ProjectSecretId>),
     /// User-scoped. Only `User` subjects and `Admin`-scoped agents can access.
     McpCreds(Option<McpCredsId>),
+    /// Serialized server configuration (the `appConfig` query). Instance-wide
+    /// and not project-scoped, so — like `McpCreds` — only `User` subjects
+    /// and `Admin`-scoped agents can read it.
+    AppConfig,
     Note(ProjectId, Option<NoteId>),
     Skill(ProjectId, Option<SkillId>),
     Workflow(ProjectId, Option<WorkflowDefinitionId>),
@@ -40,7 +44,10 @@ impl AuthResource {
             | AuthResource::Skill(project, _)
             | AuthResource::Workflow(project, _)
             | AuthResource::AuditLog(project) => Some(*project),
-            AuthResource::McpCreds(_) | AuthResource::Space(_) | AuthResource::External(_) => None,
+            AuthResource::McpCreds(_)
+            | AuthResource::AppConfig
+            | AuthResource::Space(_)
+            | AuthResource::External(_) => None,
         }
     }
 }

--- a/core/src/auth/subject.rs
+++ b/core/src/auth/subject.rs
@@ -285,6 +285,33 @@ mod tests {
         assert!(matches!(err, AuthorizationError::AuthenticationRequired));
     }
 
+    /// The serialized server config exposes infra topology and integration
+    /// endpoints — instance-wide, so only `User` subjects and `Admin`-scoped
+    /// tokens may read it; project scopes never cover it.
+    #[test]
+    fn app_config_read_is_user_and_admin_scope_only() {
+        let user = AuthSubject::User(UserId::new());
+        assert!(user.can(AuthVerb::Read, AuthResource::AppConfig).is_ok());
+
+        let admin =
+            AuthSubject::ExportedAgent(UserId::new(), McpCredsId::new(), vec![AuthScope::Admin]);
+        assert!(admin.can(AuthVerb::Read, AuthResource::AppConfig).is_ok());
+
+        let project = project();
+        for scopes in [
+            vec![AuthScope::ProjectAdmin(project)],
+            vec![AuthScope::ProjectMember(project)],
+        ] {
+            let s = AuthSubject::Agent(project, AgentId::new(), scopes);
+            assert!(s.can(AuthVerb::Read, AuthResource::AppConfig).is_err());
+        }
+
+        let err = AuthSubject::Anonymous
+            .can(AuthVerb::Read, AuthResource::AppConfig)
+            .unwrap_err();
+        assert!(matches!(err, AuthorizationError::AuthenticationRequired));
+    }
+
     #[test]
     fn project_admin_permits_management_resources() {
         let s = admin(project());

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,6 +32,7 @@ use std::sync::Arc;
 
 use agent::Agents;
 use audit::Audit;
+use auth::{AuthResource, AuthSubject, AuthVerb};
 use code_assistant::CodeAssistant;
 use git_proxy::GitProxies;
 use github_app::GitHubAppTokenProvider;
@@ -49,11 +50,13 @@ use toolset::{
     NotesTool, ProjectAgent, ProjectLog, ProjectSandbox, Read, SkillTool, SpacesTool,
     SubmitOutputTool, TextEditor, ToolSets, ToolSetsError, UseSkillTool, WorkflowTool,
 };
+use tracing::instrument;
 use user::Users;
 use workflow::Workflows;
 
 #[derive(Clone)]
 pub struct App {
+    app_config_yaml: String,
     users: Arc<Users>,
     mcp_creds: Arc<McpCredentials>,
     agents: Arc<Agents>,
@@ -78,7 +81,11 @@ pub struct App {
 }
 
 impl App {
-    pub async fn init(pool: &sqlx::PgPool, config: AppConfig) -> Result<Self, AppError> {
+    pub async fn init(
+        pool: &sqlx::PgPool,
+        config: AppConfig,
+        app_config_yaml: String,
+    ) -> Result<Self, AppError> {
         // Fail loudly at startup rather than on first project-create.
         config.agents.validate()?;
         config
@@ -387,6 +394,7 @@ impl App {
         )?);
 
         Ok(Self {
+            app_config_yaml,
             users,
             mcp_creds: Arc::new(mcp_creds),
             agents: Arc::clone(&agents),
@@ -494,6 +502,15 @@ impl App {
         &self.notes
     }
 
+    /// Serialized application configuration (YAML). Reveals infra topology
+    /// and integration endpoints, so reads are restricted to `User` subjects
+    /// and `Admin`-scoped tokens.
+    #[instrument(name = "domain.app.app_config", skip(self))]
+    pub fn app_config(&self, sub: &AuthSubject) -> Result<String, AppError> {
+        sub.can(AuthVerb::Read, AuthResource::AppConfig)?;
+        Ok(self.app_config_yaml.clone())
+    }
+
     /// Gracefully shut down background jobs. Call on SIGTERM / ctrl-c.
     pub async fn shutdown(&self) {
         self.tunnel.shutdown().await;
@@ -540,6 +557,8 @@ fn spawn_context_generation_listener(pool: sqlx::PgPool, generation: ContextGene
 pub enum AppError {
     #[error("AppError - Agent: {0}")]
     Agent(#[from] agent::AgentError),
+    #[error("AppError - Authorization: {0}")]
+    Authorization(#[from] auth::error::AuthorizationError),
     #[error("AppError - ToolSets: {0}")]
     ToolSets(#[from] ToolSetsError),
     #[error("AppError - Embedder: {0}")]

--- a/core/tests/skill_e2e.rs
+++ b/core/tests/skill_e2e.rs
@@ -177,7 +177,9 @@ async fn skill_create_propagates_to_search_and_upstream() {
         },
         ..Default::default()
     };
-    let app = App::init(&pool, config).await.expect("App::init");
+    let app = App::init(&pool, config, String::new())
+        .await
+        .expect("App::init");
 
     let sub = AuthSubject::User(UserId::new());
 

--- a/server/src/graphql/mod.rs
+++ b/server/src/graphql/mod.rs
@@ -35,11 +35,8 @@ use tokio_stream::{self as stream, StreamExt};
 use crate::AppState;
 
 pub use mutation::Mutation;
-pub use primitives::Yaml;
 pub use query::Query;
 pub use subscription::Subscription;
-
-pub struct AppConfigYaml(pub Yaml);
 
 pub type AgentsSchema = Schema<Query, Mutation, Subscription>;
 
@@ -77,8 +74,6 @@ async fn graphql_handler(
         .map(|Extension(sub)| sub)
         .unwrap_or(domain::auth::AuthSubject::Anonymous);
     request = request.data(auth_subject);
-
-    request = request.data(AppConfigYaml(state.app_config_yaml.clone()));
 
     // Replace the REST middleware's generic "api: POST /graphql" entrypoint
     // with the concrete operation name for useful audit entries.

--- a/server/src/graphql/query.rs
+++ b/server/src/graphql/query.rs
@@ -10,7 +10,6 @@ use super::primitives::*;
 use super::project::Project;
 use super::sandbox::Sandbox;
 use super::workflow::{limit, WorkflowDefinition, WorkflowRun};
-use super::AppConfigYaml;
 
 use drua_core::project::ProjectByCreatedAtCursor;
 
@@ -30,8 +29,9 @@ impl Query {
         "pong"
     }
 
-    async fn app_config(&self, ctx: &Context<'_>) -> Yaml {
-        ctx.data_unchecked::<AppConfigYaml>().0.clone()
+    async fn app_config(&self, ctx: &Context<'_>) -> async_graphql::Result<Yaml> {
+        let (app, sub) = app_and_sub_from_ctx!(ctx);
+        Ok(app.app_config(sub)?.into())
     }
 
     async fn me(&self, ctx: &Context<'_>) -> async_graphql::Result<Option<Me>> {

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -35,8 +35,6 @@ pub struct AppState {
     pub mcp_endpoint: String,
     pub github_allowed_teams: Vec<String>,
     pub code_assistant: Option<CodeAssistant>,
-    /// Exposed via the `appConfig` GraphQL query.
-    pub app_config_yaml: graphql::Yaml,
     /// Present when running in-cluster.
     pub sa_token_validator: Option<SaTokenValidator>,
     pub session_store: PgSessionStore,
@@ -57,7 +55,6 @@ impl AppState {
         login: LoginMethod,
         mcp_endpoint: String,
         github_allowed_teams: Vec<String>,
-        app_config_yaml: graphql::Yaml,
         tunnel_public_keys: TunnelPublicKeys,
     ) -> Self {
         let code_assistant = app.code_assistant().cloned();
@@ -68,7 +65,6 @@ impl AppState {
             mcp_endpoint,
             github_allowed_teams,
             code_assistant,
-            app_config_yaml,
             sa_token_validator: None,
             session_store: PgSessionStore::new(pool),
             tunnel_public_keys,
@@ -196,7 +192,7 @@ pub async fn run_server(args: RunServerArgs) -> anyhow::Result<()> {
         tunnel_runtime,
     };
 
-    let app = domain::App::init(&pool, app_config).await?;
+    let app = domain::App::init(&pool, app_config, serde_yaml::to_string(&config)?).await?;
     let app_for_shutdown = app.clone();
     let auth_config = config.auth_config();
     let oauth_client = auth_config.oauth_client();
@@ -207,8 +203,6 @@ pub async fn run_server(args: RunServerArgs) -> anyhow::Result<()> {
     };
 
     let mcp_service = drua_mcp_gateway::McpGateway::service(app.clone());
-
-    let app_config_yaml: graphql::Yaml = serde_yaml::to_string(&config)?.into();
 
     let tunnel_public_keys = tunnel::parse_configured_keys(&config.server.tunnel)?;
     if !tunnel_public_keys.is_empty() {
@@ -225,7 +219,6 @@ pub async fn run_server(args: RunServerArgs) -> anyhow::Result<()> {
         auth_config.login,
         config.server.mcp_endpoint.clone(),
         auth_config.github_allowed_teams,
-        app_config_yaml,
         std::sync::Arc::new(tunnel_public_keys),
     );
     app_state.library_repo_url = config.library.repo_url.clone();

--- a/server/tests/graphql.rs
+++ b/server/tests/graphql.rs
@@ -20,6 +20,8 @@ fn test_sub() -> drua_core::auth::AuthSubject {
     drua_core::auth::AuthSubject::User(drua_core::primitives::UserId::new())
 }
 
+const TEST_APP_CONFIG_YAML: &str = "mcp_endpoint: https://drua.test/mcp\n";
+
 /// Initialise a throwaway bare git repo under the test scratch dir and
 /// return its path. `Library::init` requires a non-empty `repo_url`
 /// and reachable upstream — this gives both without standing up a
@@ -123,7 +125,7 @@ async fn test_app(pool: &sqlx::PgPool) -> drua_core::App {
         ..Default::default()
     };
 
-    drua_core::App::init(pool, config)
+    drua_core::App::init(pool, config, TEST_APP_CONFIG_YAML.to_string())
         .await
         .expect("init test app")
 }
@@ -186,6 +188,82 @@ async fn ping_mutation_works() {
         .await;
     let json = serde_json::to_value(&response).unwrap();
     assert_eq!(json["data"]["ping"], "pong");
+}
+
+// ─── appConfig authorization tests ─────────────────────────────────────────
+
+#[tokio::test]
+async fn app_config_rejects_anonymous_and_non_admin_scopes() {
+    let pool = pool().await;
+    let app = test_app(&pool).await;
+    let schema = drua_server::graphql::schema(Some(app.clone()));
+
+    let anon = execute_graphql(
+        &schema,
+        &app,
+        &drua_core::auth::AuthSubject::Anonymous,
+        "{ appConfig }",
+        serde_json::Value::Null,
+    )
+    .await;
+    assert!(anon["data"]["appConfig"].is_null());
+    assert!(anon["errors"]
+        .as_array()
+        .is_some_and(|errs| !errs.is_empty()));
+
+    let project_id = drua_core::primitives::ProjectId::from(uuid::Uuid::new_v4());
+    let project_admin = drua_core::auth::AuthSubject::Agent(
+        project_id,
+        drua_core::primitives::AgentId::new(),
+        vec![drua_core::auth::AuthScope::ProjectAdmin(project_id)],
+    );
+    let denied = execute_graphql(
+        &schema,
+        &app,
+        &project_admin,
+        "{ appConfig }",
+        serde_json::Value::Null,
+    )
+    .await;
+    assert!(denied["data"]["appConfig"].is_null());
+    assert!(denied["errors"]
+        .as_array()
+        .is_some_and(|errs| !errs.is_empty()));
+}
+
+#[tokio::test]
+async fn app_config_allows_user_and_admin_scope() {
+    let pool = pool().await;
+    let app = test_app(&pool).await;
+    let schema = drua_server::graphql::schema(Some(app.clone()));
+
+    let user = test_sub();
+    let res = execute_graphql(
+        &schema,
+        &app,
+        &user,
+        "{ appConfig }",
+        serde_json::Value::Null,
+    )
+    .await;
+    let data = assert_no_errors(&res);
+    assert_eq!(data["appConfig"], TEST_APP_CONFIG_YAML);
+
+    let admin = drua_core::auth::AuthSubject::ExportedAgent(
+        drua_core::primitives::UserId::new(),
+        drua_core::primitives::McpCredsId::new(),
+        vec![drua_core::auth::AuthScope::Admin],
+    );
+    let res = execute_graphql(
+        &schema,
+        &app,
+        &admin,
+        "{ appConfig }",
+        serde_json::Value::Null,
+    )
+    .await;
+    let data = assert_no_errors(&res);
+    assert_eq!(data["appConfig"], TEST_APP_CONFIG_YAML);
 }
 
 // ─── Project mutation tests ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The `appConfig` query served the serialized server config from an `AppConfigYaml` value injected into **every** GraphQL request context, with no authentication or permission check. An anonymous caller could read the full runtime YAML — infra topology, SSH tunnel deployment hosts/keys, MCP upstream URLs, GitHub App identifiers, CI/CD and Zenduty endpoints (CWE-200 + CWE-862).

Mirrors the lana-bank fix for the same class of issue (`AUTHZ-VULN-01`, `cc87467daf` "gate appConfig/buildInfo/isSimulatedTime"):

- The YAML moves from the GraphQL/AppState layer into `domain::App` (passed to `App::init`)
- New `App::app_config(sub)` accessor enforces the check in the **domain layer**, per project convention — the resolver is a thin one-line delegator
- New instance-wide `AuthResource::AppConfig` (modeled on `McpCreds`): only `User` subjects and `Admin`-scoped tokens pass; project scopes (`ProjectAdmin`/`ProjectMember`) never cover it
- `AppState`/`AppConfigYaml` context injection deleted

## Before / after (the reported PoC)

```
curl -sk -X POST https://dashboard.agents.galoy.io/graphql   -H 'Content-Type: application/json' -d '{"query":"{appConfig}"}'
```

- **before**: full server YAML, no credentials required
- **after**: `AuthenticationRequired`, `data.appConfig` = `null`; also denied for project-admin agent tokens

## Notes

- GraphQL SDL unchanged (`appConfig: Yaml!`) — `make sdl-rust` diff is empty
- Secrets were never at risk of direct exposure via this query (`pg_con`, API keys, client secret, PEM path are all `#[serde(skip)]`), but the topology/endpoint data it did leak is treated as sensitive

## Test plan

- [x] new graphql integration tests: anonymous + project-admin denied, user + admin-scoped allowed (`app_config_rejects_anonymous_and_non_admin_scopes`, `app_config_allows_user_and_admin_scope`)
- [x] new unit test `app_config_read_is_user_and_admin_scope_only` in `core::auth::subject`
- [x] `drua-server` graphql suite: 23/23 · `drua-core`: 605/605
- [x] clippy + fmt clean; SDL regen unchanged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes a real unauthenticated config leak; remaining risk is limited to ensuring all code paths use `app_config(sub)` and that Admin scope assignment stays correct for exported tokens.
> 
> **Overview**
> Closes an **information disclosure** gap: the `appConfig` GraphQL query previously returned serialized server YAML to any caller because config was injected into every request context with no auth check.
> 
> **Authorization** adds instance-wide `AuthResource::AppConfig` (same pattern as `McpCreds`): only **logged-in users** and **Admin-scoped** exported-agent tokens can read; anonymous callers and project-scoped agents (`ProjectAdmin` / `ProjectMember`) are denied.
> 
> **Domain layer** now owns the YAML: it is passed into `App::init` and returned via `App::app_config(sub)`, which enforces `Read` on `AppConfig` before cloning the string. The GraphQL resolver delegates to that method instead of reading from context.
> 
> **Server cleanup** removes `AppConfigYaml` injection from the GraphQL handler and drops `app_config_yaml` from `AppState`; boot still serializes config once when calling `App::init`.
> 
> Tests cover auth subject rules and GraphQL integration for allow/deny cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8f5952678b9ce797516fb8eb70b608406328cce. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->