### PR TITLE
feat(tunnel-connector): expose per-instance Lana admin MCP upstreams

### DIFF
--- a/images/tunnel-connector/src/cli.rs
+++ b/images/tunnel-connector/src/cli.rs
@@ -1,5 +1,9 @@
 use clap::Parser;
 
+use crate::lana_admin_mcp::{
+    DEFAULT_LANA_ADMIN_MCP_CLIENT_ID, DEFAULT_LANA_ADMIN_MCP_SANDBOX_NAMESPACE,
+    DEFAULT_LANA_ADMIN_MCP_URL_TEMPLATE, DEFAULT_LANA_ADMIN_MCP_USERNAME_TEMPLATE,
+};
 use crate::postgres_mcp::{
     DEFAULT_POSTGRES_MCP_CLOUD_SQL_PROXY_IMAGE, DEFAULT_POSTGRES_MCP_CONFIG_SECRET,
     DEFAULT_POSTGRES_MCP_CONNECT_TIMEOUT_SECS, DEFAULT_POSTGRES_MCP_IMAGE,
@@ -176,6 +180,65 @@ pub(crate) struct Cli {
         default_value = DEFAULT_POSTGRES_MCP_REQUEST_MEMORY
     )]
     pub(crate) postgres_mcp_request_memory: String,
+
+    /// Enable per-instance Lana admin MCP upstreams: Ready LanaSandbox CRs are
+    /// discovered automatically, static instances come from
+    /// TUNNEL_LANA_ADMIN_MCP_STATIC_INSTANCES.
+    #[arg(long, env = "TUNNEL_LANA_ADMIN_MCP_ENABLED", default_value_t = false)]
+    pub(crate) lana_admin_mcp_enabled: bool,
+
+    /// Namespace holding the LanaSandbox CRs.
+    #[arg(
+        long,
+        env = "TUNNEL_LANA_ADMIN_MCP_SANDBOX_NAMESPACE",
+        default_value = DEFAULT_LANA_ADMIN_MCP_SANDBOX_NAMESPACE
+    )]
+    pub(crate) lana_admin_mcp_sandbox_namespace: String,
+
+    /// Public Keycloak base URL the per-instance realms live on, e.g.
+    /// https://auth.staging.galoy.io.
+    #[arg(long, env = "TUNNEL_LANA_ADMIN_MCP_KEYCLOAK_BASE_URL")]
+    pub(crate) lana_admin_mcp_keycloak_base_url: Option<String>,
+
+    /// Direct-grant client id that mints lana-admin-mcp tokens.
+    #[arg(
+        long,
+        env = "TUNNEL_LANA_ADMIN_MCP_CLIENT_ID",
+        default_value = DEFAULT_LANA_ADMIN_MCP_CLIENT_ID
+    )]
+    pub(crate) lana_admin_mcp_client_id: String,
+
+    /// Username template for the direct grant; `{instance}` is replaced with
+    /// the instance name.
+    #[arg(
+        long,
+        env = "TUNNEL_LANA_ADMIN_MCP_USERNAME_TEMPLATE",
+        default_value = DEFAULT_LANA_ADMIN_MCP_USERNAME_TEMPLATE
+    )]
+    pub(crate) lana_admin_mcp_username_template: String,
+
+    /// Password for the direct grant. Empty where the realm binds the DEV
+    /// direct-grant flow (staging sandboxes, kind).
+    #[arg(long, env = "TUNNEL_LANA_ADMIN_MCP_PASSWORD", default_value = "")]
+    pub(crate) lana_admin_mcp_password: String,
+
+    /// Admin MCP URL template for discovered sandboxes; `{instance}` is
+    /// replaced with the sandbox (and namespace) name.
+    #[arg(
+        long,
+        env = "TUNNEL_LANA_ADMIN_MCP_URL_TEMPLATE",
+        default_value = DEFAULT_LANA_ADMIN_MCP_URL_TEMPLATE
+    )]
+    pub(crate) lana_admin_mcp_url_template: String,
+
+    /// Comma-separated name=url pairs for Lana instances that are not
+    /// LanaSandbox CRs (e.g. main=http://lana-bank-admin.lana-bank-main.svc:5253/mcp).
+    #[arg(
+        long,
+        env = "TUNNEL_LANA_ADMIN_MCP_STATIC_INSTANCES",
+        default_value = ""
+    )]
+    pub(crate) lana_admin_mcp_static_instances: String,
 
     /// CPU limit for generated DBHub pods.
     #[arg(

--- a/images/tunnel-connector/src/lana_admin_mcp.rs
+++ b/images/tunnel-connector/src/lana_admin_mcp.rs
@@ -1,0 +1,380 @@
+//! Per-instance Lana admin MCP upstreams.
+//!
+//! Every Lana instance (sandbox or long-lived) serves a read-only admin MCP
+//! endpoint (`list_data_mart_models`, `describe_data_mart_model`,
+//! `run_readonly_dw_query`) on its admin server, gated by the instance's
+//! Keycloak realm (`<instance>-internal`) with the `lana-admin-mcp` scope.
+//!
+//! This controller discovers Ready `LanaSandbox` CRs and maps each one — plus
+//! any statically configured instances — to an authenticated upstream. The
+//! connector mints tokens via the realm's `admin-mcp-gateway` direct-grant
+//! client (see lana-bank `tf/modules/keycloak-realms`), which only exists
+//! where DEV auth flows are enabled (staging sandboxes, kind).
+
+use async_trait::async_trait;
+use kube::{
+    api::ListParams,
+    core::{ApiResource, DynamicObject, GroupVersionKind},
+    Api, Client,
+};
+
+use crate::mcp_upstream::{DirectGrantAuth, UpstreamConfig};
+
+pub(crate) const DEFAULT_LANA_ADMIN_MCP_SANDBOX_NAMESPACE: &str = "lana-sandbox";
+pub(crate) const DEFAULT_LANA_ADMIN_MCP_CLIENT_ID: &str = "admin-mcp-gateway";
+pub(crate) const DEFAULT_LANA_ADMIN_MCP_USERNAME_TEMPLATE: &str =
+    "{instance}-superuser@mailinator.com";
+pub(crate) const DEFAULT_LANA_ADMIN_MCP_URL_TEMPLATE: &str =
+    "http://lana-bank-admin.{instance}.svc.cluster.local:5253/mcp";
+pub(crate) const LANA_ADMIN_MCP_UPSTREAM_PREFIX: &str = "lana_admin";
+
+const LANA_SANDBOX_GROUP: &str = "sandbox.galoy.io";
+const LANA_SANDBOX_VERSION: &str = "v1alpha1";
+const LANA_SANDBOX_KIND: &str = "LanaSandbox";
+
+/// A non-sandbox Lana instance (e.g. staging `main`) exposed by explicit
+/// name + MCP URL; the realm/username conventions still apply.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct StaticLanaAdminInstance {
+    pub(crate) name: String,
+    pub(crate) url: String,
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct LanaAdminMcpConfig {
+    /// Namespace holding the LanaSandbox CRs.
+    pub(crate) sandbox_namespace: String,
+    /// Public Keycloak base URL, e.g. `https://auth.staging.galoy.io`.
+    pub(crate) keycloak_base_url: String,
+    /// Direct-grant client id minting `lana-admin-mcp` tokens.
+    pub(crate) client_id: String,
+    /// Username template; `{instance}` is replaced with the instance name.
+    pub(crate) username_template: String,
+    /// Password for the direct grant. Empty under DEV auth flows.
+    pub(crate) password: String,
+    /// Admin MCP URL template for discovered sandboxes; `{instance}` is
+    /// replaced with the sandbox (and namespace) name.
+    pub(crate) url_template: String,
+    /// Explicitly configured instances that are not LanaSandbox CRs.
+    pub(crate) static_instances: Vec<StaticLanaAdminInstance>,
+}
+
+/// Outbound discovery port — lists Ready sandbox instance names.
+#[async_trait]
+pub(crate) trait LanaAdminMcpInstanceDiscoverer: Clone + Send + Sync + 'static {
+    async fn discover_ready_sandboxes(
+        &self,
+        config: &LanaAdminMcpConfig,
+    ) -> anyhow::Result<Vec<String>>;
+}
+
+#[derive(Clone)]
+pub(crate) struct KubernetesLanaAdminMcpDiscoverer {
+    client: Client,
+}
+
+impl KubernetesLanaAdminMcpDiscoverer {
+    pub(crate) async fn try_default() -> anyhow::Result<Self> {
+        Ok(Self {
+            client: Client::try_default().await?,
+        })
+    }
+}
+
+#[async_trait]
+impl LanaAdminMcpInstanceDiscoverer for KubernetesLanaAdminMcpDiscoverer {
+    async fn discover_ready_sandboxes(
+        &self,
+        config: &LanaAdminMcpConfig,
+    ) -> anyhow::Result<Vec<String>> {
+        let resource = ApiResource::from_gvk(&GroupVersionKind::gvk(
+            LANA_SANDBOX_GROUP,
+            LANA_SANDBOX_VERSION,
+            LANA_SANDBOX_KIND,
+        ));
+        let api: Api<DynamicObject> =
+            Api::namespaced_with(self.client.clone(), &config.sandbox_namespace, &resource);
+        let sandboxes = api.list(&ListParams::default()).await?;
+
+        Ok(sandboxes
+            .items
+            .into_iter()
+            .filter(|sandbox| sandbox.metadata.deletion_timestamp.is_none())
+            .filter(|sandbox| {
+                sandbox
+                    .data
+                    .get("status")
+                    .and_then(|status| status.get("phase"))
+                    .and_then(|phase| phase.as_str())
+                    == Some("Ready")
+            })
+            .filter_map(|sandbox| sandbox.metadata.name)
+            .collect())
+    }
+}
+
+#[derive(Clone)]
+pub(crate) struct LanaAdminMcpController<D> {
+    discoverer: D,
+    config: LanaAdminMcpConfig,
+}
+
+impl<D> LanaAdminMcpController<D>
+where
+    D: LanaAdminMcpInstanceDiscoverer,
+{
+    pub(crate) fn try_new(config: LanaAdminMcpConfig, discoverer: D) -> anyhow::Result<Self> {
+        config.validate()?;
+
+        Ok(Self { discoverer, config })
+    }
+
+    /// Resolve the current set of lana-admin MCP upstreams: one per Ready
+    /// sandbox plus every static instance. Sandboxes mid-teardown or not yet
+    /// Ready simply drop out; the tunnel session's upstream-set comparison
+    /// triggers a re-registration when the set changes.
+    pub(crate) async fn reconcile(&self) -> anyhow::Result<Vec<UpstreamConfig>> {
+        let mut instances = self
+            .discoverer
+            .discover_ready_sandboxes(&self.config)
+            .await?;
+        instances.sort();
+
+        let mut upstreams =
+            Vec::with_capacity(instances.len() + self.config.static_instances.len());
+        for instance in instances {
+            match self.upstream_for_instance(&instance, None) {
+                Some(upstream) => upstreams.push(upstream),
+                None => tracing::warn!(
+                    instance = %instance,
+                    "skipping lana admin mcp sandbox with unusable name"
+                ),
+            }
+        }
+        for instance in &self.config.static_instances {
+            match self.upstream_for_instance(&instance.name, Some(&instance.url)) {
+                Some(upstream) => upstreams.push(upstream),
+                None => tracing::warn!(
+                    instance = %instance.name,
+                    "skipping static lana admin mcp instance with unusable name"
+                ),
+            }
+        }
+
+        Ok(upstreams)
+    }
+
+    fn upstream_for_instance(&self, instance: &str, url: Option<&str>) -> Option<UpstreamConfig> {
+        let normalized = normalize_upstream_component(instance)?;
+        let url = match url {
+            Some(url) => url.to_string(),
+            None => self.config.url_template.replace("{instance}", instance),
+        };
+
+        Some(UpstreamConfig {
+            name: format!("{LANA_ADMIN_MCP_UPSTREAM_PREFIX}_{normalized}"),
+            url,
+            auth: Some(DirectGrantAuth {
+                token_url: format!(
+                    "{}/realms/{instance}-internal/protocol/openid-connect/token",
+                    self.config.keycloak_base_url.trim_end_matches('/')
+                ),
+                client_id: self.config.client_id.clone(),
+                username: self
+                    .config
+                    .username_template
+                    .replace("{instance}", instance),
+                password: self.config.password.clone(),
+            }),
+        })
+    }
+}
+
+impl LanaAdminMcpConfig {
+    fn validate(&self) -> anyhow::Result<()> {
+        if self.keycloak_base_url.trim().is_empty() {
+            anyhow::bail!("lana admin mcp keycloak base url must not be empty");
+        }
+        if self.sandbox_namespace.trim().is_empty() {
+            anyhow::bail!("lana admin mcp sandbox namespace must not be empty");
+        }
+        for (field, template) in [
+            ("username_template", &self.username_template),
+            ("url_template", &self.url_template),
+        ] {
+            if !template.contains("{instance}") {
+                anyhow::bail!("lana admin mcp {field} must contain an {{instance}} placeholder");
+            }
+        }
+        for instance in &self.static_instances {
+            if instance.name.trim().is_empty() || instance.url.trim().is_empty() {
+                anyhow::bail!("lana admin mcp static instances need non-empty name and url");
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Parse `TUNNEL_LANA_ADMIN_MCP_STATIC_INSTANCES`: `name=url[,name=url,...]`.
+pub(crate) fn parse_static_instances(raw: &str) -> Vec<StaticLanaAdminInstance> {
+    raw.split(',')
+        .filter_map(|pair| {
+            let (name, url) = pair.split_once('=')?;
+            Some(StaticLanaAdminInstance {
+                name: name.trim().to_string(),
+                url: url.trim().to_string(),
+            })
+        })
+        .filter(|instance| !instance.name.is_empty() && !instance.url.is_empty())
+        .collect()
+}
+
+/// Same alphabet as the postgres source ids: drua prefixes tools with the
+/// upstream name, so keep it a valid lowercase identifier.
+fn normalize_upstream_component(value: &str) -> Option<String> {
+    let normalized = value.replace('-', "_");
+    let mut chars = normalized.chars();
+    let first = chars.next()?;
+
+    if !first.is_ascii_lowercase() {
+        return None;
+    }
+
+    if !chars.all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_') {
+        return None;
+    }
+
+    Some(normalized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_config() -> LanaAdminMcpConfig {
+        LanaAdminMcpConfig {
+            sandbox_namespace: "lana-sandbox".to_string(),
+            keycloak_base_url: "https://auth.staging.galoy.io".to_string(),
+            client_id: DEFAULT_LANA_ADMIN_MCP_CLIENT_ID.to_string(),
+            username_template: DEFAULT_LANA_ADMIN_MCP_USERNAME_TEMPLATE.to_string(),
+            password: String::new(),
+            url_template: DEFAULT_LANA_ADMIN_MCP_URL_TEMPLATE.to_string(),
+            static_instances: vec![StaticLanaAdminInstance {
+                name: "main".to_string(),
+                url: "http://lana-bank-admin.lana-bank-main.svc.cluster.local:5253/mcp".to_string(),
+            }],
+        }
+    }
+
+    #[derive(Clone)]
+    struct FakeDiscoverer {
+        instances: Vec<String>,
+    }
+
+    #[async_trait]
+    impl LanaAdminMcpInstanceDiscoverer for FakeDiscoverer {
+        async fn discover_ready_sandboxes(
+            &self,
+            _config: &LanaAdminMcpConfig,
+        ) -> anyhow::Result<Vec<String>> {
+            Ok(self.instances.clone())
+        }
+    }
+
+    #[tokio::test]
+    async fn reconcile_maps_sandboxes_and_static_instances_to_authenticated_upstreams(
+    ) -> anyhow::Result<()> {
+        let controller = LanaAdminMcpController::try_new(
+            test_config(),
+            FakeDiscoverer {
+                instances: vec!["sb-demo-verify".to_string()],
+            },
+        )?;
+
+        let upstreams = controller.reconcile().await?;
+
+        assert_eq!(upstreams.len(), 2);
+
+        let sandbox = &upstreams[0];
+        assert_eq!(sandbox.name, "lana_admin_sb_demo_verify");
+        assert_eq!(
+            sandbox.url,
+            "http://lana-bank-admin.sb-demo-verify.svc.cluster.local:5253/mcp"
+        );
+        let auth = sandbox.auth.as_ref().expect("sandbox upstream has auth");
+        assert_eq!(
+            auth.token_url,
+            "https://auth.staging.galoy.io/realms/sb-demo-verify-internal/protocol/openid-connect/token"
+        );
+        assert_eq!(auth.client_id, "admin-mcp-gateway");
+        assert_eq!(auth.username, "sb-demo-verify-superuser@mailinator.com");
+
+        let static_instance = &upstreams[1];
+        assert_eq!(static_instance.name, "lana_admin_main");
+        assert_eq!(
+            static_instance.url,
+            "http://lana-bank-admin.lana-bank-main.svc.cluster.local:5253/mcp"
+        );
+        let auth = static_instance
+            .auth
+            .as_ref()
+            .expect("static upstream has auth");
+        assert_eq!(
+            auth.token_url,
+            "https://auth.staging.galoy.io/realms/main-internal/protocol/openid-connect/token"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reconcile_drops_sandboxes_that_disappear() -> anyhow::Result<()> {
+        let mut config = test_config();
+        config.static_instances = Vec::new();
+
+        let full = LanaAdminMcpController::try_new(
+            config.clone(),
+            FakeDiscoverer {
+                instances: vec!["sb-a".to_string(), "sb-b".to_string()],
+            },
+        )?;
+        let torn_down = LanaAdminMcpController::try_new(
+            config,
+            FakeDiscoverer {
+                instances: vec!["sb-a".to_string()],
+            },
+        )?;
+
+        assert_eq!(full.reconcile().await?.len(), 2);
+        assert_eq!(torn_down.reconcile().await?.len(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn static_instances_parse_name_url_pairs() {
+        let parsed = parse_static_instances(
+            "main=http://lana-bank-admin.lana-bank-main.svc:5253/mcp, canary=https://admin.canary.staging.galoy.io/mcp",
+        );
+
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0].name, "main");
+        assert_eq!(parsed[1].url, "https://admin.canary.staging.galoy.io/mcp");
+    }
+
+    #[test]
+    fn config_requires_instance_placeholder_in_templates() {
+        let mut config = test_config();
+        config.url_template = "http://fixed-url:5253/mcp".to_string();
+
+        let result = LanaAdminMcpController::try_new(
+            config,
+            FakeDiscoverer {
+                instances: Vec::new(),
+            },
+        );
+
+        assert!(result.is_err());
+    }
+}

--- a/images/tunnel-connector/src/main.rs
+++ b/images/tunnel-connector/src/main.rs
@@ -5,6 +5,9 @@
 use std::sync::Arc;
 
 use clap::Parser;
+use lana_admin_mcp::{
+    KubernetesLanaAdminMcpDiscoverer, LanaAdminMcpConfig, LanaAdminMcpController,
+};
 use mcp_upstream::parse_upstreams;
 use postgres_mcp::{PostgresMcpCloudSqlProxyConfig, PostgresMcpConfig, PostgresMcpController};
 use postgres_mcp_kubernetes::{resolve_namespace, KubernetesPostgresMcpHandler};
@@ -12,6 +15,7 @@ use postgres_mcp_postgres::SqlxPostgresSourceDiscoverer;
 use tunnel_session::run_tunnel;
 
 mod cli;
+mod lana_admin_mcp;
 mod mcp_upstream;
 mod postgres_mcp;
 mod postgres_mcp_kubernetes;
@@ -26,6 +30,7 @@ mod tunnel_session;
 
 type ManagedPostgresMcpController =
     PostgresMcpController<KubernetesPostgresMcpHandler, SqlxPostgresSourceDiscoverer>;
+type ManagedLanaAdminMcpController = LanaAdminMcpController<KubernetesLanaAdminMcpDiscoverer>;
 
 pub(crate) const INITIAL_BACKOFF: std::time::Duration = std::time::Duration::from_secs(1);
 const MAX_BACKOFF: std::time::Duration = std::time::Duration::from_secs(60);
@@ -39,10 +44,19 @@ async fn main() -> anyhow::Result<()> {
     let cli = cli::Cli::parse();
     let static_upstreams = parse_upstreams(&cli.upstreams);
     let postgres_mcp = build_postgres_mcp(&cli).await?;
+    let lana_admin_mcp = build_lana_admin_mcp(&cli).await?;
 
     let mut backoff = INITIAL_BACKOFF;
     loop {
-        match run_tunnel(&cli, &static_upstreams, postgres_mcp.as_ref(), &mut backoff).await {
+        match run_tunnel(
+            &cli,
+            &static_upstreams,
+            postgres_mcp.as_ref(),
+            lana_admin_mcp.as_ref(),
+            &mut backoff,
+        )
+        .await
+        {
             Ok(()) => tracing::info!("tunnel closed cleanly"),
             Err(e) => tracing::error!(error = %e, "tunnel session failed"),
         }
@@ -116,4 +130,35 @@ fn trim_optional(value: &Option<String>) -> Option<String> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(str::to_string)
+}
+
+async fn build_lana_admin_mcp(
+    cli: &cli::Cli,
+) -> anyhow::Result<Option<ManagedLanaAdminMcpController>> {
+    if !cli.lana_admin_mcp_enabled {
+        return Ok(None);
+    }
+
+    let keycloak_base_url =
+        trim_optional(&cli.lana_admin_mcp_keycloak_base_url).ok_or_else(|| {
+            anyhow::anyhow!(
+            "TUNNEL_LANA_ADMIN_MCP_KEYCLOAK_BASE_URL is required when lana admin mcp is enabled"
+        )
+        })?;
+
+    let config = LanaAdminMcpConfig {
+        sandbox_namespace: cli.lana_admin_mcp_sandbox_namespace.clone(),
+        keycloak_base_url,
+        client_id: cli.lana_admin_mcp_client_id.clone(),
+        username_template: cli.lana_admin_mcp_username_template.clone(),
+        password: cli.lana_admin_mcp_password.clone(),
+        url_template: cli.lana_admin_mcp_url_template.clone(),
+        static_instances: lana_admin_mcp::parse_static_instances(
+            &cli.lana_admin_mcp_static_instances,
+        ),
+    };
+
+    let discoverer = KubernetesLanaAdminMcpDiscoverer::try_default().await?;
+
+    Ok(Some(LanaAdminMcpController::try_new(config, discoverer)?))
 }

--- a/images/tunnel-connector/src/mcp_upstream.rs
+++ b/images/tunnel-connector/src/mcp_upstream.rs
@@ -10,10 +10,23 @@ use rmcp::{
 };
 use serde::{Deserialize, Serialize};
 
+/// Direct-grant (resource-owner password) credentials for an upstream that
+/// requires a bearer token, e.g. a per-instance Lana admin MCP endpoint gated
+/// by a Keycloak realm. The connector fetches a token at connect time and
+/// re-fetches + reconnects on call failure (tokens expire mid-session).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) struct DirectGrantAuth {
+    pub(crate) token_url: String,
+    pub(crate) client_id: String,
+    pub(crate) username: String,
+    pub(crate) password: String,
+}
+
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) struct UpstreamConfig {
     pub(crate) name: String,
     pub(crate) url: String,
+    pub(crate) auth: Option<DirectGrantAuth>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -25,7 +38,15 @@ pub(crate) struct RegisteredToolSet {
     pub(crate) tools: Vec<serde_json::Value>,
 }
 
-pub(crate) type McpClients = HashMap<String, RunningService<RoleClient, ()>>;
+/// A connected upstream plus the config needed to reconnect it (token refresh
+/// on expiry requires a full transport rebuild — the rmcp client header is
+/// fixed at construction).
+pub(crate) struct UpstreamClient {
+    pub(crate) upstream: UpstreamConfig,
+    pub(crate) client: RunningService<RoleClient, ()>,
+}
+
+pub(crate) type McpClients = HashMap<String, UpstreamClient>;
 
 pub(crate) fn parse_upstreams(raw: &str) -> Vec<UpstreamConfig> {
     raw.split(',')
@@ -34,6 +55,7 @@ pub(crate) fn parse_upstreams(raw: &str) -> Vec<UpstreamConfig> {
             Some(UpstreamConfig {
                 name: name.trim().to_string(),
                 url: url.trim().to_string(),
+                auth: None,
             })
         })
         .collect()
@@ -42,13 +64,20 @@ pub(crate) fn parse_upstreams(raw: &str) -> Vec<UpstreamConfig> {
 pub(crate) async fn discover_upstream(
     upstream: &UpstreamConfig,
     deployment_id: &str,
-) -> anyhow::Result<(String, RunningService<RoleClient, ()>, RegisteredToolSet)> {
+) -> anyhow::Result<(String, UpstreamClient, RegisteredToolSet)> {
     tracing::info!(name = %upstream.name, url = %upstream.url, "connecting to local MCP server");
 
     let client = connect_upstream(upstream).await?;
     let registration = discover_tools(upstream, deployment_id, &client).await?;
 
-    Ok((upstream.name.clone(), client, registration))
+    Ok((
+        upstream.name.clone(),
+        UpstreamClient {
+            upstream: upstream.clone(),
+            client,
+        },
+        registration,
+    ))
 }
 
 pub(crate) fn registration_fingerprint(
@@ -84,15 +113,42 @@ pub(crate) async fn tool_catalog_changed(
 }
 
 pub(crate) async fn call_tool(
-    clients: &McpClients,
+    clients: &mut McpClients,
     upstream: &str,
     tool_name: &str,
     arguments: Option<serde_json::Map<String, serde_json::Value>>,
 ) -> Result<serde_json::Value, String> {
-    let client = clients
-        .get(upstream)
-        .ok_or_else(|| format!("unknown upstream: {upstream}"))?;
+    match clients.get(upstream) {
+        Some(entry) => match call_tool_on(&entry.client, tool_name, arguments.clone()).await {
+            Ok(result) => return Ok(result),
+            Err(e) => {
+                if entry.upstream.auth.is_none() {
+                    return Err(e);
+                }
+                tracing::warn!(
+                    upstream = %upstream,
+                    error = %e,
+                    "authenticated upstream call failed; refreshing token and retrying once"
+                );
+            }
+        },
+        None => return Err(format!("unknown upstream: {upstream}")),
+    }
 
+    let entry = clients.get(upstream).expect("checked above");
+    let refreshed = connect_upstream(&entry.upstream)
+        .await
+        .map_err(|e| format!("reconnect {upstream}: {e}"))?;
+    let entry = clients.get_mut(upstream).expect("checked above");
+    entry.client = refreshed;
+    call_tool_on(&entry.client, tool_name, arguments).await
+}
+
+async fn call_tool_on(
+    client: &RunningService<RoleClient, ()>,
+    tool_name: &str,
+    arguments: Option<serde_json::Map<String, serde_json::Value>>,
+) -> Result<serde_json::Value, String> {
     let mut params = CallToolRequestParams::new(tool_name.to_string());
     if let Some(args) = arguments {
         params = params.with_arguments(args);
@@ -110,9 +166,53 @@ pub(crate) async fn call_tool(
 async fn connect_upstream(
     upstream: &UpstreamConfig,
 ) -> anyhow::Result<RunningService<RoleClient, ()>> {
-    let config = StreamableHttpClientTransportConfig::with_uri(upstream.url.as_str());
+    let mut config = StreamableHttpClientTransportConfig::with_uri(upstream.url.as_str());
+    if let Some(auth) = &upstream.auth {
+        let token = fetch_direct_grant_token(auth).await?;
+        config = config.auth_header(token);
+    }
     let worker = StreamableHttpClientWorker::new(reqwest::Client::new(), config);
     Ok(().serve(worker).await?)
+}
+
+/// Mint a bearer token via the OAuth2 resource-owner password grant. Used for
+/// Lana admin MCP upstreams whose Keycloak realm runs the DEV direct-grant
+/// flow (staging sandboxes / kind), where seeded staff users have empty
+/// passwords.
+pub(crate) async fn fetch_direct_grant_token(auth: &DirectGrantAuth) -> anyhow::Result<String> {
+    let body = url::form_urlencoded::Serializer::new(String::new())
+        .append_pair("grant_type", "password")
+        .append_pair("client_id", &auth.client_id)
+        .append_pair("username", &auth.username)
+        .append_pair("password", &auth.password)
+        .finish();
+
+    let response = reqwest::Client::new()
+        .post(&auth.token_url)
+        .header(
+            reqwest::header::CONTENT_TYPE,
+            "application/x-www-form-urlencoded",
+        )
+        .body(body)
+        .send()
+        .await?;
+
+    let status = response.status();
+    let body: serde_json::Value = response.json().await.unwrap_or(serde_json::Value::Null);
+    if !status.is_success() {
+        anyhow::bail!(
+            "direct-grant token request failed with {status}: {}",
+            body.get("error_description")
+                .or_else(|| body.get("error"))
+                .and_then(|e| e.as_str())
+                .unwrap_or("unknown error")
+        );
+    }
+
+    body.get("access_token")
+        .and_then(|t| t.as_str())
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("direct-grant token response missing access_token"))
 }
 
 async fn discover_tools(

--- a/images/tunnel-connector/src/postgres_mcp.rs
+++ b/images/tunnel-connector/src/postgres_mcp.rs
@@ -180,6 +180,7 @@ where
                 "http://{}:{}/mcp",
                 self.config.resource_name, self.config.service_port
             ),
+            auth: None,
         }))
     }
 }

--- a/images/tunnel-connector/src/tunnel_registration_test.rs
+++ b/images/tunnel-connector/src/tunnel_registration_test.rs
@@ -13,6 +13,20 @@ use tokio_tungstenite::tungstenite;
 
 use super::*;
 use crate::cli::Cli;
+use crate::lana_admin_mcp::{LanaAdminMcpConfig, LanaAdminMcpInstanceDiscoverer};
+
+#[derive(Clone)]
+struct FakeLanaAdminDiscoverer;
+
+#[async_trait::async_trait]
+impl LanaAdminMcpInstanceDiscoverer for FakeLanaAdminDiscoverer {
+    async fn discover_ready_sandboxes(
+        &self,
+        _config: &LanaAdminMcpConfig,
+    ) -> anyhow::Result<Vec<String>> {
+        Ok(Vec::new())
+    }
+}
 use crate::mcp_upstream::{registration_fingerprint, RegisteredToolSet};
 use crate::postgres_mcp::{
     PostgresMcpConfig, PostgresMcpHandler, PostgresSource, PostgresSourceDiscoverer,
@@ -119,12 +133,31 @@ async fn registers_reconciled_postgres_mcp_tools() -> anyhow::Result<()> {
         postgres_mcp_request_memory: DEFAULT_POSTGRES_MCP_REQUEST_MEMORY.to_string(),
         postgres_mcp_limit_cpu: DEFAULT_POSTGRES_MCP_LIMIT_CPU.to_string(),
         postgres_mcp_limit_memory: DEFAULT_POSTGRES_MCP_LIMIT_MEMORY.to_string(),
+        lana_admin_mcp_enabled: false,
+        lana_admin_mcp_sandbox_namespace:
+            crate::lana_admin_mcp::DEFAULT_LANA_ADMIN_MCP_SANDBOX_NAMESPACE.to_string(),
+        lana_admin_mcp_keycloak_base_url: None,
+        lana_admin_mcp_client_id: crate::lana_admin_mcp::DEFAULT_LANA_ADMIN_MCP_CLIENT_ID
+            .to_string(),
+        lana_admin_mcp_username_template:
+            crate::lana_admin_mcp::DEFAULT_LANA_ADMIN_MCP_USERNAME_TEMPLATE.to_string(),
+        lana_admin_mcp_password: String::new(),
+        lana_admin_mcp_url_template: crate::lana_admin_mcp::DEFAULT_LANA_ADMIN_MCP_URL_TEMPLATE
+            .to_string(),
+        lana_admin_mcp_static_instances: String::new(),
     };
     let static_upstreams = Vec::new();
     let mut backoff = INITIAL_BACKOFF;
 
     let tunnel_task = tokio::spawn(async move {
-        run_tunnel(&cli, &static_upstreams, &postgres_mcp, &mut backoff).await
+        run_tunnel(
+            &cli,
+            &static_upstreams,
+            &postgres_mcp,
+            None::<&crate::lana_admin_mcp::LanaAdminMcpController<FakeLanaAdminDiscoverer>>,
+            &mut backoff,
+        )
+        .await
     });
 
     let registered = tokio::time::timeout(Duration::from_secs(5), registered_rx).await??;

--- a/images/tunnel-connector/src/tunnel_session.rs
+++ b/images/tunnel-connector/src/tunnel_session.rs
@@ -3,6 +3,7 @@ use tokio_tungstenite::tungstenite;
 
 use crate::{
     cli::Cli,
+    lana_admin_mcp::{LanaAdminMcpController, LanaAdminMcpInstanceDiscoverer},
     mcp_upstream::{
         call_tool, discover_upstream, registration_fingerprint, tool_catalog_changed, McpClients,
         UpstreamConfig,
@@ -12,17 +13,19 @@ use crate::{
     tunnel_protocol::TunnelMessage,
 };
 
-pub(crate) async fn run_tunnel<H, D>(
+pub(crate) async fn run_tunnel<H, D, L>(
     cli: &Cli,
     static_upstreams: &[UpstreamConfig],
     postgres_mcp: &PostgresMcpController<H, D>,
+    lana_admin_mcp: Option<&LanaAdminMcpController<L>>,
     backoff: &mut std::time::Duration,
 ) -> anyhow::Result<()>
 where
     H: PostgresMcpHandler,
     D: PostgresSourceDiscoverer,
+    L: LanaAdminMcpInstanceDiscoverer,
 {
-    let upstreams = build_upstreams(static_upstreams, postgres_mcp).await?;
+    let upstreams = build_upstreams(static_upstreams, postgres_mcp, lana_admin_mcp).await?;
     if upstreams.is_empty() {
         anyhow::bail!("all configured MCP upstreams are unavailable or disabled");
     }
@@ -106,7 +109,7 @@ where
         tokio::select! {
             biased;
             _ = refresh_tick.tick(), if refresh_enabled => {
-                match build_upstreams(static_upstreams, postgres_mcp).await {
+                match build_upstreams(static_upstreams, postgres_mcp, lana_admin_mcp).await {
                     Ok(refreshed_upstreams) if refreshed_upstreams != upstreams => {
                         tracing::info!("configured upstream set changed; reconnecting to refresh drua registration");
                         return Ok(());
@@ -151,7 +154,7 @@ where
                                 arguments,
                             } => {
                                 let response =
-                                    handle_call(&mcp_clients, id, &upstream, &tool_name, arguments).await;
+                                    handle_call(&mut mcp_clients, id, &upstream, &tool_name, arguments).await;
                                 let json = serde_json::to_string(&response)?;
                                 ws_tx.send(tungstenite::Message::Text(json.into())).await?;
                             }
@@ -176,13 +179,15 @@ where
     Ok(())
 }
 
-async fn build_upstreams<H, D>(
+async fn build_upstreams<H, D, L>(
     static_upstreams: &[UpstreamConfig],
     postgres_mcp: &PostgresMcpController<H, D>,
+    lana_admin_mcp: Option<&LanaAdminMcpController<L>>,
 ) -> anyhow::Result<Vec<UpstreamConfig>>
 where
     H: PostgresMcpHandler,
     D: PostgresSourceDiscoverer,
+    L: LanaAdminMcpInstanceDiscoverer,
 {
     let mut upstreams = static_upstreams.to_vec();
 
@@ -190,11 +195,15 @@ where
         upstreams.push(upstream);
     }
 
+    if let Some(lana_admin_mcp) = lana_admin_mcp {
+        upstreams.extend(lana_admin_mcp.reconcile().await?);
+    }
+
     Ok(upstreams)
 }
 
 async fn handle_call(
-    clients: &McpClients,
+    clients: &mut McpClients,
     id: String,
     upstream: &str,
     tool_name: &str,


### PR DESCRIPTION
## What

Registers every Ready Lana sandbox's admin MCP endpoint (`list_data_mart_models`, `describe_data_mart_model`, `run_readonly_dw_query` — the curated, read-only data-mart surface) as a per-instance upstream toolset on the gateway, e.g. `galoy_staging_lana_admin_sb_demo_verify_run_readonly_dw_query`. Toolsets appear and disappear automatically with sandbox lifecycle, complementing the existing raw per-sandbox postgres tools.

## How

- **`lana_admin_mcp.rs`** (new): controller + kube-backed discoverer lists Ready `LanaSandbox` CRs (skips deleting ones) and maps each to an upstream: name `lana_admin_<inst>`, in-cluster URL `http://lana-bank-admin.<inst>.svc.cluster.local:5253/mcp`, direct-grant auth against `<keycloak>/realms/<inst>-internal` via the `admin-mcp-gateway` client (lana-bank PR below), authenticating as the seeded per-instance superuser. Static non-sandbox instances (e.g. staging `main`) supported via `TUNNEL_LANA_ADMIN_MCP_STATIC_INSTANCES` (`name=url,...`).
- **`mcp_upstream.rs`**: `UpstreamConfig` gains optional `DirectGrantAuth`. Tokens are minted at connect time; on a failed call to an authenticated upstream the connector re-mints, rebuilds the rmcp client (the bearer header is fixed at construction), and retries once.
- **`tunnel_session.rs`**: lana-admin upstreams fold into `build_upstreams`, so the existing refresh tick + upstream-set diff reconnects and re-registers on sandbox churn.
- Feature-flagged: `TUNNEL_LANA_ADMIN_MCP_ENABLED` (default off) plus keycloak base URL / client id / username+URL templates as envs.

## Test plan

- [x] `cargo test -p tunnel-connector` (14 pass): upstream mapping, teardown drop-out, static parsing, config validation, existing postgres registration regression test
- [x] clippy + fmt clean
- [ ] Live E2E after the lana-bank client rolls out: create `sb-*` sandbox → `galoy_staging_lana_admin_sb_*` tools appear in search_tools → query a mart → delete sandbox → tools disappear

Depends on: lana-bank https://github.com/GaloyMoney/lana-bank/pull/8328 (admin-mcp-gateway client). Deployment wiring: galoy-deployments https://github.com/GaloyMoney/galoy-deployments/pull/5440 (RBAC + env).
